### PR TITLE
feat(telemetry): add stream_duration instrument value

### DIFF
--- a/.changesets/feat_ebylund_stream_duration_instrument.md
+++ b/.changesets/feat_ebylund_stream_duration_instrument.md
@@ -1,4 +1,4 @@
-### Add `stream_duration` instrument for streamed response lifecycle metrics ([PR #XXXX](https://github.com/apollographql/router/pull/XXXX))
+### Add `stream_duration` instrument for streamed response lifecycle metrics ([PR #9269](https://github.com/apollographql/router/pull/9269))
 
 Supergraph instruments now support a new `stream_duration` value that records the wall-clock time between when the supergraph response object is ready and when the response stream closes. This covers the full lifecycle of `@defer` and subscription responses — which `http.server.request.duration` does not capture, since that metric fires when the response object is prepared, before deferred chunks are emitted.
 
@@ -18,4 +18,4 @@ telemetry:
 
 Combine it with any supergraph attributes — including custom selectors — to segment the metric by operation, client, or whatever else you already use on other supergraph instruments.
 
-By [@ebylund](https://github.com/ebylund) in https://github.com/apollographql/router/pull/XXXX
+By [@ebylund](https://github.com/ebylund) in https://github.com/apollographql/router/pull/9269

--- a/.changesets/feat_ebylund_stream_duration_instrument.md
+++ b/.changesets/feat_ebylund_stream_duration_instrument.md
@@ -1,0 +1,21 @@
+### Add `stream_duration` instrument for streamed response lifecycle metrics ([PR #XXXX](https://github.com/apollographql/router/pull/XXXX))
+
+Supergraph instruments now support a new `stream_duration` value that records the wall-clock time between when the supergraph response object is ready and when the response stream closes. This covers the full lifecycle of `@defer` and subscription responses — which `http.server.request.duration` does not capture, since that metric fires when the response object is prepared, before deferred chunks are emitted.
+
+The instrument fires exactly once per request, on normal stream completion. Cancelled or errored streams do not emit a sample.
+
+```yaml
+telemetry:
+  instrumentation:
+    instruments:
+      supergraph:
+        acme.stream.duration:
+          description: End-to-end time from first chunk to last chunk on streamed responses
+          type: histogram
+          unit: s
+          value: stream_duration
+```
+
+Combine it with any supergraph attributes — including custom selectors — to segment the metric by operation, client, or whatever else you already use on other supergraph instruments.
+
+By [@ebylund](https://github.com/ebylund) in https://github.com/apollographql/router/pull/XXXX

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -6812,6 +6812,15 @@ expression: "&schema"
       "description": "The license enforcement plugin has no configuration.",
       "type": "object"
     },
+    "Lifecycle": {
+      "oneOf": [
+        {
+          "const": "stream_duration",
+          "description": "Duration of the full response-stream lifecycle — wall-clock elapsed from the moment\nthe supergraph response is ready until the stream closes. Captures the `@defer`\nor subscription tail that `http.server.request.duration` misses. Recorded once per\nrequest, on normal stream completion.",
+          "type": "string"
+        }
+      ]
+    },
     "LimitsConfig": {
       "additionalProperties": false,
       "description": "Configuration for operation limits, parser limits, HTTP limits, etc.",
@@ -12104,6 +12113,9 @@ expression: "&schema"
         },
         {
           "$ref": "#/definitions/Event5"
+        },
+        {
+          "$ref": "#/definitions/Lifecycle"
         },
         {
           "$ref": "#/definitions/SupergraphSelector"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/tests.rs
-assertion_line: 28
 expression: "&schema"
 ---
 {
@@ -6813,6 +6812,7 @@ expression: "&schema"
       "type": "object"
     },
     "Lifecycle": {
+      "description": "Lifecycle-anchored instrument values: emit once per request at a specific point in\nthe response-stream lifecycle (currently only stream end). Sibling to `Standard`\n(request-level) and `Event` (per-chunk) value-shapes; future variants would cover\nother stream-anchored emissions (e.g. first-byte, item-count).",
       "oneOf": [
         {
           "const": "stream_duration",

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/schema.json
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/schema.json
@@ -537,6 +537,11 @@
             "connector_response"
           ],
           "additionalProperties": false
+        },
+        {
+          "description": "Fires `on_stream_end` on the current supergraph instruments. Use after any\nper-chunk `graphql_response` events to simulate the response stream closing\nnormally (e.g. the last `@defer` chunk).",
+          "type": "string",
+          "const": "supergraph_stream_end"
         }
       ]
     },

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/custom_histogram_stream_duration/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/custom_histogram_stream_duration/metrics.snap
@@ -1,0 +1,24 @@
+---
+source: apollo-router/src/plugins/telemetry/config_new/instruments.rs
+description: Custom histogram stream_duration
+expression: "&metrics.all()"
+info:
+  telemetry:
+    instrumentation:
+      instruments:
+        default_requirement_level: none
+        supergraph:
+          custom.histogram.stream.duration:
+            description: histogram of streamed response lifecycle duration
+            type: histogram
+            unit: s
+            value: stream_duration
+---
+- name: custom.histogram.stream.duration
+  description: histogram of streamed response lifecycle duration
+  unit: s
+  data:
+    datapoints:
+      - sum: 0.1
+        count: 1
+        attributes: {}

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/custom_histogram_stream_duration/router.yaml
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/custom_histogram_stream_duration/router.yaml
@@ -1,0 +1,10 @@
+telemetry:
+  instrumentation:
+    instruments:
+      default_requirement_level: none
+      supergraph:
+        "custom.histogram.stream.duration":
+          description: "histogram of streamed response lifecycle duration"
+          type: histogram
+          unit: "s"
+          value: stream_duration

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/custom_histogram_stream_duration/test.yaml
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/custom_histogram_stream_duration/test.yaml
@@ -1,0 +1,28 @@
+description: Custom histogram stream_duration
+events:
+  - - router_request:
+        uri: "/"
+        method: POST
+        body: |
+          {"query":"{ primary ... @defer { deferred } }"}
+    - supergraph_request:
+        uri: "/"
+        method: POST
+        headers:
+          accept: multipart/mixed; deferSpec=20220824
+        query: "{ primary ... @defer { deferred } }"
+    - graphql_response:
+        data:
+          primary: "ready"
+    - graphql_response:
+        data:
+          deferred: "late"
+    - supergraph_stream_end
+    - supergraph_response:
+        status: 200
+        data:
+          primary: "ready"
+    - router_response:
+        body: |
+          {"data":{"primary":"ready"}}
+        status: 200

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -2473,14 +2473,22 @@ where
             inner.increment = new_incr;
         }
 
-        let increment = match &inner.increment {
+        let increment = match &mut inner.increment {
             Increment::Unit => Some(opentelemetry::Value::F64(1.0)),
             Increment::Duration(instant, unit) => Some(duration_to_value(instant.elapsed(), unit)),
             Increment::Custom(val) => val.clone(),
+            Increment::StreamDuration(instant, _) => {
+                // stream_duration is conceptually "response ready → stream close".
+                // The Instant captured at instrument construction sits at request
+                // start; reset it here so on_stream_end measures only the stream
+                // tail, not the full request-to-stream-close span. The histogram
+                // sample is recorded later in on_stream_end.
+                *instant = Instant::now();
+                return;
+            }
             Increment::EventUnit
             | Increment::EventDuration(_, _)
             | Increment::EventCustom(_)
-            | Increment::StreamDuration(_, _)
             | Increment::FieldUnit
             | Increment::FieldCustom(_) => {
                 // Nothing to do because we're incrementing on events, fields, or stream end

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -1430,6 +1430,7 @@ pub(crate) enum InstrumentValue<T> {
     Chunked(Event<T>),
     Field(Field<T>),
     Custom(T),
+    Stream(Lifecycle),
 }
 
 #[derive(Clone, Deserialize, JsonSchema, Debug)]
@@ -1470,6 +1471,20 @@ pub(crate) enum Field<T> {
     Custom(T),
 }
 
+/// Lifecycle-anchored instrument values: emit once per request at a specific point in
+/// the response-stream lifecycle (currently only stream end). Sibling to `Standard`
+/// (request-level) and `Event` (per-chunk) value-shapes; future variants would cover
+/// other stream-anchored emissions (e.g. first-byte, item-count).
+#[derive(Clone, Deserialize, JsonSchema, Debug)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub(crate) enum Lifecycle {
+    /// Duration of the full response-stream lifecycle — wall-clock elapsed from the moment
+    /// the supergraph response is ready until the stream closes. Captures the `@defer`
+    /// or subscription tail that `http.server.request.duration` misses. Recorded once per
+    /// request, on normal stream completion.
+    StreamDuration,
+}
+
 pub(crate) trait Instrumented {
     type Request;
     type Response;
@@ -1486,6 +1501,10 @@ pub(crate) trait Instrumented {
         _ctx: &Context,
     ) {
     }
+    /// Called once when a streamed response fully drains (e.g. the last `@defer` chunk
+    /// emits). Default no-op; instruments whose value is `stream_duration` use this to
+    /// record the elapsed lifecycle.
+    fn on_stream_end(&self, _ctx: &Context) {}
     fn on_error(&self, error: &BoxError, ctx: &Context);
 }
 
@@ -1522,6 +1541,10 @@ where
         ctx: &Context,
     ) {
         self.attributes.on_response_field(ty, field, value, ctx);
+    }
+
+    fn on_stream_end(&self, ctx: &Context) {
+        self.attributes.on_stream_end(ctx);
     }
 
     fn on_error(&self, error: &BoxError, ctx: &Context) {
@@ -1602,6 +1625,12 @@ where
                                 (Some(Arc::new(selector)), Increment::FieldCustom(None))
                             }
                         },
+                        InstrumentValue::Stream(_) => {
+                            failfast_error!(
+                                "stream_duration is only supported on histograms; skipping counter instrument {instrument_name:?}"
+                            );
+                            continue;
+                        }
                     };
                     match static_instruments
                         .get(instrument_name)
