### PR TITLE
fix(to-api-schema): Revert reorder of searching for imports vs fully qualified names when computing source feature

### DIFF
--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -521,57 +521,40 @@ impl LinksMetadata {
         self.by_identity.get(identity).cloned()
     }
 
-    pub fn source_link_of_type<'e>(&'e self, type_name: &'e Name) -> Option<LinkedElement> {
-        // For types, it's either fully qualified or it must be an imported name.
-        if let Some((spec_name, name_in_spec)) = type_name.split_once("__") {
-            let Ok(name_in_spec) = Name::new(name_in_spec) else {
-                return None;
-            };
-            return self
-                .by_name_in_schema
-                .get(spec_name)
-                .map(|link| LinkedElement {
-                    link: Arc::clone(link),
-                    import: None,
-                    name: type_name.clone(),
-                    name_in_spec,
-                });
-        }
-
-        self.types_by_imported_name
-            .get(type_name)
-            .map(|(link, import)| LinkedElement {
+    pub fn source_link_of_type(&self, type_name: &Name) -> Option<LinkedElement> {
+        // For types, it's either an imported name or it must be fully qualified
+        if let Some((link, import)) = self.types_by_imported_name.get(type_name) {
+            return Some(LinkedElement {
                 link: Arc::clone(link),
                 import: Some(Arc::clone(import)),
                 name: type_name.clone(),
                 name_in_spec: import.element.clone(),
+            });
+        }
+
+        type_name
+            .split_once("__")
+            .and_then(|(spec_name, name_in_spec)| {
+                let Ok(name_in_spec) = Name::new(name_in_spec) else {
+                    return None;
+                };
+                self.by_name_in_schema
+                    .get(spec_name)
+                    .map(|link| LinkedElement {
+                        link: Arc::clone(link),
+                        import: None,
+                        name: type_name.clone(),
+                        name_in_spec,
+                    })
             })
     }
 
-    pub fn source_link_of_directive<'e>(
-        &'e self,
-        directive_name: &'e Name,
-    ) -> Option<LinkedElement> {
+    pub fn source_link_of_directive(&self, directive_name: &Name) -> Option<LinkedElement> {
         // For directives, it can be either:
-        //   1. be fully qualified,
-        //   2. be an imported name,
-        //   2. or it must be the "imported" name of a linked spec (special case of a directive
-        //      named like the spec).
-        if let Some((spec_name, name_in_spec)) = directive_name.split_once("__") {
-            let Ok(name_in_spec) = Name::new(name_in_spec) else {
-                return None;
-            };
-            return self
-                .by_name_in_schema
-                .get(spec_name)
-                .map(|link| LinkedElement {
-                    link: Arc::clone(link),
-                    import: None,
-                    name: directive_name.clone(),
-                    name_in_spec,
-                });
-        }
-
+        //   1. be an imported name,
+        //   2. be the "imported" name of a linked spec (special case of a directive named like the
+        //      spec),
+        //   3. or it must be fully qualified.
         if let Some((link, import)) = self.directives_by_imported_name.get(directive_name) {
             return Some(LinkedElement {
                 link: Arc::clone(link),
@@ -581,13 +564,29 @@ impl LinksMetadata {
             });
         }
 
-        self.by_name_in_schema
-            .get(directive_name)
-            .map(|link| LinkedElement {
+        if let Some(link) = self.by_name_in_schema.get(directive_name) {
+            return Some(LinkedElement {
                 link: Arc::clone(link),
                 import: None,
                 name: directive_name.clone(),
                 name_in_spec: link.url.identity.name.clone(),
+            });
+        }
+
+        directive_name
+            .split_once("__")
+            .and_then(|(spec_name, name_in_spec)| {
+                let Ok(name_in_spec) = Name::new(name_in_spec) else {
+                    return None;
+                };
+                self.by_name_in_schema
+                    .get(spec_name)
+                    .map(|link| LinkedElement {
+                        link: Arc::clone(link),
+                        import: None,
+                        name: directive_name.clone(),
+                        name_in_spec,
+                    })
             })
     }
 

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -1028,37 +1028,38 @@ mod inconsistent_imports {
         );
     }
 
-    #[rstest]
-    #[case("@join__field")]
-    #[case("@join__graph")]
-    #[case("@join__implements")]
-    #[case("@join__type")]
-    #[case("@join__unionMember")]
-    #[case("@join__enumValue")]
-    fn errors_when_exported_directives_conflict_with_join_spec_directives(#[case] directive: &str) {
-        let subgraph_a = generate_subgraph(
-            "subgraphA",
-            &r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: [{ name: "@foo", as: "<DIRECTIVE>" }])"#.replace("<DIRECTIVE>", directive),
-            &r#"@composeDirective(name: "<DIRECTIVE>")"#.replace("<DIRECTIVE>", directive),
-            &r#"directive <DIRECTIVE>(name: String!) on FIELD_DEFINITION"#.replace("<DIRECTIVE>", directive),
-            &r#"<DIRECTIVE>(name: "a")"#.replace("<DIRECTIVE>", directive),
-        );
-        let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
-
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
-        assert_eq!(result.len(), 1);
-        let error = result.first().unwrap();
-        assert_eq!(
-            error.code().definition().code().to_string(),
-            "DIRECTIVE_COMPOSITION_ERROR"
-        );
-        assert_eq!(
-            error.to_string(),
-            format!(
-                "Directive \"{directive}\" in subgraph \"subgraphA\" cannot be composed because it is not a member of a core feature"
-            )
-        );
-    }
+    // TODO: Re-work this test after further @link validations have been added.
+    // #[rstest]
+    // #[case("@join__field")]
+    // #[case("@join__graph")]
+    // #[case("@join__implements")]
+    // #[case("@join__type")]
+    // #[case("@join__unionMember")]
+    // #[case("@join__enumValue")]
+    // fn errors_when_exported_directives_conflict_with_join_spec_directives(#[case] directive: &str) {
+    //     let subgraph_a = generate_subgraph(
+    //         "subgraphA",
+    //         &r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: [{ name: "@foo", as: "<DIRECTIVE>" }])"#.replace("<DIRECTIVE>", directive),
+    //         &r#"@composeDirective(name: "<DIRECTIVE>")"#.replace("<DIRECTIVE>", directive),
+    //         &r#"directive <DIRECTIVE>(name: String!) on FIELD_DEFINITION"#.replace("<DIRECTIVE>", directive),
+    //         &r#"<DIRECTIVE>(name: "a")"#.replace("<DIRECTIVE>", directive),
+    //     );
+    //     let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
+    //
+    //     let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+    //     assert_eq!(result.len(), 1);
+    //     let error = result.first().unwrap();
+    //     assert_eq!(
+    //         error.code().definition().code().to_string(),
+    //         "DIRECTIVE_COMPOSITION_ERROR"
+    //     );
+    //     assert_eq!(
+    //         error.to_string(),
+    //         format!(
+    //             "Directive \"{directive}\" in subgraph \"subgraphA\" cannot be composed because it is not a member of a core feature"
+    //         )
+    //     );
+    // }
 }
 
 mod validation {


### PR DESCRIPTION
In #9164, the code for `source_link_of_type()` and `source_link_of_directive()` was changed to be more in line with the JS equivalent `sourceFeature()`. As part of that, the methods were altered to attempt parsing the name as a fully qualified name before attempting to search through imports, as the JS code does. In JS these functions are only really used by composition, and flipping the order did cause a previously-ignored Rust composition test (ported from JS) to start passing.

However, in Rust, the `source_link_of_type()` and `source_link_of_directive()` are **_not_** only used by composition; the `to_api_schema()` function uses both of these methods (and in doing so, diverges from the JS implementation). And for the Rust implementation to properly handle specific edge cases around imports, it needs `source_link_of_type()` and `source_link_of_directive()` to search for imports before parsing the name as a fully qualified name.

So this PR reverts specifically just the ordering change made in #9164 to imports vs fully qualified names (the rest of the fixes in that PR remain in effect). Part of that means re-ignoring the aforementioned composition test; this will be fixed in a later PR.