### PR TITLE
perf(cache): bypass deduplication for in-memory cache hits

### DIFF
--- a/.changesets/feat_dedup_cache_fast_path.md
+++ b/.changesets/feat_dedup_cache_fast_path.md
@@ -2,6 +2,6 @@
 
 Every query plan cache lookup — including cache hits — previously acquired the `wait_map` mutex before checking whether the value was in memory. On a warm cache this was pure overhead: the mutex was locked twice, a `broadcast::Sender` was allocated, and a cleanup task was spawned, all to be immediately discarded.
 
-A fast path now checks the in-memory cache before acquiring the mutex. On a hit the value is returned immediately; the wait_map path is only entered on a miss, which is the only case where deduplication is needed. Measured improvement of +1.8–3.7% throughput at production-relevant concurrency levels (c=16–64) on a 32-vCPU instance.
+A fast path now checks the in-memory cache before acquiring the mutex. On a hit the value is returned immediately; the wait_map path is only entered on a miss, which is the only case where deduplication is needed.
 
 By [@theJC](https://github.com/theJC) in https://github.com/apollographql/router/pull/9273

--- a/.changesets/feat_dedup_cache_fast_path.md
+++ b/.changesets/feat_dedup_cache_fast_path.md
@@ -1,0 +1,7 @@
+### Improve query plan cache throughput with an in-memory fast path ([PR #9273](https://github.com/apollographql/router/pull/9273))
+
+Every query plan cache lookup — including cache hits — previously acquired the `wait_map` mutex before checking whether the value was in memory. On a warm cache this was pure overhead: the mutex was locked twice, a `broadcast::Sender` was allocated, and a cleanup task was spawned, all to be immediately discarded.
+
+A fast path now checks the in-memory cache before acquiring the mutex. On a hit the value is returned immediately; the wait_map path is only entered on a miss, which is the only case where deduplication is needed. Measured improvement of +1.8–3.7% throughput at production-relevant concurrency levels (c=16–64) on a 32-vCPU instance.
+
+By [@theJC](https://github.com/theJC) in https://github.com/apollographql/router/pull/9273

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ dependencies = [
  "apollo-smith",
  "arbitrary",
  "criterion",
+ "futures",
  "memory-stats",
  "once_cell",
  "rhai",

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dev-dependencies]
 apollo-router = { path = "../apollo-router" }
 criterion = { version = "0.8", features = ["async_tokio", "async_futures"] }
+futures = "0.3"
 memory-stats = "1.1.0"
 once_cell.workspace = true
 rhai = { version = "1.23.6", features = ["sync", "serde", "internals"] }
@@ -31,4 +32,8 @@ harness = false
 
 [[bench]]
 name = "rhai_string_interning"
+harness = false
+
+[[bench]]
+name = "query_plan_cache_concurrency"
 harness = false

--- a/apollo-router-benchmarks/benches/query_plan_cache_concurrency.rs
+++ b/apollo-router-benchmarks/benches/query_plan_cache_concurrency.rs
@@ -1,0 +1,272 @@
+//! Benchmark: concurrent cache-hit throughput through the query plan cache.
+//!
+//! Sweeps concurrency from 1 to 64 to produce an Amdahl's-law curve. Each
+//! data point shows how much of the per-request work is parallelisable when
+//! the plan is already cached.
+//!
+//! - Old implementation: every cache hit acquired the `wait_map` mutex, allocated
+//!   a `broadcast::Sender`, and spawned a cleanup task — all immediately discarded.
+//!   The wait_map contention serializes concurrent hits, flattening the speedup curve.
+//! - New implementation: a fast path checks the in-memory LRU before acquiring the
+//!   wait_map mutex. On a hit the value is returned immediately; the mutex is only
+//!   entered on a miss where deduplication is actually needed.
+//!
+//! Run with: `cargo bench --bench query_plan_cache_concurrency`
+
+use std::time::Instant;
+
+use apollo_router::plugin::test::MockSubgraph;
+use apollo_router::services::router;
+use apollo_router::services::supergraph;
+use apollo_router::MockedSubgraphs;
+use apollo_router::TestHarness;
+use futures::future::join_all;
+use serde_json::json;
+use tower::Service;
+use tower::ServiceExt;
+
+const QUERY: &str = r#"query TopProducts($first: Int) { topProducts(first: $first) { upc name reviews { id product { name } author { id name } } } }"#;
+
+/// Concurrency levels to sweep. Powers of two give a clean log-scale curve.
+const CONCURRENCY_LEVELS: &[usize] = &[1, 2, 4, 8, 16, 32, 64];
+
+/// Minimum total requests per concurrency level. Low-concurrency levels (c=1,
+/// c=2) get more waves to ensure enough wall time for a stable measurement.
+/// High-concurrency levels saturate quickly, so the wave count is lower.
+const MIN_REQUESTS: usize = 10_000;
+
+/// Warmup waves before timing each concurrency level. Lets the tokio thread
+/// pool and any per-level allocator state reach steady state before the clock
+/// starts.
+const WARMUP_WAVES: usize = 100;
+
+/// Repetitions per concurrency level. The median req/s is reported, which
+/// discards outlier runs caused by OS scheduler preemption.
+const REPS: usize = 3;
+
+fn build_harness() -> TestHarness<'static> {
+    let account_service = MockSubgraph::builder()
+        .with_json(
+            json!{{
+                "query": "query TopProducts__accounts__3($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}",
+                "operationName": "TopProducts__accounts__3",
+                "variables": {
+                    "representations": [
+                        { "__typename": "User", "id": "1" },
+                        { "__typename": "User", "id": "2" }
+                    ]
+                }
+            }},
+            json!{{ "data": { "_entities": [{ "name": "Ada Lovelace" }, { "name": "Alan Turing" }] } }},
+        )
+        .build();
+
+    let review_service = MockSubgraph::builder()
+        .with_json(
+            json!{{
+                "query": "query($representations: [_Any!]!) { _entities(representations: $representations) { ... on Product { reviews { id product { __typename upc } author { __typename id } } } } }",
+                "variables": {
+                    "representations": [
+                        { "__typename": "Product", "upc": "1" },
+                        { "__typename": "Product", "upc": "2" }
+                    ]
+                }
+            }},
+            json!{{
+                "data": {
+                    "_entities": [
+                        { "reviews": [
+                            { "id": "1", "product": { "__typename": "Product", "upc": "1" }, "author": { "__typename": "User", "id": "1" } },
+                            { "id": "4", "product": { "__typename": "Product", "upc": "1" }, "author": { "__typename": "User", "id": "2" } }
+                        ]},
+                        { "reviews": [
+                            { "id": "2", "product": { "__typename": "Product", "upc": "2" }, "author": { "__typename": "User", "id": "1" } }
+                        ]}
+                    ]
+                }
+            }},
+        )
+        .build();
+
+    let product_service = MockSubgraph::builder()
+        .with_json(
+            json!{{
+                "query": "query TopProducts__products__0($first:Int){topProducts(first:$first){__typename upc name}}",
+                "operationName": "TopProducts__products__0",
+                "variables": { "first": 2u8 }
+            }},
+            json!{{
+                "data": {
+                    "topProducts": [
+                        { "__typename": "Product", "upc": "1", "name": "Table" },
+                        { "__typename": "Product", "upc": "2", "name": "Couch" }
+                    ]
+                }
+            }},
+        )
+        .with_json(
+            json!{{
+                "query": "query TopProducts__products__2($representations:[_Any!]!){_entities(representations:$representations){...on Product{name}}}",
+                "operationName": "TopProducts__products__2",
+                "variables": {
+                    "representations": [
+                        { "__typename": "Product", "upc": "1" },
+                        { "__typename": "Product", "upc": "2" }
+                    ]
+                }
+            }},
+            json!{{ "data": { "_entities": [{ "name": "Table" }, { "name": "Couch" }] } }},
+        )
+        .build();
+
+    let mut mocks = MockedSubgraphs::default();
+    mocks.insert("accounts", account_service);
+    mocks.insert("reviews", review_service);
+    mocks.insert("products", product_service);
+
+    TestHarness::builder()
+        .try_log_level("warn")
+        .schema(include_str!("fixtures/supergraph.graphql"))
+        .extra_plugin(mocks)
+}
+
+fn make_request() -> router::Request {
+    supergraph::Request::fake_builder()
+        .query(QUERY.to_string())
+        .variable("first", 2usize)
+        .build()
+        .expect("valid request")
+        .try_into()
+        .unwrap()
+}
+
+async fn send_request(mut svc: router::BoxCloneService) {
+    svc.ready()
+        .await
+        .unwrap()
+        .call(make_request())
+        .await
+        .unwrap()
+        .next_response()
+        .await
+        .unwrap()
+        .unwrap();
+}
+
+struct Sample {
+    concurrency: usize,
+    rps: f64,
+    elapsed_secs: f64,
+    speedup: f64,
+}
+
+fn main() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let router = rt.block_on(async {
+        let svc = build_harness().build_router().await.unwrap();
+        // Prime the plan cache before any timing starts.
+        send_request(svc.clone()).await;
+        svc
+    });
+
+    // Establish the serial baseline at concurrency=1 first, then reuse it as
+    // the denominator for all speedup calculations.
+    let mut baseline_rps = 0.0_f64;
+    let mut samples: Vec<Sample> = Vec::new();
+
+    for &concurrency in CONCURRENCY_LEVELS.iter() {
+        let waves = (MIN_REQUESTS + concurrency - 1) / concurrency; // ceil div
+        let total = waves * concurrency;
+
+        // Warmup: let the tokio pool and allocator reach steady state.
+        rt.block_on(async {
+            for _ in 0..WARMUP_WAVES {
+                let tasks: Vec<_> = (0..concurrency)
+                    .map(|_| tokio::spawn(send_request(router.clone())))
+                    .collect();
+                join_all(tasks).await;
+            }
+        });
+
+        // Timed repetitions — take the median req/s.
+        let mut rps_samples: Vec<f64> = (0..REPS)
+            .map(|_| {
+                let start = Instant::now();
+                rt.block_on(async {
+                    for _ in 0..waves {
+                        let tasks: Vec<_> = (0..concurrency)
+                            .map(|_| tokio::spawn(send_request(router.clone())))
+                            .collect();
+                        join_all(tasks).await;
+                    }
+                });
+                total as f64 / start.elapsed().as_secs_f64()
+            })
+            .collect();
+        rps_samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let rps = rps_samples[REPS / 2]; // median
+
+        if concurrency == 1 {
+            baseline_rps = rps;
+            samples.push(Sample {
+                concurrency,
+                rps,
+                elapsed_secs: total as f64 / rps,
+                speedup: 1.0,
+            });
+        } else {
+            samples.push(Sample {
+                concurrency,
+                rps,
+                elapsed_secs: total as f64 / rps,
+                speedup: rps / baseline_rps,
+            });
+        }
+    }
+
+    // ── Report ───────────────────────────────────────────────────────────────
+    println!("Query plan cache — concurrency sweep");
+    println!("  Same query repeated, all cache hits | min {MIN_REQUESTS} reqs/level, {REPS} reps (median reported), {WARMUP_WAVES} warmup waves");
+    println!("  Serial fraction estimate uses Amdahl's law: S = (1/speedup - 1/N) / (1 - 1/N)");
+    println!();
+    println!(
+        "  {:<12} {:>10} {:>12} {:>10} {:>14}",
+        "concurrency", "req/s", "elapsed (s)", "speedup", "serial frac."
+    );
+    println!("  {}", "-".repeat(62));
+
+    for s in &samples {
+        // Amdahl serial fraction: S = (1/speedup - 1/N) / (1 - 1/N)
+        let serial_frac = if s.concurrency == 1 {
+            1.0
+        } else {
+            let n = s.concurrency as f64;
+            (1.0 / s.speedup - 1.0 / n) / (1.0 - 1.0 / n)
+        };
+        println!(
+            "  {:<12} {:>10.0} {:>12.3} {:>9.2}× {:>13.1}%",
+            s.concurrency,
+            s.rps,
+            s.elapsed_secs,
+            s.speedup,
+            serial_frac * 100.0,
+        );
+    }
+
+    println!();
+    println!("  Interpretation");
+    println!("  ──────────────");
+    println!("  A flat serial-fraction column means the bottleneck is consistent");
+    println!("  across concurrency levels (Amdahl's law holds cleanly).");
+    println!("  Rising serial fraction at high concurrency signals a new contention");
+    println!("  point emerging — e.g. the in-memory LRU lock or tokio scheduler");
+    println!("  overhead — that didn't exist at lower concurrency.");
+    println!();
+    println!("  Under the old wait_map path, every cache hit serialized through");
+    println!("  the wait_map mutex, so the speedup curve would have been flat near 1×");
+    println!("  and the serial fraction near 100% regardless of concurrency level.");
+}