@@ -1662,6 +1691,12 @@ where
                             Field::Custom(selector) => {
                                 (Some(Arc::new(selector)), Increment::FieldCustom(None))
                             }
+                        },
+                        InstrumentValue::Stream(incr) => match incr {
+                            Lifecycle::StreamDuration => (
+                                None,
+                                Increment::StreamDuration(Instant::now(), instrument.unit.clone()),
+                            ),
                         },
                     };
 
@@ -1767,6 +1802,15 @@ where
             histogram.on_response_field(ty, field, value, ctx);
         }
     }
+
+    fn on_stream_end(&self, ctx: &Context) {
+        for counter in &self.counters {
+            counter.on_stream_end(ctx);
+        }
+        for histogram in &self.histograms {
+            histogram.on_stream_end(ctx);
+        }
+    }
 }
 
 pub(crate) struct SupergraphInstruments {
@@ -1798,6 +1842,11 @@ impl Instrumented for SupergraphInstruments {
         self.cost.on_response_event(response, ctx);
         self.custom.on_response_event(response, ctx);
     }
+
+    fn on_stream_end(&self, ctx: &Context) {
+        self.cost.on_stream_end(ctx);
+        self.custom.on_stream_end(ctx);
+    }
 }
 
 // ---------------- Counter -----------------------
