### PR TITLE
feat(telemetry): add is_deferred subgraph selector

### DIFF
--- a/.changesets/feat_ebylund_is_deferred_subgraph_selector.md
+++ b/.changesets/feat_ebylund_is_deferred_subgraph_selector.md
@@ -1,4 +1,4 @@
-### Add `is_deferred` subgraph telemetry selector ([PR #XXXX](https://github.com/apollographql/router/pull/XXXX))
+### Add `is_deferred` subgraph telemetry selector ([PR #9262](https://github.com/apollographql/router/pull/9262))
 
 A new `is_deferred: true` selector is now available on the `subgraph` service of the telemetry instrumentation config. It returns `true` when the current subgraph fetch is part of the deferred portion of an `@defer` query plan, and `false` for primary (non-deferred) fetches.
 
@@ -17,4 +17,4 @@ telemetry:
 
 Produces two series: `http_client_request_duration_seconds{phase="true"}` (deferred fetches) and `http_client_request_duration_seconds{phase="false"}` (primary fetches).
 
-By [@ebylund](https://github.com/ebylund) in https://github.com/apollographql/router/pull/XXXX
+By [@ebylund](https://github.com/ebylund) in https://github.com/apollographql/router/pull/9262

--- a/.changesets/feat_ebylund_is_deferred_subgraph_selector.md
+++ b/.changesets/feat_ebylund_is_deferred_subgraph_selector.md
@@ -1,0 +1,20 @@
+### Add `is_deferred` subgraph telemetry selector ([PR #XXXX](https://github.com/apollographql/router/pull/XXXX))
+
+A new `is_deferred: true` selector is now available on the `subgraph` service of the telemetry instrumentation config. It returns `true` when the current subgraph fetch is part of the deferred portion of an `@defer` query plan, and `false` for primary (non-deferred) fetches.
+
+This lets you split subgraph metrics like `http.client.request.duration` between primary and deferred fetches — useful for seeing whether deferred fetches contribute disproportionately to tail latency on `@defer`-adopting operations:
+
+```yaml
+telemetry:
+  instrumentation:
+    instruments:
+      subgraph:
+        http.client.request.duration:
+          attributes:
+            phase:
+              is_deferred: true
+```
+
+Produces two series: `http_client_request_duration_seconds{phase="true"}` (deferred fetches) and `http_client_request_duration_seconds{phase="false"}` (primary fetches).
+
+By [@ebylund](https://github.com/ebylund) in https://github.com/apollographql/router/pull/XXXX

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -10882,7 +10882,7 @@ expression: "&schema"
           "additionalProperties": false,
           "properties": {
             "is_deferred": {
-              "description": "Boolean indicating whether this subgraph fetch is part of the deferred portion of an `@defer` query plan.",
+              "description": "Set to `true` to emit whether this subgraph fetch is part of the deferred portion of an `@defer` query plan.",
               "type": "boolean"
             }
           },

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -10881,6 +10881,19 @@ expression: "&schema"
         {
           "additionalProperties": false,
           "properties": {
+            "is_deferred": {
+              "description": "Boolean indicating whether this subgraph fetch is part of the deferred portion of an `@defer` query plan.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "is_deferred"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
             "default": {
               "description": "Optional default value.",
               "type": [

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -1467,6 +1467,7 @@ mod test {
             authorization: Default::default(),
             executable_document: None,
             id: SubgraphRequestId(String::new()),
+            is_deferred_fetch: false,
         };
 
         let call = tokio::spawn(service.ready().await?.call(req));
@@ -1871,6 +1872,7 @@ mod test {
             authorization: Default::default(),
             executable_document: None,
             id: SubgraphRequestId(String::new()),
+            is_deferred_fetch: false,
         };
         service.modify_subgraph_request(&mut request);
         let headers = request
@@ -1943,6 +1945,7 @@ mod test {
             authorization: Default::default(),
             executable_document: None,
             id: SubgraphRequestId(String::new()),
+            is_deferred_fetch: false,
         };
         service.modify_subgraph_request(&mut request);
         let headers = request
@@ -2025,6 +2028,7 @@ mod test {
             authorization: Default::default(),
             executable_document: None,
             id: SubgraphRequestId(String::new()),
+            is_deferred_fetch: false,
         }
     }
 

--- a/apollo-router/src/plugins/telemetry/config_new/subgraph/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/subgraph/selectors.rs
@@ -80,6 +80,10 @@ pub(crate) enum SubgraphSelector {
         /// The subgraph name
         subgraph_name: bool,
     },
+    IsDeferred {
+        /// Set to `true` to emit whether this subgraph fetch is part of the deferred portion of an `@defer` query plan.
+        is_deferred: bool,
+    },
     SubgraphQuery {
         /// The graphql query to the subgraph.
         subgraph_query: SubgraphQuery,
@@ -290,6 +294,9 @@ impl Selector for SubgraphSelector {
             }
             SubgraphSelector::SubgraphName { subgraph_name } if *subgraph_name => {
                 Some(request.subgraph_name.clone().into())
+            }
+            SubgraphSelector::IsDeferred { is_deferred } if *is_deferred => {
+                Some(opentelemetry::Value::Bool(request.is_deferred_fetch))
             }
             // .clone()
             // .map(opentelemetry::Value::from),
@@ -823,6 +830,7 @@ impl Selector for SubgraphSelector {
                 SubgraphSelector::SubgraphOperationName { .. }
                     | SubgraphSelector::SupergraphOperationName { .. }
                     | SubgraphSelector::SubgraphName { .. }
+                    | SubgraphSelector::IsDeferred { .. }
                     | SubgraphSelector::SubgraphOperationKind { .. }
                     | SubgraphSelector::SupergraphOperationKind { .. }
                     | SubgraphSelector::SupergraphQuery { .. }
@@ -1516,6 +1524,39 @@ mod test {
             ),
             Some("test".into())
         );
+    }
+
+    #[test]
+    fn is_deferred() {
+        let selector = SubgraphSelector::IsDeferred { is_deferred: true };
+        let context = crate::context::Context::new();
+
+        // Primary fetch: is_deferred_fetch is false by default.
+        let primary_request = crate::services::SubgraphRequest::fake_builder()
+            .context(context.clone())
+            .build();
+        assert_eq!(
+            selector.on_request(&primary_request),
+            Some(opentelemetry::Value::Bool(false))
+        );
+
+        // Deferred fetch: is_deferred_fetch is set to true by the query plan
+        // executor when entering a DeferredNode subtree.
+        let mut deferred_request = crate::services::SubgraphRequest::fake_builder()
+            .context(context)
+            .build();
+        deferred_request.is_deferred_fetch = true;
+        assert_eq!(
+            selector.on_request(&deferred_request),
+            Some(opentelemetry::Value::Bool(true))
+        );
+
+        // is_deferred: false in config means the selector is inactive and
+        // returns None, matching the convention of the other boolean-guarded
+        // selectors (SubgraphName, OnGraphQLError, IsPrimaryResponse).
+        let inactive_selector = SubgraphSelector::IsDeferred { is_deferred: false };
+        let request = crate::services::SubgraphRequest::fake_builder().build();
+        assert_eq!(inactive_selector.on_request(&request), None);
     }
 
     #[test]

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -88,6 +88,7 @@ impl QueryPlan {
                     subscription_handle: &subscription_handle,
                     subscription_config,
                     subgraph_schemas,
+                    is_deferred: false,
                 },
                 &root,
                 &initial_value.unwrap_or_default(),
@@ -126,6 +127,11 @@ pub(crate) struct ExecutionParameters<'a> {
     pub(crate) root_node: &'a PlanNode,
     pub(crate) subscription_handle: &'a Option<SubscriptionHandle>,
     pub(crate) subscription_config: &'a Option<SubscriptionConfig>,
+    /// `true` when the walker is inside a `DeferredNode` subtree, `false`
+    /// inside `PlanNode::Defer`'s primary branch or anywhere outside a
+    /// `Defer` node. Propagated to each `FetchRequest` so that subgraph
+    /// telemetry can split primary vs deferred fetches.
+    pub(crate) is_deferred: bool,
 }
 
 impl PlanNode {
@@ -303,6 +309,7 @@ impl PlanNode {
                                         .supergraph_request(parameters.supergraph_request.clone())
                                         .variables(variables)
                                         .current_dir(current_dir.clone())
+                                        .is_deferred(parameters.is_deferred)
                                         .build(),
                                 );
                                 let raw_errors;
@@ -403,6 +410,7 @@ impl PlanNode {
                                         subscription_handle: parameters.subscription_handle,
                                         subscription_config: parameters.subscription_config,
                                         subgraph_schemas: parameters.subgraph_schemas,
+                                        is_deferred: false,
                                     },
                                     current_dir,
                                     &value,
@@ -590,6 +598,7 @@ impl DeferredNode {
                             subscription_handle: &subscription_handle,
                             subscription_config: &subscription_config,
                             subgraph_schemas: &subgraph_schemas,
+                            is_deferred: true,
                         },
                         &Path::default(),
                         &value,

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -127,10 +127,13 @@ pub(crate) struct ExecutionParameters<'a> {
     pub(crate) root_node: &'a PlanNode,
     pub(crate) subscription_handle: &'a Option<SubscriptionHandle>,
     pub(crate) subscription_config: &'a Option<SubscriptionConfig>,
-    /// `true` when the walker is inside a `DeferredNode` subtree, `false`
-    /// inside `PlanNode::Defer`'s primary branch or anywhere outside a
-    /// `Defer` node. Propagated to each `FetchRequest` so that subgraph
-    /// telemetry can split primary vs deferred fetches.
+    /// `true` when the fetch's results are delivered in a deferred chunk rather
+    /// than the primary response: inside a `DeferredNode` subtree, or inside a
+    /// `PlanNode::Defer` primary branch that is itself nested under an outer
+    /// `DeferredNode` (the primary branch inherits the enclosing status). `false`
+    /// at the top level and in a top-level `Defer`'s primary branch. Propagated
+    /// to each `FetchRequest` so subgraph telemetry can split primary vs deferred
+    /// fetches.
     pub(crate) is_deferred: bool,
 }
 
@@ -410,7 +413,12 @@ impl PlanNode {
                                         subscription_handle: parameters.subscription_handle,
                                         subscription_config: parameters.subscription_config,
                                         subgraph_schemas: parameters.subgraph_schemas,
-                                        is_deferred: false,
+                                        // Inherit the enclosing deferred status rather than
+                                        // resetting to false. This Defer's primary branch is only
+                                        // non-deferred when the Defer itself is not already nested
+                                        // under an outer DeferredNode; a doubly-nested defer keeps
+                                        // is_deferred = true for its primary branch.
+                                        is_deferred: parameters.is_deferred,
                                     },
                                     current_dir,
                                     &value,

--- a/apollo-router/src/services/fetch.rs
+++ b/apollo-router/src/services/fetch.rs
@@ -41,6 +41,10 @@ pub(crate) struct FetchRequest {
     pub(crate) supergraph_request: Arc<http::Request<GraphQLRequest>>,
     pub(crate) variables: Variables,
     pub(crate) current_dir: Path,
+    /// Whether this fetch is part of the deferred portion of an `@defer` query
+    /// plan. Propagated to `subgraph::Request` so telemetry selectors can split
+    /// primary vs deferred fetches.
+    pub(crate) is_deferred: bool,
 }
 
 #[buildstructor::buildstructor]
@@ -55,6 +59,7 @@ impl FetchRequest {
         supergraph_request: Arc<http::Request<GraphQLRequest>>,
         variables: Variables,
         current_dir: Path,
+        is_deferred: bool,
     ) -> Self {
         Self {
             context,
@@ -62,6 +67,7 @@ impl FetchRequest {
             supergraph_request,
             variables,
             current_dir,
+            is_deferred,
         }
     }
 }

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -191,6 +191,7 @@ impl FetchService {
             variables,
             current_dir,
             context,
+            is_deferred,
         } = request;
 
         let FetchNode {
@@ -264,6 +265,10 @@ impl FetchService {
             .build();
         subgraph_request.query_hash = fetch_node.schema_aware_hash.clone();
         subgraph_request.authorization = fetch_node.authorization.clone();
+        // Renamed at the boundary: the walker carries `is_deferred` as a property
+        // of the fetch; on the subgraph request it's `is_deferred_fetch` to make
+        // clear that it describes *this* fetch (not a query-level flag).
+        subgraph_request.is_deferred_fetch = is_deferred;
         Box::pin(async move {
             Ok(fetch_node
                 .subgraph_fetch(

--- a/apollo-router/src/services/subgraph.rs
+++ b/apollo-router/src/services/subgraph.rs
@@ -82,6 +82,12 @@ pub struct Request {
 
     /// unique id for this request
     pub(crate) id: SubgraphRequestId,
+
+    /// Whether this subgraph fetch is part of the deferred portion of an
+    /// `@defer` query plan. Populated by the fetch service from the query
+    /// plan execution walker; used by the `is_deferred` subgraph telemetry
+    /// selector to split primary vs deferred fetch metrics.
+    pub(crate) is_deferred_fetch: bool,
 }
 
 #[buildstructor::buildstructor]
@@ -115,6 +121,7 @@ impl Request {
             authorization: Default::default(),
             executable_document,
             id: SubgraphRequestId::new(),
+            is_deferred_fetch: false,
         }
     }
 
@@ -223,6 +230,7 @@ impl Clone for Request {
             authorization: self.authorization.clone(),
             executable_document: self.executable_document.clone(),
             id: self.id.clone(),
+            is_deferred_fetch: self.is_deferred_fetch,
         }
     }
 }

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/selectors.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/selectors.mdx
@@ -89,6 +89,7 @@ The subgraph service executes multiple times during query execution, with each e
 | `subgraph_operation_kind`   | No          | `string`         | The operation kind from the subgraph query                                     |
 | `subgraph_query`            | Yes         | `string`         | The GraphQL query to the subgraph                                              |
 | `subgraph_name`             | No          | `true` \| `false`  | The subgraph name                                                              |
+| `is_deferred`               | No          | `true`           | Boolean indicating whether this subgraph fetch is part of the deferred portion of an `@defer` query plan. Returns `true` for fetches inside a `DeferredNode` subtree, `false` for primary fetches. For details, see [splitting subgraph metrics by defer phase](#splitting-subgraph-metrics-by-defer-phase). |
 | `subgraph_query_variable`   | Yes         |                  | The name of a subgraph query variable                                          |
 | `subgraph_response_data`    | Yes         |                  | JSON Path into the subgraph response body data (it might impact performance)   |
 | `subgraph_response_errors`  | Yes         |                  | JSON Path into the subgraph response body errors (it might impact performance) |
@@ -111,6 +112,47 @@ The subgraph service executes multiple times during query execution, with each e
 | `response_cache`            | No          | `hit` \| `miss`    | Returns the number of cache hit or miss for this subgraph request              |
 | `response_cache_status`    | No          | `hit` \| `partial_hit`\| `miss`\| `status`    | Indicates the cache status for the subgraph request: `hit` (all data from cache), `miss` (all data from subgraph), or `partial_hit` (some entities from cache).  |
 | `response_cache_control`    | No          | `max_age` \| `scope`\| `no_store`    | Provides data from the computed `Cache-Control` header, such as `max_age`, `scope` (`public`/`private`), or `no_store` status.  |
+
+### Splitting subgraph metrics by defer phase
+
+For `@defer` queries, the router issues some subgraph fetches as part of the primary response and others to satisfy deferred fields. The `is_deferred` selector lets you tag subgraph-scoped metrics with which phase produced the fetch, so you can see, for example, whether deferred fetches contribute disproportionately to tail latency:
+
+```yaml title="router.yaml"
+telemetry:
+  instrumentation:
+    instruments:
+      subgraph:
+        http.client.request.duration:
+          attributes:
+            phase:
+              is_deferred: true
+```
+
+This produces two histogram series:
+
+- `http_client_request_duration_seconds{phase="false"}` — primary fetches.
+- `http_client_request_duration_seconds{phase="true"}` — fetches issued to satisfy `@defer` fields.
+
+Combine with `subgraph_name` to get a per-subgraph, per-phase breakdown:
+
+```yaml title="router.yaml"
+telemetry:
+  instrumentation:
+    instruments:
+      subgraph:
+        http.client.request.duration:
+          attributes:
+            subgraph:
+              subgraph_name: true
+            phase:
+              is_deferred: true
+```
+
+<Note>
+
+`is_deferred` is evaluated at subgraph request time, based on whether the fetch node being dispatched lives under a `DeferredNode` in the query plan. Fetches outside of any `@defer` (including all fetches on non-deferred queries) return `false`.
+
+</Note>
 
 ### HTTP Client
 


### PR DESCRIPTION
Fixes #9241.

## Summary

New `is_deferred` selector on the `subgraph` service. Returns `true` when the fetch lives under a `DeferredNode` in the query plan, `false` for primary fetches. Lets customers split any subgraph-scoped metric (e.g. `http.client.request.duration`) by `@defer` phase:

```yaml
telemetry:
  instrumentation:
    instruments:
      subgraph:
        http.client.request.duration:
          attributes:
            phase:
              is_deferred: true
```

## Implementation

`PlanNode::Defer { primary, deferred }` already splits the two branches in `query_planner/execution.rs`. I added `is_deferred: bool` to `ExecutionParameters`, set at the three construction sites — root (`false`), Defer primary branch (`false`), `DeferredNode::execute` (**`true`**) — and threaded it through `FetchRequest` (builder field) to `subgraph::Request.is_deferred_fetch` (post-build assign, same pattern as `query_hash` / `authorization`).

The new selector variant reads `request.is_deferred_fetch` and is active at `Stage::Request`, mirroring `SubgraphName` / `OnGraphQLError` / `IsPrimaryResponse`.

**Request-side only for v1.** `is_deferred` is known at fetch-dispatch time and `http.client.request.duration` attributes evaluate from the request. Plumbing it onto `subgraph::Response` would touch ~15 call sites across plugins; straightforward follow-up if asked.

**Connector fetches untouched.** `ConnectRequest` doesn't flow through `subgraph::Request`, so the selector doesn't apply there. Separate issue if connector telemetry ever wants the same split.

## Testing

- New unit test at `config_new/subgraph/selectors.rs` covers primary → `Some(false)`, deferred → `Some(true)`, inactive config → `None`.
- `cargo xtask lint` green.
- `cargo test -p apollo-router --lib plugins::telemetry::config_new::subgraph::selectors` — 33/33 pass.
- `cargo test -p apollo-router --lib query_planner::fetch` — 40/40 pass.
- `configuration::tests::schema_generation` — regenerated snapshot for the new enum variant (`cargo insta accept`).
- `configuration::tests::validate_project_config_files` — red on this branch but **identically red on clean `origin/dev`** (`file_upload/body_limit.router.yaml` has `http_max_request_bytes` under `limits:` which the current schema rejects). Inherited, not this PR.

## Docs

Added the `is_deferred` row to the subgraph selector table and a worked example subsection ("Splitting subgraph metrics by defer phase") in `selectors.mdx`.

## Checklist

- [x] Changes are compatible with [the core feature flag system](https://github.com/apollographql/router/blob/dev/dev-docs/feature_flags.md) — N/A (no new feature flag)
- [x] Changes are compatible with [federation v2.7+](https://www.apollographql.com/docs/federation/) — N/A (telemetry-only)
- [x] Added a changeset
- [x] Added a test
- [x] `cargo xtask lint` passes locally