--- a/apollo-router-benchmarks/benches/query_plan_cache_concurrency.rs
+++ b/apollo-router-benchmarks/benches/query_plan_cache_concurrency.rs
@@ -11,15 +11,18 @@
 //!   wait_map mutex. On a hit the value is returned immediately; the mutex is only
 //!   entered on a miss where deduplication is actually needed.
 //!
-//! Run with: `cargo bench --bench query_plan_cache_concurrency`
-
-use std::time::Instant;
+//! Run with: `cargo bench -p apollo-router-benchmarks --bench query_plan_cache_concurrency`
 
 use apollo_router::plugin::test::MockSubgraph;
 use apollo_router::services::router;
 use apollo_router::services::supergraph;
 use apollo_router::MockedSubgraphs;
 use apollo_router::TestHarness;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
 use futures::future::join_all;
 use serde_json::json;
 use tower::Service;
@@ -27,22 +30,7 @@ use tower::ServiceExt;
 
 const QUERY: &str = r#"query TopProducts($first: Int) { topProducts(first: $first) { upc name reviews { id product { name } author { id name } } } }"#;
 
-/// Concurrency levels to sweep. Powers of two give a clean log-scale curve.
 const CONCURRENCY_LEVELS: &[usize] = &[1, 2, 4, 8, 16, 32, 64];
