### PR TITLE
chore(composition): cleanup code by removing unnecessary Result wrapping

### DIFF
--- a/apollo-federation/src/link/context_spec_definition.rs
+++ b/apollo-federation/src/link/context_spec_definition.rs
@@ -121,29 +121,25 @@ impl ContextSpecDefinition {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn context_directive_name(
-        schema: &FederationSchema,
-    ) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn context_directive_name(schema: &FederationSchema) -> Option<Name> {
         if let Some(spec) = Self::for_federation_schema(schema) {
             spec.directive_name_in_schema(schema, &FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC)
         } else if let Ok(fed_spec) = get_federation_spec_definition_from_subgraph(schema) {
             fed_spec.directive_name_in_schema(schema, &FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC)
         } else {
-            Ok(None)
+            None
         }
     }
 
     #[allow(dead_code)]
-    pub(crate) fn from_context_directive_name(
-        schema: &FederationSchema,
-    ) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn from_context_directive_name(schema: &FederationSchema) -> Option<Name> {
         if let Some(spec) = Self::for_federation_schema(schema) {
             spec.directive_name_in_schema(schema, &FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)
         } else if let Ok(fed_spec) = get_federation_spec_definition_from_subgraph(schema) {
             fed_spec
                 .directive_name_in_schema(schema, &FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)
         } else {
-            Ok(None)
+            None
         }
     }
 }

