### PR TITLE
fix(composition): prevent EnumTypeUsage from downgrading Both to Input/Output

### DIFF
--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -2061,18 +2061,23 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                 element_ast: element_ast.clone(),
             };
 
-            // Compute the new usage directly based on existing record and current position
+            // Compute the new usage directly based on existing record and current position.
+            // Once an enum reaches `Both`, it stays `Both` regardless of further observations.
             let new_usage = match self.enum_usages().get(base_type_name.as_str()) {
+                Some(EnumTypeUsage::Both {
+                    input_example,
+                    output_example,
+                }) => EnumTypeUsage::Both {
+                    input_example: input_example.clone(),
+                    output_example: output_example.clone(),
+                },
                 Some(EnumTypeUsage::Input { input_example }) if !is_input_position => {
                     EnumTypeUsage::Both {
                         input_example: input_example.clone(),
                         output_example: default_example(),
                     }
                 }
-                Some(EnumTypeUsage::Input { input_example })
-                | Some(EnumTypeUsage::Both { input_example, .. })
-                    if is_input_position =>
-                {
+                Some(EnumTypeUsage::Input { input_example }) if is_input_position => {
                     EnumTypeUsage::Input {
                         input_example: input_example.clone(),
                     }
@@ -2083,10 +2088,7 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                         output_example: output_example.clone(),
                     }
                 }
-                Some(EnumTypeUsage::Output { output_example })
-                | Some(EnumTypeUsage::Both { output_example, .. })
-                    if !is_input_position =>
-                {
+                Some(EnumTypeUsage::Output { output_example }) if !is_input_position => {
                     EnumTypeUsage::Output {
                         output_example: output_example.clone(),
                     }

--- a/apollo-federation/tests/composition/compose_basic.rs
+++ b/apollo-federation/tests/composition/compose_basic.rs
@@ -3,6 +3,7 @@ use insta::assert_snapshot;
 use test_log::test;
 
 use super::ServiceDefinition;
+use super::assert_composition_errors;
 use super::compose_as_fed2_subgraphs;
 use super::extract_subgraphs_from_supergraph_result;
 
@@ -390,5 +391,111 @@ fn removes_redundant_join_field_directives() {
     assert!(
         has_join_field,
         "Field Product.description should have @join__field directive"
+    );
+}
+
+// Regression test: enum usage tracking must not downgrade `Both` back to `Input` or `Output`
+// when a third (or later) field references the same enum in a position already seen.
+// Before the fix, the third output-position reference would overwrite `Both` → `Output`,
+// causing the ENUM_VALUE_MISMATCH error to be silently skipped.
+#[test]
+fn enum_value_mismatch_detected_with_multiple_output_fields() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          search(status: Status!): Result
+        }
+
+        type Result {
+          primary: Status!
+          secondary: Status!
+        }
+
+        enum Status {
+          ACTIVE
+          INACTIVE
+        }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+        type Query {
+          other: Int
+        }
+
+        enum Status {
+          ACTIVE
+        }
+        "#,
+    };
+
+    // Status is used as input (Query.search(status:)) and output (Result.primary, Result.secondary).
+    // After processing: Input → Both → must stay Both (not downgrade to Output on the second output field).
+    // Value INACTIVE is only in subgraphA, so ENUM_VALUE_MISMATCH must be reported.
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+    assert_composition_errors(
+        &result,
+        &[(
+            "ENUM_VALUE_MISMATCH",
+            r#"Enum type "Status" is used as both input type (for example, as type of "Query.search(status:)") and output type (for example, as type of "Result.primary"), but value "INACTIVE" is not defined in all the subgraphs defining "Status": "INACTIVE" is defined in subgraph "subgraphA" but not in subgraph "subgraphB""#,
+        )],
+    );
+}
+
+// Same regression but with multiple input fields: ensures `Both` isn't downgraded to `Input`.
+// The merger processes object types alphabetically, so `Alpha` (output field) is merged before
+// `Beta` (input arguments). This creates the sequence: Output → Both → Input(BUG without fix).
+#[test]
+fn enum_value_mismatch_detected_with_multiple_input_fields() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          alpha: Alpha
+          beta: Beta
+        }
+
+        type Alpha {
+          status: Status!
+        }
+
+        type Beta {
+          filterA(status: Status!): String
+          filterB(status: Status!): String
+        }
+
+        enum Status {
+          ACTIVE
+          INACTIVE
+        }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+        type Query {
+          other: Int
+        }
+
+        enum Status {
+          ACTIVE
+        }
+        "#,
+    };
+
+    // Status is used as output (Alpha.status) and input (Beta.filterA(status:), Beta.filterB(status:)).
+    // Merge order: Alpha.status(output) → Both via Beta.filterA(status:)(input) → must stay Both
+    // (not downgrade to Input on Beta.filterB(status:)).
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+    assert_composition_errors(
+        &result,
+        &[(
+            "ENUM_VALUE_MISMATCH",
+            r#"Enum type "Status" is used as both input type (for example, as type of "Beta.filterA(status:)") and output type (for example, as type of "Alpha.status"), but value "INACTIVE" is not defined in all the subgraphs defining "Status": "INACTIVE" is defined in subgraph "subgraphA" but not in subgraph "subgraphB""#,
+        )],
     );
 }


### PR DESCRIPTION
The `track_enum_usage` match arms for `Input | Both` and `Output | Both` incorrectly collapsed the `Both` variant back to a single-position usage whenever a subsequent field referenced the same enum in an already-seen position. For example, the sequence Input → Both → Output (third field) would overwrite `Both` with `Output`, silently skipping ENUM_VALUE_MISMATCH validation for enums used in both input and output contexts.

The JS composer (`merge.ts:2206`) handles this correctly: once position reaches `'Both'`, the expression `existing.position !== thisPosition` is always true, so `Both` is preserved.

The fix adds an explicit early match arm that returns `Both` unchanged, and removes the `| Both` alternatives from the `Input` and `Output` arms. This aligns RS behavior with JS for ~1,800 real-world supergraphs from the federation performance harness (groups 3.8 and 3.9).