### PR TITLE
docs(observability): document apollo.router.cache.redis.reconnection and .unresponsive metrics

### DIFF
--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -121,8 +121,8 @@ When using Redis as a cache backend, additional Redis-specific metrics are avail
 - `apollo.router.cache.redis.commands_executed` - Total number of Redis commands executed
 - `apollo.router.cache.redis.redelivery_count` - Number of Redis command redeliveries due to connection issues
 - `apollo.router.cache.redis.errors` - Number of Redis errors by error type and cache kind
-- `apollo.router.cache.redis.reconnection` - Number of reconnect events raised by the Redis client when a Redis server requires client reconnection.
-- `apollo.router.cache.redis.unresponsive` - Number of unresponsive events raised by the Redis client when a Redis server becomes unresponsive.
+- `apollo.router.cache.redis.reconnection` - Number of Redis client reconnections
+- `apollo.router.cache.redis.unresponsive` - Number of times a Redis server became unresponsive
 - `experimental.apollo.router.cache.redis.latency_avg` - Average Redis command latency in seconds
 - `experimental.apollo.router.cache.redis.network_latency_avg` - Average Redis network latency in seconds
 - `experimental.apollo.router.cache.redis.request_size_avg` - Average Redis request size in bytes

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -121,8 +121,8 @@ When using Redis as a cache backend, additional Redis-specific metrics are avail
 - `apollo.router.cache.redis.commands_executed` - Total number of Redis commands executed
 - `apollo.router.cache.redis.redelivery_count` - Number of Redis command redeliveries due to connection issues
 - `apollo.router.cache.redis.errors` - Number of Redis errors by error type and cache kind
-- `apollo.router.cache.redis.reconnection` - Number of reconnect events raised by the Redis client when a Redis server requires client reconnection
-- `apollo.router.cache.redis.unresponsive` - Number of unresponsive events raised by the Redis client when a Redis server becomes unresponsive
+- `apollo.router.cache.redis.reconnection` - Number of reconnect events raised by Redis client when a Redis server requires client reconnection.
+- `apollo.router.cache.redis.unresponsive` - Number of unresponsive events raised by Redis client when a Redis server becomes unresponsive.
 - `experimental.apollo.router.cache.redis.latency_avg` - Average Redis command latency in seconds
 - `experimental.apollo.router.cache.redis.network_latency_avg` - Average Redis network latency in seconds
 - `experimental.apollo.router.cache.redis.request_size_avg` - Average Redis request size in bytes
@@ -134,7 +134,7 @@ All Redis metrics, except for `apollo.router.cache.redis.clients`, include the f
 
 The `apollo.router.cache.redis.reconnection` and `apollo.router.cache.redis.unresponsive` metrics also include:
 
-- `server`: the Redis server that raised the event
+- `server`: the Redis server that raises the event
 
 The `apollo.router.cache.redis.errors` metric also includes an `error_type` attribute with possible values:
 - `config` - Configuration errors (invalid Redis settings)

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -121,6 +121,8 @@ When using Redis as a cache backend, additional Redis-specific metrics are avail
 - `apollo.router.cache.redis.commands_executed` - Total number of Redis commands executed
 - `apollo.router.cache.redis.redelivery_count` - Number of Redis command redeliveries due to connection issues
 - `apollo.router.cache.redis.errors` - Number of Redis errors by error type and cache kind
+- `apollo.router.cache.redis.reconnection` - Number of reconnect events raised by the Redis client when a Redis server requires client reconnection
+- `apollo.router.cache.redis.unresponsive` - Number of unresponsive events raised by the Redis client when a Redis server becomes unresponsive
 - `experimental.apollo.router.cache.redis.latency_avg` - Average Redis command latency in seconds
 - `experimental.apollo.router.cache.redis.network_latency_avg` - Average Redis network latency in seconds
 - `experimental.apollo.router.cache.redis.request_size_avg` - Average Redis request size in bytes
@@ -129,6 +131,10 @@ When using Redis as a cache backend, additional Redis-specific metrics are avail
 All Redis metrics, except for `apollo.router.cache.redis.clients`, include the following attribute:
 
 - `kind`: the cache being queried (`apq`, `query planner`, `introspection`, `entity`)
