### PR TITLE
feat(composition): preserve hints on composition failure

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -12,6 +12,7 @@ use apollo_federation::ApiSchemaOptions;
 use apollo_federation::Supergraph;
 use apollo_federation::bail;
 use apollo_federation::composition;
+use apollo_federation::composition::CompositionFailure;
 use apollo_federation::composition::CompositionOptions;
 use apollo_federation::composition::compose_with_connectors;
 use apollo_federation::composition::validate_satisfiability_with_connectors;
@@ -269,7 +270,7 @@ fn cmd_api_schema(file_paths: &[PathBuf], enable_defer: bool) -> Result<(), AnyE
 
 fn compose_files_inner(
     file_paths: &[PathBuf],
-) -> Result<composition::Supergraph<composition::Satisfiable>, Vec<CompositionError>> {
+) -> Result<composition::Supergraph<composition::Satisfiable>, CompositionFailure> {
     let mut subgraphs = Vec::new();
     let mut errors = Vec::new();
     for path in file_paths {
@@ -287,12 +288,11 @@ fn compose_files_inner(
         }
     }
     if !errors.is_empty() {
-        // Subgraph errors
         let mut composition_errors = Vec::new();
         for error in errors {
             composition_errors.extend(error.to_composition_errors());
         }
-        return Err(composition_errors);
+        return Err(CompositionFailure::from_errors(composition_errors));
     }
 
     compose_with_connectors(subgraphs, CompositionOptions::default())
@@ -301,15 +301,15 @@ fn compose_files_inner(
 /// Compose a supergraph from a Rover config YAML file.
 fn compose_from_config_inner(
     config_path: &Path,
-) -> Result<composition::Supergraph<composition::Satisfiable>, Vec<CompositionError>> {
+) -> Result<composition::Supergraph<composition::Satisfiable>, CompositionFailure> {
     let config_str = read_input(config_path);
     let config: SupergraphConfig = serde_yaml::from_str(&config_str).map_err(|e| {
-        vec![CompositionError::MergeError {
+        CompositionFailure::from_errors(vec![CompositionError::MergeError {
             error: SingleFederationError::Internal {
                 message: format!("Failed to parse YAML config: {}", e),
             },
             locations: Vec::new(),
-        }]
+        }])
     })?;
 
     let mut subgraphs = Vec::new();
@@ -326,21 +326,21 @@ fn compose_from_config_inner(
             } else {
                 config_dir.join(file_path)
             };
-            // Follow the same pattern as compose_files_inner - use unwrap for file I/O errors
             std::fs::read_to_string(&full_path).unwrap_or_else(|e| {
                 panic!("Failed to read schema file for subgraph '{}': {}", name, e)
             })
         } else {
-            // Return early with a composition error for missing schema specification
-            return Err(vec![CompositionError::MergeError {
-                error: SingleFederationError::Internal {
-                    message: format!(
-                        "Subgraph '{}' must specify either 'sdl' or 'file' in schema",
-                        name
-                    ),
+            return Err(CompositionFailure::from_errors(vec![
+                CompositionError::MergeError {
+                    error: SingleFederationError::Internal {
+                        message: format!(
+                            "Subgraph '{}' must specify either 'sdl' or 'file' in schema",
+                            name
+                        ),
+                    },
+                    locations: Vec::new(),
                 },
-                locations: Vec::new(),
-            }]);
+            ]));
         };
 
         let result = typestate::Subgraph::parse(&name, &subgraph_config.routing_url, &doc_str);
@@ -355,12 +355,11 @@ fn compose_from_config_inner(
     }
 
     if !errors.is_empty() {
-        // Subgraph errors
         let mut composition_errors = Vec::new();
         for error in errors {
             composition_errors.extend(error.to_composition_errors());
         }
-        return Err(composition_errors);
+        return Err(CompositionFailure::from_errors(composition_errors));
     }
 
     compose_with_connectors(subgraphs, CompositionOptions::default())
@@ -372,10 +371,9 @@ fn compose_files(
 ) -> Result<composition::Supergraph<composition::Satisfiable>, AnyError> {
     match compose_files_inner(file_paths) {
         Ok(supergraph) => Ok(supergraph),
-        Err(errors) => {
-            // Print composition errors
-            print_composition_errors(&errors);
-            let num_errors = errors.len();
+        Err(failure) => {
+            print_composition_errors(&failure.errors);
+            let num_errors = failure.errors.len();
             Err(anyhow!("Error: found {num_errors} composition error(s)."))
         }
     }
@@ -387,10 +385,9 @@ fn compose_from_config(
 ) -> Result<composition::Supergraph<composition::Satisfiable>, AnyError> {
     match compose_from_config_inner(config_path) {
         Ok(supergraph) => Ok(supergraph),
-        Err(errors) => {
-            // Print composition errors
-            print_composition_errors(&errors);
-            let num_errors = errors.len();
+        Err(failure) => {
+            print_composition_errors(&failure.errors);
+            let num_errors = failure.errors.len();
             Err(anyhow!("Error: found {num_errors} composition error(s)."))
         }
     }
@@ -553,10 +550,10 @@ fn cmd_satisfiability(file_path: &Path) -> Result<(), AnyError> {
             println!("[SUCCESS]");
             Ok(())
         }
-        Err(errors) => {
+        Err(failure) => {
             // Print composition errors
-            print_composition_errors(&errors);
-            let num_errors = errors.len();
+            print_composition_errors(&failure.errors);
+            let num_errors = failure.errors.len();
             Err(anyhow!(
                 "Error: found {num_errors} satisfiability error(s)."
             ))

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -18,9 +18,31 @@ use crate::subgraph::typestate::Expanded;
 use crate::subgraph::typestate::Initial;
 use crate::subgraph::typestate::Subgraph;
 use crate::subgraph::typestate::Validated;
+pub use crate::supergraph::CompositionHint;
 pub use crate::supergraph::Merged;
 pub use crate::supergraph::Satisfiable;
 pub use crate::supergraph::Supergraph;
+
+#[derive(Debug)]
+pub struct CompositionFailure {
+    pub errors: Vec<CompositionError>,
+    pub hints: Vec<CompositionHint>,
+}
+
+impl CompositionFailure {
+    pub fn from_errors(errors: Vec<CompositionError>) -> Self {
+        Self {
+            errors,
+            hints: Vec::new(),
+        }
+    }
+}
+
+impl From<Vec<CompositionError>> for CompositionFailure {
+    fn from(errors: Vec<CompositionError>) -> Self {
+        Self::from_errors(errors)
+    }
+}
 
 /// Options that configure composition. Mirrors the JS `CompositionOptions` interface
 /// (see `composition-js/src/compose.ts`). Most fields are not yet ported — add them here
@@ -36,23 +58,27 @@ pub struct CompositionOptions {
 pub fn compose(
     subgraphs: Vec<Subgraph<Initial>>,
     options: CompositionOptions,
-) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
     // explicitly sort subgraphs by their names
     // this was done automatically in JS as Subgraphs class stored subgraphs in OrderedMap (by name)
     let mut subgraphs = subgraphs;
     subgraphs.sort_by(|s1, s2| s1.name.cmp(&s2.name));
 
     tracing::debug!("Expanding subgraphs...");
-    let expanded_subgraphs = expand_subgraphs(subgraphs)?;
+    let expanded_subgraphs = expand_subgraphs(subgraphs).map_err(CompositionFailure::from_errors)?;
     tracing::debug!("Upgrading subgraphs...");
-    let validated_subgraphs = upgrade_subgraphs_if_necessary(expanded_subgraphs)?;
+    let validated_subgraphs =
+        upgrade_subgraphs_if_necessary(expanded_subgraphs).map_err(CompositionFailure::from_errors)?;
 
     tracing::debug!("Pre-merge validations...");
-    pre_merge_validations(&validated_subgraphs)?;
+    pre_merge_validations(&validated_subgraphs).map_err(CompositionFailure::from_errors)?;
     tracing::debug!("Merging subgraphs...");
     let supergraph = merge_subgraphs(validated_subgraphs, &options)?;
     tracing::debug!("Post-merge validations...");
-    post_merge_validations(&supergraph)?;
+    post_merge_validations(&supergraph).map_err(|errors| CompositionFailure {
+        errors,
+        hints: supergraph.hints().to_vec(),
+    })?;
     tracing::debug!("Validating satisfiability...");
     validate_satisfiability(supergraph, &options)
 }
@@ -61,7 +87,7 @@ pub fn compose(
 pub fn compose_with_connectors(
     subgraphs: Vec<Subgraph<Initial>>,
     options: CompositionOptions,
-) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
     // Pre-expand validation
     // - These were supposed to be pre-merge validations, but historically FBP performed these
     //   Rust-based validation, before JS composition.
@@ -69,19 +95,23 @@ pub fn compose_with_connectors(
     // TODO: (FED-855) Call `connectors::validation`, which may change the subgraphs before upgrading.
 
     tracing::debug!("Expanding subgraphs...");
-    let expanded_subgraphs = expand_subgraphs(subgraphs)?;
+    let expanded_subgraphs = expand_subgraphs(subgraphs).map_err(CompositionFailure::from_errors)?;
 
     tracing::debug!("Upgrading subgraphs...");
-    let validated_subgraphs = upgrade_subgraphs_if_necessary(expanded_subgraphs)?;
+    let validated_subgraphs =
+        upgrade_subgraphs_if_necessary(expanded_subgraphs).map_err(CompositionFailure::from_errors)?;
 
     tracing::debug!("Pre-merge validations...");
-    pre_merge_validations(&validated_subgraphs)?;
+    pre_merge_validations(&validated_subgraphs).map_err(CompositionFailure::from_errors)?;
 
     tracing::debug!("Merging subgraphs...");
     let supergraph = merge_subgraphs(validated_subgraphs, &options)?;
 
     tracing::debug!("Post-merge validations...");
-    post_merge_validations(&supergraph)?;
+    post_merge_validations(&supergraph).map_err(|errors| CompositionFailure {
+        errors,
+        hints: supergraph.hints().to_vec(),
+    })?;
     // TODO: (FED-855) Call `validate_overrides`, which validates the original subgraphs for connectors after merging.
     // - Once JS-to-Rust migration is done, we may consider to move that to the pre-merge validation step.
 
@@ -122,16 +152,16 @@ pub fn pre_merge_validations(
 pub fn merge_subgraphs(
     subgraphs: Vec<Subgraph<Validated>>,
     options: &CompositionOptions,
-) -> Result<Supergraph<Merged>, Vec<CompositionError>> {
+) -> Result<Supergraph<Merged>, CompositionFailure> {
     let merger = Merger::new(subgraphs, options.clone()).map_err(|e| {
-        vec![CompositionError::InternalError {
+        CompositionFailure::from_errors(vec![CompositionError::InternalError {
             message: e.to_string(),
-        }]
+        }])
     })?;
     let result = merger.merge().map_err(|e| {
-        vec![CompositionError::InternalError {
+        CompositionFailure::from_errors(vec![CompositionError::InternalError {
             message: e.to_string(),
-        }]
+        }])
     })?;
     tracing::trace!(
         "Merge has {} errors and {} hints",
@@ -140,14 +170,19 @@ pub fn merge_subgraphs(
     );
     if result.errors.is_empty() {
         let Some(supergraph_schema) = result.supergraph else {
-            return Err(vec![CompositionError::InternalError {
-                message: "Merge completed with no supergraph schema".to_string(),
-            }]);
+            return Err(CompositionFailure::from_errors(vec![
+                CompositionError::InternalError {
+                    message: "Merge completed with no supergraph schema".to_string(),
+                },
+            ]));
         };
         let supergraph = Supergraph::with_hints(supergraph_schema, result.hints);
         Ok(supergraph)
     } else {
-        Err(result.errors)
+        Err(CompositionFailure {
+            errors: result.errors,
+            hints: result.hints,
+        })
     }
 }
 
@@ -165,15 +200,21 @@ pub fn post_merge_validations(
 pub fn validate_satisfiability_with_connectors(
     supergraph: Supergraph<Merged>,
     options: &CompositionOptions,
-) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
-    // Expand connectors for satisfiability validation.
+) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
+    let merge_hints = supergraph.hints().to_vec();
     let supergraph_str = supergraph.schema().schema().to_string();
-    let expansion_result = expand_connectors(&supergraph_str, &Default::default())
-        .map_err(|e| vec![CompositionError::InternalError {
-            message: format!("Composition failed due to an internal error when expanding connectors, please report this: {e}"),
-        }])?;
+    let expansion_result = match expand_connectors(&supergraph_str, &Default::default()) {
+        Ok(result) => result,
+        Err(e) => {
+            return Err(CompositionFailure {
+                errors: vec![CompositionError::InternalError {
+                    message: format!("Composition failed due to an internal error when expanding connectors, please report this: {e}"),
+                }],
+                hints: merge_hints,
+            });
+        }
+    };
 
-    // Verify satisfiability
     match expansion_result {
         ExpansionResult::Expanded {
             raw_sdl,
@@ -182,27 +223,35 @@ pub fn validate_satisfiability_with_connectors(
             },
             ..
         } => {
-            let supergraph = Supergraph::parse(&raw_sdl).map_err(|e| {
-                vec![CompositionError::InternalError {
-                    message: e.to_string(),
-                }]
-            })?;
-            let mut result = validate_satisfiability(supergraph, options);
-
-            // Sanitize connectors subgraph names in errors and hints.
-            match &mut result {
-                Ok(supergraph) => {
+            let expanded_supergraph = match Supergraph::parse(&raw_sdl) {
+                Ok(s) => s,
+                Err(e) => {
+                    return Err(CompositionFailure {
+                        errors: vec![CompositionError::InternalError {
+                            message: e.to_string(),
+                        }],
+                        hints: merge_hints,
+                    });
+                }
+            };
+            match validate_satisfiability(expanded_supergraph, options) {
+                Ok(mut supergraph) => {
                     for hint in supergraph.hints_mut() {
                         sanitize_connectors_message(&mut hint.message, by_service_name.iter());
                     }
+                    Ok(supergraph)
                 }
-                Err(issues) => {
-                    for issue in issues.iter_mut() {
-                        sanitize_connectors_error(issue, by_service_name.iter());
+                Err(mut failure) => {
+                    failure.hints.extend(merge_hints);
+                    for error in failure.errors.iter_mut() {
+                        sanitize_connectors_error(error, by_service_name.iter());
                     }
+                    for hint in failure.hints.iter_mut() {
+                        sanitize_connectors_message(&mut hint.message, by_service_name.iter());
+                    }
+                    Err(failure)
                 }
             }
-            result
         }
         ExpansionResult::Unchanged => validate_satisfiability(supergraph, options),
     }

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -65,20 +65,17 @@ pub fn compose(
     subgraphs.sort_by(|s1, s2| s1.name.cmp(&s2.name));
 
     tracing::debug!("Expanding subgraphs...");
-    let expanded_subgraphs = expand_subgraphs(subgraphs).map_err(CompositionFailure::from_errors)?;
+    let expanded_subgraphs = expand_subgraphs(subgraphs)?;
     tracing::debug!("Upgrading subgraphs...");
-    let validated_subgraphs =
-        upgrade_subgraphs_if_necessary(expanded_subgraphs).map_err(CompositionFailure::from_errors)?;
+    let validated_subgraphs = upgrade_subgraphs_if_necessary(expanded_subgraphs)
+        .map_err(CompositionFailure::from_errors)?;
 
     tracing::debug!("Pre-merge validations...");
-    pre_merge_validations(&validated_subgraphs).map_err(CompositionFailure::from_errors)?;
+    pre_merge_validations(&validated_subgraphs)?;
     tracing::debug!("Merging subgraphs...");
     let supergraph = merge_subgraphs(validated_subgraphs, &options)?;
     tracing::debug!("Post-merge validations...");
-    post_merge_validations(&supergraph).map_err(|errors| CompositionFailure {
-        errors,
-        hints: supergraph.hints().to_vec(),
-    })?;
+    post_merge_validations(&supergraph)?;
     tracing::debug!("Validating satisfiability...");
     validate_satisfiability(supergraph, &options)
 }
@@ -95,23 +92,20 @@ pub fn compose_with_connectors(
     // TODO: (FED-855) Call `connectors::validation`, which may change the subgraphs before upgrading.
 
     tracing::debug!("Expanding subgraphs...");
-    let expanded_subgraphs = expand_subgraphs(subgraphs).map_err(CompositionFailure::from_errors)?;
+    let expanded_subgraphs = expand_subgraphs(subgraphs)?;
 
     tracing::debug!("Upgrading subgraphs...");
-    let validated_subgraphs =
-        upgrade_subgraphs_if_necessary(expanded_subgraphs).map_err(CompositionFailure::from_errors)?;
+    let validated_subgraphs = upgrade_subgraphs_if_necessary(expanded_subgraphs)
+        .map_err(CompositionFailure::from_errors)?;
 
     tracing::debug!("Pre-merge validations...");
-    pre_merge_validations(&validated_subgraphs).map_err(CompositionFailure::from_errors)?;
+    pre_merge_validations(&validated_subgraphs)?;
 
     tracing::debug!("Merging subgraphs...");
     let supergraph = merge_subgraphs(validated_subgraphs, &options)?;
 
     tracing::debug!("Post-merge validations...");
-    post_merge_validations(&supergraph).map_err(|errors| CompositionFailure {
-        errors,
-        hints: supergraph.hints().to_vec(),
-    })?;
+    post_merge_validations(&supergraph)?;
     // TODO: (FED-855) Call `validate_overrides`, which validates the original subgraphs for connectors after merging.
     // - Once JS-to-Rust migration is done, we may consider to move that to the pre-merge validation step.
 
@@ -124,7 +118,7 @@ pub fn compose_with_connectors(
 #[instrument(skip(subgraphs))]
 pub fn expand_subgraphs(
     subgraphs: Vec<Subgraph<Initial>>,
-) -> Result<Vec<Subgraph<Expanded>>, Vec<CompositionError>> {
+) -> Result<Vec<Subgraph<Expanded>>, CompositionFailure> {
     let mut errors: Vec<CompositionError> = vec![];
     let expanded: Vec<Subgraph<Expanded>> = subgraphs
         .into_iter()
@@ -134,16 +128,14 @@ pub fn expand_subgraphs(
     if errors.is_empty() {
         Ok(expanded)
     } else {
-        Err(errors)
+        Err(CompositionFailure::from_errors(errors))
     }
 }
 
 /// Perform validations that require information about all available subgraphs.
 #[instrument(skip(subgraphs))]
-pub fn pre_merge_validations(
-    subgraphs: &[Subgraph<Validated>],
-) -> Result<(), Vec<CompositionError>> {
-    validate_consistent_root_fields(subgraphs)?;
+pub fn pre_merge_validations(subgraphs: &[Subgraph<Validated>]) -> Result<(), CompositionFailure> {
+    validate_consistent_root_fields(subgraphs).map_err(CompositionFailure::from_errors)?;
     // TODO: (FED-713) Implement any pre-merge validations that require knowledge of all subgraphs.
     Ok(())
 }
@@ -187,9 +179,7 @@ pub fn merge_subgraphs(
 }
 
 #[instrument(skip(_supergraph))]
-pub fn post_merge_validations(
-    _supergraph: &Supergraph<Merged>,
-) -> Result<(), Vec<CompositionError>> {
+pub fn post_merge_validations(_supergraph: &Supergraph<Merged>) -> Result<(), CompositionFailure> {
     // TODO: (FED-714) Implement any post-merge validations other than satisfiability, which is
     // checked separately.
     Ok(())
@@ -208,7 +198,9 @@ pub fn validate_satisfiability_with_connectors(
         Err(e) => {
             return Err(CompositionFailure {
                 errors: vec![CompositionError::InternalError {
-                    message: format!("Composition failed due to an internal error when expanding connectors, please report this: {e}"),
+                    message: format!(
+                        "Composition failed due to an internal error when expanding connectors, please report this: {e}"
+                    ),
                 }],
                 hints: merge_hints,
             });

--- a/apollo-federation/src/composition/satisfiability.rs
+++ b/apollo-federation/src/composition/satisfiability.rs
@@ -10,6 +10,7 @@ use tracing::instrument;
 use tracing::trace;
 
 use crate::api_schema;
+use crate::composition::CompositionFailure;
 use crate::composition::CompositionOptions;
 use crate::composition::satisfiability::validation_traversal::ValidationTraversal;
 use crate::error::CompositionError;
@@ -27,17 +28,20 @@ use crate::supergraph::Supergraph;
 pub fn validate_satisfiability(
     mut supergraph: Supergraph<Merged>,
     options: &CompositionOptions,
-) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
     let supergraph_schema = supergraph.schema().clone();
     let mut errors = vec![];
     let mut hints = supergraph.hints_mut().drain(..).collect();
-    validate_satisfiability_inner(supergraph, options, &mut errors, &mut hints).map_err(|e| {
-        vec![CompositionError::InternalError {
-            message: e.to_string(),
-        }]
-    })?;
+    if let Err(e) = validate_satisfiability_inner(supergraph, options, &mut errors, &mut hints) {
+        return Err(CompositionFailure {
+            errors: vec![CompositionError::InternalError {
+                message: e.to_string(),
+            }],
+            hints,
+        });
+    }
     if !errors.is_empty() {
-        return Err(errors);
+        return Err(CompositionFailure { errors, hints });
     }
     Ok(Supergraph::<Satisfiable>::new(supergraph_schema, hints))
 }

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -210,7 +210,7 @@ mod federation_directives {
         );
         let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -258,7 +258,7 @@ mod federation_directives {
 
         let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -303,7 +303,7 @@ mod federation_directives {
         );
         let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -382,7 +382,7 @@ mod inconsistent_feature_versions {
             r#"@foo(name: "b")"#,
         );
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -640,7 +640,7 @@ mod inconsistent_imports {
             r#"@bar(name: "b")"#,
         );
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -880,7 +880,7 @@ mod inconsistent_imports {
         );
         let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -910,7 +910,7 @@ mod inconsistent_imports {
             r#"@bar(name: "b")"#,
         );
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -940,7 +940,7 @@ mod inconsistent_imports {
             r#"@foo(name: "a")"#,
         );
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -970,7 +970,7 @@ mod inconsistent_imports {
             r#"@foo(name: "a")"#,
         );
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -1015,7 +1015,7 @@ mod inconsistent_imports {
             }
         "#).unwrap();
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -1073,7 +1073,7 @@ mod validation {
         let subgraph_a = generate_subgraph("subgraphA", "", compose_text, "", "");
         let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -1097,7 +1097,7 @@ mod validation {
         );
         let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(
@@ -1139,7 +1139,7 @@ mod validation {
         );
         let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
 
-        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(result.len(), 1);
         let error = result.first().unwrap();
         assert_eq!(

--- a/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
@@ -734,7 +734,9 @@ mod override_tests {
             "#,
         };
 
-        let errors = compose_services(&[subgraph_a, subgraph_b]).unwrap_err().errors;
+        let errors = compose_services(&[subgraph_a, subgraph_b])
+            .unwrap_err()
+            .errors;
         assert_eq!(
             errors.len(),
             1,

--- a/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
@@ -1,4 +1,4 @@
-use apollo_federation::error::CompositionError;
+use apollo_federation::composition::CompositionFailure;
 use apollo_federation::subgraph::test_utils::remove_indentation;
 use apollo_federation::subgraph::typestate::Subgraph;
 use apollo_federation::supergraph::Satisfiable;
@@ -11,7 +11,7 @@ use super::extract_subgraphs_from_supergraph_result;
 
 fn compose_services(
     service_list: &[ServiceDefinition<'_>],
-) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
     let mut subgraphs = Vec::new();
     let mut errors = Vec::new();
     for service in service_list {
@@ -30,7 +30,7 @@ fn compose_services(
         }
     }
     if !errors.is_empty() {
-        return Err(errors);
+        return Err(CompositionFailure::from_errors(errors));
     }
 
     compose(subgraphs)
@@ -734,7 +734,7 @@ mod override_tests {
             "#,
         };
 
-        let errors = compose_services(&[subgraph_a, subgraph_b]).unwrap_err();
+        let errors = compose_services(&[subgraph_a, subgraph_b]).unwrap_err().errors;
         assert_eq!(
             errors.len(),
             1,

--- a/apollo-federation/tests/composition/compose_inaccessible.rs
+++ b/apollo-federation/tests/composition/compose_inaccessible.rs
@@ -328,7 +328,7 @@ fn referenced_inaccessible_merge_error_includes_subgraph_locations() {
     };
 
     let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
 
     let merge_errors: Vec<_> = errors
         .iter()

--- a/apollo-federation/tests/composition/compose_set_context.rs
+++ b/apollo-federation/tests/composition/compose_set_context.rs
@@ -126,7 +126,7 @@ fn invalid_context_name_shouldnt_throw() {
     };
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -176,7 +176,7 @@ fn forbid_default_values_on_contextual_arguments() {
     };
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -230,7 +230,7 @@ fn forbid_contextual_arguments_on_interfaces() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -282,7 +282,7 @@ fn contextual_argument_on_directive_definition_argument() {
     };
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -415,7 +415,7 @@ fn contextual_argument_is_present_in_multiple_subgraphs_not_nullable_no_default(
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -506,7 +506,7 @@ fn context_selection_references_interface_object() {
     };
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -556,7 +556,7 @@ fn context_selection_contains_query_directive() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -604,7 +604,7 @@ fn context_name_is_invalid() {
     };
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 2, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -652,7 +652,7 @@ fn context_selection_contains_an_alias() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -703,7 +703,7 @@ fn at_least_one_key_on_object_with_context_must_be_resolvable() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -796,7 +796,7 @@ fn selection_contains_more_than_one_value() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -892,7 +892,7 @@ fn context_fails_on_union_when_type_is_missing_prop() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -1037,7 +1037,7 @@ fn type_matches_no_type_conditions() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -1086,7 +1086,7 @@ fn context_variable_does_not_appear_in_selection() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(
         errors.len(),
         1,
@@ -1143,7 +1143,7 @@ fn resolved_field_is_not_available_in_context() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -1193,7 +1193,7 @@ fn context_is_never_set() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -1300,7 +1300,7 @@ fn setcontext_with_multiple_contexts_duck_typing_type_mismatch() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();
@@ -1395,7 +1395,7 @@ fn nullability_mismatch_is_not_ok_if_argument_is_non_nullable() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
 
-    let errors = result.expect_err("Expected composition to fail");
+    let errors = result.expect_err("Expected composition to fail").errors;
     assert_eq!(errors.len(), 1, "Expected exactly 1 error");
 
     let error_message = errors[0].to_string();

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -568,7 +568,7 @@ fn satisfiability_validation_uses_proper_error_code() {
     let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
     // This test specifically checks that the error code is SATISFIABILITY_ERROR
     // The exact error message is tested elsewhere
-    let errors = result.expect_err("Expected composition to fail due to satisfiability");
+    let errors = result.expect_err("Expected composition to fail due to satisfiability").errors;
     let error_codes: Vec<String> = errors
         .iter()
         .map(|e| e.code().definition().code().to_string())

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -568,7 +568,9 @@ fn satisfiability_validation_uses_proper_error_code() {
     let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
     // This test specifically checks that the error code is SATISFIABILITY_ERROR
     // The exact error message is tested elsewhere
-    let errors = result.expect_err("Expected composition to fail due to satisfiability").errors;
+    let errors = result
+        .expect_err("Expected composition to fail due to satisfiability")
+        .errors;
     let error_codes: Vec<String> = errors
         .iter()
         .map(|e| e.code().definition().code().to_string())

--- a/apollo-federation/tests/composition/connectors.rs
+++ b/apollo-federation/tests/composition/connectors.rs
@@ -327,7 +327,7 @@ mod tests {
             "Composition should fail due to missing http argument in @source directive"
         );
 
-        let errors = result.unwrap_err();
+        let errors = result.unwrap_err().errors;
         // Check that we have exactly 1 error
         assert_eq!(errors.len(), 1, "Should have exactly 1 error");
 
@@ -384,7 +384,7 @@ mod tests {
             "Composition should fail due to missing http argument in @connect directive"
         );
 
-        let errors = result.unwrap_err();
+        let errors = result.unwrap_err().errors;
         // Check that we have exactly 1 error
         assert_eq!(errors.len(), 1, "Should have exactly 1 error");
 

--- a/apollo-federation/tests/composition/demand_control.rs
+++ b/apollo-federation/tests/composition/demand_control.rs
@@ -514,7 +514,7 @@ fn errors_when_subgraphs_use_different_names() {
         subgraph_with_default_name,
         subgraph_with_different_name,
     ])
-    .unwrap_err();
+    .unwrap_err().errors;
 
     assert_eq!(errors.len(), 1, "Expected 1 error but got {}", errors.len());
     let error = errors.first().unwrap();

--- a/apollo-federation/tests/composition/demand_control.rs
+++ b/apollo-federation/tests/composition/demand_control.rs
@@ -514,7 +514,8 @@ fn errors_when_subgraphs_use_different_names() {
         subgraph_with_default_name,
         subgraph_with_different_name,
     ])
-    .unwrap_err().errors;
+    .unwrap_err()
+    .errors;
 
     assert_eq!(errors.len(), 1, "Expected 1 error but got {}", errors.len());
     let error = errors.first().unwrap();

--- a/apollo-federation/tests/composition/mod.rs
+++ b/apollo-federation/tests/composition/mod.rs
@@ -126,7 +126,10 @@ pub(crate) mod test_helpers {
         result: &Result<Supergraph<Satisfiable>, CompositionFailure>,
         expected_errors: &[(&str, &str)],
     ) {
-        let errors = &result.as_ref().expect_err("Expected composition to fail").errors;
+        let errors = &result
+            .as_ref()
+            .expect_err("Expected composition to fail")
+            .errors;
         let error_strings: Vec<(String, String)> = errors
             .iter()
             .map(|e| (e.code().definition().code().to_string(), e.to_string()))

--- a/apollo-federation/tests/composition/mod.rs
+++ b/apollo-federation/tests/composition/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod test_helpers {
     use std::iter::zip;
 
     use apollo_federation::ValidFederationSubgraphs;
+    use apollo_federation::composition::CompositionFailure;
     use apollo_federation::composition::CompositionOptions;
     use apollo_federation::error::CompositionError;
     use apollo_federation::error::FederationError;
@@ -47,7 +48,7 @@ pub(crate) mod test_helpers {
     /// [`CompositionOptions::default()`], so tests don't have to spell it out.
     pub(crate) fn compose(
         subgraphs: Vec<Subgraph<Initial>>,
-    ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+    ) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
         apollo_federation::composition::compose(subgraphs, CompositionOptions::default())
     }
 
@@ -56,7 +57,7 @@ pub(crate) mod test_helpers {
     // PORT_NOTE: This function corresponds to `composeAsFed2Subgraphs` in JS implementation.
     pub(crate) fn compose_as_fed2_subgraphs(
         service_list: &[ServiceDefinition<'_>],
-    ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+    ) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
         compose_as_fed2_subgraphs_with_options(service_list, CompositionOptions::default())
     }
 
@@ -65,7 +66,7 @@ pub(crate) mod test_helpers {
     pub(crate) fn compose_as_fed2_subgraphs_with_options(
         service_list: &[ServiceDefinition<'_>],
         options: CompositionOptions,
-    ) -> Result<Supergraph<Satisfiable>, Vec<CompositionError>> {
+    ) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
         let fed2_subgraphs = as_fed2_subgraphs(service_list)?;
         apollo_federation::composition::compose(fed2_subgraphs, options)
     }
@@ -122,10 +123,10 @@ pub(crate) mod test_helpers {
 
     /// Helper function to assert composition errors
     pub(crate) fn assert_composition_errors(
-        result: &Result<Supergraph<Satisfiable>, Vec<CompositionError>>,
+        result: &Result<Supergraph<Satisfiable>, CompositionFailure>,
         expected_errors: &[(&str, &str)],
     ) {
-        let errors = result.as_ref().expect_err("Expected composition to fail");
+        let errors = &result.as_ref().expect_err("Expected composition to fail").errors;
         let error_strings: Vec<(String, String)> = errors
             .iter()
             .map(|e| (e.code().definition().code().to_string(), e.to_string()))

--- a/apollo-federation/tests/composition/override_directive.rs
+++ b/apollo-federation/tests/composition/override_directive.rs
@@ -418,7 +418,7 @@ fn invalid_override_key_field_breaks_composition() {
     };
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
-    let errors = result.as_ref().expect_err("composition failed");
+    let errors = &result.as_ref().expect_err("composition failed").errors;
     assert_eq!(errors.len(), 2);
     insta::assert_snapshot!(errors[0].to_string(), @r#"
     The following supergraph API query:
@@ -584,7 +584,7 @@ fn override_with_provides_on_overridden_field() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
     // Check that we get the override collision error (there may be additional errors)
-    let errors = result.as_ref().expect_err("composition failed");
+    let errors = &result.as_ref().expect_err("composition failed").errors;
     assert!(
         errors.iter().any(|e| e.to_string() == r#"@override cannot be used on field "T.u" on subgraph "Subgraph1" since "T.u" on "Subgraph2" is marked with directive "@provides""#),
         "Expected OverrideCollisionWithAnotherDirective error not found"
@@ -629,7 +629,7 @@ fn override_with_requires_on_overridden_field() {
 
     let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
     // Check that we get the override collision error (there may be additional errors)
-    let errors = result.as_ref().expect_err("composition failed");
+    let errors = &result.as_ref().expect_err("composition failed").errors;
     assert!(
         errors.iter().any(|e| e.to_string() == r#"@override cannot be used on field "T.u" on subgraph "Subgraph1" since "T.u" on "Subgraph2" is marked with directive "@requires""#),
         "Expected OverrideCollisionWithAnotherDirective error not found"
@@ -1219,7 +1219,7 @@ mod progressive_override {
             };
 
             let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
-            let errors = result.as_ref().expect_err("composition failed");
+            let errors = &result.as_ref().expect_err("composition failed").errors;
             assert_eq!(errors.len(), 1);
             insta::assert_snapshot!(errors[0].to_string(), @r#"
             The following supergraph API query:

--- a/apollo-federation/tests/composition/subscription.rs
+++ b/apollo-federation/tests/composition/subscription.rs
@@ -76,7 +76,9 @@ fn directives_incompatible_with_subscriptions_wont_compose() {
             "#,
     };
 
-    let errors = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]).unwrap_err().errors;
+    let errors = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b])
+        .unwrap_err()
+        .errors;
     assert_eq!(errors.len(), 1);
     let msg = errors.first().unwrap().to_string();
     assert_eq!(
@@ -119,7 +121,9 @@ fn subscription_name_collisions_across_subgraphs_should_not_compose() {
             "#,
     };
 
-    let errors = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]).unwrap_err().errors;
+    let errors = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b])
+        .unwrap_err()
+        .errors;
     assert_eq!(errors.len(), 1);
     let msg = errors.first().unwrap().to_string();
     assert_eq!(

--- a/apollo-federation/tests/composition/subscription.rs
+++ b/apollo-federation/tests/composition/subscription.rs
@@ -76,7 +76,7 @@ fn directives_incompatible_with_subscriptions_wont_compose() {
             "#,
     };
 
-    let errors = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]).unwrap_err();
+    let errors = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]).unwrap_err().errors;
     assert_eq!(errors.len(), 1);
     let msg = errors.first().unwrap().to_string();
     assert_eq!(
@@ -119,7 +119,7 @@ fn subscription_name_collisions_across_subgraphs_should_not_compose() {
             "#,
     };
 
-    let errors = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]).unwrap_err();
+    let errors = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]).unwrap_err().errors;
     assert_eq!(errors.len(), 1);
     let msg = errors.first().unwrap().to_string();
     assert_eq!(


### PR DESCRIPTION
Previously, when composition failed (either during merge or satisfiability validation), all WARN-level hints were silently discarded because the error type `Vec<CompositionError>` had no room for them.

Introduce `CompositionFailure { errors, hints }` as the error type for `merge_subgraphs`, `validate_satisfiability`, `compose`, and related functions. This preserves `INCONSISTENT_*` warnings, `UNUSED_ENUM_TYPE`, `OVERRIDDEN_FIELD_CAN_BE_REMOVED`, and other hints alongside errors on all failure paths:

- `merge_subgraphs`: carries merge hints when merge produces errors
- `validate_satisfiability`: carries accumulated hints when satisfiability fails
- `validate_satisfiability_with_connectors`: merges hints from both merge and satisfiability phases, sanitizes connector names in both
- `compose` / `compose_with_connectors`: propagates hints through the full pipeline; pre-merge phases (no hints) convert via `From<Vec<CompositionError>>`

<!-- [FED-1010] -->

[FED-1010]: https://apollographql.atlassian.net/browse/FED-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