### PR TITLE
fix(authentication): improve JWKS fetch error messages

### DIFF
--- a/.changesets/fix_caroline_router_1375.md
+++ b/.changesets/fix_caroline_router_1375.md
@@ -1,0 +1,5 @@
+### JWKS fetch errors now log the URL and failure category for easier diagnosis ([PR #9258](https://github.com/apollographql/router/pull/9258))
+
+When the JWKS server is unreachable, the router now logs a specific, actionable message that includes the URL and the failure category (timed out, connection failed, or generic failure) rather than the previous vague `"could not get url"` message.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9258

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -200,7 +200,15 @@ pub(super) async fn get_jwks(url: Url, headers: Vec<Header>) -> Option<JwkSet> {
             .send()
             .await
             .map_err(|e| {
-                tracing::error!(%e, "could not get url");
+                let url = e.url().map(Url::as_str).unwrap_or("<unknown>");
+                let msg = if e.is_timeout() {
+                    "JWKS request timed out"
+                } else if e.is_connect() {
+                    "JWKS request connection failed"
+                } else {
+                    "JWKS request failed"
+                };
+                tracing::error!(url, %e, "{msg}");
                 e
             })
             .ok()?
@@ -940,5 +948,21 @@ mod test {
 
         let expiry = jwt_expires_in(&context);
         assert_eq!(expiry, Duration::from_secs(3600));
+    }
+
+    /// Verifies that a connection failure to a JWKS URL produces an actionable error log
+    /// that includes both the URL and the failure category (timeout, connection error, etc.)
+    /// rather than a generic "could not get url" message.
+    #[tokio::test]
+    async fn test_get_jwks_unreachable_url_logs_helpful_error() {
+        let _guard = tracing_test::dispatcher_guard();
+
+        let url = "http://127.0.0.1:1/jwks.json".parse().expect("valid URL");
+
+        let result = super::get_jwks(url, vec![]).await;
+        assert!(result.is_none());
+
+        assert!(tracing_test::logs_contain("JWKS request connection failed"));
+        assert!(tracing_test::logs_contain("127.0.0.1:1"));
     }
 }


### PR DESCRIPTION
<!-- [ROUTER-1375] -->

## Motivation

When the JWKS server is unreachable, the router logs a vague `"could not get url"` message:

```
"message":"could not get url","e":"error sending request for url (http://proxy:3088/jwks.json)"
```

This makes it hard to identify the problem at a glance, especially in log aggregators where the `e` field may not be immediately visible.

## Changes

- Replace the generic message with categorized messages that include the URL as a structured field:
  - `"JWKS request timed out"` — when `e.is_timeout()`
  - `"JWKS request connection failed"` — when `e.is_connect()` (connection refused, DNS failure, etc.)
  - `"JWKS request failed"` — all other cases
- The URL is sourced from `reqwest::Error::url()` inside the error closure, so there is zero overhead on the success path.

Example log line after this change:
```
ERROR apollo_router::plugins::authentication::jwks: JWKS request connection failed url="http://proxy:3088/jwks.json" e=error sending request for url (http://proxy:3088/jwks.json)
```

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible
- [ ] Documentation completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added and documented
- Tests added and passing
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

No documentation update needed.


[ROUTER-1375]: https://apollographql.atlassian.net/browse/ROUTER-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