+
+The `apollo.router.cache.redis.reconnection` and `apollo.router.cache.redis.unresponsive` metrics also include:
+
+- `server`: the Redis server that raised the event
 
 The `apollo.router.cache.redis.errors` metric also includes an `error_type` attribute with possible values:
 - `config` - Configuration errors (invalid Redis settings)

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -121,8 +121,8 @@ When using Redis as a cache backend, additional Redis-specific metrics are avail
 - `apollo.router.cache.redis.commands_executed` - Total number of Redis commands executed
 - `apollo.router.cache.redis.redelivery_count` - Number of Redis command redeliveries due to connection issues
 - `apollo.router.cache.redis.errors` - Number of Redis errors by error type and cache kind
-- `apollo.router.cache.redis.reconnection` - Number of reconnect events raised by Redis client when a Redis server requires client reconnection.
-- `apollo.router.cache.redis.unresponsive` - Number of unresponsive events raised by Redis client when a Redis server becomes unresponsive.
+- `apollo.router.cache.redis.reconnection` - Number of reconnect events raised by the Redis client when a Redis server requires client reconnection.
+- `apollo.router.cache.redis.unresponsive` - Number of unresponsive events raised by the Redis client when a Redis server becomes unresponsive.
 - `experimental.apollo.router.cache.redis.latency_avg` - Average Redis command latency in seconds
 - `experimental.apollo.router.cache.redis.network_latency_avg` - Average Redis network latency in seconds
 - `experimental.apollo.router.cache.redis.request_size_avg` - Average Redis request size in bytes
@@ -134,7 +134,7 @@ All Redis metrics, except for `apollo.router.cache.redis.clients`, include the f
 
 The `apollo.router.cache.redis.reconnection` and `apollo.router.cache.redis.unresponsive` metrics also include:
 
-- `server`: the Redis server that raises the event
+- `server`: the Redis server that raised the event
 
 The `apollo.router.cache.redis.errors` metric also includes an `error_type` attribute with possible values:
 - `config` - Configuration errors (invalid Redis settings)

--- a/docs/source/routing/performance/caching/response-caching/observability.mdx
+++ b/docs/source/routing/performance/caching/response-caching/observability.mdx
@@ -88,8 +88,8 @@ The latency metrics are marked as experimental because Apollo might change them 
   - `apollo.router.cache.redis.commands_executed`: Total number of Redis commands executed
   - `apollo.router.cache.redis.redelivery_count`: Commands retried due to connection issues
   - `apollo.router.cache.redis.errors`: Redis errors by type (auth, timeout, io, etc.)
-  - `apollo.router.cache.redis.reconnection`: Reconnect events raised by the Redis client when Redis requires client reconnection. Includes `kind` and `server` attributes.
-  - `apollo.router.cache.redis.unresponsive`: Unresponsive events raised by the Redis client when Redis becomes unresponsive. Includes `kind` and `server` attributes.
+  - `apollo.router.cache.redis.reconnection`: Reconnect events raised by Redis when Redis requires client reconnection. Includes `kind` and `server` attributes.
+  - `apollo.router.cache.redis.unresponsive`: Unresponsive events raised by Redis when Redis becomes unresponsive. Includes `kind` and `server` attributes.
 
 #### Experimental Redis performance metrics
   - `experimental.apollo.router.cache.redis.network_latency_avg`: Average network latency to Redis

--- a/docs/source/routing/performance/caching/response-caching/observability.mdx
+++ b/docs/source/routing/performance/caching/response-caching/observability.mdx
@@ -88,8 +88,8 @@ The latency metrics are marked as experimental because Apollo might change them 
   - `apollo.router.cache.redis.commands_executed`: Total number of Redis commands executed
   - `apollo.router.cache.redis.redelivery_count`: Commands retried due to connection issues
   - `apollo.router.cache.redis.errors`: Redis errors by type (auth, timeout, io, etc.)