-
-/// Minimum total requests per concurrency level. Low-concurrency levels (c=1,
-/// c=2) get more waves to ensure enough wall time for a stable measurement.
-/// High-concurrency levels saturate quickly, so the wave count is lower.
-const MIN_REQUESTS: usize = 10_000;
-
-/// Warmup waves before timing each concurrency level. Lets the tokio thread
-/// pool and any per-level allocator state reach steady state before the clock
-/// starts.
-const WARMUP_WAVES: usize = 100;
-
-/// Repetitions per concurrency level. The median req/s is reported, which
-/// discards outlier runs caused by OS scheduler preemption.
-const REPS: usize = 3;
 
 fn build_harness() -> TestHarness<'static> {
     let account_service = MockSubgraph::builder()
@@ -137,136 +125,53 @@ fn make_request() -> router::Request {
         .build()
         .expect("valid request")
         .try_into()
-        .unwrap()
+        .expect("valid router request")
 }
 
 async fn send_request(mut svc: router::BoxCloneService) {
     svc.ready()
         .await
-        .unwrap()
+        .expect("service ready")
         .call(make_request())
         .await
-        .unwrap()
+        .expect("request succeeded")
         .next_response()
         .await
-        .unwrap()
-        .unwrap();
+        .expect("response body")
+        .expect("valid response");
 }
 
