### PR TITLE
chore: update samples test to check if deferred responses are equivalent when an extra chunk is used to signal termination

### DIFF
--- a/apollo-router/tests/samples_tests.rs
+++ b/apollo-router/tests/samples_tests.rs
@@ -663,7 +663,9 @@ impl TestExecution {
             Value::Array(chunks)
         };
 
-        if expected_response != &graphql_response {
+        if expected_response != &graphql_response
+            && !deferred_responses_equivalent(expected_response, &graphql_response)
+        {
             self.print_received_requests(out).await;
 
             writeln!(out, "assertion `left == right` failed").unwrap();
@@ -756,6 +758,38 @@ fn open_file(path: &Path, out: &mut String) -> Result<String, Failed> {
         f
     })?;
     Ok(s)
+}
+
+/// Due to a race in `filter_stream` (execution/service.rs), deferred responses can arrive in two
+/// equivalent forms depending on whether the channel disconnects before or after `try_recv`:
+///
+///   Fast path: [..., { incremental: [...], hasNext: false }]
+///   Slow path: [..., { incremental: [...], hasNext: true }, { data: null, hasNext: false }]
+///
+/// Both are spec-compliant. This function returns true when `received` is the slow-path form of
+/// `expected`.
+fn deferred_responses_equivalent(expected: &Value, received: &Value) -> bool {
+    let (Some(expected), Some(received)) = (expected.as_array(), received.as_array()) else {
+        return false;
+    };
+
+    if received.len() != expected.len() + 1 {
+        return false;
+    }
+
+    if let Some(last_received) = received.last()
+        && let Some(last_expected) = expected.last()
+        && *last_received == serde_json::json!({ "data": null, "hasNext": false })
+        && expected[..expected.len() - 1] == received[..expected.len() - 1]
+    {
+        let mut normalized = received[expected.len() - 1].clone();
+        if let Some(obj) = normalized.as_object_mut() {
+            obj.insert("hasNext".to_string(), Value::Bool(false));
+        }
+        normalized == *last_expected
+    } else {
+        false
+    }
 }
 
 fn check_path(path: &Path, out: &mut String) -> Result<(), Failed> {


### PR DESCRIPTION
At the moment, `apollo-router::samples /enterprise/connectors-defer` is one of our flakiest tests as sometimes a 3-chunk deferred response will be returned, where the extra chunk is `{"data":null,"hasNext":false}` instead of `hasNext: false` being set to true in a previous chunk. This is valid per the spec, so doesn't indicate there's a bug in the router, and is instead being caused by slower CI runs making the router send the 2nd chunk before we know that there's no more, requiring a 3rd chunk to be sent to signal no more responses.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
