### PR TITLE
fix(compliance): upgrade packages to fix CI on dev-v2.10.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
  "mime",
  "multi_try",
  "multimap 0.10.1",
- "nom",
+ "nom 7.1.3",
  "nom_locate",
  "parking_lot",
  "percent-encoding",
@@ -1388,13 +1388,14 @@ dependencies = [
 
 [[package]]
 name = "bnf"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c09ea5795b3dd735ff47c4b8adf64c46e3ce056fa3c4880b865a352e4c40a2"
+checksum = "35b77b055f8cb1d566fa4ef55bc699f60eefb17927dc25fa454a05b6fabf7aa4"
 dependencies = [
- "getrandom 0.2.16",
- "nom",
- "rand 0.8.6",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nom 8.0.0",
+ "rand 0.9.3",
  "serde",
  "serde_json",
 ]
@@ -2487,7 +2488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4333,6 +4334,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom_locate"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4340,7 +4350,7 @@ checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
 dependencies = [
  "bytecount",
  "memchr",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -5513,7 +5523,7 @@ dependencies = [
  "cookie-factory",
  "crc16",
  "log",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -5817,6 +5827,7 @@ dependencies = [
  "http 1.4.0",
  "libfuzzer-sys",
  "log",
+ "rand 0.8.6",
  "reqwest",
  "schemars",
  "serde",
@@ -5951,7 +5962,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6190,16 +6201,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap 2.12.1",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -7732,7 +7743,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8388,6 +8399,12 @@ dependencies = [
  "indexmap 2.12.1",
  "memchr",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6003,9 +6003,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5827,7 +5827,7 @@ dependencies = [
  "http 1.4.0",
  "libfuzzer-sys",
  "log",
- "rand 0.8.6",
+ "rand 0.9.3",
  "reqwest",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
  "prost",
  "prost-types",
  "proteus",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "reqwest",
  "rhai",
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
 dependencies = [
  "filetime",
  "futures-core",
@@ -1394,7 +1394,7 @@ checksum = "14c09ea5795b3dd735ff47c4b8adf64c46e3ce056fa3c4880b865a352e4c40a2"
 dependencies = [
  "getrandom 0.2.16",
  "nom",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
 ]
@@ -2487,7 +2487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2757,7 +2757,7 @@ dependencies = [
  "glob-match",
  "log",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "redis-protocol",
  "rustls",
  "rustls-native-certs",
@@ -3268,7 +3268,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "thiserror 2.0.17",
  "tinyvec",
@@ -3290,7 +3290,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.3",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.17",
@@ -4798,7 +4798,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -5341,7 +5341,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -5397,9 +5397,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5408,9 +5408,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -5817,7 +5817,6 @@ dependencies = [
  "http 1.4.0",
  "libfuzzer-sys",
  "log",
- "rand 0.8.5",
  "reqwest",
  "schemars",
  "serde",
@@ -5952,7 +5951,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6003,9 +6002,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6626,9 +6625,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -6683,9 +6682,9 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 dependencies = [
  "serde",
 ]
@@ -7036,7 +7035,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -7305,7 +7304,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -7733,7 +7732,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -288,7 +288,7 @@ ryu = "1.0.15"
 apollo-environment-detector = "0.1.0"
 log = "0.4.22"
 scopeguard = "1.2.0"
-tokio-tar = { package = "astral-tokio-tar", version = "0.5.3" }
+tokio-tar = { package = "astral-tokio-tar", version = "0.6.0" }
 blake3 = { version = "1.8.2", features = ["serde"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ ignore = [
     "RUSTSEC-2024-0436", # TODO replace the `paste` crate with a maintained equivalent
     "RUSTSEC-2024-0388", # TODO replace the `derivative` crate with a maintained equivalent
     "RUSTSEC-2025-0134", # TODO figure out what to do with rustls-pemfile, which is no longer maintained (trans dep of hyper-rustls, tonic)
+<<<<<<< HEAD
 
     # Temporary exemption: the CRL matching bug requires a compromised trusted CA to exploit, and the
     # router does not enable CRL revocation checking, so this code path is not reachable in practice.
@@ -43,6 +44,8 @@ ignore = [
     "RUSTSEC-2026-0066", # TODO: update tar (ROUTER-1676)
     "RUSTSEC-2026-0067", # TODO: update tar (ROUTER-1676)
     "RUSTSEC-2026-0068", # TODO: update tar (ROUTER-1676)
+=======
+>>>>>>> 8bc3c76b (chore: upgrade `rustls-webpki` and remove temporary RUSTSEC exemption (#9143))
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/deny.toml
+++ b/deny.toml
@@ -34,18 +34,6 @@ ignore = [
     "RUSTSEC-2024-0436", # TODO replace the `paste` crate with a maintained equivalent
     "RUSTSEC-2024-0388", # TODO replace the `derivative` crate with a maintained equivalent
     "RUSTSEC-2025-0134", # TODO figure out what to do with rustls-pemfile, which is no longer maintained (trans dep of hyper-rustls, tonic)
-<<<<<<< HEAD
-
-    # Temporary exemption: the CRL matching bug requires a compromised trusted CA to exploit, and the
-    # router does not enable CRL revocation checking, so this code path is not reachable in practice.
-    "RUSTSEC-2026-0049", # TODO: update rustls-webpki (ROUTER-1675)
-
-    # Temporary exemption: the router doesn't unpack or parse existing tarballs.
-    "RUSTSEC-2026-0066", # TODO: update tar (ROUTER-1676)
-    "RUSTSEC-2026-0067", # TODO: update tar (ROUTER-1676)
-    "RUSTSEC-2026-0068", # TODO: update tar (ROUTER-1676)
-=======
->>>>>>> 8bc3c76b (chore: upgrade `rustls-webpki` and remove temporary RUSTSEC exemption (#9143))
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,8 +17,6 @@ apollo-smith.workspace = true
 bnf = "0.5.0"
 env_logger = "0.11.0"
 log = "0.4"
-# Required until https://github.com/shnewto/bnf/pull/175, remove when bnf 0.6 is out
-rand = "=0.8.5"
 reqwest = { workspace = true, features = ["json", "blocking"] }
 serde_json.workspace = true
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,7 +17,7 @@ apollo-smith.workspace = true
 bnf = "0.6.0"
 env_logger = "0.11.0"
 log = "0.4"
-rand = "0.8"
+rand = "0.9"
 reqwest = { workspace = true, features = ["json", "blocking"] }
 serde_json.workspace = true
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,6 +17,7 @@ apollo-smith.workspace = true
 bnf = "0.5.0"
 env_logger = "0.11.0"
 log = "0.4"
+rand = "0.8"
 reqwest = { workspace = true, features = ["json", "blocking"] }
 serde_json.workspace = true
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ libfuzzer-sys = "=0.4.10"
 apollo-federation = { path = "../apollo-federation" }
 apollo-parser.workspace = true
 apollo-smith.workspace = true
-bnf = "0.5.0"
+bnf = "0.6.0"
 env_logger = "0.11.0"
 log = "0.4"
 rand = "0.8"


### PR DESCRIPTION
Fixes CI on `dev-v2.10.x` by resolving several RUSTSEC advisories. Bundles and supersedes #9245 and #9246.

## Changes

- Cherry-pick #9245: upgrade `rustls-webpki` and remove its temporary RUSTSEC-2026-0049 exemption
- Cherry-pick #9246: remove temporary tar exemptions (RUSTSEC-2026-0066/0067/0068)
- Bump `astral-tokio-tar` `0.5.6` → `0.6.0` (resolves RUSTSEC-2026-0066)
- Upgrade `tar` `0.4.44` → `0.4.45` (resolves RUSTSEC-2026-0067, RUSTSEC-2026-0068)
- Upgrade `rustls-webpki` `0.103.10` → `0.103.13` (resolves RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104)
- Upgrade `rand` `0.8.5` → `0.8.6` and `0.9.2` → `0.9.3` (resolves RUSTSEC-2026-0097)
- Upgrade `bnf` `0.5.0` → `0.6.0` in `fuzz/` and remove the exact `rand = "=0.8.5"` pin that was a workaround for `bnf <0.6`

Closes #9245
Closes #9246

<!-- start metadata -->

<!-- [ROUTER-1675] -->
<!-- [ROUTER-1676] -->

[ROUTER-1675]: https://apollographql.atlassian.net/browse/ROUTER-1675
[ROUTER-1676]: https://apollographql.atlassian.net/browse/ROUTER-1676