-struct Sample {
-    concurrency: usize,
-    rps: f64,
-    elapsed_secs: f64,
-    speedup: f64,
-}
-
-fn main() {
+fn bench_cache_hit_concurrency(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .unwrap();
+        .expect("tokio runtime");
 
     let router = rt.block_on(async {
-        let svc = build_harness().build_router().await.unwrap();
+        let svc = build_harness().build_router().await.expect("router built");
         // Prime the plan cache before any timing starts.
         send_request(svc.clone()).await;
         svc
     });
 
-    // Establish the serial baseline at concurrency=1 first, then reuse it as
-    // the denominator for all speedup calculations.
-    let mut baseline_rps = 0.0_f64;
-    let mut samples: Vec<Sample> = Vec::new();
-
-    for &concurrency in CONCURRENCY_LEVELS.iter() {
-        let waves = (MIN_REQUESTS + concurrency - 1) / concurrency; // ceil div
-        let total = waves * concurrency;
-
-        // Warmup: let the tokio pool and allocator reach steady state.
-        rt.block_on(async {
-            for _ in 0..WARMUP_WAVES {
-                let tasks: Vec<_> = (0..concurrency)
-                    .map(|_| tokio::spawn(send_request(router.clone())))
-                    .collect();
-                join_all(tasks).await;
-            }
-        });
-
-        // Timed repetitions — take the median req/s.
-        let mut rps_samples: Vec<f64> = (0..REPS)
-            .map(|_| {
-                let start = Instant::now();
-                rt.block_on(async {
-                    for _ in 0..waves {
-                        let tasks: Vec<_> = (0..concurrency)
-                            .map(|_| tokio::spawn(send_request(router.clone())))
-                            .collect();
-                        join_all(tasks).await;
-                    }
+    let mut group = c.benchmark_group("query_plan_cache_concurrency");
+    for &concurrency in CONCURRENCY_LEVELS {
+        group.throughput(Throughput::Elements(concurrency as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(concurrency),
+            &concurrency,
+            |b, &concurrency| {
+                b.to_async(&rt).iter(|| async {
+                    let tasks: Vec<_> = (0..concurrency)
+                        .map(|_| tokio::spawn(send_request(router.clone())))
+                        .collect();
+                    join_all(tasks).await;
                 });
-                total as f64 / start.elapsed().as_secs_f64()
-            })
-            .collect();
-        rps_samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        let rps = rps_samples[REPS / 2]; // median
-
-        if concurrency == 1 {
-            baseline_rps = rps;
-            samples.push(Sample {
-                concurrency,
-                rps,
-                elapsed_secs: total as f64 / rps,
-                speedup: 1.0,
-            });
-        } else {
-            samples.push(Sample {
-                concurrency,
-                rps,
-                elapsed_secs: total as f64 / rps,
-                speedup: rps / baseline_rps,
-            });
-        }
-    }
-
-    // ── Report ───────────────────────────────────────────────────────────────
-    println!("Query plan cache — concurrency sweep");
-    println!("  Same query repeated, all cache hits | min {MIN_REQUESTS} reqs/level, {REPS} reps (median reported), {WARMUP_WAVES} warmup waves");
-    println!("  Serial fraction estimate uses Amdahl's law: S = (1/speedup - 1/N) / (1 - 1/N)");
-    println!();
-    println!(
-        "  {:<12} {:>10} {:>12} {:>10} {:>14}",
-        "concurrency", "req/s", "elapsed (s)", "speedup", "serial frac."
-    );
-    println!("  {}", "-".repeat(62));
-
-    for s in &samples {
-        // Amdahl serial fraction: S = (1/speedup - 1/N) / (1 - 1/N)
-        let serial_frac = if s.concurrency == 1 {
-            1.0
-        } else {
-            let n = s.concurrency as f64;
-            (1.0 / s.speedup - 1.0 / n) / (1.0 - 1.0 / n)
-        };
-        println!(
-            "  {:<12} {:>10.0} {:>12.3} {:>9.2}× {:>13.1}%",
-            s.concurrency,
-            s.rps,
-            s.elapsed_secs,
-            s.speedup,
-            serial_frac * 100.0,
+            },
         );
     }
-
-    println!();
-    println!("  Interpretation");
-    println!("  ──────────────");
-    println!("  A flat serial-fraction column means the bottleneck is consistent");
-    println!("  across concurrency levels (Amdahl's law holds cleanly).");
-    println!("  Rising serial fraction at high concurrency signals a new contention");
-    println!("  point emerging — e.g. the in-memory LRU lock or tokio scheduler");
-    println!("  overhead — that didn't exist at lower concurrency.");
-    println!();
-    println!("  Under the old wait_map path, every cache hit serialized through");
-    println!("  the wait_map mutex, so the speedup curve would have been flat near 1×");
-    println!("  and the serial fraction near 100% regardless of concurrency level.");
+    group.finish();
 }
+
+criterion_group!(benches, bench_cache_hit_concurrency);
+criterion_main!(benches);

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -225,10 +225,6 @@ where
         matches!(self.inner, EntryInner::First { .. })
     }
 
-    pub(crate) fn is_value(&self) -> bool {
-        matches!(self.inner, EntryInner::Value(_))
-    }
-
     pub(crate) async fn get(self) -> Result<V, EntryError<UncachedError>> {
         match self.inner {
             // there was already a value in cache
@@ -372,40 +368,6 @@ mod tests {
                 async move {
                     let entry = cache.get(&"key".to_string(), |_| Ok(())).await;
                     assert!(!entry.is_first(), "warm-cache hit should not be First");
-                    entry.get().await.unwrap()
-                }
-            })
-            .collect();
-
-        while let Some(result) = tasks.next().await {
-            assert_eq!(result, "value");
-        }
-    }
-
-    #[test(tokio::test)]
-    async fn fast_path_returns_value_on_warm_cache() {
-        let cache: DeduplicatingCache<String, String> =
-            DeduplicatingCache::with_capacity(NonZeroUsize::new(10).unwrap(), None, "test")
-                .await
-                .unwrap();
-
-        // Populate the cache
-        let entry = cache.get(&"key".to_string(), |_| Ok(())).await;
-        assert!(entry.is_first());
-        entry.insert("value".to_string()).await;
-
-        // With the fast path, all concurrent lookups bypass the wait_map and return Value
-        // directly. Without it, interleaving at wait_map.lock() would cause some tasks to
-        // subscribe as Receiver instead.
-        let mut tasks: FuturesUnordered<_> = (0..100)
-            .map(|_| {
-                let cache = cache.clone();
-                async move {
-                    let entry = cache.get(&"key".to_string(), |_| Ok(())).await;
-                    assert!(
-                        entry.is_value(),
-                        "warm-cache hit should return Value via fast path"
-                    );
                     entry.get().await.unwrap()
                 }
             })

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -70,6 +70,24 @@ where
         key: &K,
         init_from_redis: impl FnMut(&mut V) -> Result<(), String>,
     ) -> Entry<K, V, UncachedError> {
+        // Fast path: if the value is already in the in-memory cache, return it without
+        // acquiring the wait_map mutex. This is the common case for a warm cache and
+        // removes all wait_map contention on cache hits — the mutex is only needed for
+        // miss deduplication (preventing thundering herd when multiple tasks race to
+        // compute the same value). Redis-only entries still fall through to the slow path.
+        if let Some(value) = self.storage.get_in_memory(key).await {
+            return Entry {
+                inner: EntryInner::Value(value),
+            };
+        }
+
+        // Slow path: acquire wait_map mutex for miss deduplication.
+        //
+        // Note: storage.get() below will re-check the in-memory cache, so on a miss this path
+        // locks `inner` twice. The redundant check is intentional — it catches values inserted
+        // between the fast-path miss above and the wait_map lock below (TOCTOU). The overhead
+        // is nanoseconds on a path already dominated by plan computation or a Redis round-trip.
+        //
         // waiting on a value from the cache is a potentially long(millisecond scale) task that
         // can involve a network call to an external database. To reduce the waiting time, we
         // go through a wait map to register interest in data associated with a key.
@@ -316,5 +334,34 @@ mod tests {
 
         // To be really sure, check there is only one value in the cache
         assert_eq!(cache.storage.len().await, 1);
+    }
+
+    #[test(tokio::test)]
+    async fn fast_path_bypasses_wait_map_on_hit() {
+        let cache: DeduplicatingCache<String, String> =
+            DeduplicatingCache::with_capacity(NonZeroUsize::new(10).unwrap(), None, "test")
+                .await
+                .unwrap();
+
+        // Populate the cache
+        let entry = cache.get(&"key".to_string(), |_| Ok(())).await;
+        assert!(entry.is_first());
+        entry.insert("value".to_string()).await;
+
+        // All concurrent gets should hit the fast path — none should be First
+        let mut tasks: FuturesUnordered<_> = (0..100)
+            .map(|_| {
+                let cache = cache.clone();
+                async move {
+                    let entry = cache.get(&"key".to_string(), |_| Ok(())).await;
+                    assert!(!entry.is_first(), "warm-cache hit should not be First");
+                    entry.get().await.unwrap()
+                }
+            })
+            .collect();
+
+        while let Some(result) = tasks.next().await {
+            assert_eq!(result, "value");
+        }
     }
 }

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -86,7 +86,7 @@ where
         // removes all wait_map contention on cache hits — the mutex is only needed for
         // miss deduplication (preventing thundering herd when multiple tasks race to
         // compute the same value). Redis-only entries still fall through to the slow path.
-        if let Some(value) = self.storage.get_in_memory(key).await {
+        if let Some(value) = self.storage.peek_in_memory(key).await {
             return Entry {
                 inner: EntryInner::Value(value),
             };

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -95,9 +95,10 @@ where
         // Slow path: acquire wait_map mutex for miss deduplication.
         //
         // Note: storage.get() below will re-check the in-memory cache, so on a miss this path
-        // locks `inner` twice. The redundant check is intentional — it catches values inserted
-        // between the fast-path miss above and the wait_map lock below (TOCTOU). The overhead
-        // is nanoseconds on a path already dominated by plan computation or a Redis round-trip.
+        // locks `inner` twice. The redundant check is intentional — it closes the
+        // time-of-check/time-of-use race between the fast-path miss above and the wait_map
+        // lock below. The overhead is nanoseconds on a path already dominated by plan
+        // computation or a Redis round-trip.
         //
         // waiting on a value from the cache is a potentially long(millisecond scale) task that
         // can involve a network call to an external database. To reduce the waiting time, we

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -63,8 +63,19 @@ where
         Self::with_capacity(config.in_memory.limit, config.redis.clone(), caller).await
     }
 
-    /// `init_from_redis` is called with values newly deserialized from Redis cache
-    /// if an error is returned, the value is ignored and considered a cache miss.
+    /// Look up `key` in the cache, returning an [`Entry`] that describes how to proceed:
+    ///
+    /// - **In-memory hit (fast path)**: the value is returned immediately without acquiring
+    ///   the `wait_map` mutex.
+    /// - **First waiter** ([`Entry::is_first`] returns `true`): this task missed in all cache
+    ///   layers and is responsible for computing the value. Call [`Entry::insert`] when done to
+    ///   store the result and unblock any concurrent waiters for the same key.
+    /// - **Subsequent waiter**: another task is already computing the value for this key. Call
+    ///   [`Entry::get`] to wait for the result.
+    ///
+    /// `init_from_redis` is called on values freshly deserialized from Redis. Return `Err` to
+    /// reject the entry and treat the lookup as a miss (e.g. the cached plan is no longer valid
+    /// for the current schema).
     pub(crate) async fn get(
         &self,
         key: &K,

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -224,6 +224,10 @@ where
         matches!(self.inner, EntryInner::First { .. })
     }
 
+    pub(crate) fn is_value(&self) -> bool {
+        matches!(self.inner, EntryInner::Value(_))
+    }
+
     pub(crate) async fn get(self) -> Result<V, EntryError<UncachedError>> {
         match self.inner {
             // there was already a value in cache
@@ -348,7 +352,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn fast_path_bypasses_wait_map_on_hit() {
+    async fn warm_cache_hit_never_returns_first() {
         let cache: DeduplicatingCache<String, String> =
             DeduplicatingCache::with_capacity(NonZeroUsize::new(10).unwrap(), None, "test")
                 .await
@@ -359,13 +363,48 @@ mod tests {
         assert!(entry.is_first());
         entry.insert("value".to_string()).await;
 
-        // All concurrent gets should hit the fast path — none should be First
+        // A warm-cache lookup should never return First — the value is found by the in-memory
+        // fast path or by storage.get()'s re-check inside the wait_map path.
         let mut tasks: FuturesUnordered<_> = (0..100)
             .map(|_| {
                 let cache = cache.clone();
                 async move {
                     let entry = cache.get(&"key".to_string(), |_| Ok(())).await;
                     assert!(!entry.is_first(), "warm-cache hit should not be First");
+                    entry.get().await.unwrap()
+                }
+            })
+            .collect();
+
+        while let Some(result) = tasks.next().await {
+            assert_eq!(result, "value");
+        }
+    }
+
+    #[test(tokio::test)]
+    async fn fast_path_returns_value_on_warm_cache() {
+        let cache: DeduplicatingCache<String, String> =
+            DeduplicatingCache::with_capacity(NonZeroUsize::new(10).unwrap(), None, "test")
+                .await
+                .unwrap();
+
+        // Populate the cache
+        let entry = cache.get(&"key".to_string(), |_| Ok(())).await;
+        assert!(entry.is_first());
+        entry.insert("value".to_string()).await;
+
+        // With the fast path, all concurrent lookups bypass the wait_map and return Value
+        // directly. Without it, interleaving at wait_map.lock() would cause some tasks to
+        // subscribe as Receiver instead.
+        let mut tasks: FuturesUnordered<_> = (0..100)
+            .map(|_| {
+                let cache = cache.clone();
+                async move {
+                    let entry = cache.get(&"key".to_string(), |_| Ok(())).await;
+                    assert!(
+                        entry.is_value(),
+                        "warm-cache hit should return Value via fast path"
+                    );
                     entry.get().await.unwrap()
                 }
             })

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -222,6 +222,22 @@ where
         }
     }
 
+    /// Check only the in-memory cache, bypassing Redis.
+    /// Used by `DeduplicatingCache` as a fast path on warm-cache hits.
+    ///
+    /// Emits `cache.hit.time` on a hit but intentionally emits nothing on a miss:
+    /// callers that miss here always fall through to `storage.get()`, which emits
+    /// `cache.miss.time` unconditionally. Emitting here too would double-count every
+    /// miss.
+    pub(crate) async fn get_in_memory(&self, key: &K) -> Option<V> {
+        let instant = Instant::now();
+        let res = self.inner.lock().await.get(key).cloned();
+        if res.is_some() {
+            self.record_cache_hit_duration(instant.elapsed(), CacheStorageName::Memory);
+        }
+        res
+    }
+
     pub(crate) async fn insert(&self, key: K, value: V) {
         if let Some(redis) = self.redis.as_ref() {
             redis
@@ -260,22 +276,6 @@ where
 
     pub(crate) fn in_memory_cache(&self) -> InMemoryCache<K, V> {
         self.inner.clone()
-    }
-
-    /// Check only the in-memory cache, bypassing Redis.
-    /// Used by `DeduplicatingCache` as a fast path on warm-cache hits.
-    ///
-    /// Emits `cache.hit.time` on a hit but intentionally emits nothing on a miss:
-    /// callers that miss here always fall through to `storage.get()`, which emits
-    /// `cache.miss.time` unconditionally. Emitting here too would double-count every
-    /// miss.
-    pub(crate) async fn get_in_memory(&self, key: &K) -> Option<V> {
-        let instant = Instant::now();
-        let res = self.inner.lock().await.get(key).cloned();
-        if res.is_some() {
-            self.record_cache_hit_duration(instant.elapsed(), CacheStorageName::Memory);
-        }
-        res
     }
 
     #[cfg(test)]

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -220,11 +220,9 @@ where
         key: &K,
         mut init_from_redis: impl FnMut(&mut V) -> Result<(), String>,
     ) -> Option<V> {
-        let Some(redis) = self.redis.as_ref() else {
-            return None;
-        };
+        let redis = self.redis.as_ref()?;
 
-        let instant_redis = Instant::now();
+        let instant = Instant::now();
         let redis_value = redis
             .get(RedisKey(key.clone()))
             .await
@@ -237,10 +235,10 @@ where
                 }
             });
         if let Some(v) = redis_value {
-            self.record_cache_hit_duration(instant_redis.elapsed(), CacheStorageName::Redis);
+            self.record_cache_hit_duration(instant.elapsed(), CacheStorageName::Redis);
             Some(v.0)
         } else {
-            self.record_cache_miss_duration(instant_redis.elapsed(), CacheStorageName::Redis);
+            self.record_cache_miss_duration(instant.elapsed(), CacheStorageName::Redis);
             None
         }
     }

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -168,19 +168,42 @@ where
         key: &K,
         init_from_redis: impl FnMut(&mut V) -> Result<(), String>,
     ) -> Option<V> {
-        let instant_memory = Instant::now();
-        let res = self.inner.lock().await.get(key).cloned();
-
-        match res {
-            Some(v) => {
-                self.record_cache_hit_duration(instant_memory.elapsed(), CacheStorageName::Memory);
-                Some(v)
-            }
-            None => {
-                self.record_cache_miss_duration(instant_memory.elapsed(), CacheStorageName::Memory);
-                self.get_from_redis(key, init_from_redis).await
-            }
+        if let Some(v) = self.get_in_memory(key).await {
+            Some(v)
+        } else {
+            self.get_from_redis(key, init_from_redis).await
         }
+    }
+
+    /// Check only the in-memory cache, bypassing Redis.
+    /// Emits `cache.hit.time` on a hit and `cache.miss.time` on a miss.
+    pub(crate) async fn get_in_memory(&self, key: &K) -> Option<V> {
+        let instant = Instant::now();
+        let res = self.inner.lock().await.get(key).cloned();
+        if res.is_some() {
+            self.record_cache_hit_duration(instant.elapsed(), CacheStorageName::Memory);
+        } else {
+            self.record_cache_miss_duration(instant.elapsed(), CacheStorageName::Memory);
+        }
+        res
+    }
+
+    /// For use by [`DeduplicatingCache`] only, as the in-memory fast path that avoids
+    /// acquiring the wait_map mutex on warm-cache hits.
+    ///
+    /// Identical to [`CacheStorage::get_in_memory`] except it does not emit
+    /// `cache.miss.time` on a miss — this check is an implementation detail of the
+    /// deduplication layer, not a cache event visible to observers. On a miss, the caller
+    /// falls through to `storage.get()`, which emits either `cache.hit.time` or
+    /// `cache.miss.time` depending on whether another task inserted the value between
+    /// this check and `storage.get()`'s in-memory re-check.
+    pub(crate) async fn peek_in_memory(&self, key: &K) -> Option<V> {
+        let instant = Instant::now();
+        let res = self.inner.lock().await.get(key).cloned();
+        if res.is_some() {
+            self.record_cache_hit_duration(instant.elapsed(), CacheStorageName::Memory);
+        }
+        res
     }
 
     /// Check only Redis, inserting any hit into the in-memory cache.
@@ -220,24 +243,6 @@ where
                 None
             }
         }
-    }
-
-    /// Check only the in-memory cache, bypassing Redis.
-    /// Used by `DeduplicatingCache` as a fast path on warm-cache hits.
-    ///
-    /// Emits `cache.hit.time` on a hit but nothing on a miss. This is intentional:
-    /// the fast-path check is an implementation detail of the deduplication layer,
-    /// not a cache event visible to observers. On a miss, the caller falls through
-    /// to `storage.get()`, which emits either `cache.hit.time` or `cache.miss.time`
-    /// depending on whether another task inserted the value between this check and
-    /// `storage.get()`'s in-memory re-check.
-    pub(crate) async fn get_in_memory(&self, key: &K) -> Option<V> {
-        let instant = Instant::now();
-        let res = self.inner.lock().await.get(key).cloned();
-        if res.is_some() {
-            self.record_cache_hit_duration(instant.elapsed(), CacheStorageName::Memory);
-        }
-        res
     }
 
     pub(crate) async fn insert(&self, key: K, value: V) {

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -170,8 +170,11 @@ where
     ) -> Option<V> {
         if let Some(v) = self.get_in_memory(key).await {
             Some(v)
+        } else if let Some(v) = self.get_from_redis(key, init_from_redis).await {
+            self.insert_in_memory(key.clone(), v.clone()).await;
+            Some(v)
         } else {
-            self.get_from_redis(key, init_from_redis).await
+            None
         }
     }
 
@@ -206,8 +209,9 @@ where
         res
     }
 
-    /// Check only Redis, inserting any hit into the in-memory cache.
-    /// Called by [`CacheStorage::get`] after an in-memory miss.
+    /// Check only Redis, returning the value without promoting it to the in-memory cache.
+    /// Called by [`CacheStorage::get`] after an in-memory miss; promotion is the caller's
+    /// responsibility.
     ///
     /// `init_from_redis` is called on values freshly deserialized from Redis. Return `Err` to
     /// reject the entry and treat the lookup as a miss.
@@ -235,7 +239,6 @@ where
         match redis_value {
             Some(v) => {
                 self.record_cache_hit_duration(instant_redis.elapsed(), CacheStorageName::Redis);
-                self.insert_in_memory(key.clone(), v.0.clone()).await;
                 Some(v.0)
             }
             None => {

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -206,46 +206,47 @@ where
         key: &K,
         mut init_from_redis: impl FnMut(&mut V) -> Result<(), String>,
     ) -> Option<V> {
-        let instant_redis = Instant::now();
-        if let Some(redis) = self.redis.as_ref() {
-            let inner_key = RedisKey(key.clone());
-            let redis_value = redis.get(inner_key).await.ok().and_then(|mut v| {
-                match init_from_redis(&mut v.0) {
-                    Ok(()) => Some(v),
-                    Err(e) => {
-                        tracing::error!("Invalid value from Redis cache: {e}");
-                        None
-                    }
-                }
-            });
-            match redis_value {
-                Some(v) => {
-                    self.insert_in_memory(key.clone(), v.0.clone()).await;
+        let Some(redis) = self.redis.as_ref() else {
+            return None;
+        };
 
-                    let duration = instant_redis.elapsed();
-                    f64_histogram!(
-                        "apollo.router.cache.hit.time",
-                        "Time to get a value from the cache in seconds",
-                        duration.as_secs_f64(),
-                        kind = self.caller,
-                        storage = CacheStorageName::Redis.to_string()
-                    );
-                    Some(v.0)
-                }
-                None => {
-                    let duration = instant_redis.elapsed();
-                    f64_histogram!(
-                        "apollo.router.cache.miss.time",
-                        "Time to check the cache for an uncached value in seconds",
-                        duration.as_secs_f64(),
-                        kind = self.caller,
-                        storage = CacheStorageName::Redis.to_string()
-                    );
+        let instant_redis = Instant::now();
+        let redis_value = redis
+            .get(RedisKey(key.clone()))
+            .await
+            .ok()
+            .and_then(|mut v| match init_from_redis(&mut v.0) {
+                Ok(()) => Some(v),
+                Err(e) => {
+                    tracing::error!("Invalid value from Redis cache: {e}");
                     None
                 }
+            });
+        match redis_value {
+            Some(v) => {
+                self.insert_in_memory(key.clone(), v.0.clone()).await;
+
+                let duration = instant_redis.elapsed();
+                f64_histogram!(
+                    "apollo.router.cache.hit.time",
+                    "Time to get a value from the cache in seconds",
+                    duration.as_secs_f64(),
+                    kind = self.caller,
+                    storage = CacheStorageName::Redis.to_string()
+                );
+                Some(v.0)
             }
-        } else {
-            None
+            None => {
+                let duration = instant_redis.elapsed();
+                f64_histogram!(
+                    "apollo.router.cache.miss.time",
+                    "Time to check the cache for an uncached value in seconds",
+                    duration.as_secs_f64(),
+                    kind = self.caller,
+                    storage = CacheStorageName::Redis.to_string()
+                );
+                None
+            }
         }
     }
 

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -156,12 +156,16 @@ where
             .build()
     }
 
-    /// `init_from_redis` is called with values newly deserialized from Redis cache
-    /// if an error is returned, the value is ignored and considered a cache miss.
+    /// Check the in-memory cache, then Redis on a miss. A Redis hit is promoted to the
+    /// in-memory cache before returning. Emits `cache.hit.time` or `cache.miss.time` for
+    /// each layer checked.
+    ///
+    /// `init_from_redis` is called on values freshly deserialized from Redis. Return `Err` to
+    /// reject the entry and treat the lookup as a miss.
     pub(crate) async fn get(
         &self,
         key: &K,
-        mut init_from_redis: impl FnMut(&mut V) -> Result<(), String>,
+        init_from_redis: impl FnMut(&mut V) -> Result<(), String>,
     ) -> Option<V> {
         let instant_memory = Instant::now();
         let res = self.inner.lock().await.get(key).cloned();
@@ -187,49 +191,61 @@ where
                     kind = self.caller,
                     storage = CacheStorageName::Memory.to_string()
                 );
+                self.get_from_redis(key, init_from_redis).await
+            }
+        }
+    }
 
-                let instant_redis = Instant::now();
-                if let Some(redis) = self.redis.as_ref() {
-                    let inner_key = RedisKey(key.clone());
-                    let redis_value = redis.get(inner_key).await.ok().and_then(|mut v| {
-                        match init_from_redis(&mut v.0) {
-                            Ok(()) => Some(v),
-                            Err(e) => {
-                                tracing::error!("Invalid value from Redis cache: {e}");
-                                None
-                            }
-                        }
-                    });
-                    match redis_value {
-                        Some(v) => {
-                            self.insert_in_memory(key.clone(), v.0.clone()).await;
-
-                            let duration = instant_redis.elapsed();
-                            f64_histogram!(
-                                "apollo.router.cache.hit.time",
-                                "Time to get a value from the cache in seconds",
-                                duration.as_secs_f64(),
-                                kind = self.caller,
-                                storage = CacheStorageName::Redis.to_string()
-                            );
-                            Some(v.0)
-                        }
-                        None => {
-                            let duration = instant_redis.elapsed();
-                            f64_histogram!(
-                                "apollo.router.cache.miss.time",
-                                "Time to check the cache for an uncached value in seconds",
-                                duration.as_secs_f64(),
-                                kind = self.caller,
-                                storage = CacheStorageName::Redis.to_string()
-                            );
-                            None
-                        }
+    /// Check only Redis, inserting any hit into the in-memory cache.
+    /// Called by [`CacheStorage::get`] after an in-memory miss.
+    ///
+    /// `init_from_redis` is called on values freshly deserialized from Redis. Return `Err` to
+    /// reject the entry and treat the lookup as a miss.
+    async fn get_from_redis(
+        &self,
+        key: &K,
+        mut init_from_redis: impl FnMut(&mut V) -> Result<(), String>,
+    ) -> Option<V> {
+        let instant_redis = Instant::now();
+        if let Some(redis) = self.redis.as_ref() {
+            let inner_key = RedisKey(key.clone());
+            let redis_value = redis.get(inner_key).await.ok().and_then(|mut v| {
+                match init_from_redis(&mut v.0) {
+                    Ok(()) => Some(v),
+                    Err(e) => {
+                        tracing::error!("Invalid value from Redis cache: {e}");
+                        None
                     }
-                } else {
+                }
+            });
+            match redis_value {
+                Some(v) => {
+                    self.insert_in_memory(key.clone(), v.0.clone()).await;
+
+                    let duration = instant_redis.elapsed();
+                    f64_histogram!(
+                        "apollo.router.cache.hit.time",
+                        "Time to get a value from the cache in seconds",
+                        duration.as_secs_f64(),
+                        kind = self.caller,
+                        storage = CacheStorageName::Redis.to_string()
+                    );
+                    Some(v.0)
+                }
+                None => {
+                    let duration = instant_redis.elapsed();
+                    f64_histogram!(
+                        "apollo.router.cache.miss.time",
+                        "Time to check the cache for an uncached value in seconds",
+                        duration.as_secs_f64(),
+                        kind = self.caller,
+                        storage = CacheStorageName::Redis.to_string()
+                    );
                     None
                 }
             }
+        } else {
+            None
         }
     }
 

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -273,6 +273,28 @@ where
         self.inner.clone()
     }
 
+    /// Check only the in-memory cache, bypassing Redis.
+    /// Used by `DeduplicatingCache` as a fast path on warm-cache hits.
+    ///
+    /// Emits `cache.hit.time` on a hit but intentionally emits nothing on a miss:
+    /// callers that miss here always fall through to `storage.get()`, which emits
+    /// `cache.miss.time` unconditionally. Emitting here too would double-count every
+    /// miss.
+    pub(crate) async fn get_in_memory(&self, key: &K) -> Option<V> {
+        let instant = Instant::now();
+        let res = self.inner.lock().await.get(key).cloned();
+        if res.is_some() {
+            f64_histogram!(
+                "apollo.router.cache.hit.time",
+                "Time to get a value from the cache in seconds",
+                instant.elapsed().as_secs_f64(),
+                kind = self.caller,
+                storage = CacheStorageName::Memory.to_string()
+            );
+        }
+        res
+    }
+
     #[cfg(test)]
     pub(crate) async fn len(&self) -> usize {
         self.inner.lock().await.len()

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -236,15 +236,12 @@ where
                     None
                 }
             });
-        match redis_value {
-            Some(v) => {
-                self.record_cache_hit_duration(instant_redis.elapsed(), CacheStorageName::Redis);
-                Some(v.0)
-            }
-            None => {
-                self.record_cache_miss_duration(instant_redis.elapsed(), CacheStorageName::Redis);
-                None
-            }
+        if let Some(v) = redis_value {
+            self.record_cache_hit_duration(instant_redis.elapsed(), CacheStorageName::Redis);
+            Some(v.0)
+        } else {
+            self.record_cache_miss_duration(instant_redis.elapsed(), CacheStorageName::Redis);
+            None
         }
     }
 

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -225,10 +225,12 @@ where
     /// Check only the in-memory cache, bypassing Redis.
     /// Used by `DeduplicatingCache` as a fast path on warm-cache hits.
     ///
-    /// Emits `cache.hit.time` on a hit but intentionally emits nothing on a miss:
-    /// callers that miss here always fall through to `storage.get()`, which emits
-    /// `cache.miss.time` unconditionally. Emitting here too would double-count every
-    /// miss.
+    /// Emits `cache.hit.time` on a hit but nothing on a miss. This is intentional:
+    /// the fast-path check is an implementation detail of the deduplication layer,
+    /// not a cache event visible to observers. On a miss, the caller falls through
+    /// to `storage.get()`, which emits either `cache.hit.time` or `cache.miss.time`
+    /// depending on whether another task inserted the value between this check and
+    /// `storage.get()`'s in-memory re-check.
     pub(crate) async fn get_in_memory(&self, key: &K) -> Option<V> {
         let instant = Instant::now();
         let res = self.inner.lock().await.get(key).cloned();

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -5,6 +5,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use lru::LruCache;
 use opentelemetry::KeyValue;
@@ -172,25 +173,11 @@ where
 
         match res {
             Some(v) => {
-                let duration = instant_memory.elapsed();
-                f64_histogram!(
-                    "apollo.router.cache.hit.time",
-                    "Time to get a value from the cache in seconds",
-                    duration.as_secs_f64(),
-                    kind = self.caller,
-                    storage = CacheStorageName::Memory.to_string()
-                );
+                self.record_cache_hit_duration(instant_memory.elapsed(), CacheStorageName::Memory);
                 Some(v)
             }
             None => {
-                let duration = instant_memory.elapsed();
-                f64_histogram!(
-                    "apollo.router.cache.miss.time",
-                    "Time to check the cache for an uncached value in seconds",
-                    duration.as_secs_f64(),
-                    kind = self.caller,
-                    storage = CacheStorageName::Memory.to_string()
-                );
+                self.record_cache_miss_duration(instant_memory.elapsed(), CacheStorageName::Memory);
                 self.get_from_redis(key, init_from_redis).await
             }
         }
@@ -224,27 +211,12 @@ where
             });
         match redis_value {
             Some(v) => {
+                self.record_cache_hit_duration(instant_redis.elapsed(), CacheStorageName::Redis);
                 self.insert_in_memory(key.clone(), v.0.clone()).await;
-
-                let duration = instant_redis.elapsed();
-                f64_histogram!(
-                    "apollo.router.cache.hit.time",
-                    "Time to get a value from the cache in seconds",
-                    duration.as_secs_f64(),
-                    kind = self.caller,
-                    storage = CacheStorageName::Redis.to_string()
-                );
                 Some(v.0)
             }
             None => {
-                let duration = instant_redis.elapsed();
-                f64_histogram!(
-                    "apollo.router.cache.miss.time",
-                    "Time to check the cache for an uncached value in seconds",
-                    duration.as_secs_f64(),
-                    kind = self.caller,
-                    storage = CacheStorageName::Redis.to_string()
-                );
+                self.record_cache_miss_duration(instant_redis.elapsed(), CacheStorageName::Redis);
                 None
             }
         }
@@ -301,13 +273,7 @@ where
         let instant = Instant::now();
         let res = self.inner.lock().await.get(key).cloned();
         if res.is_some() {
-            f64_histogram!(
-                "apollo.router.cache.hit.time",
-                "Time to get a value from the cache in seconds",
-                instant.elapsed().as_secs_f64(),
-                kind = self.caller,
-                storage = CacheStorageName::Memory.to_string()
-            );
+            self.record_cache_hit_duration(instant.elapsed(), CacheStorageName::Memory);
         }
         res
     }
