### PR TITLE
chore: upgrade `rustls-webpki` and remove temporary RUSTSEC exemption (backport #9143)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5952,7 +5952,11 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
+<<<<<<< HEAD
  "windows-sys 0.60.2",
+=======
+ "windows-sys 0.59.0",
+>>>>>>> 8bc3c76b (chore: upgrade `rustls-webpki` and remove temporary RUSTSEC exemption (#9143))
 ]
 
 [[package]]
@@ -6003,9 +6007,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6645,7 +6649,11 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
+<<<<<<< HEAD
  "windows-sys 0.61.0",
+=======
+ "windows-sys 0.59.0",
+>>>>>>> 8bc3c76b (chore: upgrade `rustls-webpki` and remove temporary RUSTSEC exemption (#9143))
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ ignore = [
     "RUSTSEC-2024-0436", # TODO replace the `paste` crate with a maintained equivalent
     "RUSTSEC-2024-0388", # TODO replace the `derivative` crate with a maintained equivalent
     "RUSTSEC-2025-0134", # TODO figure out what to do with rustls-pemfile, which is no longer maintained (trans dep of hyper-rustls, tonic)
+<<<<<<< HEAD
 
     # Temporary exemption: the CRL matching bug requires a compromised trusted CA to exploit, and the
     # router does not enable CRL revocation checking, so this code path is not reachable in practice.
@@ -43,6 +44,8 @@ ignore = [
     "RUSTSEC-2026-0066", # TODO: update tar (ROUTER-1676)
     "RUSTSEC-2026-0067", # TODO: update tar (ROUTER-1676)
     "RUSTSEC-2026-0068", # TODO: update tar (ROUTER-1676)
+=======
+>>>>>>> 8bc3c76b (chore: upgrade `rustls-webpki` and remove temporary RUSTSEC exemption (#9143))
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
Exemption was added temporarily to be able to cut a patch release - the real solution is to upgrade the `rustls-webpki` package.




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1675]: https://apollographql.atlassian.net/browse/ROUTER-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #9143 done by [Mergify](https://mergify.com).