### PR TITLE
[do not merge] feat(include_subgraph_errors): add redact_service_name option

### DIFF
--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -155,6 +155,12 @@ impl FetchError {
                 }
                 _ => (),
             }
+            if let Some(redacted) = self.display_without_service() {
+                extensions.insert(
+                    "apollo.private.fetch.message_no_service",
+                    redacted.into(),
+                );
+            }
         }
 
         Error::builder()
@@ -170,6 +176,28 @@ impl FetchError {
         Response {
             errors: vec![self.to_graphql_error(None)],
             ..Response::default()
+        }
+    }
+
+    /// Returns a version of the error message with the service name removed, if applicable.
+    pub(crate) fn display_without_service(&self) -> Option<String> {
+        match self {
+            FetchError::SubrequestHttpError { reason, .. } => {
+                Some(format!("HTTP fetch failed: {reason}"))
+            }
+            FetchError::SubrequestMalformedResponse { reason, .. } => {
+                Some(format!("response was malformed: {reason}"))
+            }
+            FetchError::SubrequestUnexpectedPatchResponse { .. } => Some(
+                "subgraph returned a PATCH response which was not expected".to_string(),
+            ),
+            FetchError::SubrequestWsError { reason, .. } => {
+                Some(format!("Websocket fetch failed: {reason}"))
+            }
+            FetchError::SubrequestBatchingError { reason, .. } => {
+                Some(format!("Batching error: {reason}"))
+            }
+            _ => None,
         }
     }
 }
@@ -669,6 +697,10 @@ mod tests {
             .extension(
                 "http",
                 serde_json_bytes::json!({"status": Value::Number(400.into())}),
+            )
+            .extension(
+                "apollo.private.fetch.message_no_service",
+                Value::String("HTTP fetch failed: invalid request".into()),
             )
             .build();
 

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -156,10 +156,7 @@ impl FetchError {
                 _ => (),
             }
             if let Some(redacted) = self.display_without_service() {
-                extensions.insert(
-                    "apollo.private.fetch.message_no_service",
-                    redacted.into(),
-                );
+                extensions.insert("apollo.private.fetch.message_no_service", redacted.into());
             }
         }
 
