### PR TITLE
fix(tests): tear down test-owned coprocessor servers before graceful_shutdown

### DIFF
--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -723,6 +723,11 @@ async fn test_coprocessor_receives_response_cache_keys() -> Result<(), BoxError>
 
     assert_eq!(cache_keys, expected);
 
+    // Shut down the wiremock coprocessor before signalling the router.  Leaving it running
+    // keeps the router's outbound keep-alive connection to the coprocessor live; the router's
+    // drain then waits for it to close and the test's 3s shutdown budget expires as a "hang."
+    drop(mock_server);
+
     router.graceful_shutdown().await;
 
     Ok(())
@@ -825,7 +830,7 @@ async fn test_coprocessor_unix_domain_socket_with_path() -> Result<(), tower::Bo
     let uds = UnixListener::bind(&sock_path).expect("bind uds");
     let expected_path_owned = expected_path.to_string();
 
-    tokio::spawn(async move {
+    let coprocessor_handle = tokio::spawn(async move {
         loop {
             let (stream, _) = uds.accept().await.expect("accept");
             let io = TokioIo::new(stream);
@@ -891,6 +896,17 @@ async fn test_coprocessor_unix_domain_socket_with_path() -> Result<(), tower::Bo
     // if we get a 200 it's because we've hit the target path; see above for how this works, but
     // any path _not_ explicitly the one we've set (/api/v1/coprocessor) will return a 500
     assert_eq!(response.status(), 200);
+
+    // The response body is never read, so the Response struct still pins an open TCP
+    // connection to the router.  Drop it before shutdown so the router's drain can complete
+    // within the assert_shutdown budget.
+    drop(response);
+
+    // Shut down the coprocessor accept loop before signalling the router.  Leaving it running
+    // keeps the router's outbound keep-alive connection to the coprocessor live; the router's
+    // drain then waits for it to close and the test's 3s shutdown budget expires as a "hang."
+    // Aborting the task drops the UnixListener and any in-flight serve_connection futures.
+    coprocessor_handle.abort();
 
     router.graceful_shutdown().await;
     Ok(())
@@ -1426,6 +1442,11 @@ async fn test_connector_coprocessor_request_response() -> Result<(), BoxError> {
         called_stages.contains(&"ConnectorResponse".to_string()),
         "ConnectorResponse stage should have been called, got: {called_stages:?}"
     );
+
+    // Shut down the wiremock coprocessor before signalling the router.  Leaving it running
+    // keeps the router's outbound keep-alive connection to the coprocessor live; the router's
+    // drain then waits for it to close and the test's 3s shutdown budget expires as a "hang."
+    drop(mock_coprocessor);
 
     router.graceful_shutdown().await;
     Ok(())


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-####] -->
---

## What's going on

Three integration tests in `apollo-router/tests/integration/coprocessor.rs` flake on CI with the now-familiar `"unable to shutdown router, this probably means a hang and should be investigated"` panic at `common.rs:1577`:

- `test_coprocessor_unix_domain_socket_with_path`
- `test_connector_coprocessor_request_response`
- `test_coprocessor_receives_response_cache_keys`

Each test sets up its own coprocessor server — a spawned UDS-accept loop in the first, `wiremock::MockServer` in the other two — and the router opens an outbound keep-alive connection to it during the test.  At function end the test drops the server, but that drop happens *after* `graceful_shutdown` returns — and `graceful_shutdown` is blocked waiting for the keep-alive connection to close, which won't happen until the server goes away.  Catch-22, the 3 s `assert_shutdown` budget expires, panic.

Easy to miss because on a fast laptop the race usually wins.  CI runners are slower / more contended, so the drain check loses.

## The fix

Test-only.  For each test, shut the coprocessor server down *before* calling `router.graceful_shutdown().await`:

- UDS test — capture the `tokio::spawn(...)` as `coprocessor_handle`, call `coprocessor_handle.abort()`.  Aborting drops the `UnixListener` and any in-flight `serve_connection` futures.  Also `drop(response)` since that test never reads the response body, so the unconsumed `Response` is itself pinning a TCP connection back to the router.
- The two wiremock-based tests — `drop(mock_coprocessor)` / `drop(mock_server)` directly.  `wiremock::MockServer` shuts down on drop.

No non-test code touched.  No customer-visible behavior change.

## Validation

Used a local `repro-flaky-router-test` skill's build-once / loop-the-binary mechanic — single `cargo nextest` invocation up front, then loop the compiled test binary directly with `nice -n 19` and a `pkill -TERM router` cleanup trap.  Each iter ~3–5 s, 100 iters ~5–8 min wall.

| Test | Baseline (cold + warm) | Post-fix (cold + warm) |
|---|---|---|
| `test_coprocessor_unix_domain_socket_with_path` | 1 hang in ~100 | 0 in 200 |
| `test_connector_coprocessor_request_response` | 1 hang in ~100 | 0 in 200 |
| `test_coprocessor_receives_response_cache_keys` | 0 hangs in 200 (didn't reproduce locally) | n/a — theory-driven by analogy |

The third test couldn't be reproduced on M-series hardware — fast scheduler timing margins, the race always wins.  Same panic site, same file, same setup pattern as the other two; fix is the same shape.  Will be validated against CI re-runs.

## Why I want a second look

Particularly on the `wiremock::MockServer` drop: I'm assuming `MockServer::drop` synchronously closes the listening socket and any active connections in a way that lets the router's drain notice the close before the 3 s budget expires.  Reading wiremock's source suggests this is the case (it owns its listener via `Arc<MockServerInner>` whose Drop signals shutdown to the spawned server task), but I haven't dug into the timing in detail.  If anyone knows wiremock's shutdown semantics better than me, a sanity check would be appreciated.

---

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary) — *no ticket; this is CI-flakiness driven*
- [ ] Changeset is included for user-facing changes — *test-only, not user-facing*
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed — *N/A*
- [ ] Performance impact assessed and acceptable — *N/A, test-only*
- [ ] Metrics and logs are added[^3] and documented — *N/A*
- Tests added and passing[^4]
    - [ ] Unit tests
    - [x] Integration tests — *the tests themselves are what's being fixed*
    - [ ] Manual tests, as necessary

**Exceptions**

Test-only change — no changeset, docs, metrics, or performance impact.  The tests themselves are what's being fixed.

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