--- a/apollo-federation/src/link/cost_spec_definition.rs
+++ b/apollo-federation/src/link/cost_spec_definition.rs
@@ -58,7 +58,7 @@ macro_rules! propagate_demand_control_directives {
             subgraph_schema: &FederationSchema,
             dest: &mut $directives_ty,
         ) -> Result<(), FederationError> {
-            let cost_directive = Self::cost_directive_name(supergraph_schema)?
+            let cost_directive = Self::cost_directive_name(supergraph_schema)
                 .and_then(|name| source.get(name.as_str()));
             if let Some(cost_directive) = cost_directive {
                 dest.push($wrap_ty(Self::cost_directive(
@@ -67,7 +67,7 @@ macro_rules! propagate_demand_control_directives {
                 )?));
             }
 
-            let list_size_directive = Self::list_size_directive_name(supergraph_schema)?
+            let list_size_directive = Self::list_size_directive_name(supergraph_schema)
                 .and_then(|name| source.get(name.as_str()));
             if let Some(list_size_directive) = list_size_directive {
                 dest.push($wrap_ty(Self::list_size_directive(
@@ -89,7 +89,7 @@ macro_rules! propagate_demand_control_directives_to_position {
             pos: &$pos_ty,
         ) -> Result<(), FederationError> {
             let source = pos.get(supergraph_schema.schema())?;
-            let cost_directive = Self::cost_directive_name(supergraph_schema)?
+            let cost_directive = Self::cost_directive_name(supergraph_schema)
                 .and_then(|name| source.directives.get(name.as_str()));
             if let Some(cost_directive) = cost_directive {
                 pos.insert_directive(
@@ -101,7 +101,7 @@ macro_rules! propagate_demand_control_directives_to_position {
                 )?;
             }
 
-            let list_size_directive = Self::list_size_directive_name(supergraph_schema)?
+            let list_size_directive = Self::list_size_directive_name(supergraph_schema)
                 .and_then(|name| source.directives.get(name.as_str()));
             if let Some(list_size_directive) = list_size_directive {
                 pos.insert_directive(
@@ -133,7 +133,7 @@ impl CostSpecDefinition {
         schema: &FederationSchema,
         arguments: Vec<Node<Argument>>,
     ) -> Result<Directive, FederationError> {
-        let name = Self::cost_directive_name(schema)?.ok_or_else(|| {
+        let name = Self::cost_directive_name(schema).ok_or_else(|| {
             internal_error!("The \"@cost\" directive is undefined in the target schema")
         })?;
 
@@ -144,7 +144,7 @@ impl CostSpecDefinition {
         schema: &FederationSchema,
         arguments: Vec<Node<Argument>>,
     ) -> Result<Directive, FederationError> {
-        let name = Self::list_size_directive_name(schema)?.ok_or_else(|| {
+        let name = Self::list_size_directive_name(schema).ok_or_else(|| {
             internal_error!("The \"@listSize\" directive is undefined in the target schema")
         })?;
 
@@ -182,30 +182,26 @@ impl CostSpecDefinition {
     /// Returns the name of the `@cost` directive in the given schema, accounting for import aliases or specification name
     /// prefixes such as `@federation__cost`. This checks the linked cost specification, if there is one, and falls back
     /// to the federation spec.
-    pub(crate) fn cost_directive_name(
-        schema: &FederationSchema,
-    ) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn cost_directive_name(schema: &FederationSchema) -> Option<Name> {
         if let Some(spec) = Self::for_federation_schema(schema) {
             spec.directive_name_in_schema(schema, &COST_DIRECTIVE_NAME)
         } else if let Ok(fed_spec) = get_federation_spec_definition_from_subgraph(schema) {
             fed_spec.directive_name_in_schema(schema, &COST_DIRECTIVE_NAME)
         } else {
-            Ok(None)
+            None
         }
     }
 
     /// Returns the name of the `@listSize` directive in the given schema, accounting for import aliases or specification name
     /// prefixes such as `@federation__listSize`. This checks the linked cost specification, if there is one, and falls back
     /// to the federation spec.
-    pub(crate) fn list_size_directive_name(
-        schema: &FederationSchema,
-    ) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn list_size_directive_name(schema: &FederationSchema) -> Option<Name> {
         if let Some(spec) = Self::for_federation_schema(schema) {
             spec.directive_name_in_schema(schema, &LIST_SIZE_DIRECTIVE_NAME)
         } else if let Ok(fed_spec) = get_federation_spec_definition_from_subgraph(schema) {
             fed_spec.directive_name_in_schema(schema, &LIST_SIZE_DIRECTIVE_NAME)
         } else {
-            Ok(None)
+            None
         }
     }
 
@@ -214,7 +210,7 @@ impl CostSpecDefinition {
         argument: &InputValueDefinition,
         ty: &ExtendedType,
     ) -> Result<Option<CostDirective>, FederationError> {
-        let directive_name = Self::cost_directive_name(schema)?;
+        let directive_name = Self::cost_directive_name(schema);
         if let Some(name) = directive_name.as_ref() {
             Ok(CostDirective::from_directives(name, &argument.directives)
                 .or(CostDirective::from_schema_directives(name, ty.directives())))
@@ -227,25 +223,25 @@ impl CostSpecDefinition {
         schema: &FederationSchema,
         field: &FieldDefinition,
         ty: &ExtendedType,
-    ) -> Result<Option<CostDirective>, FederationError> {
-        let directive_name = Self::cost_directive_name(schema)?;
+    ) -> Option<CostDirective> {
+        let directive_name = Self::cost_directive_name(schema);
         if let Some(name) = directive_name.as_ref() {
-            Ok(CostDirective::from_directives(name, &field.directives)
-                .or(CostDirective::from_schema_directives(name, ty.directives())))
+            CostDirective::from_directives(name, &field.directives)
+                .or(CostDirective::from_schema_directives(name, ty.directives()))
         } else {
-            Ok(None)
+            None
         }
     }
 
     pub fn list_size_directive_from_field_definition(
         schema: &FederationSchema,
         field: &FieldDefinition,
-    ) -> Result<Option<ListSizeDirective>, FederationError> {
-        let directive_name = Self::list_size_directive_name(schema)?;
+    ) -> Option<ListSizeDirective> {
+        let directive_name = Self::list_size_directive_name(schema);
         if let Some(name) = directive_name.as_ref() {
-            Ok(ListSizeDirective::from_field_definition(name, field))
+            ListSizeDirective::from_field_definition(name, field)
         } else {
-            Ok(None)
+            None
         }
     }
 
@@ -254,7 +250,7 @@ impl CostSpecDefinition {
         schema: &FederationSchema,
         field: &FieldDefinition,
     ) -> Result<Vec<ListSizeDirective>, FederationError> {
-        let directive_name = Self::list_size_directive_name(schema)?;
+        let directive_name = Self::list_size_directive_name(schema);
         let Some(name) = directive_name.as_ref() else {
             return Ok(Vec::new());
         };

--- a/apollo-federation/src/link/federation_spec_definition.rs
+++ b/apollo-federation/src/link/federation_spec_definition.rs
@@ -197,11 +197,11 @@ impl FederationSpecDefinition {
         &self,
         schema: &FederationSchema,
         name_in_spec: &Name,
-    ) -> Result<Option<Name>, FederationError> {
+    ) -> Option<Name> {
         if schema.is_fed_2() {
             self.directive_name_in_schema(schema, name_in_spec)
         } else {
-            Ok(Some(name_in_spec.clone()))
+            Some(name_in_spec.clone())
         }
     }
 
@@ -215,7 +215,7 @@ impl FederationSpecDefinition {
         schema: &'schema FederationSchema,
         name_in_spec: &Name,
     ) -> Result<Option<&'schema Node<DirectiveDefinition>>, FederationError> {
-        match self.federation_directive_name_in_schema(schema, name_in_spec)? {
+        match self.federation_directive_name_in_schema(schema, name_in_spec) {
             Some(name) => schema
                 .schema()
                 .directive_definitions
@@ -255,7 +255,7 @@ impl FederationSpecDefinition {
         resolvable: bool,
     ) -> Result<Directive, FederationError> {
         let name_in_schema = self
-            .federation_directive_name_in_schema(schema, &FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC)?
+            .federation_directive_name_in_schema(schema, &FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC)
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find federation spec in schema".to_owned(),
             })?;
@@ -321,7 +321,7 @@ impl FederationSpecDefinition {
             .into());
         }
         let name_in_schema = self
-            .directive_name_in_schema(schema, &FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC)?
+            .directive_name_in_schema(schema, &FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC)
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find federation spec in schema".to_owned(),
             })?;
@@ -346,7 +346,7 @@ impl FederationSpecDefinition {
     pub(crate) fn external_directive_name_in_schema(
         &self,
         schema: &FederationSchema,
-    ) -> Result<Option<Name>, FederationError> {
+    ) -> Option<Name> {
         self.federation_directive_name_in_schema(
             schema,
             &FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC,
@@ -373,7 +373,7 @@ impl FederationSpecDefinition {
         reason: Option<String>,
     ) -> Result<Directive, FederationError> {
         let name_in_schema = self
-            .external_directive_name_in_schema(schema)?
+            .external_directive_name_in_schema(schema)
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find federation spec in schema".to_owned(),
             })?;
@@ -423,7 +423,7 @@ impl FederationSpecDefinition {
         name: String,
     ) -> Result<Directive, FederationError> {
         let name_in_schema = self
-            .federation_directive_name_in_schema(schema, &FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC)?
+            .federation_directive_name_in_schema(schema, &FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC)
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find federation spec in schema".to_owned(),
             })?;
@@ -469,7 +469,7 @@ impl FederationSpecDefinition {
             .federation_directive_name_in_schema(
                 schema,
                 &FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC,
-            )?
+            )
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find federation spec in schema".to_owned(),
             })?;
@@ -517,7 +517,7 @@ impl FederationSpecDefinition {
             .federation_directive_name_in_schema(
                 schema,
                 &FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC,
-            )?
+            )
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find federation spec in schema".to_owned(),
             })?;
@@ -545,7 +545,7 @@ impl FederationSpecDefinition {
     pub(crate) fn shareable_directive_name_in_schema(
         &self,
         schema: &FederationSchema,
-    ) -> Result<Option<Name>, FederationError> {
+    ) -> Option<Name> {
         self.directive_name_in_schema(schema, &FEDERATION_SHAREABLE_DIRECTIVE_NAME_IN_SPEC)
     }
 
@@ -566,7 +566,7 @@ impl FederationSpecDefinition {
         schema: &FederationSchema,
     ) -> Result<Directive, FederationError> {
         let name_in_schema = self
-            .shareable_directive_name_in_schema(schema)?
+            .shareable_directive_name_in_schema(schema)
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find federation spec in schema".to_owned(),
             })?;
@@ -595,7 +595,7 @@ impl FederationSpecDefinition {
         label: &Option<&str>,
     ) -> Result<Directive, FederationError> {
         let name_in_schema = self
-            .directive_name_in_schema(schema, &FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC)?
+            .directive_name_in_schema(schema, &FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC)
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find federation spec in schema".to_owned(),
             })?;
@@ -648,7 +648,7 @@ impl FederationSpecDefinition {
         name: String,
     ) -> Result<Directive, FederationError> {
         let name_in_schema = self
-            .directive_name_in_schema(schema, &FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
+            .directive_name_in_schema(schema, &FEDERATION_CONTEXT_DIRECTIVE_NAME_IN_SPEC)
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find federation spec in schema".to_owned(),
             })?;
@@ -701,7 +701,7 @@ impl FederationSpecDefinition {
         name: String,
     ) -> Result<Directive, FederationError> {
         let name_in_schema = self
-            .directive_name_in_schema(schema, &FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)?
+            .directive_name_in_schema(schema, &FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find federation spec in schema".to_owned(),
             })?;

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -914,7 +914,7 @@ fn validate_inaccessible(
     inaccessible_spec: &InaccessibleSpecDefinition,
 ) -> Result<(), FederationError> {
     let inaccessible_directive = inaccessible_spec
-        .directive_name_in_schema(schema, &INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC)?
+        .directive_name_in_schema(schema, &INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC)
         .ok_or_else(|| SingleFederationError::Internal {
             message: "Unexpectedly could not find inaccessible spec in schema".to_owned(),
         })?;
@@ -1138,7 +1138,7 @@ fn remove_inaccessible_elements(
     inaccessible_spec: &InaccessibleSpecDefinition,
 ) -> Result<(), FederationError> {
     let directive_name = inaccessible_spec
-        .directive_name_in_schema(schema, &INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC)?
+        .directive_name_in_schema(schema, &INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC)
         .ok_or_else(|| SingleFederationError::Internal {
             message: "Unexpectedly could not find inaccessible spec in schema".to_owned(),
         })?;

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -1089,7 +1089,7 @@ impl JoinSpecDefinition {
 
         // Get the graph enum name to access it directly from the schema
         let graph_enum_name = self
-            .type_name_in_schema(schema, &JOIN_GRAPH_ENUM_NAME_IN_SPEC)?
+            .type_name_in_schema(schema, &JOIN_GRAPH_ENUM_NAME_IN_SPEC)
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Could not find graph enum name in schema".to_owned(),
             })?;

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -442,7 +442,7 @@ impl JoinSpecDefinition {
         subgraph_name: &Name,
         member_name: &str,
     ) -> Result<Directive, FederationError> {
-        let Ok(Some(name_in_schema)) =
+        let Some(name_in_schema) =
             self.directive_name_in_schema(schema, &JOIN_UNIONMEMBER_DIRECTIVE_NAME_IN_SPEC)
         else {
             bail!("Unexpectedly could not find unionMember directive in schema");
@@ -496,7 +496,7 @@ impl JoinSpecDefinition {
         subgraph_name: &Name,
     ) -> Result<Directive, FederationError> {
         let name_in_schema = self
-            .directive_name_in_schema(schema, &JOIN_ENUMVALUE_DIRECTIVE_NAME_IN_SPEC)?
+            .directive_name_in_schema(schema, &JOIN_ENUMVALUE_DIRECTIVE_NAME_IN_SPEC)
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Unexpectedly could not find enumValue directive in schema".to_owned(),
             })?;
@@ -656,8 +656,7 @@ impl JoinSpecDefinition {
             }));
         }
 
-        let Some(name) =
-            self.directive_name_in_schema(schema, &JOIN_TYPE_DIRECTIVE_NAME_IN_SPEC)?
+        let Some(name) = self.directive_name_in_schema(schema, &JOIN_TYPE_DIRECTIVE_NAME_IN_SPEC)
         else {
             bail!("Unexpectedly could not find @join__type directive in schema")
         };
@@ -854,7 +853,7 @@ impl JoinSpecDefinition {
         interface: &str,
     ) -> Result<Directive, FederationError> {
         let Some(name) =
-            self.directive_name_in_schema(schema, &JOIN_IMPLEMENTS_DIRECTIVE_NAME_IN_SPEC)?
+            self.directive_name_in_schema(schema, &JOIN_IMPLEMENTS_DIRECTIVE_NAME_IN_SPEC)
         else {
             bail!("Unexpectedly could not find @join__implements directive in schema");
         };
@@ -1001,7 +1000,7 @@ impl JoinSpecDefinition {
         args: impl IntoIterator<Item = Node<Argument>>,
     ) -> Result<Directive, FederationError> {
         let Some(directive_name) =
-            self.directive_name_in_schema(schema, &JOIN_DIRECTIVE_DIRECTIVE_NAME_IN_SPEC)?
+            self.directive_name_in_schema(schema, &JOIN_DIRECTIVE_DIRECTIVE_NAME_IN_SPEC)
         else {
             bail!("Unexpectedly could not find @join__directive directive in schema");
         };
@@ -1083,7 +1082,7 @@ impl JoinSpecDefinition {
 
         // Get the graph directive name once (used for all enum values)
         let graph_directive_name = self
-            .directive_name_in_schema(schema, &JOIN_GRAPH_DIRECTIVE_NAME_IN_SPEC)?
+            .directive_name_in_schema(schema, &JOIN_GRAPH_DIRECTIVE_NAME_IN_SPEC)
             .ok_or_else(|| SingleFederationError::Internal {
                 message: "Could not find graph directive name in schema".to_owned(),
             })?;

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -94,11 +94,11 @@ pub(crate) trait SpecDefinition {
         &self,
         schema: &FederationSchema,
         name_in_spec: &Name,
-    ) -> Result<Option<Name>, FederationError> {
-        let Some(link) = self.link_in_schema(schema)? else {
-            return Ok(None);
+    ) -> Option<Name> {
+        let Some(link) = self.link_in_schema(schema) else {
+            return None;
         };
-        Ok(Some(link.directive_name_in_schema(name_in_spec)))
+        Some(link.directive_name_in_schema(name_in_spec))
     }
 
     fn type_name_in_schema(
@@ -106,7 +106,7 @@ pub(crate) trait SpecDefinition {
         schema: &FederationSchema,
         name_in_spec: &Name,
     ) -> Result<Option<Name>, FederationError> {
-        let Some(link) = self.link_in_schema(schema)? else {
+        let Some(link) = self.link_in_schema(schema) else {
             return Ok(None);
         };
         Ok(Some(link.type_name_in_schema(name_in_spec)))
@@ -117,7 +117,7 @@ pub(crate) trait SpecDefinition {
         schema: &'schema FederationSchema,
         name_in_spec: &Name,
     ) -> Result<Option<&'schema Node<DirectiveDefinition>>, FederationError> {
-        match self.directive_name_in_schema(schema, name_in_spec)? {
+        match self.directive_name_in_schema(schema, name_in_spec) {
             Some(name) => schema
                 .schema()
                 .directive_definitions
@@ -132,6 +132,17 @@ pub(crate) trait SpecDefinition {
                 })
                 .map(Some),
             None => Ok(None),
+        }
+    }
+
+    fn try_directive_definition<'schema>(
+        &self,
+        schema: &'schema FederationSchema,
+        name_in_spec: &Name,
+    ) -> Option<&'schema Node<DirectiveDefinition>> {
+        match self.directive_name_in_schema(schema, name_in_spec) {
+            Some(name) => schema.schema().directive_definitions.get(&name),
+            None => None,
         }
     }
 
@@ -158,14 +169,11 @@ pub(crate) trait SpecDefinition {
         }
     }
 
-    fn link_in_schema(
-        &self,
-        schema: &FederationSchema,
-    ) -> Result<Option<Arc<Link>>, FederationError> {
+    fn link_in_schema(&self, schema: &FederationSchema) -> Option<Arc<Link>> {
         let Some(metadata) = schema.metadata() else {
-            return Ok(None);
+            return None;
         };
-        Ok(metadata.for_identity(self.identity()))
+        metadata.for_identity(self.identity())
     }
 
     fn to_string(&self) -> String {
@@ -173,7 +181,7 @@ pub(crate) trait SpecDefinition {
     }
 
     fn add_elements_to_schema(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
-        let link = self.link_in_schema(schema)?;
+        let link = self.link_in_schema(schema);
         ensure!(
             link.is_some(),
             "The {self_url} specification should have been added to the schema before this is called",

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -99,15 +99,9 @@ pub(crate) trait SpecDefinition {
         Some(link.directive_name_in_schema(name_in_spec))
     }
 
-    fn type_name_in_schema(
-        &self,
-        schema: &FederationSchema,
-        name_in_spec: &Name,
-    ) -> Result<Option<Name>, FederationError> {
-        let Some(link) = self.link_in_schema(schema) else {
-            return Ok(None);
-        };
-        Ok(Some(link.type_name_in_schema(name_in_spec)))
+    fn type_name_in_schema(&self, schema: &FederationSchema, name_in_spec: &Name) -> Option<Name> {
+        let link = self.link_in_schema(schema)?;
+        Some(link.type_name_in_schema(name_in_spec))
     }
 
     fn directive_definition<'schema>(
@@ -149,7 +143,7 @@ pub(crate) trait SpecDefinition {
         schema: &'schema FederationSchema,
         name_in_spec: &Name,
     ) -> Result<Option<&'schema ExtendedType>, FederationError> {
-        match self.type_name_in_schema(schema, name_in_spec)? {
+        match self.type_name_in_schema(schema, name_in_spec) {
             Some(name) => schema
                 .schema()
                 .types

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -95,9 +95,7 @@ pub(crate) trait SpecDefinition {
         schema: &FederationSchema,
         name_in_spec: &Name,
     ) -> Option<Name> {
-        let Some(link) = self.link_in_schema(schema) else {
-            return None;
-        };
+        let link = self.link_in_schema(schema)?;
         Some(link.directive_name_in_schema(name_in_spec))
     }
 
@@ -170,9 +168,7 @@ pub(crate) trait SpecDefinition {
     }
 
     fn link_in_schema(&self, schema: &FederationSchema) -> Option<Arc<Link>> {
-        let Some(metadata) = schema.metadata() else {
-            return None;
-        };
+        let metadata = schema.metadata()?;
         metadata.for_identity(self.identity())
     }
 

--- a/apollo-federation/src/merger/compose_directive_manager.rs
+++ b/apollo-federation/src/merger/compose_directive_manager.rs
@@ -247,21 +247,11 @@ impl ComposeDirectiveManager {
 
         let tag_names_in_subgraphs: MultiMap<Name, String> = subgraphs
             .iter()
-            .filter_map(|s| {
-                s.tag_directive_name()
-                    .ok()
-                    .flatten()
-                    .zip(Some(s.name.clone()))
-            })
+            .filter_map(|s| s.tag_directive_name().zip(Some(s.name.clone())))
             .collect();
         let inaccessible_names_in_subgraphs: MultiMap<Name, String> = subgraphs
             .iter()
-            .filter_map(|s| {
-                s.inaccessible_directive_name()
-                    .ok()
-                    .flatten()
-                    .zip(Some(s.name.clone()))
-            })
+            .filter_map(|s| s.inaccessible_directive_name().zip(Some(s.name.clone())))
             .collect();
 
         for subgraph in subgraphs {

--- a/apollo-federation/src/merger/merge_argument.rs
+++ b/apollo-federation/src/merger/merge_argument.rs
@@ -122,7 +122,7 @@ impl Merger {
                 let arg_opt = pos.get_argument(subgraph.schema(), arg_name);
 
                 if let Some(arg) = arg_opt
-                    && let Ok(Some(from_context)) = subgraph.from_context_directive_name()
+                    && let Some(from_context) = subgraph.from_context_directive_name()
                     && arg.directives.iter().any(|d| d.name == from_context)
                 {
                     is_contextual_in_subgraph.insert(*idx, true);

--- a/apollo-federation/src/merger/merge_directive.rs
+++ b/apollo-federation/src/merger/merge_directive.rs
@@ -657,10 +657,7 @@ impl Merger {
                     &POLICY_DIRECTIVE_NAME_IN_SPEC,
                 ] {
                     let directive = federation_spec
-                        .directive_name_in_schema(subgraph.schema(), access_control_directive)?
-                        .and_then(|name| {
-                            subgraph.schema().schema().directive_definitions.get(&name)
-                        });
+                        .try_directive_definition(subgraph.schema(), access_control_directive);
                     if let Some(directive) = directive {
                         let referencers = subgraph_referencers.get_directive(&directive.name);
                         for type_position in &referencers.object_types {

--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -1005,24 +1005,17 @@ impl Merger {
             let external = source
                 .try_into()
                 .is_ok_and(|pos| self.is_field_external(idx, &pos));
-            let requires = self.get_field_set(
-                &field_def,
-                subgraph.requires_directive_name().ok().flatten().as_ref(),
-            );
+            let requires =
+                self.get_field_set(&field_def, subgraph.requires_directive_name().as_ref());
 
-            let provides = self.get_field_set(
-                &field_def,
-                subgraph.provides_directive_name().ok().flatten().as_ref(),
-            );
+            let provides =
+                self.get_field_set(&field_def, subgraph.provides_directive_name().as_ref());
 
             let has_unknown_target = merge_context.has_override_with_unknown_target(idx);
             let override_from = if has_unknown_target {
                 None
             } else {
-                self.get_override_from(
-                    &field_def,
-                    subgraph.override_directive_name().ok().flatten().as_ref(),
-                )
+                self.get_override_from(&field_def, subgraph.override_directive_name().as_ref())
             };
 
             let context_arguments = self.extract_context_arguments(idx, &field_def)?;
@@ -1078,7 +1071,7 @@ impl Merger {
         for (&idx, source_opt) in &sources {
             if let Some(source_pos) = source_opt
                 && let Some(subgraph) = self.subgraphs.get(idx)
-                && let Ok(Some(override_directive_name)) = subgraph.override_directive_name()
+                && let Some(override_directive_name) = subgraph.override_directive_name()
             {
                 let has_override = match source_pos {
                     DirectiveTargetPosition::ObjectField(pos) => !pos
@@ -1139,8 +1132,8 @@ impl Merger {
         //   3) none of the field is @external.
         for (&idx, source_opt) in &sources {
             let subgraph = &self.subgraphs[idx];
-            let provides_directive_name = subgraph.provides_directive_name().ok().flatten();
-            let requires_directive_name = subgraph.requires_directive_name().ok().flatten();
+            let provides_directive_name = subgraph.provides_directive_name();
+            let requires_directive_name = subgraph.requires_directive_name();
             let overridden = merge_context.is_unused_overridden(idx);
             match source_opt {
                 Some(source_pos) => {
@@ -1231,7 +1224,7 @@ impl Merger {
 
         // Check if the @fromContext directive is defined in the schema
         // If the directive is not defined in the schema, we cannot extract context arguments
-        let Ok(Some(from_context_name)) = self.subgraphs[idx].from_context_directive_name() else {
+        let Some(from_context_name) = self.subgraphs[idx].from_context_directive_name() else {
             return Ok(None);
         };
 

--- a/apollo-federation/src/merger/merge_interface.rs
+++ b/apollo-federation/src/merger/merge_interface.rs
@@ -32,7 +32,7 @@ impl Merger {
                 continue;
             }
 
-            let Some(key_directive_name) = subgraph.key_directive_name()? else {
+            let Some(key_directive_name) = subgraph.key_directive_name() else {
                 continue;
             };
             let interface_pos: TypeDefinitionPosition = dest.clone().into();

--- a/apollo-federation/src/merger/merge_type.rs
+++ b/apollo-federation/src/merger/merge_type.rs
@@ -144,8 +144,7 @@ impl Merger {
             let subgraph = &self.subgraphs[*idx];
             let is_interface_object = subgraph.is_interface_object_type(source);
 
-            let key_directive_name = subgraph.key_directive_name()?;
-            let keys = if let Some(key_directive_name) = &key_directive_name {
+            let keys = if let Some(key_directive_name) = &subgraph.key_directive_name() {
                 source.get_applied_directives(subgraph.schema(), key_directive_name)
             } else {
                 Vec::new()
@@ -168,8 +167,6 @@ impl Merger {
                 // If this type has keys, we apply a `@join__type` for each key.
                 let extends_directive_name = subgraph
                     .extends_directive_name()
-                    .ok()
-                    .flatten()
                     .clone()
                     .unwrap_or(FEDERATION_EXTENDS_DIRECTIVE_NAME_IN_SPEC);
 

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -307,7 +307,7 @@ impl Merger {
         subgraphs
             .iter()
             .fold(Default::default(), |mut acc, subgraph| {
-                if let Ok(Some(directive_name)) = subgraph.from_context_directive_name() {
+                if let Some(directive_name) = subgraph.from_context_directive_name() {
                     let referencers = subgraph
                         .schema()
                         .referencers()
@@ -326,7 +326,7 @@ impl Merger {
         subgraphs
             .iter()
             .fold(Default::default(), |mut acc, subgraph| {
-                if let Ok(Some(directive_name)) = subgraph.override_directive_name() {
+                if let Some(directive_name) = subgraph.override_directive_name() {
                     let referencers = subgraph
                         .schema()
                         .referencers()
@@ -1406,7 +1406,7 @@ impl Merger {
         field: &ObjectOrInterfaceFieldDefinitionPosition,
     ) -> Result<Option<Component<Directive>>, FederationError> {
         let subgraph = &self.subgraphs[source_idx];
-        let Some(override_directive_name) = subgraph.override_directive_name()? else {
+        let Some(override_directive_name) = subgraph.override_directive_name() else {
             return Ok(None);
         };
 
@@ -1463,7 +1463,7 @@ impl Merger {
         let from_subgraph_name = &self.names[from_idx];
 
         // Check for conflict with @requires
-        if let Ok(Some(requires_name)) = from_subgraph.requires_directive_name()
+        if let Some(requires_name) = from_subgraph.requires_directive_name()
             && field.has_applied_directive(from_subgraph.schema(), &requires_name)
         {
             return Ok(Some((
@@ -1473,7 +1473,7 @@ impl Merger {
         }
 
         // Check for conflict with @provides
-        if let Ok(Some(provides_name)) = from_subgraph.provides_directive_name()
+        if let Some(provides_name) = from_subgraph.provides_directive_name()
             && field.has_applied_directive(from_subgraph.schema(), &provides_name)
         {
             return Ok(Some((
@@ -1485,7 +1485,7 @@ impl Merger {
         // Check for conflict with @external
         let overriding_subgraph_name = &self.names[overriding_idx];
         let field_pos: FieldDefinitionPosition = field.clone().into();
-        if let Ok(Some(external_name)) = from_subgraph.external_directive_name()
+        if let Some(external_name) = from_subgraph.external_directive_name()
             && self.is_field_external(overriding_idx, &field_pos)
         {
             return Ok(Some((
@@ -1623,7 +1623,7 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
 
         let mut sources: Sources<_> = Default::default();
         for (idx, subgraph) in self.subgraphs.iter().enumerate() {
-            let Some(key_directive_name) = subgraph.key_directive_name()? else {
+            let Some(key_directive_name) = subgraph.key_directive_name() else {
                 continue;
             };
             if let Some(node) = obj.try_get(subgraph.schema().schema()) {
@@ -2386,7 +2386,7 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
 
         let Some(link_directive_name) = self
             .link_spec_definition
-            .directive_name_in_schema(&self.merged, &DEFAULT_LINK_NAME)?
+            .directive_name_in_schema(&self.merged, &DEFAULT_LINK_NAME)
         else {
             bail!(
                 "Link directive must exist in the supergraph schema in order to apply join directives"
@@ -2458,7 +2458,7 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
         if self
             .join_spec_definition
             .directive_name_in_schema(&self.merged, &JOIN_DIRECTIVE_DIRECTIVE_NAME_IN_SPEC)
-            .is_err()
+            .is_none()
         {
             // If we got here and have no definition for `@join__directive`, then we're probably
             // operating on a schema that uses join v0.3 or earlier. We don't want to break those
@@ -2523,7 +2523,7 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
     pub(crate) fn remove_redundant_join_fields(&mut self) -> Result<(), FederationError> {
         let Some(join_field_directive_name) = self
             .join_spec_definition
-            .directive_name_in_schema(&self.merged, &JOIN_FIELD_DIRECTIVE_NAME_IN_SPEC)?
+            .directive_name_in_schema(&self.merged, &JOIN_FIELD_DIRECTIVE_NAME_IN_SPEC)
         else {
             return Ok(());
         };

--- a/apollo-federation/src/merger/supergraph_coordinate.rs
+++ b/apollo-federation/src/merger/supergraph_coordinate.rs
@@ -406,7 +406,7 @@ fn subgraph_locations_for_single_inaccessible_error(
             continue;
         };
         for (idx, subgraph) in subgraphs.iter().enumerate() {
-            let Ok(Some(inaccessible_name)) = subgraph.inaccessible_directive_name() else {
+            let Some(inaccessible_name) = subgraph.inaccessible_directive_name() else {
                 continue;
             };
             if !parsed.exists_in(subgraph.schema()) {

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -222,7 +222,7 @@ impl FederationBlueprint {
                 };
             }
 
-            let Ok(Some(name_in_schema)) = metadata
+            let Some(name_in_schema) = metadata
                 .federation_spec_definition()
                 .directive_name_in_schema(schema, &Name::new_unchecked(unknown_directive_name))
             else {

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -1039,7 +1039,7 @@ impl FederationSchema {
     pub(crate) fn list_size_directive_applications(
         &self,
     ) -> FallibleDirectiveIterator<ListSizeDirective<'_>> {
-        let Some(list_size_directive_name) = CostSpecDefinition::list_size_directive_name(self)?
+        let Some(list_size_directive_name) = CostSpecDefinition::list_size_directive_name(self)
         else {
             return Ok(Vec::new());
         };
@@ -1056,18 +1056,15 @@ impl FederationSchema {
                 self,
                 field_definition,
             ) {
-                Ok(Some(list_size_directive)) => {
+                Some(list_size_directive) => {
                     applications.push(Ok(ListSizeDirective {
                         directive: list_size_directive,
                         parent_type: field_definition_position.type_name().clone(),
                         target: field_definition,
                     }));
                 }
-                Ok(None) => {
+                None => {
                     // No listSize directive found, continue
-                }
-                Err(error) => {
-                    applications.push(Err(error));
                 }
             }
         }

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -2172,7 +2172,7 @@ impl SchemaDefinitionPosition {
             Some(metadata) => {
                 let link_spec_definition = metadata.link_spec_definition()?;
                 let link_name_in_schema = link_spec_definition
-                    .directive_name_in_schema(schema, &link_spec_definition.identity().name)?
+                    .directive_name_in_schema(schema, &link_spec_definition.identity().name)
                     .ok_or_else(|| SingleFederationError::Internal {
                         message: "Unexpectedly could not find core/link spec usage".to_owned(),
                     })?;

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -136,10 +136,10 @@ impl SchemaUpgrader {
         // Run pre-upgrade validations to check for issues that would prevent upgrade
         let mut upgrade_metadata = UpgradeMetadata {
             subgraph_name: subgraph.name.clone(),
-            key_directive_name: subgraph.key_directive_name()?.clone(),
-            requires_directive_name: subgraph.requires_directive_name()?.clone(),
-            provides_directive_name: subgraph.provides_directive_name()?.clone(),
-            extends_directive_name: subgraph.extends_directive_name()?.clone(),
+            key_directive_name: subgraph.key_directive_name().clone(),
+            requires_directive_name: subgraph.requires_directive_name().clone(),
+            provides_directive_name: subgraph.provides_directive_name().clone(),
+            extends_directive_name: subgraph.extends_directive_name().clone(),
             metadata: subgraph.metadata().clone(),
             orphan_extension_types: orphan_extensions,
         };

--- a/apollo-federation/src/schema/subgraph_metadata.rs
+++ b/apollo-federation/src/schema/subgraph_metadata.rs
@@ -240,7 +240,7 @@ impl SubgraphMetadata {
         // identify key fields (because if we know nothing is marked @shareable, then the only fields that are shareable
         // by default are key fields).
         let Some(shareable_directive_name) =
-            federation_spec_definition.shareable_directive_name_in_schema(schema)?
+            federation_spec_definition.shareable_directive_name_in_schema(schema)
         else {
             return Ok(shareable_fields);
         };
@@ -356,7 +356,7 @@ impl SubgraphMetadata {
         let mut interface_object_types = IndexSet::default();
 
         let Some(interface_object_directive_name) = federation_spec_definition
-            .directive_name_in_schema(schema, &FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC)?
+            .directive_name_in_schema(schema, &FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC)
         else {
             return Ok(interface_object_types);
         };
@@ -448,7 +448,7 @@ impl ExternalMetadata {
         schema: &FederationSchema,
     ) -> Result<IndexSet<FieldDefinitionPosition>, FederationError> {
         let Some(external_directive_name) =
-            federation_spec_definition.external_directive_name_in_schema(schema)?
+            federation_spec_definition.external_directive_name_in_schema(schema)
         else {
             return Ok(Default::default());
         };
@@ -519,7 +519,7 @@ impl ExternalMetadata {
         schema: &FederationSchema,
     ) -> Result<IndexSet<FieldDefinitionPosition>, FederationError> {
         let Some(external_directive_name) =
-            federation_spec_definition.external_directive_name_in_schema(schema)?
+            federation_spec_definition.external_directive_name_in_schema(schema)
         else {
             return Ok(Default::default());
         };

--- a/apollo-federation/src/schema/validators/access_control.rs
+++ b/apollo-federation/src/schema/validators/access_control.rs
@@ -56,9 +56,7 @@ pub(crate) fn validate_no_access_control_on_interfaces(
         REQUIRES_SCOPES_DIRECTIVE_NAME_IN_SPEC,
         POLICY_DIRECTIVE_NAME_IN_SPEC,
     ] {
-        if let Some(directive_name) =
-            federation_spec.directive_name_in_schema(schema, &directive)?
-        {
+        if let Some(directive_name) = federation_spec.directive_name_in_schema(schema, &directive) {
             let references = schema.referencers().get_directive(&directive_name);
             for interface_field in &references.interface_fields {
                 errors
@@ -129,15 +127,12 @@ pub(crate) fn validate_transitive_access_control_requirements_in_the_supergraph(
             );
         }
 
-        let federation_spec = subgraph.metadata().federation_spec_definition();
-        let from_context_directive = federation_spec
-            .directive_name_in_schema(
+        let from_context_directive = subgraph.metadata()
+            .federation_spec_definition()
+            .try_directive_definition(
                 subgraph.schema(),
-                &crate::link::federation_spec_definition::FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC,
-            )?
-            .and_then(|name| {
-                subgraph.schema().schema().directive_definitions.get(&name)
-            });
+                &crate::link::federation_spec_definition::FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC
+            );
         if let Some(from_context_directive) = from_context_directive {
             let from_context_referencers = subgraph
                 .schema()
@@ -210,52 +205,43 @@ impl<'validator> AccessControlValidator<'validator> {
                 AUTHENTICATED_VERSIONS
                     .find(&authenticated_spec.url.version)
                     .and_then(|authenticated_definition| {
-                        authenticated_definition
-                            .directive_name_in_schema(
-                                supergraph_schema,
-                                &AUTHENTICATED_DIRECTIVE_NAME_IN_SPEC,
-                            )
-                            .transpose()
+                        authenticated_definition.directive_name_in_schema(
+                            supergraph_schema,
+                            &AUTHENTICATED_DIRECTIVE_NAME_IN_SPEC,
+                        )
                     })
-            })
-            .transpose()?;
+            });
         let requires_scopes_directive_name = links_metadata
             .for_identity(&Identity::requires_scopes_identity())
             .and_then(|requires_scopes_spec| {
                 REQUIRES_SCOPES_VERSIONS
                     .find(&requires_scopes_spec.url.version)
                     .and_then(|requires_scopes_definition| {
-                        requires_scopes_definition
-                            .directive_name_in_schema(
-                                supergraph_schema,
-                                &REQUIRES_SCOPES_DIRECTIVE_NAME_IN_SPEC,
-                            )
-                            .transpose()
+                        requires_scopes_definition.directive_name_in_schema(
+                            supergraph_schema,
+                            &REQUIRES_SCOPES_DIRECTIVE_NAME_IN_SPEC,
+                        )
                     })
-            })
-            .transpose()?;
+            });
         let policy_directive_name = links_metadata
             .for_identity(&Identity::policy_identity())
             .and_then(|policy_spec| {
                 POLICY_VERSIONS
                     .find(&policy_spec.url.version)
                     .and_then(|policy_definition| {
-                        policy_definition
-                            .directive_name_in_schema(
-                                supergraph_schema,
-                                &POLICY_DIRECTIVE_NAME_IN_SPEC,
-                            )
-                            .transpose()
+                        policy_definition.directive_name_in_schema(
+                            supergraph_schema,
+                            &POLICY_DIRECTIVE_NAME_IN_SPEC,
+                        )
                     })
-            })
-            .transpose()?;
+            });
 
         let mut contexts: IndexMap<String, IndexSet<Name>> = IndexMap::default();
         if let Some(context_spec_definition) = links_metadata
             .for_identity(&Identity::context_identity())
             .and_then(|context_spec| CONTEXT_VERSIONS.find(&context_spec.url.version))
             && let Some(context_directive_name) = context_spec_definition
-                .directive_name_in_schema(supergraph_schema, &CONTEXT_DIRECTIVE_NAME)?
+                .directive_name_in_schema(supergraph_schema, &CONTEXT_DIRECTIVE_NAME)
         {
             let references = supergraph_schema
                 .referencers

--- a/apollo-federation/src/schema/validators/cost.rs
+++ b/apollo-federation/src/schema/validators/cost.rs
@@ -8,7 +8,7 @@ pub(crate) fn validate_cost_directives(
     schema: &FederationSchema,
     errors: &mut MultipleFederationErrors,
 ) -> Result<(), FederationError> {
-    let Some(cost_directive_name) = CostSpecDefinition::cost_directive_name(schema)? else {
+    let Some(cost_directive_name) = CostSpecDefinition::cost_directive_name(schema) else {
         return Ok(());
     };
     let cost_directive_referencers = schema

--- a/apollo-federation/src/schema/validators/key.rs
+++ b/apollo-federation/src/schema/validators/key.rs
@@ -33,7 +33,7 @@ pub(crate) fn validate_key_directives(
 ) -> Result<(), FederationError> {
     let directive_name = meta
         .federation_spec_definition()
-        .directive_name_in_schema(schema, &FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC)?
+        .directive_name_in_schema(schema, &FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC)
         .unwrap_or(FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC);
 
     let fieldset_rules: Vec<Box<dyn SchemaFieldSetValidator<KeyDirective>>> = vec![

--- a/apollo-federation/src/schema/validators/provides.rs
+++ b/apollo-federation/src/schema/validators/provides.rs
@@ -33,7 +33,7 @@ pub(crate) fn validate_provides_directives(
 ) -> Result<(), FederationError> {
     let provides_directive_name = metadata
         .federation_spec_definition()
-        .directive_name_in_schema(schema, &FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC)?
+        .directive_name_in_schema(schema, &FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC)
         .unwrap_or(FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC);
 
     let fieldset_rules: Vec<Box<dyn SchemaFieldSetValidator<ProvidesDirective>>> = vec![

--- a/apollo-federation/src/schema/validators/requires.rs
+++ b/apollo-federation/src/schema/validators/requires.rs
@@ -30,7 +30,7 @@ pub(crate) fn validate_requires_directives(
 ) -> Result<(), FederationError> {
     let requires_directive_name = meta
         .federation_spec_definition()
-        .directive_name_in_schema(schema, &FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC)?
+        .directive_name_in_schema(schema, &FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC)
         .unwrap_or(FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC);
 
     let fieldset_rules: Vec<Box<dyn SchemaFieldSetValidator<RequiresDirective>>> = vec![

--- a/apollo-federation/src/schema/validators/shareable.rs
+++ b/apollo-federation/src/schema/validators/shareable.rs
@@ -17,7 +17,7 @@ pub(crate) fn validate_shareable_directives(
 ) -> Result<(), FederationError> {
     let directive_name = meta
         .federation_spec_definition()
-        .shareable_directive_name_in_schema(schema)?
+        .shareable_directive_name_in_schema(schema)
         .unwrap_or(FEDERATION_SHAREABLE_DIRECTIVE_NAME_IN_SPEC);
     let shareable_referencers = schema.referencers().get_directive(&directive_name);
 

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -666,14 +666,14 @@ impl<S: HasMetadata> Subgraph<S> {
         self.schema().schema().to_string()
     }
 
-    pub(crate) fn extends_directive_name(&self) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn extends_directive_name(&self) -> Option<Name> {
         self.metadata()
             .federation_spec_definition()
             .directive_name_in_schema(self.schema(), &FEDERATION_EXTENDS_DIRECTIVE_NAME_IN_SPEC)
     }
 
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn from_context_directive_name(&self) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn from_context_directive_name(&self) -> Option<Name> {
         self.metadata()
             .federation_spec_definition()
             .directive_name_in_schema(
@@ -682,43 +682,43 @@ impl<S: HasMetadata> Subgraph<S> {
             )
     }
 
-    pub(crate) fn inaccessible_directive_name(&self) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn inaccessible_directive_name(&self) -> Option<Name> {
         self.metadata()
             .federation_spec_definition()
             .directive_name_in_schema(self.schema(), &INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC)
     }
 
-    pub(crate) fn key_directive_name(&self) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn key_directive_name(&self) -> Option<Name> {
         self.metadata()
             .federation_spec_definition()
             .directive_name_in_schema(self.schema(), &FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC)
     }
 
-    pub(crate) fn override_directive_name(&self) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn override_directive_name(&self) -> Option<Name> {
         self.metadata()
             .federation_spec_definition()
             .directive_name_in_schema(self.schema(), &FEDERATION_OVERRIDE_DIRECTIVE_NAME_IN_SPEC)
     }
 
-    pub(crate) fn provides_directive_name(&self) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn provides_directive_name(&self) -> Option<Name> {
         self.metadata()
             .federation_spec_definition()
             .directive_name_in_schema(self.schema(), &FEDERATION_PROVIDES_DIRECTIVE_NAME_IN_SPEC)
     }
 
-    pub(crate) fn requires_directive_name(&self) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn requires_directive_name(&self) -> Option<Name> {
         self.metadata()
             .federation_spec_definition()
             .directive_name_in_schema(self.schema(), &FEDERATION_REQUIRES_DIRECTIVE_NAME_IN_SPEC)
     }
 
-    pub(crate) fn external_directive_name(&self) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn external_directive_name(&self) -> Option<Name> {
         self.metadata()
             .federation_spec_definition()
             .directive_name_in_schema(self.schema(), &FEDERATION_EXTERNAL_DIRECTIVE_NAME_IN_SPEC)
     }
 
-    pub(crate) fn tag_directive_name(&self) -> Result<Option<Name>, FederationError> {
+    pub(crate) fn tag_directive_name(&self) -> Option<Name> {
         self.metadata()
             .federation_spec_definition()
             .directive_name_in_schema(self.schema(), &FEDERATION_TAG_DIRECTIVE_NAME_IN_SPEC)
@@ -783,7 +783,7 @@ pub(crate) fn schema_as_fed2_subgraph(
             "Fed2 schema must use @link with version >= 1.0, but schema uses {spec_url}",
             spec_url = link_spec.url()
         );
-        let Some(link) = link_spec.link_in_schema(schema)? else {
+        let Some(link) = link_spec.link_in_schema(schema) else {
             bail!("Core schema is missing the link spec link directive");
         };
         (link.spec_name_in_schema().clone(), metadata)

--- a/apollo-router/src/plugins/demand_control/cost_calculator/schema.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/schema.rs
@@ -97,7 +97,7 @@ impl FieldDefinition {
                 ))
             })?;
         let cost_directive =
-            CostSpecDefinition::cost_directive_from_field(schema, field_definition, field_type)?;
+            CostSpecDefinition::cost_directive_from_field(schema, field_definition, field_type);
         let directives = CostSpecDefinition::list_size_directives_from_field_definition(
             schema,
             field_definition,


### PR DESCRIPTION
adding `try_directive_definition` and cleaning up unnecessary `Result` wrapping (`link_in_schema` does not throw so directive name lookups won't throw either)