### PR TITLE
fix: new location for `http_max_request_bytes` in file upload test fixture

### DIFF
--- a/apollo-router/tests/fixtures/file_upload/body_limit.router.yaml
+++ b/apollo-router/tests/fixtures/file_upload/body_limit.router.yaml
@@ -14,6 +14,7 @@ preview_file_uploads:
         max_file_size: 5mb
         max_files: 5
 limits:
-  http_max_request_bytes: 50000
+  router:
+    http_max_request_bytes: 50000
 include_subgraph_errors:
   all: true


### PR DESCRIPTION
## Summary

- Updates `body_limit.router.yaml` test fixture to use the correct nested config path `limits.router.http_max_request_bytes`
- The fixture was written when `http_max_request_bytes` lived at the top level of `limits`, but the config was restructured in a separate PR before #9226 landed — since dev wasn't merged in beforehand, the fixture slipped through with the old path

## Test plan

- [ ] Existing file upload integration tests pass with this fixture update

🤖 Generated with [Claude Code](https://claude.com/claude-code)