### PR TITLE
perf(subgraph_service): avoid unnecessary clones on subgraph requests

### DIFF
--- a/.changesets/maint_caroline_avoid_subgraph_request_clones.md
+++ b/.changesets/maint_caroline_avoid_subgraph_request_clones.md
@@ -1,0 +1,5 @@
+### Avoid unnecessary clones on subgraph requests ([PR #9266](https://github.com/apollographql/router/pull/9266))
+
+The router now avoids some unnecessary memory allocations when making subgraph requests, particularly on the APQ (Automatic Persisted Queries) path.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9266

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -22,7 +22,6 @@ use tracing::Span;
 use crate::Context;
 use crate::error::FetchError;
 use crate::error::SubgraphBatchingError;
-use crate::graphql;
 use crate::plugins::telemetry::otel::span_ext::OpenTelemetrySpanExt;
 use crate::services::SubgraphRequest;
 use crate::services::SubgraphResponse;
@@ -95,7 +94,6 @@ impl BatchQuery {
         &self,
         client_factory: HttpClientServiceFactory,
         request: SubgraphRequest,
-        gql_request: graphql::Request,
     ) -> Result<oneshot::Receiver<Result<SubgraphResponse, BoxError>>, BoxError> {
         // Create a receiver for this query so that it can eventually get the request meant for it
         let (tx, rx) = oneshot::channel();
@@ -115,7 +113,6 @@ impl BatchQuery {
                     index: self.index,
                     client_factory,
                     request,
-                    gql_request,
                     response_sender: tx,
                     span_context: Span::current().context(),
                 },
@@ -185,7 +182,6 @@ struct BatchHandlerMessageProgress {
     index: usize,
     client_factory: HttpClientServiceFactory,
     request: SubgraphRequest,
-    gql_request: graphql::Request,
     response_sender: oneshot::Sender<Result<SubgraphResponse, BoxError>>,
     span_context: otelContext,
 }
@@ -194,9 +190,6 @@ struct BatchHandlerMessageProgress {
 pub(crate) struct BatchQueryInfo {
     /// The owning subgraph request
     request: SubgraphRequest,
-
-    /// The GraphQL request tied to this subgraph request
-    gql_request: graphql::Request,
 
     /// Notifier for the subgraph service handler
     ///
@@ -319,7 +312,6 @@ impl Batch {
                             index,
                             client_factory,
                             request,
-                            gql_request,
                             response_sender,
                             span_context,
                         } = *progress;
@@ -336,7 +328,6 @@ impl Batch {
                         Span::current().add_link(span_context.span().span_context().clone());
                         requests[index].push(BatchQueryInfo {
                             request,
-                            gql_request,
                             sender: response_sender,
                         })
                     }
@@ -361,7 +352,6 @@ impl Batch {
             let mut svc_map: HashMap<String, Vec<BatchQueryInfo>> = HashMap::new();
             for BatchQueryInfo {
                 request: sg_request,
-                gql_request,
                 sender: tx,
             } in all_in_one
             {
@@ -373,7 +363,6 @@ impl Batch {
                     .or_default();
                 value.push(BatchQueryInfo {
                     request: sg_request,
-                    gql_request,
                     sender: tx,
                 });
             }
@@ -441,24 +430,21 @@ pub(crate) async fn assemble_batch(
     ),
     BoxError,
 > {
-    // Extract the collection of parts from the requests
-    let (txs, request_pairs): (Vec<_>, Vec<_>) = requests
+    let (txs, requests): (Vec<_>, Vec<_>) = requests
         .into_iter()
-        .map(|r| (r.sender, (r.request, r.gql_request)))
+        .map(|r| (r.sender, r.request))
         .unzip();
-    let (requests, gql_requests): (Vec<_>, Vec<_>) = request_pairs.into_iter().unzip();
-
-    // Construct the actual byte body of the batched request
-    let bytes = router::body::into_bytes(serde_json::to_string(&gql_requests)?).await?;
 
     // Retain the various contexts for later use
     let contexts = requests
         .iter()
         .map(|request| (request.context.clone(), request.id.clone()))
         .collect::<Vec<(Context, SubgraphRequestId)>>();
-    // Grab the common info from the first request
-    let first_request = requests
-        .into_iter()
+
+    // Extract the GraphQL body from each request. The first request also provides the HTTP
+    // parts (URI, headers, etc.) used as the transport envelope for the whole batch.
+    let mut requests_iter = requests.into_iter();
+    let first_request = requests_iter
         .next()
         .ok_or(SubgraphBatchingError::RequestsIsEmpty)?
         .subgraph_request;
@@ -467,7 +453,16 @@ pub(crate) async fn assemble_batch(
         .operation_name
         .clone()
         .unwrap_or_default();
-    let (parts, _) = first_request.into_parts();
+    let (parts, first_body) = first_request.into_parts();
+
+    let mut gql_requests = vec![first_body];
+    for r in requests_iter {
+        let (_, body) = r.subgraph_request.into_parts();
+        gql_requests.push(body);
+    }
+
+    // Construct the actual byte body of the batched request
+    let bytes = router::body::into_bytes(serde_json::to_string(&gql_requests)?).await?;
 
     // Generate the final request and pass it up
     let request = http::Request::from_parts(parts, router::body::from_bytes(bytes));
@@ -521,11 +516,10 @@ mod tests {
                     BatchQueryInfo {
                         request: SubgraphRequest::fake_builder()
                             .subgraph_request(
-                                http::Request::builder().body(gql_request.clone()).unwrap(),
+                                http::Request::builder().body(gql_request).unwrap(),
                             )
                             .subgraph_name(format!("slot{index}"))
                             .build(),
-                        gql_request,
                         sender: tx,
                     },
                 )
@@ -665,14 +659,13 @@ mod tests {
             bq.signal_progress(
                 factory.clone(),
                 request.clone(),
-                graphql::Request::default()
             )
             .await
             .is_ok()
         );
         assert!(bq.finished());
         assert!(
-            bq.signal_progress(factory, request, graphql::Request::default())
+            bq.signal_progress(factory, request)
                 .await
                 .is_err()
         );
@@ -704,7 +697,7 @@ mod tests {
         );
         assert!(!bq.finished());
         assert!(
-            bq.signal_progress(factory, request, graphql::Request::default())
+            bq.signal_progress(factory, request)
                 .await
                 .is_ok()
         );
@@ -739,7 +732,7 @@ mod tests {
         assert!(bq.set_query_hashes(vec![qh.clone(), qh]).await.is_ok());
         assert!(!bq.finished());
         assert!(
-            bq.signal_progress(factory, request, graphql::Request::default())
+            bq.signal_progress(factory, request)
                 .await
                 .is_ok()
         );

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -430,10 +430,8 @@ pub(crate) async fn assemble_batch(
     ),
     BoxError,
 > {
-    let (txs, requests): (Vec<_>, Vec<_>) = requests
-        .into_iter()
-        .map(|r| (r.sender, r.request))
-        .unzip();
+    let (txs, requests): (Vec<_>, Vec<_>) =
+        requests.into_iter().map(|r| (r.sender, r.request)).unzip();
 
     // Retain the various contexts for later use
     let contexts = requests
@@ -455,7 +453,8 @@ pub(crate) async fn assemble_batch(
         .unwrap_or_default();
     let (parts, first_body) = first_request.into_parts();
 
-    let mut gql_requests = vec![first_body];
+    let mut gql_requests = Vec::with_capacity(txs.len());
+    gql_requests.push(first_body);
     for r in requests_iter {
         let (_, body) = r.subgraph_request.into_parts();
         gql_requests.push(body);
@@ -515,9 +514,7 @@ mod tests {
                     rx,
                     BatchQueryInfo {
                         request: SubgraphRequest::fake_builder()
-                            .subgraph_request(
-                                http::Request::builder().body(gql_request).unwrap(),
-                            )
+                            .subgraph_request(http::Request::builder().body(gql_request).unwrap())
                             .subgraph_name(format!("slot{index}"))
                             .build(),
                         sender: tx,
@@ -656,19 +653,12 @@ mod tests {
         );
         assert!(!bq.finished());
         assert!(
-            bq.signal_progress(
-                factory.clone(),
-                request.clone(),
-            )
-            .await
-            .is_ok()
+            bq.signal_progress(factory.clone(), request.clone())
+                .await
+                .is_ok()
         );
         assert!(bq.finished());
-        assert!(
-            bq.signal_progress(factory, request)
-                .await
-                .is_err()
-        );
+        assert!(bq.signal_progress(factory, request).await.is_err());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -696,11 +686,7 @@ mod tests {
                 .is_ok()
         );
         assert!(!bq.finished());
-        assert!(
-            bq.signal_progress(factory, request)
-                .await
-                .is_ok()
-        );
+        assert!(bq.signal_progress(factory, request).await.is_ok());
         assert!(bq.finished());
         assert!(
             bq.signal_cancelled("only once though".to_string())
@@ -731,11 +717,7 @@ mod tests {
         let qh = Arc::new(QueryHash::default());
         assert!(bq.set_query_hashes(vec![qh.clone(), qh]).await.is_ok());
         assert!(!bq.finished());
-        assert!(
-            bq.signal_progress(factory, request)
-                .await
-                .is_ok()
-        );
+        assert!(bq.signal_progress(factory, request).await.is_ok());
         assert!(!bq.finished());
         assert!(
             bq.signal_cancelled("only twice though".to_string())

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -197,30 +197,20 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
                 return call_http(request, client_factory.clone(), &service_name).await;
             }
 
-            // Else, if APQ is enabled,
-            // Calculate the query hash and try the request with
-            // a persistedQuery instead of the whole query.
-            let body = request.subgraph_request.body();
+            // APQ works by sending the query hash via extensions with an empty query body.
+            // We use query.take() to save the query in case it's needed for a retry.
+            let body = request.subgraph_request.body_mut();
+            let original_query = body.query.take();
+
             let hash_value =
-                apq::calculate_hash_for_query(body.query.as_deref().unwrap_or_default());
-
-            let persisted_query = serde_json_bytes::json!({
-                HASH_VERSION_KEY: HASH_VERSION_VALUE,
-                HASH_KEY: hash_value
-            });
-
-            let mut extensions_with_apq = body.extensions.clone();
-            extensions_with_apq.insert(PERSISTED_QUERY_KEY, persisted_query);
-
-            let apq_body = graphql::Request {
-                query: None,
-                operation_name: body.operation_name.clone(),
-                variables: body.variables.clone(),
-                extensions: extensions_with_apq,
-            };
-
-            // Replace the body with the APQ body, saving the original for potential retries.
-            let original_body = std::mem::replace(request.subgraph_request.body_mut(), apq_body);
+                apq::calculate_hash_for_query(original_query.as_deref().unwrap_or_default());
+            body.extensions.insert(
+                PERSISTED_QUERY_KEY,
+                serde_json_bytes::json!({
+                    HASH_VERSION_KEY: HASH_VERSION_VALUE,
+                    HASH_KEY: hash_value
+                }),
+            );
 
             let response =
                 call_http(request.clone(), client_factory.clone(), &service_name).await?;
@@ -233,11 +223,14 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
             match get_apq_error(gql_response) {
                 APQError::PersistedQueryNotSupported => {
                     apq_enabled.store(false, Relaxed);
-                    *request.subgraph_request.body_mut() = original_body;
+                    let body = request.subgraph_request.body_mut();
+                    body.query = original_query;
+                    // Remove the persistedQuery extension we added for the APQ attempt.
+                    body.extensions.remove(PERSISTED_QUERY_KEY);
                     call_http(request, client_factory.clone(), &service_name).await
                 }
                 APQError::PersistedQueryNotFound => {
-                    request.subgraph_request.body_mut().query = original_body.query;
+                    request.subgraph_request.body_mut().query = original_query;
                     call_http(request, client_factory.clone(), &service_name).await
                 }
                 _ => Ok(response),

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -222,8 +222,8 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
             // Replace the body with the APQ body, saving the original for potential retries.
             let original_body = std::mem::replace(request.subgraph_request.body_mut(), apq_body);
 
-            let response = call_http(request.clone(), client_factory.clone(), &service_name)
-                .await?;
+            let response =
+                call_http(request.clone(), client_factory.clone(), &service_name).await?;
 
             // Check the error for the request with only persistedQuery.
             // If PersistedQueryNotSupported, disable APQ for this subgraph
@@ -783,7 +783,11 @@ pub(crate) async fn call_single_http(
     } = request;
 
     let (parts, body) = subgraph_request.into_parts();
-    let operation_name = body.operation_name.as_deref().unwrap_or_default().to_owned();
+    let operation_name = body
+        .operation_name
+        .as_deref()
+        .unwrap_or_default()
+        .to_owned();
     let body = serde_json::to_string(&body)?;
     tracing::debug!("our JSON body: {body:?}");
     let mut request = http::Request::from_parts(parts, router::body::from_bytes(body));

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -182,7 +182,7 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, request: SubgraphRequest) -> Self::Future {
+    fn call(&mut self, mut request: SubgraphRequest) -> Self::Future {
         let service_name = (*self.service).to_owned();
 
         let client_factory = self.client_factory.clone();
@@ -190,66 +190,40 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
         let arc_apq_enabled = self.apq.clone();
 
         let make_calls = async move {
-            // XXX(@goto-bus-stop): We are cloning the subgraph request potentially 3 times below.
-            // It will normally not be super expensive? but it still does not seem great or
-            // necessary.
-
-            let SubgraphRequest {
-                subgraph_request,
-                context,
-                ..
-            } = request.clone();
-            let body = subgraph_request.into_body();
-
             // If APQ is not enabled, simply make the graphql call
             // with the same request body.
             let apq_enabled = arc_apq_enabled.as_ref();
             if !apq_enabled.load(Relaxed) {
-                return call_http(
-                    request,
-                    body,
-                    context,
-                    client_factory.clone(),
-                    &service_name,
-                )
-                .await;
+                return call_http(request, client_factory.clone(), &service_name).await;
             }
 
             // Else, if APQ is enabled,
             // Calculate the query hash and try the request with
             // a persistedQuery instead of the whole query.
-            let graphql::Request {
-                query,
-                operation_name,
-                variables,
-                extensions,
-            } = body.clone();
-
-            let hash_value = apq::calculate_hash_for_query(query.as_deref().unwrap_or_default());
+            let body = request.subgraph_request.body();
+            let hash_value =
+                apq::calculate_hash_for_query(body.query.as_deref().unwrap_or_default());
 
             let persisted_query = serde_json_bytes::json!({
                 HASH_VERSION_KEY: HASH_VERSION_VALUE,
                 HASH_KEY: hash_value
             });
 
-            let mut extensions_with_apq = extensions.clone();
+            let mut extensions_with_apq = body.extensions.clone();
             extensions_with_apq.insert(PERSISTED_QUERY_KEY, persisted_query);
 
-            let mut apq_body = graphql::Request {
+            let apq_body = graphql::Request {
                 query: None,
-                operation_name,
-                variables,
+                operation_name: body.operation_name.clone(),
+                variables: body.variables.clone(),
                 extensions: extensions_with_apq,
             };
 
-            let response = call_http(
-                request.clone(),
-                apq_body.clone(),
-                context.clone(),
-                client_factory.clone(),
-                &service_name,
-            )
-            .await?;
+            // Replace the body with the APQ body, saving the original for potential retries.
+            let original_body = std::mem::replace(request.subgraph_request.body_mut(), apq_body);
+
+            let response = call_http(request.clone(), client_factory.clone(), &service_name)
+                .await?;
 
             // Check the error for the request with only persistedQuery.
             // If PersistedQueryNotSupported, disable APQ for this subgraph
@@ -259,25 +233,12 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
             match get_apq_error(gql_response) {
                 APQError::PersistedQueryNotSupported => {
                     apq_enabled.store(false, Relaxed);
-                    call_http(
-                        request,
-                        body,
-                        context,
-                        client_factory.clone(),
-                        &service_name,
-                    )
-                    .await
+                    *request.subgraph_request.body_mut() = original_body;
+                    call_http(request, client_factory.clone(), &service_name).await
                 }
                 APQError::PersistedQueryNotFound => {
-                    apq_body.query = query;
-                    call_http(
-                        request,
-                        apq_body,
-                        context,
-                        client_factory.clone(),
-                        &service_name,
-                    )
-                    .await
+                    request.subgraph_request.body_mut().query = original_body.query;
+                    call_http(request, client_factory.clone(), &service_name).await
                 }
                 _ => Ok(response),
             }
@@ -758,9 +719,7 @@ pub(crate) async fn process_batches(
 }
 
 async fn call_http(
-    request: SubgraphRequest,
-    body: graphql::Request,
-    context: Context,
+    mut request: SubgraphRequest,
     client_factory: HttpClientServiceFactory,
     service_name: &str,
 ) -> Result<SubgraphResponse, BoxError> {
@@ -771,7 +730,7 @@ async fn call_http(
     // If we are processing a batch, then we'd like to park tasks here, but we can't park them whilst
     // we have the context extensions lock held. That would be very bad...
     // We grab the (potential) BatchQuery and then operate on it later
-    let opt_batch_query = context.extensions().with_lock(|lock| {
+    let opt_batch_query = request.context.extensions().with_lock(|lock| {
         lock.get::<Batching>()
             .and_then(|batching_config| batching_config.batch_include(service_name).then_some(()))
             .and_then(|_| lock.get::<BatchQuery>().cloned())
@@ -782,7 +741,13 @@ async fn call_http(
     if let Some(query) = opt_batch_query {
         // Let the owning batch know that this query is ready to process, getting back the channel
         // from which we'll eventually receive our response.
-        let response_rx = query.signal_progress(client_factory, request, body).await?;
+        //
+        // signal_progress takes request and gql_request separately: it uses request for transport
+        // details (URI, headers, context) and gql_request for the GraphQL payload.
+        // TODO: taking the body out of the request is not actually safe — assemble_batch reads
+        // operation_name from first_request.body(), which will be empty after this take.
+        let gql_request = std::mem::take(request.subgraph_request.body_mut());
+        let response_rx = query.signal_progress(client_factory, request, gql_request).await?;
 
         // Park this query until we have our response and pass it back up
         response_rx
@@ -794,19 +759,18 @@ async fn call_http(
     } else {
         tracing::debug!("we called http");
         let client = client_factory.create(service_name);
-        call_single_http(request, body, context, client, service_name).await
+        call_single_http(request, client, service_name).await
     }
 }
 
 /// call_single_http makes http calls with modified graphql::Request (body)
 pub(crate) async fn call_single_http(
     request: SubgraphRequest,
-    body: graphql::Request,
-    context: Context,
     client: crate::services::http::BoxService,
     service_name: &str,
 ) -> Result<SubgraphResponse, BoxError> {
-    let subgraph_request_event = context
+    let subgraph_request_event = request
+        .context
         .extensions()
         .with_lock(|lock| lock.get::<SubgraphEventRequest>().cloned());
     let log_request_level = subgraph_request_event.and_then(|s| {
@@ -819,17 +783,13 @@ pub(crate) async fn call_single_http(
 
     let SubgraphRequest {
         subgraph_request,
+        context,
         id: subgraph_request_id,
         ..
     } = request;
 
-    let operation_name = subgraph_request
-        .body()
-        .operation_name
-        .clone()
-        .unwrap_or_default();
-
-    let (parts, _) = subgraph_request.into_parts();
+    let (parts, body) = subgraph_request.into_parts();
+    let operation_name = body.operation_name.as_deref().unwrap_or_default().to_owned();
     let body = serde_json::to_string(&body)?;
     tracing::debug!("our JSON body: {body:?}");
     let mut request = http::Request::from_parts(parts, router::body::from_bytes(body));

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -719,7 +719,7 @@ pub(crate) async fn process_batches(
 }
 
 async fn call_http(
-    mut request: SubgraphRequest,
+    request: SubgraphRequest,
     client_factory: HttpClientServiceFactory,
     service_name: &str,
 ) -> Result<SubgraphResponse, BoxError> {
@@ -741,13 +741,7 @@ async fn call_http(
     if let Some(query) = opt_batch_query {
         // Let the owning batch know that this query is ready to process, getting back the channel
         // from which we'll eventually receive our response.
-        //
-        // signal_progress takes request and gql_request separately: it uses request for transport
-        // details (URI, headers, context) and gql_request for the GraphQL payload.
-        // TODO: taking the body out of the request is not actually safe — assemble_batch reads
-        // operation_name from first_request.body(), which will be empty after this take.
-        let gql_request = std::mem::take(request.subgraph_request.body_mut());
-        let response_rx = query.signal_progress(client_factory, request, gql_request).await?;
+        let response_rx = query.signal_progress(client_factory, request).await?;
 
         // Park this query until we have our response and pass it back up
         response_rx

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1226,6 +1226,7 @@ mod tests {
     use super::*;
     use crate::Context;
     use crate::assert_response_eq_ignoring_error_id;
+    use crate::configuration::shared::Client as ClientConfiguration;
     use crate::configuration::subgraph::SubgraphConfiguration;
     use crate::graphql::Error;
     use crate::graphql::Request;
@@ -2962,6 +2963,209 @@ mod tests {
         };
 
         assert_eq!(resp.response.body(), &expected_resp);
+    }
+
+    mod apq_body_preservation {
+        use super::*;
+
+        const APQ_TEST_QUERY: &str = "query MyOp($id: ID!) { thing(id: $id) { name } }";
+
+        /// Spins up a mock subgraph server with APQ enabled and drives a single request through it.
+        /// Each test supplies a `handle` function that acts as the subgraph server: it asserts on
+        /// the received body and returns an HTTP response.
+        async fn run_apq_test<Handler, Fut>(
+            gql_body: graphql::Request,
+            handle: Handler,
+        ) -> SubgraphResponse
+        where
+            Handler: (Fn(http::Request<Body>) -> Fut) + Clone + Sync + Send + 'static,
+            Fut: std::future::Future<Output = Result<http::Response<Body>, Infallible>>
+                + Send
+                + 'static,
+        {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let socket_addr = listener.local_addr().unwrap();
+            let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
+            tokio::task::spawn(serve(listener, handle));
+
+            let subgraph_service = SubgraphService::new(
+                "test",
+                true,
+                HttpClientServiceFactory::from_config(
+                    "test",
+                    &Configuration::default(),
+                    ClientConfiguration::default(),
+                ),
+            )
+            .expect("can create a SubgraphService");
+
+            let query = gql_body.query.clone().unwrap_or_default();
+            let subgraph_request = http::Request::builder()
+                .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                .uri(url)
+                .body(gql_body)
+                .unwrap();
+
+            subgraph_service
+                .oneshot(
+                    SubgraphRequest::builder()
+                        .supergraph_request(supergraph_request(&query))
+                        .subgraph_request(subgraph_request)
+                        .operation_kind(OperationKind::Query)
+                        .subgraph_name(String::from("test"))
+                        .context(Context::new())
+                        .build(),
+                )
+                .await
+                .unwrap()
+        }
+
+        // Verifies that operation_name, variables, and custom extensions are all forwarded
+        // into the APQ body, not just the persistedQuery hash. The mock server handler
+        // asserts on the received body directly, so the test fails if any field is missing.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_apq_body_preserves_all_fields() {
+            async fn handle(
+                request: http::Request<Body>,
+            ) -> Result<http::Response<Body>, Infallible> {
+                let bytes = router::body::into_bytes(request.into_body())
+                    .await
+                    .expect("can read request body");
+                let graphql_request: graphql::Request =
+                    serde_json::from_reader(bytes.reader()).expect("valid graphql request");
+
+                assert!(
+                    graphql_request.query.is_none(),
+                    "APQ body should omit query on first attempt"
+                );
+                assert_eq!(
+                    graphql_request.operation_name.as_deref(),
+                    Some("MyOp"),
+                    "operation_name should be preserved in APQ body"
+                );
+                assert_eq!(
+                    graphql_request.variables.get("id"),
+                    Some(&serde_json_bytes::json!("42")),
+                    "variables should be preserved in APQ body"
+                );
+                assert!(
+                    graphql_request.extensions.contains_key(PERSISTED_QUERY_KEY),
+                    "persistedQuery hash should be present"
+                );
+                assert!(
+                    graphql_request.extensions.contains_key("myExt"),
+                    "custom extensions should be preserved alongside persistedQuery"
+                );
+
+                let response = Response {
+                    data: Some(Value::String(ByteString::from("test"))),
+                    ..Response::default()
+                };
+                Ok(http::Response::builder()
+                    .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                    .status(StatusCode::OK)
+                    .body(serde_json::to_string(&response).unwrap().into())
+                    .unwrap())
+            }
+
+            let gql_body = graphql::Request {
+                query: Some(APQ_TEST_QUERY.to_string()),
+                operation_name: Some("MyOp".to_string()),
+                variables: serde_json_bytes::json!({"id": "42"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                extensions: serde_json_bytes::json!({"myExt": "value"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            };
+            let response = run_apq_test(gql_body, handle).await.response.into_body();
+            assert_eq!(response.data, Some(Value::String(ByteString::from("test"))));
+            assert!(response.errors.is_empty());
+        }
+
+        // Verifies that on a PersistedQueryNotFound retry, the original query string,
+        // operation name, and variables are all sent correctly. The mock server handler
+        // distinguishes the first attempt (no query) from the retry (query present) and
+        // asserts on the retry body fields directly.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_apq_not_found_retry_preserves_original_body() {
+            async fn handle(
+                request: http::Request<Body>,
+            ) -> Result<http::Response<Body>, Infallible> {
+                let bytes = router::body::into_bytes(request.into_body())
+                    .await
+                    .expect("can read request body");
+                let graphql_request: graphql::Request =
+                    serde_json::from_reader(bytes.reader()).expect("valid graphql request");
+
+                assert!(
+                    graphql_request.extensions.contains_key(PERSISTED_QUERY_KEY),
+                    "both attempts should include the persistedQuery hash"
+                );
+
+                if graphql_request.query.is_none() {
+                    // First attempt: return PersistedQueryNotFound
+                    let pqnf_response = Response {
+                        errors: vec![
+                            Error::builder()
+                                .message(PERSISTED_QUERY_NOT_FOUND_MESSAGE)
+                                .build(),
+                        ],
+                        ..Response::default()
+                    };
+                    return Ok(http::Response::builder()
+                        .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                        .status(StatusCode::OK)
+                        .body(serde_json::to_string(&pqnf_response).unwrap().into())
+                        .unwrap());
+                }
+
+                // Second attempt: verify the retry body contains the original fields
+                assert_eq!(
+                    graphql_request.query.as_deref(),
+                    Some(APQ_TEST_QUERY),
+                    "retry should send the original query string"
+                );
+                assert_eq!(
+                    graphql_request.operation_name.as_deref(),
+                    Some("MyOp"),
+                    "operation_name should be preserved on retry"
+                );
+                assert_eq!(
+                    graphql_request.variables.get("id"),
+                    Some(&serde_json_bytes::json!("42")),
+                    "variables should be preserved on retry"
+                );
+
+                let success_response = Response {
+                    data: Some(Value::String(ByteString::from("test"))),
+                    ..Response::default()
+                };
+                Ok(http::Response::builder()
+                    .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                    .status(StatusCode::OK)
+                    .body(serde_json::to_string(&success_response).unwrap().into())
+                    .unwrap())
+            }
+
+            let gql_body = graphql::Request {
+                query: Some(APQ_TEST_QUERY.to_string()),
+                operation_name: Some("MyOp".to_string()),
+                variables: serde_json_bytes::json!({"id": "42"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                extensions: serde_json_bytes::json!({"myExt": "value"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            };
+            let response = run_apq_test(gql_body, handle).await.response.into_body();
+            assert_eq!(response.data, Some(Value::String(ByteString::from("test"))));
+            assert!(response.errors.is_empty());
+        }
     }
 
     #[test]

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -3159,6 +3159,81 @@ mod tests {
             assert_eq!(response.data, Some(Value::String(ByteString::from("test"))));
             assert!(response.errors.is_empty());
         }
+
+        // Verifies that on a PersistedQueryNotSupported retry, the full original body is
+        // restored: the query is present, the persistedQuery extension is removed, and any
+        // other extensions are preserved. The mock server handler distinguishes the first
+        // attempt (no query) from the retry (query present) and asserts on the retry body.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_apq_not_supported_retry_restores_original_body() {
+            async fn handle(
+                request: http::Request<Body>,
+            ) -> Result<http::Response<Body>, Infallible> {
+                let bytes = router::body::into_bytes(request.into_body())
+                    .await
+                    .expect("can read request body");
+                let graphql_request: graphql::Request =
+                    serde_json::from_reader(bytes.reader()).expect("valid graphql request");
+
+                if graphql_request.query.is_none() {
+                    // First attempt: return PersistedQueryNotSupported
+                    let pqns_response = Response {
+                        errors: vec![
+                            Error::builder()
+                                .message(PERSISTED_QUERY_NOT_SUPPORTED_MESSAGE)
+                                .build(),
+                        ],
+                        ..Response::default()
+                    };
+                    return Ok(http::Response::builder()
+                        .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                        .status(StatusCode::OK)
+                        .body(serde_json::to_string(&pqns_response).unwrap().into())
+                        .unwrap());
+                }
+
+                // Second attempt: verify the retry body is the full original body
+                assert_eq!(
+                    graphql_request.query.as_deref(),
+                    Some(APQ_TEST_QUERY),
+                    "retry should send the original query string"
+                );
+                assert!(
+                    !graphql_request.extensions.contains_key(PERSISTED_QUERY_KEY),
+                    "persistedQuery extension should be removed on retry"
+                );
+                assert!(
+                    graphql_request.extensions.contains_key("myExt"),
+                    "other extensions should be preserved on retry"
+                );
+
+                let success_response = Response {
+                    data: Some(Value::String(ByteString::from("test"))),
+                    ..Response::default()
+                };
+                Ok(http::Response::builder()
+                    .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                    .status(StatusCode::OK)
+                    .body(serde_json::to_string(&success_response).unwrap().into())
+                    .unwrap())
+            }
+
+            let gql_body = graphql::Request {
+                query: Some(APQ_TEST_QUERY.to_string()),
+                operation_name: Some("MyOp".to_string()),
+                variables: serde_json_bytes::json!({"id": "42"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                extensions: serde_json_bytes::json!({"myExt": "value"})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            };
+            let response = run_apq_test(gql_body, handle).await.response.into_body();
+            assert_eq!(response.data, Some(Value::String(ByteString::from("test"))));
+            assert!(response.errors.is_empty());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Inspired by #9203, this PR extends the work done there to avoid unnecessary clones in the subgraph request path:

- **Avoid cloning `SubgraphRequest` on every fetch**: Rather than cloning the full request upfront and working from the clone, keep the body inside `SubgraphRequest` at all times. On the non-APQ path, no clone is needed at all. On the APQ path, `request.clone()` is still required for the first attempt (in case of retries), but the body fields are no longer separately duplicated.
- **Avoid cloning `operation_name` and `variables` in the APQ path**: Instead of constructing a new `graphql::Request` struct for the APQ body and swapping it in with `mem::replace`, mutate the existing body in-place. `query.take()` sets the query to `None` and saves it for retries; the `persistedQuery` hash is inserted directly into the existing extensions map. On `PersistedQueryNotSupported`, the key is removed rather than restoring a cloned copy. This eliminates all field clones in the APQ path except `request.clone()`.
- **Refactor `BatchQueryInfo`**: Remove the redundant `gql_request` field; `assemble_batch` now extracts bodies from requests via `into_parts()` rather than relying on a separately-stored copy.
- **Tests**: Add an `apq_body_preservation` test module covering that `operation_name`, `variables`, and custom extensions are preserved in the APQ first-attempt body, and that the full original body is restored correctly on `PersistedQueryNotFound` retry.

## Reviewing by commit

This PR is easiest to review commit-by-commit:

1. `869f87e` — core change: avoid cloning subgraph request body on every fetch
2. `9576208` — refactor: remove redundant `gql_request` from `BatchQueryInfo`
3. `deaef4d` — chore: formatting and pre-allocate vec in `assemble_batch`
4. `fcaf485` — test: add APQ field preservation tests
5. `acc7d3a` — perf: avoid cloning `operation_name` and `variables` in APQ path

## Test plan

- [ ] All existing `subgraph_service` and `batching` unit tests pass
- [ ] New `apq_body_preservation` tests verify field preservation through the APQ flow