@@ -328,6 +294,26 @@ where
         if let Some(redis) = &self.redis {
             redis.activate();
         }
+    }
+
+    fn record_cache_hit_duration(&self, duration: Duration, storage: CacheStorageName) {
+        f64_histogram!(
+            "apollo.router.cache.hit.time",
+            "Time to get a value from the cache in seconds",
+            duration.as_secs_f64(),
+            kind = self.caller,
+            storage = storage.to_string()
+        );
+    }
+
+    fn record_cache_miss_duration(&self, duration: Duration, storage: CacheStorageName) {
+        f64_histogram!(
+            "apollo.router.cache.miss.time",
+            "Time to check the cache for an uncached value in seconds",
+            duration.as_secs_f64(),
+            kind = self.caller,
+            storage = storage.to_string()
+        );
     }
 }
 


### PR DESCRIPTION
This is a lightly refactored version of [@theJC](https://github.com/theJC)'s [PR #9273](https://github.com/apollographql/router/pull/9273), which adds a fast path to `DeduplicatingCache::get()` that checks the in-memory LRU before acquiring the `wait_map` mutex.

## What changed

**Core change (from #9273):** on a warm-cache hit, `DeduplicatingCache::get()` now returns immediately via `storage.peek_in_memory()` without acquiring the `wait_map` mutex, allocating a `broadcast::Sender`, or spawning a cleanup task. The slow path is only entered on a miss, which is the only case where deduplication is actually needed.

**Refactoring on top:**
- Extracted `get_from_redis()` as a private method on `CacheStorage`, keeping it a pure Redis fetch (in-memory promotion is `get()`'s responsibility)
- Split `get_in_memory()` (records both hit and miss durations) from `peek_in_memory()` (records hits only — miss duration would be double-counted since the caller falls through to `get()`)
- Extracted `record_cache_hit_duration` / `record_cache_miss_duration` helpers
- Expanded doc comments on `DeduplicatingCache::get()` and the TOCTOU note in the slow path
- Replaced the custom timing benchmark with a Criterion benchmark that sweeps concurrency levels 1→64

## Test plan

- [ ] `cargo test -p apollo-router --lib -- cache::tests cache::storage::test` — all pass
- [ ] `cargo bench -p apollo-router-benchmarks --bench query_plan_cache_concurrency` — throughput scales as expected across concurrency levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)