### PR TITLE
fix(comp): `@join__field` is no longer emitted due to `@override` with nonexistent subgraph.

### DIFF
--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -915,7 +915,8 @@ impl Merger {
         // Skip if no join__field directive is required for this field.
         trace!("Checking if join__field is needed for field {dest}");
         match self.needs_join_field(sources, &parent_name, all_types_equal, merge_context) {
-            Ok(needs) if !needs => {
+            Ok(true) => {} // needs join field, continue
+            Ok(false) => {
                 trace!("Field {dest} does not need join__field");
                 return Ok(());
             } // No join__field needed, exit early
@@ -923,7 +924,6 @@ impl Merger {
                 trace!("Error implies parent of {dest} does not exist, skipping join__field");
                 return Ok(());
             } // Skip on error - invalid parent name
-            Ok(_) => {} // needs join field, continue
         }
 
         // Filter source fields by override usage and override label presence.
@@ -1066,27 +1066,6 @@ impl Merger {
 
         let sources = map_sources(sources, |source| source.clone().map(|s| s.into()));
 
-        // Check if any field has @override directive
-        for (&idx, source_opt) in &sources {
-            if let Some(source_pos) = source_opt
-                && let Some(subgraph) = self.subgraphs.get(idx)
-                && let Some(override_directive_name) = subgraph.override_directive_name()
-            {
-                let has_override = match source_pos {
-                    DirectiveTargetPosition::ObjectField(pos) => !pos
-                        .get_applied_directives(subgraph.schema(), &override_directive_name)
-                        .is_empty(),
-                    DirectiveTargetPosition::InterfaceField(pos) => !pos
-                        .get_applied_directives(subgraph.schema(), &override_directive_name)
-                        .is_empty(),
-                    _ => false,
-                };
-                if has_override {
-                    return Ok(true);
-                }
-            }
-        }
-
         // Check if any field has @fromContext directive
         for source in sources.values().flatten() {
             // Check if THIS specific source is in fields_with_from_context
@@ -1131,43 +1110,38 @@ impl Merger {
         //   3) none of the field is @external.
         for (&idx, source_opt) in &sources {
             let subgraph = &self.subgraphs[idx];
-            let provides_directive_name = subgraph.provides_directive_name();
-            let requires_directive_name = subgraph.requires_directive_name();
             let overridden = merge_context.is_unused_overridden(idx);
-            match source_opt {
-                Some(source_pos) => {
-                    if !overridden {
-                        // Check if field is external
-                        let is_external = match source_pos {
-                            DirectiveTargetPosition::ObjectField(pos) => self.is_field_external(
-                                idx,
-                                &FieldDefinitionPosition::Object(pos.clone()),
-                            ),
-                            DirectiveTargetPosition::InterfaceField(pos) => self.is_field_external(
-                                idx,
-                                &FieldDefinitionPosition::Interface(pos.clone()),
-                            ),
-                            _ => false, // Non-field positions can't be external
-                        };
-                        if is_external {
-                            return Ok(true);
-                        }
+            match (source_opt, !overridden) {
+                (Some(source_pos), true) => {
+                    // Check if field is external
+                    let is_external = match source_pos {
+                        DirectiveTargetPosition::ObjectField(pos) => self
+                            .is_field_external(idx, &FieldDefinitionPosition::Object(pos.clone())),
+                        DirectiveTargetPosition::InterfaceField(pos) => self.is_field_external(
+                            idx,
+                            &FieldDefinitionPosition::Interface(pos.clone()),
+                        ),
+                        _ => false, // Non-field positions can't be external
+                    };
+                    if is_external {
+                        return Ok(true);
+                    }
 
-                        // Check for requires and provides directives using subgraph-specific metadata
-                        if provides_directive_name.is_some_and(|provides| {
-                            !source_pos
-                                .get_applied_directives(subgraph.schema(), &provides)
-                                .is_empty()
-                        }) {
-                            return Ok(true);
-                        }
-                        if requires_directive_name.is_some_and(|requires| {
-                            !source_pos
-                                .get_applied_directives(subgraph.schema(), &requires)
-                                .is_empty()
-                        }) {
-                            return Ok(true);
-                        }
+                    // Check for requires and provides directives using subgraph-specific metadata
+                    if subgraph.provides_directive_name().is_some_and(|provides| {
+                        !source_pos
+                            .get_applied_directives(subgraph.schema(), &provides)
+                            .is_empty()
+                    }) {
+                        return Ok(true);
+                    }
+
+                    if subgraph.requires_directive_name().is_some_and(|requires| {
+                        !source_pos
+                            .get_applied_directives(subgraph.schema(), &requires)
+                            .is_empty()
+                    }) {
+                        return Ok(true);
                     }
 
                     let field_name = match source_pos {
@@ -1197,7 +1171,7 @@ impl Merger {
                 // TODO(FED-883): Now that the block above checks for a field's existence in all
                 // subgraphs (without relying on this explicit None being set), we should be able
                 // to switch `Sources` to be `IndexMap<usize, T>` instead of holding `Option<T>`.
-                None => {
+                _ => {
                     // This subgraph does not have the field, so if it has the field type, we need a join__field.
                     if subgraph
                         .schema()

--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -1092,18 +1092,6 @@ impl Merger {
             }
         }
 
-        // Check if any subgraph defines this type as an @interfaceObject
-        // If so, we need @join__field directives to distinguish which subgraphs provide which fields
-        let has_interface_object = self.subgraphs.iter().any(|subgraph| {
-            let obj_pos = ObjectTypeDefinitionPosition {
-                type_name: parent_name.clone(),
-            };
-            subgraph.is_interface_object_type(&obj_pos.into())
-        });
-        if has_interface_object {
-            return Ok(true);
-        }
-
         // We can avoid the join__field if:
         //   1) the field exists in all sources having the field parent type,
         //   2) none of the field instance has a @requires or @provides.

--- a/apollo-federation/tests/composition/compose_interface_object.rs
+++ b/apollo-federation/tests/composition/compose_interface_object.rs
@@ -640,3 +640,300 @@ fn interface_object_chains_are_not_supported() {
         )],
     );
 }
+
+// =============================================================================
+// @interfaceObject JOIN FIELD EMISSION TESTS
+//
+// Verifies that @join__field directives are only emitted when necessary on
+// interface fields involving @interfaceObject. Fields shared by ALL subgraphs
+// that declare the type should omit @join__field (implicit semantics suffice).
+// =============================================================================
+
+#[test]
+fn interface_object_shared_key_fields_omit_join_field() {
+    // Mirrors the real-world pattern (e.g. ShoppableProduct) where an
+    // interface spans two subgraphs — one as a real interface, the other as
+    // an @interfaceObject — while additional unrelated subgraphs participate
+    // in the composition. Key fields shared by both interface-declaring
+    // subgraphs should NOT get @join__field; subgraph-specific fields should.
+    //
+    // The bystander subgraph is critical: without it, the post-merge
+    // remove_redundant_join_fields cleanup would strip the extra directives
+    // (since they'd cover all graphs globally), masking the bug.
+    let subgraph_a = ServiceDefinition {
+        name: "SubgraphA",
+        type_defs: r#"
+        type Query {
+          items: [I]
+        }
+
+        interface I @key(fields: "id code") {
+          id: ID!
+          code: String!
+          onlyInA: Int
+        }
+
+        type A implements I @key(fields: "id code") {
+          id: ID!
+          code: String!
+          onlyInA: Int
+        }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "SubgraphB",
+        type_defs: r#"
+        type I @interfaceObject @key(fields: "id code") {
+          id: ID!
+          code: String!
+          onlyInB: Boolean
+        }
+        "#,
+    };
+
+    let bystander = ServiceDefinition {
+        name: "Bystander",
+        type_defs: r#"
+        type Unrelated @key(fields: "id") {
+          id: ID!
+          name: String
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b, bystander]);
+    let supergraph = result.expect("composition should succeed");
+    let schema = supergraph.schema().schema();
+
+    let iface = schema
+        .types
+        .get("I")
+        .expect("type I should exist")
+        .as_interface()
+        .expect("I should be an interface");
+
+    // Key fields present in BOTH subgraphs should NOT have @join__field
+    for field_name in ["id", "code"] {
+        let field = iface
+            .fields
+            .get(field_name)
+            .expect("field should exist on interface I");
+        let join_fields: Vec<_> = field
+            .directives
+            .iter()
+            .filter(|d| d.name == "join__field")
+            .collect();
+        assert!(
+            join_fields.is_empty(),
+            "Interface field I.{field_name} is shared by all declaring subgraphs \
+             and should NOT have @join__field, but has: {join_fields:?}"
+        );
+    }
+
+    // Fields present in only ONE subgraph should have @join__field
+    for field_name in ["onlyInA", "onlyInB"] {
+        let field = iface
+            .fields
+            .get(field_name)
+            .expect("field should exist on interface I");
+        let has_join_field = field.directives.iter().any(|d| d.name == "join__field");
+        assert!(
+            has_join_field,
+            "Interface field I.{field_name} exists in only one subgraph \
+             and should have @join__field"
+        );
+    }
+}
+
+#[test]
+fn interface_object_shared_key_fields_with_three_subgraphs() {
+    // Interface declared in SubgraphA with all implementations,
+    // @interfaceObject in SubgraphB and SubgraphC, plus a bystander.
+    // Key fields shared by all three interface-declaring subgraphs should
+    // omit @join__field; subgraph-specific fields should not.
+    let subgraph_a = ServiceDefinition {
+        name: "SubgraphA",
+        type_defs: r#"
+        type Query {
+          items: [I]
+        }
+
+        interface I @key(fields: "id") {
+          id: ID!
+          aOnly: Int
+        }
+
+        type Impl implements I @key(fields: "id") {
+          id: ID!
+          aOnly: Int
+        }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "SubgraphB",
+        type_defs: r#"
+        type I @interfaceObject @key(fields: "id") {
+          id: ID!
+          bOnly: Float
+        }
+        "#,
+    };
+
+    let subgraph_c = ServiceDefinition {
+        name: "SubgraphC",
+        type_defs: r#"
+        type I @interfaceObject @key(fields: "id") {
+          id: ID!
+          cOnly: Boolean
+        }
+        "#,
+    };
+
+    let bystander = ServiceDefinition {
+        name: "Bystander",
+        type_defs: r#"
+        type Unrelated @key(fields: "id") {
+          id: ID!
+          name: String
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b, subgraph_c, bystander]);
+    let supergraph = result.expect("composition should succeed");
+    let schema = supergraph.schema().schema();
+
+    let iface = schema
+        .types
+        .get("I")
+        .expect("type I should exist")
+        .as_interface()
+        .expect("I should be an interface");
+
+    // `id` is in ALL three subgraphs → should NOT have @join__field
+    let id_field = iface.fields.get("id").expect("id field should exist");
+    let id_join_fields: Vec<_> = id_field
+        .directives
+        .iter()
+        .filter(|d| d.name == "join__field")
+        .collect();
+    assert!(
+        id_join_fields.is_empty(),
+        "Interface field I.id is shared by all declaring subgraphs \
+         and should NOT have @join__field, but has: {id_join_fields:?}"
+    );
+
+    // Fields in only one subgraph should have exactly 1 @join__field
+    for field_name in ["aOnly", "bOnly", "cOnly"] {
+        let field = iface
+            .fields
+            .get(field_name)
+            .expect("field should exist on interface I");
+        let join_count = field
+            .directives
+            .iter()
+            .filter(|d| d.name == "join__field")
+            .count();
+        assert_eq!(
+            join_count, 1,
+            "Interface field I.{field_name} exists in only one subgraph \
+             and should have exactly 1 @join__field, but has {join_count}"
+        );
+    }
+}
+
+#[test]
+fn interface_object_partial_overlap_needs_join_field() {
+    // When a non-key field is present in some-but-not-all subgraphs that
+    // declare the interface, @join__field is required even with @interfaceObject.
+    // SubgraphA: interface with id + partial, SubgraphB: @interfaceObject with
+    // id + partial, SubgraphC: @interfaceObject with id only, plus a bystander.
+    let subgraph_a = ServiceDefinition {
+        name: "SubgraphA",
+        type_defs: r#"
+        type Query {
+          items: [I]
+        }
+
+        interface I @key(fields: "id") {
+          id: ID!
+          partial: String
+        }
+
+        type X implements I @key(fields: "id") {
+          id: ID!
+          partial: String @shareable
+        }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "SubgraphB",
+        type_defs: r#"
+        type I @interfaceObject @key(fields: "id") {
+          id: ID!
+          partial: String @shareable
+        }
+        "#,
+    };
+
+    let subgraph_c = ServiceDefinition {
+        name: "SubgraphC",
+        type_defs: r#"
+        type I @interfaceObject @key(fields: "id") {
+          id: ID!
+        }
+        "#,
+    };
+
+    let bystander = ServiceDefinition {
+        name: "Bystander",
+        type_defs: r#"
+        type Unrelated @key(fields: "id") {
+          id: ID!
+          name: String
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b, subgraph_c, bystander]);
+    let supergraph = result.expect("composition should succeed");
+    let schema = supergraph.schema().schema();
+
+    let iface = schema
+        .types
+        .get("I")
+        .expect("type I should exist")
+        .as_interface()
+        .expect("I should be an interface");
+
+    // `id` is in all three → no @join__field
+    let id_field = iface.fields.get("id").expect("id field should exist");
+    let id_join_count = id_field
+        .directives
+        .iter()
+        .filter(|d| d.name == "join__field")
+        .count();
+    assert_eq!(
+        id_join_count, 0,
+        "I.id is shared by all subgraphs and should NOT have @join__field"
+    );
+
+    // `partial` is in A and B but NOT C → needs @join__field
+    let partial_field = iface
+        .fields
+        .get("partial")
+        .expect("partial field should exist");
+    let partial_join_count = partial_field
+        .directives
+        .iter()
+        .filter(|d| d.name == "join__field")
+        .count();
+    assert_eq!(
+        partial_join_count, 2,
+        "I.partial is in 2 of 3 subgraphs and should have exactly 2 @join__field directives, \
+         but has {partial_join_count}"
+    );
+}


### PR DESCRIPTION
The Rust composition code was emitting `@join__field` uncertain unnecessary conditions. If a subgraph uses `@override` on a field and points to a nonexistent subgraph, the Rust code had logic that was not present in the original JS code that cause `@join__field` to be unnecessarily emitted.

This PR removes that logic and adjusts some additional logic to better match the [JS code](https://github.com/apollographql/federation/blob/main/composition-js/src/merging/merge.ts#L2028).

<!-- start metadata -->

<!-- [FED-966] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [x] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[FED-966]: https://apollographql.atlassian.net/browse/FED-966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