### PR TITLE
Group mise rust updates into the rustc Renovate group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -74,11 +74,23 @@
       groupSlug: null,
     },
 
-    // Put all the rustc dependencies in a single PR
+    // Put all the rustc dependencies in a single PR.
+    //
+    // Note the two `matchPackageNames` entries: the `mise` manager reports
+    // rust as `rust-lang/rust` (its upstream `packageName`), while the other
+    // three managers report it as just `rust`.  Renovate's `matchPackageNames`
+    // only matches against `packageName` — not `depName` — so we have to list
+    // both to catch every manager's view of the Rust release.
+    //
+    // The `minimumReleaseAge` here aligns the soak window across all four
+    // managers: otherwise `dockerfile` / `custom.regex` / `rust-release-channel`
+    // open their PR immediately while `mise` waits out its own 5-day soak
+    // (set below), and the two halves never meet in the same PR.
     {
-      matchPackageNames: ['rust'],
+      matchPackageNames: ['rust', 'rust-lang/rust'],
       matchManagers: ['custom.regex', 'dockerfile', 'mise', 'rust-release-channel'],
       groupName: 'rustc',
+      minimumReleaseAge: '5 days',
     },
 
     // Keep serde_yaml at 0.8.x - version 0.9.x has breaking changes and the


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-1697] -->
---

## What

Two small tweaks to `.github/renovate.json5`:

- `matchPackageNames: ['rust']` → `['rust', 'rust-lang/rust']` on the `rustc` group rule
- Add `minimumReleaseAge: '5 days'` to the same rule

## Why

A Rust release currently opens *two* PRs, not one:

- `renovate/rustc` — carries `dockerfile` + custom-regex + `rust-release-channel` updates.  This is what sweeps `rust-toolchain.toml`, `apollo-router/Cargo.toml` MSRV, README prose, and `Dockerfile.repo`.
- `renovate/rust-1.x` — carries just the `mise` configs, and auto-merges on its own branch before the other PR lands.

That's what happened on 1.95.0: #9208 grouped four files and sat open for five days until a human merged it, while #9224 auto-merged the two mise configs on its own.  The quiet problem — which is what ROUTER-1697 was filed about — is that CI on #9224 only exercised the new compiler in the mise *install* step.  `rust-toolchain.toml` still pointed at 1.94.1, so `cargo` downloaded the old toolchain via rustup and CI ran the old compiler anyway.  In other words: the PR labeled "update rust to 1.95.0" never actually exercised 1.95.0 against our code.

## Theory

Renovate's `matchPackageNames` matches only against `packageName` — never `depName` — as verified in [`lib/util/package-rules/package-names.ts`](https://github.com/renovatebot/renovate/blob/main/lib/util/package-rules/package-names.ts).  The `mise` manager hard-codes `packageName: 'rust-lang/rust'` for rust in its [upgradeable-tooling registry](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/mise/upgradeable-tooling.ts).  Our existing `matchPackageNames: ['rust']` rule therefore silently missed mise's update, which fell back to Renovate's default grouping (`renovate/rust-1.x`) and triggered the auto-merge rule on `['docker', 'mise', 'github-actions', 'circleci']`.

Adding `'rust-lang/rust'` pulls mise back into the `rustc` group.  The `minimumReleaseAge: '5 days'` aligns the soak window: today the `dockerfile` / custom-regex / `rust-release-channel` managers open their PR on day 1, while `mise` waits out its own 5-day soak from rule 3 — so even grouping wouldn't be enough unless they're synchronized.

## Open questions — mostly why this is up for awareness

- **Auto-merge on the grouped PR** — not changing that here.  Today the `rustc` group has mixed auto-merge across its member deps, so Renovate falls back to manual merge (consistent with #9208 being human-merged).  After this change the mixed situation persists — still manual merge.  If we *do* want auto-merge after a 5-day soak on Rust, that'd be an explicit `automerge: true` on rule 5, but feels premature for a compiler bump.
- **Not dry-run verified** — we're not running Renovate locally.  Next Rust release will be the real test.  Raising this mostly so others can poke at the theory before the next bump and catch anything I'm missing.

---

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (ROUTER-1697)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible
- [x] Documentation completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added and documented
- Tests added and passing
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

- No changeset: config-only change to `.github/renovate.json5`, no user-facing behavior.
- No tests: Renovate config isn't executed by our test suite.  Verification is the next real Rust release — if a single grouped `rustc` PR shows up covering all six files with the new version, the theory holds.
- No metrics/logs: not applicable.


[ROUTER-1697]: https://apollographql.atlassian.net/browse/ROUTER-1697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