@@ -1808,6 +1857,9 @@ pub(crate) enum Increment {
     FieldUnit,
     Duration(Instant, String),
     EventDuration(Instant, String),
+    // Timer started at instrument creation, recorded once when the response stream closes.
+    // Only valid for histograms.
+    StreamDuration(Instant, String),
     Custom(Option<opentelemetry::Value>),
     EventCustom(Option<opentelemetry::Value>),
     FieldCustom(Option<opentelemetry::Value>),
@@ -1937,6 +1989,10 @@ where
     fn on_response(&self, response: &Self::Response) {
         let mut inner = self.inner.lock();
         if !inner.condition.evaluate_response(response) {
+            // Stream-lifecycle instruments are intentionally NOT in this keep-list:
+            // their condition is evaluated against the response (not per chunk), so a
+            // failed response-level condition should drop the instrument now and
+            // prevent any later on_stream_end emission.
             if !matches!(
                 &inner.increment,
                 Increment::EventCustom(_)
@@ -1982,9 +2038,10 @@ where
             Increment::EventUnit
             | Increment::EventDuration(_, _)
             | Increment::EventCustom(_)
+            | Increment::StreamDuration(_, _)
             | Increment::FieldUnit
             | Increment::FieldCustom(_) => {
-                // Nothing to do because we're incrementing on events or fields
+                // Nothing to do because we're incrementing on events, fields, or stream end
                 return;
             }
         } {
@@ -2067,6 +2124,11 @@ where
             Increment::Duration(instant, unit) | Increment::EventDuration(instant, unit) => {
                 duration_to_value(instant.elapsed(), unit)
             }
+            Increment::StreamDuration(_, _) => {
+                // Stream-lifecycle instruments do not emit on error — an errored request
+                // never reached normal stream completion, so no lifecycle duration is defined.
+                return;
+            }
             Increment::Custom(val) | Increment::EventCustom(val) | Increment::FieldCustom(val) => {
                 val.as_ref()
                     .cloned()
@@ -2079,6 +2141,10 @@ where
         {
             counter.add(value, &attrs);
         }
+    }
+
+    fn on_stream_end(&self, _ctx: &Context) {
+        // stream_duration is histogram-only — see CustomInstruments::new. Counters skip.
     }
 
     fn on_response_field(
@@ -2121,6 +2187,7 @@ where
             | Increment::Duration(_, _)
             | Increment::Custom(_)
             | Increment::EventDuration(_, _)
+            | Increment::StreamDuration(_, _)
             | Increment::EventCustom(_)
             | Increment::EventUnit => {
                 // Nothing to do because we're incrementing on fields
@@ -2175,11 +2242,14 @@ where
                     Increment::Custom(val) | Increment::EventCustom(val) => {
                         val.as_ref().and_then(value_to_f64)
                     }
-                    Increment::FieldUnit | Increment::FieldCustom(_) => {
-                        // Dropping a metric on a field will never increment.
-                        // We can't increment graphql metrics unless we actually process the result.
-                        // It's not like we're counting the number of requests, where we want to increment
-                        // with the data that we know so far if the request stops.
+                    Increment::StreamDuration(_, _)
+                    | Increment::FieldUnit
+                    | Increment::FieldCustom(_) => {
+                        // Stream-lifecycle instruments only emit on normal stream close
+                        // (via on_stream_end); a dropped / cancelled stream does not emit.
+                        // Field instruments likewise cannot emit on drop — we can't
+                        // increment GraphQL field metrics unless we actually processed
+                        // the result.
                         return;
                     }
                 }
@@ -2364,6 +2434,8 @@ where
     fn on_response(&self, response: &Self::Response) {
         let mut inner = self.inner.lock();
         if !inner.condition.evaluate_response(response) {
+            // See sibling note in CustomCounter::on_response — StreamDuration is gated
+            // here, not in on_stream_end.
             if !matches!(
                 &inner.increment,
                 Increment::EventCustom(_)
@@ -2408,9 +2480,10 @@ where
             Increment::EventUnit
             | Increment::EventDuration(_, _)
             | Increment::EventCustom(_)
+            | Increment::StreamDuration(_, _)
             | Increment::FieldUnit
             | Increment::FieldCustom(_) => {
-                // Nothing to do because we're incrementing on events or fields
+                // Nothing to do because we're incrementing on events, fields, or stream end
                 return;
             }
         };
@@ -2465,6 +2538,7 @@ where
             Increment::Unit
             | Increment::Duration(_, _)
             | Increment::Custom(_)
+            | Increment::StreamDuration(_, _)
             | Increment::FieldUnit
             | Increment::FieldCustom(_) => {
                 // Nothing to do because we're incrementing on events
@@ -2492,6 +2566,10 @@ where
             }
             Increment::Duration(instant, unit) | Increment::EventDuration(instant, unit) => {
                 Some(duration_to_value(instant.elapsed(), unit))
+            }
+            Increment::StreamDuration(_, _) => {
+                // Stream-lifecycle instruments do not emit on error — see CustomCounter::on_error.
+                return;
             }
             Increment::Custom(val) | Increment::EventCustom(val) | Increment::FieldCustom(val) => {
                 val.clone()
@@ -2545,6 +2623,7 @@ where
             | Increment::Duration(_, _)
             | Increment::Custom(_)
             | Increment::EventDuration(_, _)
+            | Increment::StreamDuration(_, _)
             | Increment::EventCustom(_)
             | Increment::EventUnit => {
                 // Nothing to do because we're incrementing on fields
@@ -2573,6 +2652,18 @@ where
             inner.attributes.truncate(original_length);
         }
     }
+
+    fn on_stream_end(&self, _ctx: &Context) {
+        let mut inner = self.inner.lock();
+        let value = match &inner.increment {
+            Increment::StreamDuration(instant, unit) => duration_to_value(instant.elapsed(), unit),
+            _ => return,
+        };
+        if let (Some(histogram), Some(sample)) = (&inner.histogram, value_to_f64(&value)) {
+            histogram.record(sample, &inner.attributes);
+            inner.updated = true;
+        }
+    }
 }
 
 impl<A, T, Request, Response, EventResponse> Drop
@@ -2596,11 +2687,14 @@ where
                         Some(duration_to_value(instant.elapsed(), unit))
                     }
                     Increment::Custom(val) | Increment::EventCustom(val) => val.clone(),
-                    Increment::FieldUnit | Increment::FieldCustom(_) => {
-                        // Dropping a metric on a field will never increment.
-                        // We can't increment graphql metrics unless we actually process the result.
-                        // It's not like we're counting the number of requests, where we want to increment
-                        // with the data that we know so far if the request stops.
+                    Increment::StreamDuration(_, _)
+                    | Increment::FieldUnit
+                    | Increment::FieldCustom(_) => {
+                        // Stream-lifecycle instruments only emit on normal stream close —
+                        // a dropped / cancelled stream does not produce a duration sample.
+                        // Field instruments likewise cannot emit on drop — we can't
+                        // increment GraphQL field metrics unless we actually processed
+                        // the result.
                         return;
                     }
                 };
@@ -2807,6 +2901,10 @@ mod tests {
             #[schemars(with = "Option<serde_json::Value>")]
             mapping_problems: Vec<Problem>,
         },
+        /// Fires `on_stream_end` on the current supergraph instruments. Use after any
+        /// per-chunk `graphql_response` events to simulate the response stream closing
+        /// normally (e.g. the last `@defer` chunk).
+        SupergraphStreamEnd,
     }
 
     #[derive(Deserialize, JsonSchema)]
@@ -3390,6 +3488,14 @@ mod tests {
                                         .take()
                                         .expect("connector request must have been made first")
                                         .on_response(&response);
+                                }
+                                Event::SupergraphStreamEnd => {
+                                    supergraph_instruments
+                                        .as_ref()
+                                        .expect(
+                                            "supergraph request event should have happened first",
+                                        )
+                                        .on_stream_end(&context);
                                 }
                             }
                         }

--- a/apollo-router/src/plugins/telemetry/config_new/supergraph/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/supergraph/selectors.rs
@@ -19,6 +19,7 @@ use crate::plugins::telemetry::config_new::cost::CostValue;
 use crate::plugins::telemetry::config_new::get_baggage;
 use crate::plugins::telemetry::config_new::instruments::Event;
 use crate::plugins::telemetry::config_new::instruments::InstrumentValue;
+use crate::plugins::telemetry::config_new::instruments::Lifecycle;
 use crate::plugins::telemetry::config_new::instruments::Standard;
 use crate::plugins::telemetry::config_new::selectors::ErrorRepr;
 use crate::plugins::telemetry::config_new::selectors::OperationKind;
@@ -34,6 +35,7 @@ use crate::spec::operation_limits::OperationLimits;
 pub(crate) enum SupergraphValue {
     Standard(Standard),
     Event(Event<SupergraphSelector>),
+    Stream(Lifecycle),
     Custom(SupergraphSelector),
 }
 
@@ -48,6 +50,7 @@ impl From<&SupergraphValue> for InstrumentValue<SupergraphSelector> {
                 _ => InstrumentValue::Custom(selector.clone()),
             },
             SupergraphValue::Event(e) => InstrumentValue::Chunked(e.clone()),
+            SupergraphValue::Stream(l) => InstrumentValue::Stream(l.clone()),
         }
     }
 }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -166,6 +166,7 @@ pub(crate) mod reload;
 pub(crate) mod resource;
 pub(crate) mod span_ext;
 mod span_factory;
