### PR TITLE
fix(response_cache): entity fields returning null with cache-control: no-cache (backport #9197 → 2.14.0)

### DIFF
--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -1035,12 +1035,7 @@ async fn cache_lookup_entities(
     expose_keys_in_context: bool,
     request_cache_control: Option<&CacheControl>,
 ) -> Result<ControlFlow<subgraph::Response, (subgraph::Request, EntityCacheResults)>, BoxError> {
-    if request_cache_control.is_some_and(|c| c.is_no_cache()) {
-        return Ok(ControlFlow::Continue((
-            request,
-            EntityCacheResults(vec![], None),
-        )));
-    }
+    let is_no_cache = request_cache_control.is_some_and(|c| c.is_no_cache());
 
     let body = request.subgraph_request.body_mut();
     let keys = extract_cache_keys(
@@ -1055,28 +1050,37 @@ async fn cache_lookup_entities(
         private_id,
     )?;
 
-    let redis_keys = keys.iter().map(|k| RedisKey(k.clone())).collect::<Vec<_>>();
-    let result_len = redis_keys.len();
-    let cache_result: Vec<Option<CacheEntry>> = cache
-        .get_multiple(redis_keys)
-        .await
-        .map(|values| {
-            values
-                .into_iter()
-                .map(|r| r.map(|v: RedisValue<CacheEntry>| v.0))
-                .map(|v| match v {
-                    Err(_) => None,
-                    Ok(v) => {
-                        if v.control.can_use() {
-                            Some(v)
-                        } else {
-                            None
+    let keys_len = keys.len();
+    let cache_result: Vec<Option<CacheEntry>> = if is_no_cache {
+        // no-cache means bypass the cache for lookup but still fetch from the subgraph.
+        // Treat every entity as a cache miss so filter_representations includes all of them
+        // in the outgoing request. This avoids the previous early-return bug (ROUTER-1689)
+        // where an empty IntermediateResult list caused insert_entities_in_result to
+        // produce an empty _entities array, making entity fields return null.
+        vec![None; keys_len]
+    } else {
+        let redis_keys = keys.iter().map(|k| RedisKey(k.clone())).collect::<Vec<_>>();
+        cache
+            .get_multiple(redis_keys)
+            .await
+            .map(|values| {
+                values
+                    .into_iter()
+                    .map(|r| r.map(|v: RedisValue<CacheEntry>| v.0))
+                    .map(|v| match v {
+                        Err(_) => None,
+                        Ok(v) => {
+                            if v.control.can_use() {
+                                Some(v)
+                            } else {
+                                None
+                            }
                         }
-                    }
-                })
-                .collect()
-        })
-        .unwrap_or(vec![None; result_len]);
+                    })
+                    .collect()
+            })
+            .unwrap_or(vec![None; keys_len])
+    };
 
     let representations = body
         .variables
@@ -1084,8 +1088,14 @@ async fn cache_lookup_entities(
         .and_then(|value| value.as_array_mut())
         .expect("we already checked that representations exist");
     // remove from representations the entities we already obtained from the cache
-    let (new_representations, cache_result, cache_control) =
-        filter_representations(&name, representations, keys, cache_result, &request.context)?;
+    let (new_representations, cache_result, cache_control) = filter_representations(
+        &name,
+        representations,
+        keys,
+        cache_result,
+        &request.context,
+        !is_no_cache,
+    )?;
 
     if expose_keys_in_context {
         let mut cache_entries = Vec::with_capacity(cache_result.len());
@@ -1612,6 +1622,7 @@ fn filter_representations(
     keys: Vec<String>,
     mut cache_result: Vec<Option<CacheEntry>>,
     context: &Context,
+    record_metrics: bool,
 ) -> Result<(Vec<Value>, Vec<IntermediateResult>, Option<CacheControl>), BoxError> {
     let mut new_representations: Vec<Value> = Vec::new();
     let mut result = Vec::new();
@@ -1661,10 +1672,12 @@ fn filter_representations(
         });
     }
 
-    let _ = context.insert(
-        CacheMetricContextKey::new(subgraph_name.to_string()),
-        CacheSubgraph(cache_hit),
-    );
+    if record_metrics {
+        let _ = context.insert(
+            CacheMetricContextKey::new(subgraph_name.to_string()),
+            CacheSubgraph(cache_hit),
+        );
+    }
 
     Ok((new_representations, result, cache_control))
 }

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -1489,6 +1489,8 @@ async fn cache_lookup_entities(
     debug: bool,
     cache_control: Option<&CacheControl>,
 ) -> Result<ControlFlow<subgraph::Response, (subgraph::Request, ResponseCacheResults)>, BoxError> {
+    let is_no_cache = cache_control.is_some_and(|c| c.is_no_cache());
+
     let cache_metadata = extract_cache_keys(
         &name,
         supergraph_schema,
@@ -1504,41 +1506,39 @@ async fn cache_lookup_entities(
         .iter()
         .map(|k| k.cache_key.as_str())
         .collect::<Vec<&str>>();
-    let cache_result = cache.fetch_multiple(&cache_keys, &name).await;
     Span::current().set_span_dyn_attribute(
         "cache.keys".into(),
         opentelemetry::Value::Array(Array::String(
             cache_keys
-                .into_iter()
+                .iter()
                 .map(|ck| StringValue::from(ck.to_string()))
                 .collect(),
         )),
     );
 
-    if cache_control.is_some_and(|c| c.is_no_cache()) {
-        // skip cache lookup if no-cache is set - we have no means of revalidating entries without
-        // just performing the query, so there's no benefit to hitting the cache
-        return Ok(ControlFlow::Continue((
-            request,
-            ResponseCacheResults::default(),
-        )));
-    }
+    // When no-cache is set, skip using any cached values: treat every entity as a cache miss
+    // so that all representations are fetched fresh from the subgraph. We still build the
+    // IntermediateResult list (all with cache_entry = None) so that insert_entities_in_result
+    // can properly assemble the response in the correct order.
+    let cache_result: Vec<Option<CacheEntry>> = if is_no_cache {
+        vec![None; keys_len]
+    } else {
+        match cache.fetch_multiple(&cache_keys, &name).await {
+            Ok(res) => res
+                .into_iter()
+                .map(|v| match v {
+                    Some(v) if v.control.can_use() => Some(v),
+                    _ => None,
+                })
+                .collect(),
+            Err(err) => {
+                if !err.is_row_not_found() {
+                    let span = Span::current();
+                    span.mark_as_error(format!("cannot get cache entry: {err}"));
+                }
 
-    let cache_result: Vec<Option<CacheEntry>> = match cache_result {
-        Ok(res) => res
-            .into_iter()
-            .map(|v| match v {
-                Some(v) if v.control.can_use() => Some(v),
-                _ => None,
-            })
-            .collect(),
-        Err(err) => {
-            if !err.is_row_not_found() {
-                let span = Span::current();
-                span.mark_as_error(format!("cannot get cache entry: {err}"));
+                vec![None; keys_len]
             }
-
-            std::iter::repeat_n(None, keys_len).collect()
         }
     };
     let body = request.subgraph_request.body_mut();
@@ -1548,6 +1548,9 @@ async fn cache_lookup_entities(
         .get_mut(REPRESENTATIONS)
         .and_then(|value| value.as_array_mut())
         .expect("we already checked that representations exist");
+    // When no-cache is set, skip recording cache metrics: the cache was not consulted so
+    // registering every entity as a miss would produce misleading telemetry data.
+
     // remove from representations the entities we already obtained from the cache
     let (new_representations, cache_result, cache_control) = filter_representations(
         &name,
@@ -1556,6 +1559,7 @@ async fn cache_lookup_entities(
         cache_metadata,
         cache_result,
         &request.context,
+        !is_no_cache,
     )?;
 
     if !new_representations.is_empty() {
@@ -2331,6 +2335,7 @@ fn filter_representations(
     keys: Vec<CacheMetadata>,
     mut cache_result: Vec<Option<CacheEntry>>,
     context: &Context,
+    record_metrics: bool,
 ) -> Result<(Vec<Value>, Vec<IntermediateResult>, Option<CacheControl>), BoxError> {
     let mut new_representations: Vec<Value> = Vec::new();
     let mut result = Vec::new();
@@ -2403,10 +2408,12 @@ fn filter_representations(
         save_original_cache_control(subgraph_req_id.clone(), context, non_updated_cache_control);
     }
 
-    let _ = context.insert(
-        CacheMetricContextKey::new(subgraph_name.to_string()),
-        CacheSubgraph(cache_hit),
-    );
+    if record_metrics {
+        let _ = context.insert(
+            CacheMetricContextKey::new(subgraph_name.to_string()),
+            CacheSubgraph(cache_hit),
+        );
+    }
 
     Ok((new_representations, result, cache_control))
 }

--- a/apollo-router/src/plugins/response_cache/tests.rs
+++ b/apollo-router/src/plugins/response_cache/tests.rs
@@ -13,6 +13,7 @@ use tower::Service;
 use tower::ServiceExt;
 use uuid::Uuid;
 
+use super::plugin::CacheSubgraph;
 use super::plugin::ResponseCache;
 use crate::Context;
 use crate::MockedSubgraphs;
@@ -25,6 +26,7 @@ use crate::plugin::test::MockSubgraphService;
 use crate::plugins::response_cache::debugger::CacheKeysContext;
 use crate::plugins::response_cache::invalidation::InvalidationRequest;
 use crate::plugins::response_cache::invalidation_endpoint::SubgraphInvalidationConfig;
+use crate::plugins::response_cache::metrics::CacheMetricContextKey;
 use crate::plugins::response_cache::plugin::CACHE_DEBUG_HEADER_NAME;
 use crate::plugins::response_cache::plugin::CONTEXT_CACHE_KEY;
 use crate::plugins::response_cache::plugin::INVALIDATION_SHARED_KEY;
@@ -1480,6 +1482,155 @@ async fn no_store_from_request() {
         .await
         .unwrap();
     assert_eq!(invalidations_by_subgraph.into_values().sum::<u64>(), 0);
+}
+
+// Regression test for ROUTER-1689:
+// When `cache-control: no-cache` is sent by the client and response_cache is enabled,
+// entity fields resolved via `_entities` queries must not be discarded.
+// Previously, the no-cache fast-path returned an empty IntermediateResult list,
+// causing insert_entities_in_result to produce `_entities: []` and entity fields to be null.
+#[tokio::test]
+async fn no_cache_from_request() {
+    let valid_schema = Arc::new(Schema::parse_and_validate(SCHEMA, "test.graphql").unwrap());
+    let query = "query { currentUser { activeOrganization { id creatorUser { __typename id } } } }";
+
+    let subgraphs = serde_json::json!({
+        "user": {
+            "query": {
+                "currentUser": {
+                    "activeOrganization": {
+                        "__typename": "Organization",
+                        "id": "1",
+                    }
+                }
+            }
+        },
+        "orga": {
+            "entities": [
+                {
+                    "__typename": "Organization",
+                    "id": "1",
+                    "creatorUser": {
+                        "__typename": "User",
+                        "id": 2
+                    }
+                }
+            ]
+        },
+    });
+
+    let (drop_tx, drop_rx) = tokio::sync::broadcast::channel(2);
+    let storage = Storage::new(&Config::test(false, &Uuid::new_v4().to_string()), drop_rx)
+        .await
+        .unwrap();
+    let response_cache = ResponseCache::for_test(
+        storage.clone(),
+        Default::default(),
+        valid_schema.clone(),
+        false,
+        drop_tx,
+    )
+    .await
+    .unwrap();
+
+    // Phase 1: Warm up the cache with a normal request (no cache-control header)
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true }, "experimental_mock_subgraphs": subgraphs.clone(), "headers": {
+            "all": {
+                "request": [{
+                    "propagate": {
+                        "named": "cache-control"
+                    }
+                }]
+            }
+        } }))
+        .unwrap()
+        .schema(SCHEMA)
+        .extra_private_plugin(response_cache.clone())
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .query(query)
+        .context(Context::new())
+        .build()
+        .unwrap();
+    let mut response = service.oneshot(request).await.unwrap();
+    let response = response.next_response().await.unwrap();
+
+    // Sanity-check: normal request returns entity data
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "currentUser": {
+          "activeOrganization": {
+            "id": "1",
+            "creatorUser": {
+              "__typename": "User",
+              "id": 2
+            }
+          }
+        }
+      }
+    }
+    "#);
+
+    // Phase 2: Request with `no-cache` — cache must be bypassed for lookup but entity data
+    // from the subgraph must still be returned correctly (regression for ROUTER-1689).
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true }, "experimental_mock_subgraphs": subgraphs.clone(), "headers": {
+            "all": {
+                "request": [{
+                    "propagate": {
+                        "named": "cache-control"
+                    }
+                }]
+            }
+        } }))
+        .unwrap()
+        .schema(SCHEMA)
+        .extra_private_plugin(response_cache.clone())
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let no_cache_context = Context::new();
+    let request = supergraph::Request::fake_builder()
+        .query(query)
+        .context(no_cache_context.clone())
+        .header(CACHE_CONTROL, HeaderValue::from_static("no-cache"))
+        .build()
+        .unwrap();
+    let mut response = service.oneshot(request).await.unwrap();
+    let response = response.next_response().await.unwrap();
+
+    // Entity fields must NOT be null — this was the regression
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "currentUser": {
+          "activeOrganization": {
+            "id": "1",
+            "creatorUser": {
+              "__typename": "User",
+              "id": 2
+            }
+          }
+        }
+      }
+    }
+    "#);
+
+    // Metrics must NOT be recorded for no-cache requests (no misleading cache hit/miss counters)
+    let orga_metric = no_cache_context
+        .get::<_, CacheSubgraph>(CacheMetricContextKey::new("orga".to_string()))
+        .ok()
+        .flatten();
+    assert!(
+        orga_metric.is_none(),
+        "no-cache requests should not record cache hit/miss metrics"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Backport of [#9197](https://github.com/apollographql/router/pull/9197) into `2.14.0`.

Cherry-picked cleanly with no conflicts.

### Original fix (ROUTER-1689 / RH-1337)

When `response_cache` is enabled and a request carries `cache-control: no-cache`, entity fields resolved via `_entities` queries were returning `null`. Root fields were unaffected. Regression introduced in v2.13.0 via #8948.

**Root cause:** `cache_lookup_entities` had an early return when `no-cache` was detected, producing an empty `Vec<IntermediateResult>`. `insert_entities_in_result` iterates over that list to assemble the response — with an empty list the loop never ran, `_entities: []` was written, and all entity fields came back `null`.

**Changes (both `response_cache` and `preview_entity_cache`):**
- Replace the early return with an all-`None` cache result so `filter_representations` builds a correctly sized `IntermediateResult` list
- Move `cache.fetch_multiple` inside an `else` branch to skip the Redis round-trip for `no-cache` requests
- Skip recording cache hit/miss metrics for `no-cache` requests (`record_metrics` param added to `filter_representations`)

## Test plan

- [ ] CI green on this branch