### PR TITLE
fix(composition): fix FederationSchema::collect_deep_references to collect all errors

### DIFF
--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -33,6 +33,7 @@ use strum::IntoEnumIterator;
 use crate::bail;
 use crate::error::CompositionError;
 use crate::error::FederationError;
+use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
 use crate::link::database::links_metadata;
 use crate::link::spec_definition::SpecDefinition;
@@ -8055,67 +8056,59 @@ impl FederationSchema {
         }
     }
 
+    /// Collects schema referencers.
     pub(crate) fn collect_deep_references(&mut self) -> Result<(), FederationError> {
-        SchemaDefinitionPosition.insert_references(
+        let mut errors = MultipleFederationErrors { errors: vec![] };
+
+        if let Err(e) = SchemaDefinitionPosition.insert_references(
             &self.schema.schema_definition,
             &self.schema,
             &mut self.referencers,
-        )?;
+        ) {
+            errors.push(e);
+        }
         for (type_name, type_) in self.schema.types.iter() {
-            match type_ {
-                ExtendedType::Scalar(type_) => {
-                    ScalarTypeDefinitionPosition {
-                        type_name: type_name.clone(),
-                    }
-                    .insert_references(type_, &mut self.referencers)?;
+            let result = match type_ {
+                ExtendedType::Scalar(type_) => ScalarTypeDefinitionPosition {
+                    type_name: type_name.clone(),
                 }
-                ExtendedType::Object(type_) => {
-                    ObjectTypeDefinitionPosition {
-                        type_name: type_name.clone(),
-                    }
-                    .insert_references(
-                        type_,
-                        &self.schema,
-                        &mut self.referencers,
-                    )?;
+                .insert_references(type_, &mut self.referencers),
+                ExtendedType::Object(type_) => ObjectTypeDefinitionPosition {
+                    type_name: type_name.clone(),
                 }
-                ExtendedType::Interface(type_) => {
-                    InterfaceTypeDefinitionPosition {
-                        type_name: type_name.clone(),
-                    }
-                    .insert_references(
-                        type_,
-                        &self.schema,
-                        &mut self.referencers,
-                    )?;
+                .insert_references(type_, &self.schema, &mut self.referencers),
+                ExtendedType::Interface(type_) => InterfaceTypeDefinitionPosition {
+                    type_name: type_name.clone(),
                 }
-                ExtendedType::Union(type_) => {
-                    UnionTypeDefinitionPosition {
-                        type_name: type_name.clone(),
-                    }
-                    .insert_references(type_, &mut self.referencers)?;
+                .insert_references(type_, &self.schema, &mut self.referencers),
+                ExtendedType::Union(type_) => UnionTypeDefinitionPosition {
+                    type_name: type_name.clone(),
                 }
-                ExtendedType::Enum(type_) => {
-                    EnumTypeDefinitionPosition {
-                        type_name: type_name.clone(),
-                    }
-                    .insert_references(type_, &mut self.referencers)?;
+                .insert_references(type_, &mut self.referencers),
+                ExtendedType::Enum(type_) => EnumTypeDefinitionPosition {
+                    type_name: type_name.clone(),
                 }
-                ExtendedType::InputObject(type_) => {
-                    InputObjectTypeDefinitionPosition {
-                        type_name: type_name.clone(),
-                    }
-                    .insert_references(type_, &mut self.referencers)?;
+                .insert_references(type_, &mut self.referencers),
+                ExtendedType::InputObject(type_) => InputObjectTypeDefinitionPosition {
+                    type_name: type_name.clone(),
                 }
+                .insert_references(type_, &mut self.referencers),
+            };
+            if let Err(e) = result {
+                errors.push(e);
             }
         }
         for (directive_name, directive) in self.schema.directive_definitions.iter() {
-            DirectiveDefinitionPosition {
+            let definition_position = DirectiveDefinitionPosition {
                 directive_name: directive_name.clone(),
+            };
+
+            if let Err(e) = definition_position.insert_references(directive, &mut self.referencers)
+            {
+                errors.push(e);
             }
-            .insert_references(directive, &mut self.referencers)?;
         }
-        Ok(())
+        errors.into_result()
     }
 }
 

--- a/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
@@ -211,3 +211,61 @@ fn fed2_uses_standard_federation_directive_definitions() {
         directive @key(fields: federation__FieldSet!) on OBJECT
     "#);
 }
+
+/// Fed1 upgrade must not add @shareable to key fields. Two subgraphs share the
+/// same entity so the upgrader's `add_shareable` logic is exercised — it should
+/// recognize key fields as already shareable and skip them.
+///
+/// This tests an error scenario where schemas include `_entities` / `_service`
+/// on Query without defining the `_Entity` / `_Service` types. Previously,
+/// during expansion, `collect_deep_references` would error on `Query` because those
+/// types don't exist yet. Without the fix, the first error aborted the loop,
+/// leaving later types' @key directives unregistered in `referencers`.
+#[test]
+fn upgrade_does_not_add_shareable_to_key_fields_in_partial_schemas() {
+    // in order to trigger @shareable logic same element has to be defined in multiple schemas
+    let s1 = Subgraph::parse(
+        "s1",
+        "http://s1",
+        r#"
+            type Query {
+                product(id: ID!): Product
+                _entities(representations: [_Any!]!): [_Entity]!
+                _service: _Service!
+            }
+
+            type Product @key(fields: "id") {
+                id: ID!
+                name: String
+            }
+        "#,
+    )
+    .expect("parses")
+    .expand_links()
+    .expect("expands");
+
+    let s2 = Subgraph::parse(
+        "s2",
+        "http://s2",
+        r#"
+            type Query {
+                _entities(representations: [_Any!]!): [_Entity]!
+                _service: _Service!
+            }
+
+            type Product @key(fields: "id") {
+                id: ID!
+                price: Float
+            }
+        "#,
+    )
+    .expect("parses")
+    .expand_links()
+    .expect("expands");
+
+    let mut upgraded = upgrade_subgraphs_if_necessary(vec![s1, s2]).expect("upgrade succeeds");
+    upgraded.sort_by(|a, b| a.name.cmp(&b.name));
+
+    assert_snapshot!("s1", upgraded[0].schema_string());
+    assert_snapshot!("s2", upgraded[1].schema_string());
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_upgrade_subgraphs__s1.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_upgrade_subgraphs__s1.snap
@@ -1,0 +1,65 @@
+---
+source: apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
+expression: "upgraded[0].schema_string()"
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject"]) {
+  query: Query
+}
+
+directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @extends on OBJECT | INTERFACE
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @override(from: String!) on FIELD_DEFINITION
+
+directive @composeDirective(name: String) repeatable on SCHEMA
+
+directive @interfaceObject on OBJECT
+
+type Query {
+  product(id: ID!): Product
+  _entities(representations: [_Any!]!): [_Entity]! @shareable
+  _service: _Service! @shareable
+}
+
+type Product @key(fields: "id") {
+  id: ID!
+  name: String
+}
+
+union _Entity = Product
+
+scalar _Any
+
+type _Service @shareable {
+  sdl: String
+}
+
+scalar federation__FieldSet
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_upgrade_subgraphs__s2.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_upgrade_subgraphs__s2.snap
@@ -1,0 +1,64 @@
+---
+source: apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
+expression: "upgraded[1].schema_string()"
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.4", import: ["@key", "@requires", "@provides", "@external", "@tag", "@extends", "@shareable", "@inaccessible", "@override", "@composeDirective", "@interfaceObject"]) {
+  query: Query
+}
+
+directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @extends on OBJECT | INTERFACE
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @override(from: String!) on FIELD_DEFINITION
+
+directive @composeDirective(name: String) repeatable on SCHEMA
+
+directive @interfaceObject on OBJECT
+
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]! @shareable
+  _service: _Service! @shareable
+}
+
+type Product @key(fields: "id") {
+  id: ID!
+  price: Float
+}
+
+union _Entity = Product
+
+scalar _Any
+
+type _Service @shareable {
+  sdl: String
+}
+
+scalar federation__FieldSet
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import


### PR DESCRIPTION
Update `FederationSchema::collect_deep_references` to collect all errors before returning.

If reference collection fails (which could happen if user provides a partial federation schema), our metadata would be incomplete and result in unnecessary inclusion of `@shareable` on some elements (e.g. `@key` fields).

<!-- [FED-987] -->

[FED-987]: https://apollographql.atlassian.net/browse/FED-987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