-  - `apollo.router.cache.redis.reconnection`: Reconnect events raised by the Redis client when a Redis server requires client reconnection. Includes `kind` and `server` attributes.
-  - `apollo.router.cache.redis.unresponsive`: Unresponsive events raised by the Redis client when a Redis server becomes unresponsive. Includes `kind` and `server` attributes.
+  - `apollo.router.cache.redis.reconnection`: Reconnect events raised by the Redis client when Redis requires client reconnection. Includes `kind` and `server` attributes.
+  - `apollo.router.cache.redis.unresponsive`: Unresponsive events raised by the Redis client when Redis becomes unresponsive. Includes `kind` and `server` attributes.
 
 #### Experimental Redis performance metrics
   - `experimental.apollo.router.cache.redis.network_latency_avg`: Average network latency to Redis

--- a/docs/source/routing/performance/caching/response-caching/observability.mdx
+++ b/docs/source/routing/performance/caching/response-caching/observability.mdx
@@ -88,8 +88,8 @@ The latency metrics are marked as experimental because Apollo might change them 
   - `apollo.router.cache.redis.commands_executed`: Total number of Redis commands executed
   - `apollo.router.cache.redis.redelivery_count`: Commands retried due to connection issues
   - `apollo.router.cache.redis.errors`: Redis errors by type (auth, timeout, io, etc.)
-  - `apollo.router.cache.redis.reconnection`: Reconnect events raised by Redis when Redis requires client reconnection. Includes `kind` and `server` attributes.
-  - `apollo.router.cache.redis.unresponsive`: Unresponsive events raised by Redis when Redis becomes unresponsive. Includes `kind` and `server` attributes.
+  - `apollo.router.cache.redis.reconnection`: Number of Redis client reconnections
+  - `apollo.router.cache.redis.unresponsive`: Number of times a Redis server became unresponsive
 
 #### Experimental Redis performance metrics
   - `experimental.apollo.router.cache.redis.network_latency_avg`: Average network latency to Redis

--- a/docs/source/routing/performance/caching/response-caching/observability.mdx
+++ b/docs/source/routing/performance/caching/response-caching/observability.mdx
@@ -88,6 +88,8 @@ The latency metrics are marked as experimental because Apollo might change them 
   - `apollo.router.cache.redis.commands_executed`: Total number of Redis commands executed
   - `apollo.router.cache.redis.redelivery_count`: Commands retried due to connection issues
   - `apollo.router.cache.redis.errors`: Redis errors by type (auth, timeout, io, etc.)
+  - `apollo.router.cache.redis.reconnection`: Reconnect events raised by the Redis client when a Redis server requires client reconnection. Includes `kind` and `server` attributes.
+  - `apollo.router.cache.redis.unresponsive`: Unresponsive events raised by the Redis client when a Redis server becomes unresponsive. Includes `kind` and `server` attributes.
 
 #### Experimental Redis performance metrics
   - `experimental.apollo.router.cache.redis.network_latency_avg`: Average network latency to Redis


### PR DESCRIPTION
## docs: document `apollo.router.cache.redis.reconnection` and `apollo.router.cache.redis.unresponsive` metrics

<!-- start metadata -->

<!-- [TSH-22642] -->
---

Both `apollo.router.cache.redis.reconnection` and `apollo.router.cache.redis.unresponsive` were
introduced in PR #8185 but were never added to the reference documentation. This PR adds them to:

- The [standard instruments reference page](https://www.apollographql.com/docs/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments)
- The [response cache observability page](https://www.apollographql.com/docs/graphos/routing/performance/caching/response-caching/observability)

Both metrics are counters that track Redis client events (`reconnection` fires when a server
requires the client to reconnect; `unresponsive` fires when a server stops responding). Both
include `kind` and `server` attributes. The `server` attribute is unique to these two metrics
among all Redis metrics, so the standard instruments page now includes an explicit note for it.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

- No changeset needed — docs-only change, no code or behavior modified.
- No tests needed — no implementation changes.
- Performance impact: none.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[TSH-22642]: https://apollographql.atlassian.net/browse/TSH-22642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