### PR TITLE
chore: remove temporary RUSTSEC exemption (backport #9142)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -38,11 +38,6 @@ ignore = [
     # Temporary exemption: the CRL matching bug requires a compromised trusted CA to exploit, and the
     # router does not enable CRL revocation checking, so this code path is not reachable in practice.
     "RUSTSEC-2026-0049", # TODO: update rustls-webpki (ROUTER-1675)
-
-    # Temporary exemption: the router doesn't unpack or parse existing tarballs.
-    "RUSTSEC-2026-0066", # TODO: update tar (ROUTER-1676)
-    "RUSTSEC-2026-0067", # TODO: update tar (ROUTER-1676)
-    "RUSTSEC-2026-0068", # TODO: update tar (ROUTER-1676)
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
`tokio-tar` was updated in #9024, so we no longer need these exemptions.




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1676]: https://apollographql.atlassian.net/browse/ROUTER-1676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #9142 done by [Mergify](https://mergify.com).