@@ -188,9 +185,9 @@ impl FetchError {
             FetchError::SubrequestMalformedResponse { reason, .. } => {
                 Some(format!("response was malformed: {reason}"))
             }
-            FetchError::SubrequestUnexpectedPatchResponse { .. } => Some(
-                "subgraph returned a PATCH response which was not expected".to_string(),
-            ),
+            FetchError::SubrequestUnexpectedPatchResponse { .. } => {
+                Some("subgraph returned a PATCH response which was not expected".to_string())
+            }
             FetchError::SubrequestWsError { reason, .. } => {
                 Some(format!("Websocket fetch failed: {reason}"))
             }

--- a/apollo-router/src/plugins/include_subgraph_errors/config.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/config.rs
@@ -32,6 +32,9 @@ pub(crate) enum ErrorMode {
         allow_extensions_keys: Vec<String>,
         /// redact error messages for all subgraphs
         redact_message: bool,
+        /// remove service name from error messages and extensions
+        #[serde(default)]
+        redact_service_name: bool,
     },
     /// Deny specific extension keys with required redact_message
     Deny {
@@ -39,6 +42,9 @@ pub(crate) enum ErrorMode {
         deny_extensions_keys: Vec<String>,
         /// redact error messages for all subgraphs
         redact_message: bool,
+        /// remove service name from error messages and extensions
+        #[serde(default)]
+        redact_service_name: bool,
     },
 }
 
@@ -80,6 +86,8 @@ impl<'de> Deserialize<'de> for ErrorMode {
                     allow_extensions_keys: Option<Vec<String>>,
                     deny_extensions_keys: Option<Vec<String>>,
                     redact_message: bool,
+                    #[serde(default)]
+                    redact_service_name: bool,
                 }
 
                 let helper = Helper::deserialize(de::value::MapAccessDeserializer::new(map))?;
@@ -91,10 +99,12 @@ impl<'de> Deserialize<'de> for ErrorMode {
                     (Some(allow), None) => Ok(ErrorMode::Allow {
                         allow_extensions_keys: allow,
                         redact_message: helper.redact_message,
+                        redact_service_name: helper.redact_service_name,
                     }),
                     (None, Some(deny)) => Ok(ErrorMode::Deny {
                         deny_extensions_keys: deny,
                         redact_message: helper.redact_message,
+                        redact_service_name: helper.redact_service_name,
                     }),
                     // If neither allow nor deny is present, but redact_message is,
                     // treat it as Included(true) with the specified redaction.
@@ -124,6 +134,9 @@ pub(crate) enum SubgraphConfig {
         /// Redact error messages for a subgraph
         #[serde(skip_serializing_if = "Option::is_none")]
         redact_message: Option<bool>,
+        /// Remove service name from error messages and extensions for a subgraph
+        #[serde(skip_serializing_if = "Option::is_none")]
+        redact_service_name: Option<bool>,
         /// Exclude specific extension keys from global allow/deny list
         #[serde(default)]
         exclude_global_keys: Vec<String>,
@@ -135,6 +148,9 @@ pub(crate) enum SubgraphConfig {
         /// Redact error messages for a subgraph
         #[serde(skip_serializing_if = "Option::is_none")]
         redact_message: Option<bool>,
+        /// Remove service name from error messages and extensions for a subgraph
+        #[serde(skip_serializing_if = "Option::is_none")]
+        redact_service_name: Option<bool>,
         /// Exclude specific extension keys from global allow/deny list
         #[serde(default)]
         exclude_global_keys: Vec<String>,
@@ -144,6 +160,9 @@ pub(crate) enum SubgraphConfig {
         /// Redact error messages for a subgraph
         #[serde(skip_serializing_if = "Option::is_none")]
         redact_message: Option<bool>,
+        /// Remove service name from error messages and extensions for a subgraph
+        #[serde(skip_serializing_if = "Option::is_none")]
+        redact_service_name: Option<bool>,
         /// Exclude specific extension keys from global allow/deny list
         #[serde(default)]
         exclude_global_keys: Vec<String>,
@@ -185,6 +204,7 @@ impl<'de> Deserialize<'de> for SubgraphConfig {
                     allow_extensions_keys: Option<Vec<String>>,
                     deny_extensions_keys: Option<Vec<String>>,
                     redact_message: Option<bool>,
+                    redact_service_name: Option<bool>,
                     #[serde(default)]
                     exclude_global_keys: Vec<String>,
                 }
@@ -199,17 +219,20 @@ impl<'de> Deserialize<'de> for SubgraphConfig {
                     (Some(allow), None) => Ok(SubgraphConfig::Allow {
                         allow_extensions_keys: allow,
                         redact_message: config.redact_message,
+                        redact_service_name: config.redact_service_name,
                         exclude_global_keys: config.exclude_global_keys,
                     }),
                     (None, Some(deny)) => Ok(SubgraphConfig::Deny {
                         deny_extensions_keys: deny,
                         redact_message: config.redact_message,
+                        redact_service_name: config.redact_service_name,
                         exclude_global_keys: config.exclude_global_keys,
                     }),
                     (None, None) => {
                         // If neither allow nor deny keys are present, it's CommonOnly
                         Ok(SubgraphConfig::CommonOnly {
                             redact_message: config.redact_message,
+                            redact_service_name: config.redact_service_name,
                             exclude_global_keys: config.exclude_global_keys,
                         })
                     }

--- a/apollo-router/src/plugins/include_subgraph_errors/effective_config.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/effective_config.rs
@@ -31,98 +31,133 @@ impl TryFrom<Config> for EffectiveConfig {
         // Calculate effective config for each specific subgraph
         for (name, subgraph_config) in &config.subgraphs {
             // Compute effective configuration by merging global and subgraph settings.
-            let (effective_include_errors, effective_redact, effective_allow, effective_deny) =
-                match subgraph_config {
-                    SubgraphConfig::Allow {
-                        allow_extensions_keys: sub_allow,
-                        redact_message: sub_redact,
-                        exclude_global_keys,
-                    } => {
-                        let redact = sub_redact.unwrap_or(default_config.redact_message);
-                        match &default_config.allow_extensions_keys {
-                            Some(global_allow) => {
-                                let mut allow_list = global_allow
+            let (
+                effective_include_errors,
+                effective_redact,
+                effective_redact_service_name,
+                effective_allow,
+                effective_deny,
+            ) = match subgraph_config {
+                SubgraphConfig::Allow {
+                    allow_extensions_keys: sub_allow,
+                    redact_message: sub_redact,
+                    redact_service_name: sub_redact_service_name,
+                    exclude_global_keys,
+                } => {
+                    let redact = sub_redact.unwrap_or(default_config.redact_message);
+                    let redact_service_name =
+                        sub_redact_service_name.unwrap_or(default_config.redact_service_name);
+                    match &default_config.allow_extensions_keys {
+                        Some(global_allow) => {
+                            let mut allow_list = global_allow
+                                .iter()
+                                .filter(|k| !exclude_global_keys.contains(k))
+                                .cloned()
+                                .collect::<Vec<_>>();
+                            // Add subgraph's allow keys
+                            allow_list.extend(sub_allow.iter().cloned());
+                            (true, redact, redact_service_name, Some(allow_list), None)
+                        }
+                        None => (
+                            true,
+                            redact,
+                            redact_service_name,
+                            Some(sub_allow.to_vec()),
+                            None,
+                        ),
+                    }
+                }
+                SubgraphConfig::Deny {
+                    deny_extensions_keys: sub_deny,
+                    redact_message: sub_redact,
+                    redact_service_name: sub_redact_service_name,
+                    exclude_global_keys,
+                } => {
+                    let redact = sub_redact.unwrap_or(default_config.redact_message);
+                    let redact_service_name =
+                        sub_redact_service_name.unwrap_or(default_config.redact_service_name);
+                    match &default_config.deny_extensions_keys {
+                        Some(global_deny) => {
+                            let mut deny_list = global_deny
+                                .iter()
+                                .filter(|k| !exclude_global_keys.contains(k))
+                                .cloned()
+                                .collect::<Vec<_>>();
+                            deny_list.extend(sub_deny.clone());
+                            (true, redact, redact_service_name, None, Some(deny_list))
+                        }
+                        None => (
+                            true,
+                            redact,
+                            redact_service_name,
+                            None,
+                            Some(sub_deny.to_vec()),
+                        ),
+                    }
+                }
+                SubgraphConfig::Included(enabled) => {
+                    // Discard global allow/deny when subgraph is bool.
+                    // Inherit redact_service_name from global when enabled, otherwise irrelevant.
+                    let redact_service_name = if *enabled {
+                        default_config.redact_service_name
+                    } else {
+                        false
+                    };
+                    (*enabled, false, redact_service_name, None, None)
+                }
+                SubgraphConfig::CommonOnly {
+                    redact_message: sub_redact,
+                    redact_service_name: sub_redact_service_name,
+                    exclude_global_keys,
+                } => {
+                    let redact = sub_redact.unwrap_or(default_config.redact_message);
+                    let redact_service_name =
+                        sub_redact_service_name.unwrap_or(default_config.redact_service_name);
+                    // Inherit global allow/deny lists when using CommonOnly
+                    match config.all.clone() {
+                        ErrorMode::Allow {
+                            allow_extensions_keys,
+                            ..
+                        } => (
+                            true,
+                            redact,
+                            redact_service_name,
+                            Some(
+                                allow_extensions_keys
                                     .iter()
                                     .filter(|k| !exclude_global_keys.contains(k))
                                     .cloned()
-                                    .collect::<Vec<_>>();
-                                // Add subgraph's allow keys
-                                allow_list.extend(sub_allow.iter().cloned());
-                                (true, redact, Some(allow_list), None)
-                            }
-                            None => (true, redact, Some(sub_allow.to_vec()), None),
-                        }
-                    }
-                    SubgraphConfig::Deny {
-                        deny_extensions_keys: sub_deny,
-                        redact_message: sub_redact,
-                        exclude_global_keys,
-                    } => {
-                        let redact = sub_redact.unwrap_or(default_config.redact_message);
-                        match &default_config.deny_extensions_keys {
-                            Some(global_deny) => {
-                                let mut deny_list = global_deny
+                                    .collect(),
+                            ),
+                            None,
+                        ),
+                        ErrorMode::Deny {
+                            deny_extensions_keys,
+                            ..
+                        } => (
+                            true,
+                            redact,
+                            redact_service_name,
+                            None,
+                            Some(
+                                deny_extensions_keys
                                     .iter()
                                     .filter(|k| !exclude_global_keys.contains(k))
                                     .cloned()
-                                    .collect::<Vec<_>>();
-                                deny_list.extend(sub_deny.clone());
-                                (true, redact, None, Some(deny_list))
-                            }
-                            None => (true, redact, None, Some(sub_deny.to_vec())),
-                        }
-                    }
-                    SubgraphConfig::Included(enabled) => (
-                        // Discard global allow/deny when subgraph is bool
-                        *enabled, false, None, None,
-                    ),
-                    SubgraphConfig::CommonOnly {
-                        redact_message: sub_redact,
-                        exclude_global_keys,
-                    } => {
-                        let redact = sub_redact.unwrap_or(default_config.redact_message);
-                        // Inherit global allow/deny lists when using CommonOnly
-                        match config.all.clone() {
-                            ErrorMode::Allow {
-                                allow_extensions_keys,
-                                ..
-                            } => (
-                                true,
-                                redact,
-                                Some(
-                                    allow_extensions_keys
-                                        .iter()
-                                        .filter(|k| !exclude_global_keys.contains(k))
-                                        .cloned()
-                                        .collect(),
-                                ),
-                                None,
+                                    .collect(),
                             ),
-                            ErrorMode::Deny {
-                                deny_extensions_keys,
-                                ..
-                            } => (
-                                true,
-                                redact,
-                                None,
-                                Some(
-                                    deny_extensions_keys
-                                        .iter()
-                                        .filter(|k| !exclude_global_keys.contains(k))
-                                        .cloned()
-                                        .collect(),
-                                ),
-                            ),
-                            _ => (true, redact, None, None),
-                        }
+                        ),
+                        _ => (true, redact, redact_service_name, None, None),
                     }
-                };
+                }
+            };
 
             effective_config.subgraphs.insert(
                 name.clone(),
                 SubgraphEffectiveConfig {
                     include_errors: effective_include_errors,
                     redact_message: effective_redact,
+                    redact_service_name: effective_redact_service_name,
                     allow_extensions_keys: effective_allow,
                     deny_extensions_keys: effective_deny,
                 },
@@ -139,6 +174,8 @@ pub(crate) struct SubgraphEffectiveConfig {
     pub(crate) include_errors: bool,
     /// Whether the error message should be redacted.
     pub(crate) redact_message: bool,
+    /// Whether the service name should be removed from error messages and extensions.
+    pub(crate) redact_service_name: bool,
     /// Set of extension keys explicitly allowed. If `None`, all are allowed unless denied.
     pub(crate) allow_extensions_keys: Option<Vec<String>>,
     /// Set of extension keys explicitly denied. Applied *after* allow list filtering.
@@ -147,43 +184,53 @@ pub(crate) struct SubgraphEffectiveConfig {
 
 impl EffectiveConfig {
     fn default_config(config: &Config) -> SubgraphEffectiveConfig {
-        let (global_include_errors, global_redact_message, global_allow_keys, global_deny_keys) =
-            match &config.all {
-                ErrorMode::Included(enabled) => (*enabled, !*enabled, None, None), // Redact if not enabled
-                ErrorMode::Allow {
-                    allow_extensions_keys,
-                    redact_message,
-                } => (
-                    true,
-                    *redact_message,
-                    Some(
-                        allow_extensions_keys
-                            .iter()
-                            .sorted()
-                            .cloned()
-                            .collect::<Vec<_>>(),
-                    ),
-                    None,
+        let (
+            global_include_errors,
+            global_redact_message,
+            global_redact_service_name,
+            global_allow_keys,
+            global_deny_keys,
+        ) = match &config.all {
+            ErrorMode::Included(enabled) => (*enabled, !*enabled, false, None, None), // Redact if not enabled
+            ErrorMode::Allow {
+                allow_extensions_keys,
+                redact_message,
+                redact_service_name,
+            } => (
+                true,
+                *redact_message,
+                *redact_service_name,
+                Some(
+                    allow_extensions_keys
+                        .iter()
+                        .sorted()
+                        .cloned()
+                        .collect::<Vec<_>>(),
                 ),
-                ErrorMode::Deny {
-                    deny_extensions_keys,
-                    redact_message,
-                } => (
-                    true,
-                    *redact_message,
-                    None,
-                    Some(
-                        deny_extensions_keys
-                            .iter()
-                            .sorted()
-                            .cloned()
-                            .collect::<Vec<_>>(),
-                    ),
+                None,
+            ),
+            ErrorMode::Deny {
+                deny_extensions_keys,
+                redact_message,
+                redact_service_name,
+            } => (
+                true,
+                *redact_message,
+                *redact_service_name,
+                None,
+                Some(
+                    deny_extensions_keys
+                        .iter()
+                        .sorted()
+                        .cloned()
+                        .collect::<Vec<_>>(),
                 ),
-            };
+            ),
+        };
         SubgraphEffectiveConfig {
             include_errors: global_include_errors,
             redact_message: global_redact_message,
+            redact_service_name: global_redact_service_name,
             allow_extensions_keys: global_allow_keys,
             deny_extensions_keys: global_deny_keys,
         }

--- a/apollo-router/src/plugins/include_subgraph_errors/mod.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/mod.rs
@@ -121,28 +121,46 @@ impl IncludeSubgraphErrors {
                     subgraph_name,
                     effective_config
                 );
-                // Process errors based on the effective config
+
+                // Always remove the private extension — prevents accidental leakage regardless of config.
+                let no_service_message = error
+                    .extensions
+                    .remove("apollo.private.fetch.message_no_service");
+
                 // 1. Redact message if needed
                 if effective_config.redact_message {
                     error.message = REDACTED_ERROR_MESSAGE.to_string();
                 }
 
-                // 2. Add 'service' extension (unless denied)
-                let service_key = "service".to_string();
-                let is_service_denied = effective_config
-                    .deny_extensions_keys
-                    .as_ref()
-                    .is_some_and(|deny| deny.contains(&service_key));
-                let is_service_allowed = effective_config
-                    .allow_extensions_keys
-                    .as_ref()
-                    .is_none_or(|allow| allow.contains(&service_key)); // Allowed if no allow list or if present in allow list
+                // 2. Service name handling
+                if effective_config.redact_service_name {
+                    if !effective_config.redact_message {
+                        if let Some(msg) =
+                            no_service_message.and_then(|v| v.as_str().map(str::to_owned))
+                        {
+                            error.message = msg;
+                        }
+                    }
+                    // Remove pre-set service extension and skip injection below.
+                    error.extensions.remove("service");
+                } else {
+                    // Add 'service' extension (unless denied by allow/deny lists)
+                    let service_key = "service".to_string();
+                    let is_service_denied = effective_config
+                        .deny_extensions_keys
+                        .as_ref()
+                        .is_some_and(|deny| deny.contains(&service_key));
+                    let is_service_allowed = effective_config
+                        .allow_extensions_keys
+                        .as_ref()
+                        .is_none_or(|allow| allow.contains(&service_key));
 
-                if !is_service_denied && is_service_allowed {
-                    error
-                        .extensions
-                        .entry(service_key)
-                        .or_insert(subgraph_name.clone().into());
+                    if !is_service_denied && is_service_allowed {
+                        error
+                            .extensions
+                            .entry(service_key)
+                            .or_insert(subgraph_name.clone().into());
+                    }
                 }
 
                 // 3. Filter extensions based on allow list

--- a/apollo-router/src/plugins/include_subgraph_errors/mod.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/mod.rs
@@ -134,12 +134,11 @@ impl IncludeSubgraphErrors {
 
                 // 2. Service name handling
                 if effective_config.redact_service_name {
-                    if !effective_config.redact_message {
-                        if let Some(msg) =
+                    if !effective_config.redact_message
+                        && let Some(msg) =
                             no_service_message.and_then(|v| v.as_str().map(str::to_owned))
-                        {
-                            error.message = msg;
-                        }
+                    {
+                        error.message = msg;
                     }
                     // Remove pre-set service extension and skip injection below.
                     error.extensions.remove("service");

--- a/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_basic.snap
+++ b/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_basic.snap
@@ -1,0 +1,10 @@
+---
+source: apollo-router/src/plugins/include_subgraph_errors/tests.rs
+description: "CONFIG:\n---\nall:\n  deny_extensions_keys: []\n  redact_message: false\n  redact_service_name: true\n\n\nREQUEST:\n[\n  {\n    \"data\": null,\n    \"errors\": [\n      {\n        \"message\": \"HTTP fetch failed from 'products': 503 Service Unavailable\",\n        \"path\": [],\n        \"extensions\": {\n          \"code\": \"SUBREQUEST_HTTP_ERROR\",\n          \"service\": \"products\",\n          \"apollo.private.fetch.message_no_service\": \"HTTP fetch failed: 503 Service Unavailable\",\n          \"apollo.private.subgraph.name\": \"products\"\n        }\n      }\n    ]\n  }\n]"
+expression: actual_responses
+---
+- errors:
+    - message: "HTTP fetch failed: 503 Service Unavailable"
+      path: []
+      extensions:
+        code: SUBREQUEST_HTTP_ERROR

--- a/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_default_false.snap
+++ b/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_default_false.snap
@@ -1,0 +1,11 @@
+---
+source: apollo-router/src/plugins/include_subgraph_errors/tests.rs
+description: "CONFIG:\n---\nall:\n  deny_extensions_keys: []\n  redact_message: false\n\n\nREQUEST:\n[\n  {\n    \"data\": null,\n    \"errors\": [\n      {\n        \"message\": \"HTTP fetch failed from 'products': 503 Service Unavailable\",\n        \"path\": [],\n        \"extensions\": {\n          \"code\": \"SUBREQUEST_HTTP_ERROR\",\n          \"service\": \"products\",\n          \"apollo.private.fetch.message_no_service\": \"HTTP fetch failed: 503 Service Unavailable\",\n          \"apollo.private.subgraph.name\": \"products\"\n        }\n      }\n    ]\n  }\n]"
+expression: actual_responses
+---
+- errors:
+    - message: "HTTP fetch failed from 'products': 503 Service Unavailable"
+      path: []
+      extensions:
+        code: SUBREQUEST_HTTP_ERROR
+        service: products

--- a/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_non_subgraph_error.snap
+++ b/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_non_subgraph_error.snap
@@ -1,0 +1,13 @@
+---
+source: apollo-router/src/plugins/include_subgraph_errors/tests.rs
+description: "CONFIG:\n---\nall:\n  deny_extensions_keys: []\n  redact_message: false\n  redact_service_name: true\n\n\nREQUEST:\n[\n  {\n    \"data\": {\n      \"topProducts\": null\n    },\n    \"errors\": [\n      {\n        \"message\": \"Authentication error\",\n        \"path\": [],\n        \"extensions\": {\n          \"test\": \"value\",\n          \"code\": \"AUTH_ERROR\"\n        }\n      }\n    ]\n  }\n]"
+expression: actual_responses
+---
+- data:
+    topProducts: ~
+  errors:
+    - message: Authentication error
+      path: []
+      extensions:
+        test: value
+        code: AUTH_ERROR

--- a/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_per_subgraph_opt_out.snap
+++ b/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_per_subgraph_opt_out.snap
@@ -1,0 +1,11 @@
+---
+source: apollo-router/src/plugins/include_subgraph_errors/tests.rs
+description: "CONFIG:\n---\nall:\n  deny_extensions_keys: []\n  redact_message: false\n  redact_service_name: true\nsubgraphs:\n  products:\n    redact_service_name: false\n\n\nREQUEST:\n[\n  {\n    \"data\": null,\n    \"errors\": [\n      {\n        \"message\": \"HTTP fetch failed from 'products': 503 Service Unavailable\",\n        \"path\": [],\n        \"extensions\": {\n          \"code\": \"SUBREQUEST_HTTP_ERROR\",\n          \"service\": \"products\",\n          \"apollo.private.fetch.message_no_service\": \"HTTP fetch failed: 503 Service Unavailable\",\n          \"apollo.private.subgraph.name\": \"products\"\n        }\n      }\n    ]\n  }\n]"
+expression: actual_responses
+---
+- errors:
+    - message: "HTTP fetch failed from 'products': 503 Service Unavailable"
+      path: []
+      extensions:
+        code: SUBREQUEST_HTTP_ERROR
+        service: products

--- a/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_removes_preset_service_ext.snap
+++ b/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_removes_preset_service_ext.snap
@@ -1,0 +1,10 @@
+---
+source: apollo-router/src/plugins/include_subgraph_errors/tests.rs
+description: "CONFIG:\n---\nall:\n  allow_extensions_keys:\n    - code\n    - service\n  redact_message: false\n  redact_service_name: true\n\n\nREQUEST:\n[\n  {\n    \"data\": null,\n    \"errors\": [\n      {\n        \"message\": \"HTTP fetch failed from 'products': 503 Service Unavailable\",\n        \"path\": [],\n        \"extensions\": {\n          \"code\": \"SUBREQUEST_HTTP_ERROR\",\n          \"service\": \"products\",\n          \"apollo.private.fetch.message_no_service\": \"HTTP fetch failed: 503 Service Unavailable\",\n          \"apollo.private.subgraph.name\": \"products\"\n        }\n      }\n    ]\n  }\n]"
+expression: actual_responses
+---
+- errors:
+    - message: "HTTP fetch failed: 503 Service Unavailable"
+      path: []
+      extensions:
+        code: SUBREQUEST_HTTP_ERROR

--- a/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_with_redact_message.snap
+++ b/apollo-router/src/plugins/include_subgraph_errors/snapshots/apollo_router__plugins__include_subgraph_errors__tests__redact_service_name_with_redact_message.snap
@@ -1,0 +1,10 @@
+---
+source: apollo-router/src/plugins/include_subgraph_errors/tests.rs
+description: "CONFIG:\n---\nall:\n  deny_extensions_keys: []\n  redact_message: true\n  redact_service_name: true\n\n\nREQUEST:\n[\n  {\n    \"data\": null,\n    \"errors\": [\n      {\n        \"message\": \"HTTP fetch failed from 'products': 503 Service Unavailable\",\n        \"path\": [],\n        \"extensions\": {\n          \"code\": \"SUBREQUEST_HTTP_ERROR\",\n          \"service\": \"products\",\n          \"apollo.private.fetch.message_no_service\": \"HTTP fetch failed: 503 Service Unavailable\",\n          \"apollo.private.subgraph.name\": \"products\"\n        }\n      }\n    ]\n  }\n]"
+expression: actual_responses
+---
+- errors:
+    - message: Subgraph errors redacted
+      path: []
+      extensions:
+        code: SUBREQUEST_HTTP_ERROR

--- a/apollo-router/src/plugins/include_subgraph_errors/tests.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/tests.rs
@@ -13,6 +13,12 @@ use crate::services::supergraph; // Required for collect
 const PRODUCT_ERROR_RESPONSE: &[&str] = &[
     r#"{"data":{"topProducts":null},"errors":[{"message":"Could not query products","path":[],"extensions":{"test":"value","code":"FETCH_ERROR", "apollo.private.subgraph.name": "products"}}]}"#,
 ];
+// Simulates an error produced by FetchError::SubrequestHttpError::to_graphql_error():
+// the service name appears in the message, in extensions["service"], and the pre-computed
+// no-service message is stored in the private extension.
+const PRODUCT_HTTP_FETCH_ERROR_RESPONSE: &[&str] = &[
+    r#"{"data":null,"errors":[{"message":"HTTP fetch failed from 'products': 503 Service Unavailable","path":[],"extensions":{"code":"SUBREQUEST_HTTP_ERROR","service":"products","apollo.private.fetch.message_no_service":"HTTP fetch failed: 503 Service Unavailable","apollo.private.subgraph.name":"products"}}]}"#,
+];
 const ACCOUNT_ERROR_RESPONSE: &[&str] = &[
     r#"{"data":null,"errors":[{"message":"Account service error","path":[],"extensions":{"code":"ACCOUNT_FAIL", "apollo.private.subgraph.name": "accounts"}}]}"#,
 ];
@@ -500,6 +506,109 @@ async fn it_processes_incremental_responses() {
         }),
         INCREMENTAL_RESPONSE,
         "incremental_response",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn it_redacts_service_name_in_message_and_removes_service_extension() {
+    run_test_case(
+        &json!({
+            "all": {
+                "deny_extensions_keys": [],
+                "redact_message": false,
+                "redact_service_name": true
+            }
+        }),
+        PRODUCT_HTTP_FETCH_ERROR_RESPONSE,
+        "redact_service_name_basic",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn it_redacts_service_name_globally_with_per_subgraph_opt_out() {
+    run_test_case(
+        &json!({
+            "all": {
+                "deny_extensions_keys": [],
+                "redact_message": false,
+                "redact_service_name": true
+            },
+            "subgraphs": {
+                "products": { "redact_service_name": false }
+            }
+        }),
+        PRODUCT_HTTP_FETCH_ERROR_RESPONSE,
+        "redact_service_name_per_subgraph_opt_out",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn it_redact_message_wins_over_redact_service_name() {
+    // When both redact_message and redact_service_name are true, full redaction wins
+    // and service extension is still removed.
+    run_test_case(
+        &json!({
+            "all": {
+                "deny_extensions_keys": [],
+                "redact_message": true,
+                "redact_service_name": true
+            }
+        }),
+        PRODUCT_HTTP_FETCH_ERROR_RESPONSE,
+        "redact_service_name_with_redact_message",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn it_removes_pre_set_service_extension_when_redacting_service_name() {
+    // The service extension is pre-set by to_graphql_error() before the plugin runs.
+    // Verify it is explicitly removed even though we did not inject it.
+    run_test_case(
+        &json!({
+            "all": {
+                "allow_extensions_keys": ["code", "service"],
+                "redact_message": false,
+                "redact_service_name": true
+            }
+        }),
+        PRODUCT_HTTP_FETCH_ERROR_RESPONSE,
+        "redact_service_name_removes_preset_service_ext",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn it_does_not_redact_service_name_by_default() {
+    // Default behaviour (redact_service_name: false) is unchanged — service name visible.
+    run_test_case(
+        &json!({
+            "all": {
+                "deny_extensions_keys": [],
+                "redact_message": false
+            }
+        }),
+        PRODUCT_HTTP_FETCH_ERROR_RESPONSE,
+        "redact_service_name_default_false",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn it_does_not_redact_service_name_for_non_subgraph_errors() {
+    run_test_case(
+        &json!({
+            "all": {
+                "deny_extensions_keys": [],
+                "redact_message": false,
+                "redact_service_name": true
+            }
+        }),
+        NON_SUBGRAPH_ERROR,
+        "redact_service_name_non_subgraph_error",
     )
     .await;
 }

--- a/apollo-router/src/plugins/subscription/fetch.rs
+++ b/apollo-router/src/plugins/subscription/fetch.rs
@@ -229,9 +229,9 @@ fn subscription_with_subgraph_service(
             None => {
                 vec![
                     Error::builder()
-                        .message(format!(
-                            "subscription mode is not configured for subgraph {service_name:?}"
-                        ))
+                        .message(
+                            "subscription mode is not configured for this subgraph",
+                        )
                         .extension_code("INVALID_SUBSCRIPTION_MODE")
                         .build(),
                 ]

--- a/apollo-router/src/plugins/subscription/fetch.rs
+++ b/apollo-router/src/plugins/subscription/fetch.rs
@@ -229,9 +229,7 @@ fn subscription_with_subgraph_service(
             None => {
                 vec![
                     Error::builder()
-                        .message(
-                            "subscription mode is not configured for this subgraph",
-                        )
+                        .message("subscription mode is not configured for this subgraph")
                         .extension_code("INVALID_SUBSCRIPTION_MODE")
                         .build(),
                 ]


### PR DESCRIPTION
> **⚠️ Do not merge** — this is a draft implementation of one possible config option for service-name redaction, written for comparison against an alternative strategy. The final design (field names, placement, behaviour) has not been decided.

## Summary

- Adds `redact_service_name: bool` to `include_subgraph_errors` config (inside `ErrorMode::Allow/Deny` and as `Option<bool>` in per-subgraph overrides). Defaults to `false` — no breaking change.
- When enabled, the subgraph name is stripped from error messages (using a pre-computed private extension on `FetchError::to_graphql_error()`) and `extensions.service` is removed.
- Also fixes a separate leak in `subscription/fetch.rs` where the service name was hard-coded into an error message string.

## Example config

```yaml
include_subgraph_errors:
  all:
    deny_extensions_keys: []
    redact_service_name: true   # strips service name from message + removes extensions.service
  subgraphs:
    internal-subgraph:
      redact_service_name: false  # opt this subgraph back in
```

## Behaviour table

| Config | Message | `extensions.service` |
|---|---|---|
| `all: true` (existing default) | original (with service name) | present |
| `all: true` + `redact_service_name: true` | no service name in message | absent |
| `all: true` + `redact_message: true` + `redact_service_name: true` | `"Subgraph errors redacted"` | absent |

## Test plan

- [ ] 35 unit tests pass (`cargo test -p apollo-router plugins::include_subgraph_errors`)
- [ ] 6 new snapshot tests cover: basic redaction, per-subgraph opt-out, `redact_message` precedence, pre-set `service` extension removal, default-false behaviour, non-subgraph errors unaffected
- [ ] `cargo build -p apollo-router` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)