+mod stream_end;
 pub(crate) mod tracing;
 pub(crate) mod utils;
 
@@ -1359,6 +1360,11 @@ impl Telemetry {
         // Wait for the first response of the stream
         let (parts, stream) = response.response.into_parts();
         let config_cloned = config.clone();
+        // Shared between the per-chunk inspect and the end-of-stream hook below; both
+        // dispatch to the same supergraph instruments.
+        let custom_instruments = Arc::new(custom_instruments);
+        let instruments_for_chunk = custom_instruments.clone();
+        let ctx_for_chunk = ctx.clone();
         let stream = stream.inspect(move |resp| {
             let span = Span::current();
             span.set_span_dyn_attributes(
@@ -1367,20 +1373,21 @@ impl Telemetry {
                     .spans
                     .supergraph
                     .attributes
-                    .on_response_event(resp, &ctx),
+                    .on_response_event(resp, &ctx_for_chunk),
             );
-            custom_instruments.on_response_event(resp, &ctx);
-            custom_events.on_response_event(resp, &ctx);
-            custom_graphql_instruments.on_response_event(resp, &ctx);
+            instruments_for_chunk.on_response_event(resp, &ctx_for_chunk);
+            custom_events.on_response_event(resp, &ctx_for_chunk);
+            custom_graphql_instruments.on_response_event(resp, &ctx_for_chunk);
         });
         let (first_response, rest) = StreamExt::into_future(stream).await;
 
-        let response = http::Response::from_parts(
-            parts,
-            once(ready(first_response.unwrap_or_default()))
-                .chain(rest)
-                .boxed(),
-        );
+        let chained = once(ready(first_response.unwrap_or_default())).chain(rest);
+        let instruments_for_end = custom_instruments;
+        let observed = stream_end::StreamEndObserver::new(chained, move || {
+            instruments_for_end.on_stream_end(&ctx);
+        });
+
+        let response = http::Response::from_parts(parts, observed.boxed());
 
         Ok(SupergraphResponse { context, response })
     }

--- a/apollo-router/src/plugins/telemetry/stream_end.rs
+++ b/apollo-router/src/plugins/telemetry/stream_end.rs
@@ -1,0 +1,101 @@
+//! Stream combinator that fires a one-shot callback when a `Stream` completes normally
+//! (i.e. `poll_next` returns `Poll::Ready(None)`). Used to drive `on_stream_end` telemetry
+//! hooks — see `crate::plugins::telemetry::config_new::instruments::Instrumented::on_stream_end`.
+//!
+//! Drop without normal completion deliberately does not fire the callback: a cancelled
+//! or client-disconnected stream has no well-defined lifecycle duration.
+
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+use futures::Stream;
+use pin_project_lite::pin_project;
+
+pin_project! {
+    pub(crate) struct StreamEndObserver<S, F>
+    where
+        F: FnOnce(),
+    {
+        #[pin]
+        inner: S,
+        on_end: Option<F>,
+    }
+}
+
+impl<S, F> StreamEndObserver<S, F>
+where
+    F: FnOnce(),
+{
+    pub(crate) fn new(inner: S, on_end: F) -> Self {
+        Self {
+            inner,
+            on_end: Some(on_end),
+        }
+    }
+}
+
+impl<S, F> Stream for StreamEndObserver<S, F>
+where
+    S: Stream,
+    F: FnOnce(),
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        match this.inner.poll_next(cx) {
+            Poll::Ready(None) => {
+                if let Some(cb) = this.on_end.take() {
+                    cb();
+                }
+                Poll::Ready(None)
+            }
+            other => other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use futures::StreamExt;
+    use futures::stream;
+
+    use super::StreamEndObserver;
+
+    #[tokio::test]
+    async fn fires_once_on_normal_completion() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_for_cb = count.clone();
+        let inner = stream::iter(vec![1, 2, 3]);
+        let observed = StreamEndObserver::new(inner, move || {
+            count_for_cb.fetch_add(1, Ordering::SeqCst);
+        });
+
+        let items: Vec<i32> = observed.collect().await;
+
+        assert_eq!(items, vec![1, 2, 3]);
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn does_not_fire_when_dropped_before_completion() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_for_cb = count.clone();
+        let inner = stream::iter(vec![1, 2, 3]);
+        let mut observed = Box::pin(StreamEndObserver::new(inner, move || {
+            count_for_cb.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        // Pull a single item then drop the stream — emulates a client disconnect
+        // partway through the response.
+        assert_eq!(observed.next().await, Some(1));
+        drop(observed);
+
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+    }
+}

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/instruments.mdx
@@ -351,12 +351,31 @@ The [service](#router-request-lifecycle-services) you define an instrument on de
 
 </td>
 </tr>
+<tr>
+<td>
+
+##### `stream_duration`
+
+</td>
+<td>The wall-clock duration of the full response-stream lifecycle — from the moment the supergraph response is ready until the response stream closes. Captures the `@defer` or subscription tail that `duration` (which fires on the response object, before streaming) does not. Histogram-only; recorded once per request, on normal stream completion.</td>
+<td>
+
+`supergraph`
+
+</td>
+</tr>
 </tbody>
 </table>
 
 <Note>
 
 `event_*` are mandantory when you want to use a [selector](/router/configuration/telemetry/instrumentation/selectors) on the supergraph response body (`response_data` and `response_errors`).
+
+</Note>
+
+<Note>
+
+Use `stream_duration` to capture how long a streamed response takes to fully drain — for example, the total time between the first and last chunk of a `@defer` query. The built-in `http.server.request.duration` only captures time up to when the router's response object is ready, which excludes the deferred tail. `stream_duration` does not emit on errored or cancelled streams — only on normal completion.
 
 </Note>
 
@@ -415,7 +434,7 @@ telemetry:
 
 ##### Duration unit conversion
 
-For instruments with `value: duration` or `value: event_duration`, the router automatically converts the measured duration to match the configured `unit`. This feature supports the following time units:
+For instruments with `value: duration`, `value: event_duration`, or `value: stream_duration`, the router automatically converts the measured duration to match the configured `unit`. This feature supports the following time units:
 
 - `s` - seconds (default, recommended)
 - `ms` - milliseconds
@@ -561,7 +580,7 @@ telemetry:
 | `type`                      | `counter` \| `histogram`                                                         |            | The name of the custom instrument.            |
 | `unit`                      |                                                                                |            | A unit name, for example `By` or `{request}`. |
 | `description`               |                                                                                |            | The description of the custom instrument.     |
-| `value`                     | `unit` \| `duration` \| `<custom>` \| `event_unit` \| `event_duration` \| `event_custom` |            | The value of the instrument.                  |
+| `value`                     | `unit` \| `duration` \| `<custom>` \| `event_unit` \| `event_duration` \| `event_custom` \| `stream_duration` |            | The value of the instrument.                  |
 
 ### Production instrumentation example
 


### PR DESCRIPTION
Fixes #9242 (option B).

## Summary

Adds a new `stream_duration` value-shape for supergraph custom instruments. Records the wall-clock time between the supergraph response being ready and the response stream closing — i.e. the full `@defer` or subscription lifecycle that `http.server.request.duration` does not currently capture (it fires on response-object preparation, before any deferred chunks are emitted).

```yaml
telemetry:
  instrumentation:
    instruments:
      supergraph:
        acme.stream.duration:
          description: End-to-end time from response ready to last chunk
          type: histogram
          unit: s
          value: stream_duration
```

Combine with any supergraph attributes — once #9262 lands, `is_deferred` becomes a natural attribute to segment by.

## Why a new instrument vs. extending `http.server.request.duration`

Option A in #9242 was to extend the supergraph span / `http.server.request.duration` to cover the full stream lifecycle. We chose option B (separate instrument) per concerns raised in the GraphOS observability guild thread — extending the standard instrument would change the semantics of the most widely used router-health signal so deferred queries skew it. Option B keeps the existing metric stable and makes the streaming-tail measurement opt-in. Long-term this kind of metric is a candidate for the OpenTelemetry GraphQL working group; until there's a standard, the Router-specific name and opt-in posture seems right.

## Implementation

1. New `Lifecycle::StreamDuration` value-shape and `Increment::StreamDuration(Instant, String)` increment in `apollo-router/src/plugins/telemetry/config_new/instruments.rs`. Instant is captured at instrument construction; emission happens once on stream close.
2. `Instrumented::on_stream_end(&self, ctx: &Context)` trait hook (default no-op). Implemented for real on `CustomHistogram`; `CustomCounter` is a no-op since `value: stream_duration` on a counter is rejected at `CustomInstruments::new` time.
3. Small pin-projected `StreamEndObserver` combinator (`apollo-router/src/plugins/telemetry/stream_end.rs`) that fires a one-shot callback when the wrapped stream returns `Poll::Ready(None)`. Drop without normal completion deliberately does not fire — a cancelled or client-disconnected stream has no well-defined lifecycle duration.
4. Wired into `update_otel_metrics` in `apollo-router/src/plugins/telemetry/mod.rs`; `SupergraphInstruments` is `Arc`-shared between the per-chunk `inspect` closure and the end-of-stream callback.
5. Condition gating happens at `on_response` time (response-level data only). A failed `condition: ...` causes the histogram to be taken there, so `on_stream_end` no-ops — same lifecycle as `Standard::Duration`.

## Tests

- New fixture `custom_histogram_stream_duration` exercising the happy path through the data-driven `test_instruments` runner. Adds a `supergraph_stream_end` event variant.
- Unit tests on the `StreamEndObserver` combinator covering normal completion (callback fires once) and partial-drop (callback does not fire).

A full integration test against a real `@defer` query + slow subgraph is deferred — the pattern lands cleanly once #9238's integration tests are merged. Will follow up.

## Open questions for review

I made these calls in absence of guidance — would like sign-off:

1. **Custom instrument value-shape (`value: stream_duration`) vs. built-in standard instrument.** Picked the former so users can name and attribute the metric themselves and stack it with `is_deferred` from #9262. Alternative would be a built-in like `http.server.stream_duration` toggled on/off.
2. **Timer starts at supergraph response ready** (i.e. wrapper construction in `update_otel_metrics`), not literal first-chunk emission. Differs by microseconds in practice. The docs describe this semantic explicitly.
3. **Fires only on `Poll::Ready(None)`, not on `Drop`.** A cancelled stream produces no sample. Documented.
4. **Wired in `telemetry/mod.rs` (plugin layer)** rather than `services/supergraph/service.rs` — the plugin is where `SupergraphInstruments` is in scope.

## Sibling PRs

- #9238 — `is_primary_response` selector fix (still pending merge).
- #9262 — `is_deferred` subgraph selector (DRAFT).

Together with this PR, the three address the `@defer` observability gaps tracked in #9240 / #9241 / #9242.