### PR TITLE
feat(metrics): add `apollo.router.connection.acquire.duration` histogram

### DIFF
--- a/.changesets/feat_caroline_rh_1334_connection_acquire_duration.md
+++ b/.changesets/feat_caroline_rh_1334_connection_acquire_duration.md
@@ -1,4 +1,4 @@
-### Add `apollo.router.connection.acquire.duration` metric for TCP/TLS connection timing ([PR #PULL_NUMBER](https://github.com/apollographql/router/pull/PULL_NUMBER))
+### Add `apollo.router.connection.acquire.duration` metric for TCP/TLS connection timing ([PR #9309](https://github.com/apollographql/router/pull/9309))
 
 Adds a new histogram metric, `apollo.router.connection.acquire.duration`, that records how long it takes to establish a new TCP or Unix socket connection to a downstream service (subgraph, connector, or coprocessor). The metric fires only when the connection pool opens a new connection — pool hits are not recorded.
 
@@ -11,4 +11,4 @@ Attributes:
 - `connector.source.name`: name of the connector source (for connector connections)
 - `coprocessor`: `true` (for coprocessor connections)
 
-By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/PULL_NUMBER
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9309

--- a/.changesets/feat_caroline_rh_1334_connection_acquire_duration.md
+++ b/.changesets/feat_caroline_rh_1334_connection_acquire_duration.md
@@ -1,0 +1,14 @@
+### Add `apollo.router.connection.acquire.duration` metric for TCP/TLS connection timing ([PR #PULL_NUMBER](https://github.com/apollographql/router/pull/PULL_NUMBER))
+
+Adds a new histogram metric, `apollo.router.connection.acquire.duration`, that records how long it takes to establish a new TCP or Unix socket connection to a downstream service (subgraph, connector, or coprocessor). The metric fires only when the connection pool opens a new connection — pool hits are not recorded.
+
+This metric is useful for diagnosing connection establishment latency. For example, if a subgraph shows elevated overall response latency, a high `connection.acquire.duration` indicates the delay is in TCP/TLS setup; a near-zero value (or no data) points to post-connection causes like slow server responses.
+
+Attributes:
+
+- `network.transport`: `tcp` for HTTP connections, `unix` for Unix socket connections
+- `subgraph.name`: name of the subgraph (for subgraph connections)
+- `connector.source.name`: name of the connector source (for connector connections)
+- `coprocessor`: `true` (for coprocessor connections)
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/PULL_NUMBER

--- a/apollo-router/src/services/http.rs
+++ b/apollo-router/src/services/http.rs
@@ -9,6 +9,7 @@ use super::Plugins;
 use super::router::body::RouterBody;
 use crate::Context;
 
+pub(crate) mod connection_timing;
 pub(crate) mod service;
 #[cfg(test)]
 mod tests;
@@ -91,4 +92,19 @@ where
     fn make(&self) -> BoxService {
         self.clone().boxed()
     }
+}
+
+/// The kind of remote service an [`HttpClientService`] is configured to talk to.
+///
+/// Used by [`service::HttpClientService`] to derive the service name and by
+/// [`connection_timing::ConnectionTimingConnector`] to select the OTel attributes emitted on the
+/// `apollo.router.connection.acquire.duration` histogram.
+#[derive(Clone)]
+enum ServiceTarget {
+    /// A coprocessor: emits `coprocessor = true`.
+    Coprocessor,
+    /// A subgraph: emits `subgraph.name = name`.
+    Subgraph { name: Arc<str> },
+    /// A connector source: emits `connector.source.name = name`.
+    Connector { name: Arc<str> },
 }

--- a/apollo-router/src/services/http/connection_timing.rs
+++ b/apollo-router/src/services/http/connection_timing.rs
@@ -1,0 +1,79 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Instant;
+
+use opentelemetry::KeyValue;
+use tower::Service;
+
+use super::ServiceTarget;
+
+/// Wraps a connector and records `apollo.router.connection.acquire.duration` each time a new
+/// connection is established. Pool hits skip the connector entirely and are not recorded.
+#[derive(Clone)]
+pub(crate) struct ConnectionTimingConnector<C> {
+    inner: C,
+    metric_attributes: Arc<[KeyValue]>,
+}
+
+impl<C> ConnectionTimingConnector<C> {
+    pub(in crate::services::http) fn new(
+        inner: C,
+        target: ServiceTarget,
+        transport: &'static str,
+    ) -> Self {
+        let service_attribute = match target {
+            ServiceTarget::Subgraph { name } => KeyValue::new("subgraph.name", name.to_string()),
+            ServiceTarget::Connector { name } => {
+                KeyValue::new("connector.source.name", name.to_string())
+            }
+            ServiceTarget::Coprocessor => KeyValue::new("coprocessor", true),
+        };
+        let metric_attributes = Arc::from(
+            [
+                KeyValue::new("network.transport", transport),
+                service_attribute,
+            ]
+            .as_slice(),
+        );
+        Self {
+            inner,
+            metric_attributes,
+        }
+    }
+}
+
+impl<C, T> Service<T> for ConnectionTimingConnector<C>
+where
+    C: Service<T>,
+    C::Future: Send + 'static,
+    C::Response: Send + 'static,
+    C::Error: Send + 'static,
+{
+    type Response = C::Response;
+    type Error = C::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<C::Response, C::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, target: T) -> Self::Future {
+        let start = Instant::now();
+        let attributes = self.metric_attributes.clone();
+        let fut = self.inner.call(target);
+        Box::pin(async move {
+            let result = fut.await;
+            f64_histogram_with_unit!(
+                "apollo.router.connection.acquire.duration",
+                "Time to establish a new connection to a service",
+                "s",
+                start.elapsed().as_secs_f64(),
+                attributes.as_ref()
+            );
+            result
+        })
+    }
+}

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -40,6 +40,8 @@ use tracing::Span;
 
 use super::HttpRequest;
 use super::HttpResponse;
+use super::ServiceTarget;
+use super::connection_timing::ConnectionTimingConnector;
 use crate::Configuration;
 use crate::axum_factory::compression::Compressor;
 use crate::configuration::TlsClientAuth;
@@ -158,14 +160,16 @@ where
 type HTTPClient = Decompression<
     WireBodySizeService<
         hyper_util::client::legacy::Client<
-            HttpsConnector<HttpConnector<AsyncHyperResolver>>,
+            ConnectionTimingConnector<HttpsConnector<HttpConnector<AsyncHyperResolver>>>,
             RouterBody,
         >,
     >,
 >;
 #[cfg(unix)]
 type UnixHTTPClient = Decompression<
-    WireBodySizeService<hyper_util::client::legacy::Client<UnixConnector, RouterBody>>,
+    WireBodySizeService<
+        hyper_util::client::legacy::Client<ConnectionTimingConnector<UnixConnector>, RouterBody>,
+    >,
 >;
 #[cfg(unix)]
 type MixedClient = Either<HTTPClient, UnixHTTPClient>;
@@ -210,7 +214,7 @@ pub(crate) struct HttpClientService {
     http_client: HTTPClient,
     #[cfg(unix)]
     unix_client: UnixHTTPClient,
-    service: Arc<String>,
+    service: Arc<str>,
 }
 
 impl HttpClientService {
@@ -224,22 +228,29 @@ impl HttpClientService {
         tls_config: ClientConfig,
         client_config: crate::configuration::shared::Client,
     ) -> Result<Self, BoxError> {
-        Self::new(service, tls_config, client_config)
+        let service_target = ServiceTarget::Subgraph {
+            name: Arc::from(service.into().as_str()),
+        };
+        Self::new(service_target, tls_config, client_config)
     }
 
     /// Create a new HttpClientService using:
     ///
-    /// - the service's name (eg, connector name, hardcoded "coprocessor", or the subgraph's name) for
-    ///   use in errors and potentially signing requests
+    /// - the target service kind (subgraph/connector with its name, or coprocessor), used for
+    ///   metrics and error reporting; the name is also used for request signing
     /// - the tls config to be used in setting tls; though, this is actually rustls's and hyper
     ///   figuring out which parts of a broader config to use for tls
     /// - the client's config, which is _our_ set of options from the router config for use in
     ///   enabling/disabling features like http/2
     fn new(
-        service: impl Into<String>,
+        service_target: ServiceTarget,
         tls_config: ClientConfig,
         client_config: crate::configuration::shared::Client,
     ) -> Result<Self, BoxError> {
+        let service_name: Arc<str> = match &service_target {
+            ServiceTarget::Coprocessor => Arc::from("coprocessor"),
+            ServiceTarget::Subgraph { name } | ServiceTarget::Connector { name } => name.clone(),
+        };
         let mut http_connector =
             new_async_http_connector(client_config.dns_resolution_strategy.unwrap_or_default())?;
         http_connector.set_nodelay(true);
@@ -284,7 +295,11 @@ impl HttpClientService {
                 // connections are detected before a request is made on them
                 .http2_keep_alive_while_idle(true);
         }
-        let http_client = client_builder.build(connector);
+        let http_client = client_builder.build(ConnectionTimingConnector::new(
+            connector,
+            service_target.clone(),
+            "tcp",
+        ));
 
         #[cfg(unix)]
         let unix_client = {
@@ -295,7 +310,11 @@ impl HttpClientService {
                     // unless you're also removing `pool_idle_timeout`
                     .pool_timer(TokioTimer::new())
                     .http2_only(http2 == Http2Config::Http2Only)
-                    .build(UnixConnector);
+                    .build(ConnectionTimingConnector::new(
+                        UnixConnector,
+                        service_target,
+                        "unix",
+                    ));
 
             ServiceBuilder::new()
                 .layer(DecompressionLayer::new())
@@ -310,7 +329,7 @@ impl HttpClientService {
                 .service(http_client),
             #[cfg(unix)]
             unix_client,
-            service: Arc::new(service.into()),
+            service: service_name,
         })
     }
 
@@ -349,8 +368,11 @@ impl HttpClientService {
 
         let tls_client_config =
             generate_tls_client_config(tls_cert_store, client_cert_config.map(|arc| arc.as_ref()))?;
+        let service_target = ServiceTarget::Subgraph {
+            name: Arc::from(name.as_str()),
+        };
 
-        Self::new(name, tls_client_config, client_config)
+        Self::new(service_target, tls_client_config, client_config)
     }
 
     /// Creates a client for talking to connectors-connected subgraphs
@@ -388,8 +410,11 @@ impl HttpClientService {
 
         let tls_client_config =
             generate_tls_client_config(tls_cert_store, client_cert_config.map(|arc| arc.as_ref()))?;
+        let service_target = ServiceTarget::Connector {
+            name: Arc::from(name.as_str()),
+        };
 
-        Self::new(name, tls_client_config, client_config)
+        Self::new(service_target, tls_client_config, client_config)
     }
 
     /// Creates a client for talking to coprocessors
@@ -402,7 +427,7 @@ impl HttpClientService {
         // Coprocessors don't use client certificates, so use no client auth
         let tls_client_config = generate_tls_client_config(tls_root_store.clone(), None)?;
 
-        Self::new("coprocessor".to_string(), tls_client_config, client_config)
+        Self::new(ServiceTarget::Coprocessor, tls_client_config, client_config)
     }
 
     /// Creates a root certificate store with native certificates. These are used for root-of-trust
@@ -449,7 +474,10 @@ impl HttpClientService {
         let tls_root_store = RootCertStore::empty();
         let tls_client_config = generate_tls_client_config(tls_root_store, None)?;
 
-        HttpClientService::new("test".to_string(), tls_client_config, client_config)
+        let service_target = ServiceTarget::Subgraph {
+            name: Arc::from("test"),
+        };
+        HttpClientService::new(service_target, tls_client_config, client_config)
     }
 }
 
@@ -635,6 +663,7 @@ mod tests {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::registry::LookupSpan;
 
+    use super::super::ServiceTarget;
     use crate::Context;
     use crate::plugins::telemetry::dynamic_attribute::DynAttributeLayer;
     use crate::plugins::telemetry::otel;
@@ -737,8 +766,11 @@ mod tests {
             .await
             .expect("unable to create telemetry plugin");
 
+        let service_target = ServiceTarget::Subgraph {
+            name: Arc::from(service_name),
+        };
         let http_client_service = HttpClientService::new(
-            service_name,
+            service_target,
             rustls::ClientConfig::builder()
                 .with_native_roots()
                 .expect("Able to load native roots")
@@ -886,8 +918,11 @@ mod tests {
             .expect("unable to create telemetry plugin");
 
         // Create HTTP client service
+        let service_target = ServiceTarget::Subgraph {
+            name: Arc::from("test"),
+        };
         let http_client_service = HttpClientService::new(
-            "test",
+            service_target,
             rustls::ClientConfig::builder()
                 .with_native_roots()
                 .expect("Able to load native roots")
@@ -976,8 +1011,11 @@ mod tests {
             .unwrap();
         });
 
+        let service_target = ServiceTarget::Subgraph {
+            name: Arc::from("test"),
+        };
         let http_client_service = HttpClientService::new(
-            "test",
+            service_target,
             rustls::ClientConfig::builder()
                 .with_native_roots()
                 .expect("read native TLS root certificates")

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -1590,6 +1590,129 @@ mod pool_idle_timeout {
     }
 }
 
+mod connection_timing_metrics {
+    use std::str::FromStr;
+    use std::time::Duration;
+
+    use http::StatusCode;
+    use http::Uri;
+    use opentelemetry_sdk::metrics::data::AggregatedMetrics;
+    use opentelemetry_sdk::metrics::data::MetricData;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers;
+
+    use super::*;
+    use crate::metrics::FutureMetricsExt;
+
+    /// Verifies that `apollo.router.connection.acquire_duration` fires once per TCP
+    /// connection established, not once per HTTP request.
+    ///
+    /// Two requests to the same server: the first creates a TCP connection (connector called →
+    /// metric count = 1), the second reuses the pooled connection (connector skipped → count
+    /// stays at 1).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn connection_acquire_duration_fires_for_connections_not_requests() {
+        async {
+            let server = MockServer::start().await;
+            Mock::given(matchers::any())
+                .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"data":null}"#))
+                .mount(&server)
+                .await;
+
+            let uri = Uri::from_str(&server.uri()).unwrap();
+
+            let mut service = HttpClientService::test_new(
+                "test",
+                rustls::ClientConfig::builder()
+                    .with_native_roots()
+                    .expect("native TLS roots")
+                    .with_no_client_auth(),
+                crate::configuration::shared::Client::builder().build(),
+            )
+            .expect("can create HttpClientService");
+
+            // First request: establishes a new TCP connection → connector fires.
+            let response = send_request(service.clone(), uri.clone(), r#"{"query":"{ a }"}"#).await;
+            assert_eq!(response.http_response.status(), StatusCode::OK);
+
+            // Second request: hyper reuses the pooled connection → connector NOT called.
+            tower::ServiceExt::ready(&mut service).await.unwrap();
+            let response = send_request(service, uri, r#"{"query":"{ b }"}"#).await;
+            assert_eq!(response.http_response.status(), StatusCode::OK);
+
+            // Metric count = 1, not 2: one connection was established for two HTTP requests.
+            assert_histogram_count!(
+                "apollo.router.connection.acquire.duration",
+                1u64,
+                "subgraph.name" = "test",
+                "network.transport" = "tcp"
+            );
+        }
+        .with_metrics()
+        .await;
+    }
+
+    /// Verifies that `apollo.router.connection.acquire_duration` measures only connection
+    /// establishment time, not total request time.
+    ///
+    /// The server delays its response by 200ms. The metric must be recorded before the response
+    /// arrives, and its value must be well under 200ms.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn connection_acquire_duration_does_not_include_response_time() {
+        async {
+            let response_delay = Duration::from_millis(200);
+
+            let server = MockServer::start().await;
+            Mock::given(matchers::any())
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_string(r#"{"data":null}"#)
+                        .set_delay(response_delay),
+                )
+                .mount(&server)
+                .await;
+
+            let uri = Uri::from_str(&server.uri()).unwrap();
+            let service = HttpClientService::test_new(
+                "test",
+                rustls::ClientConfig::builder()
+                    .with_native_roots()
+                    .expect("native TLS roots")
+                    .with_no_client_auth(),
+                crate::configuration::shared::Client::builder().build(),
+            )
+            .expect("can create HttpClientService");
+
+            let response = send_request(service, uri, r#"{"query":"{ a }"}"#).await;
+            assert_eq!(response.http_response.status(), StatusCode::OK);
+
+            // Extract the actual recorded histogram sum from the metrics data.
+            let acquire_secs = crate::metrics::collect_metrics()
+                .find("apollo.router.connection.acquire.duration")
+                .and_then(|m| {
+                    if let AggregatedMetrics::F64(MetricData::Histogram(h)) = m.data() {
+                        h.data_points().next().map(|dp| dp.sum())
+                    } else {
+                        None
+                    }
+                })
+                .expect("apollo.router.connection.acquire_duration should be recorded");
+
+            // TCP handshake to localhost is in the low-millisecond range; the 200ms response
+            // delay must NOT appear in the metric.
+            assert!(
+                acquire_secs < response_delay.as_secs_f64(),
+                "acquire_duration ({acquire_secs:.4}s) should be less than the server response delay ({:.3}s)",
+                response_delay.as_secs_f64(),
+            );
+        }
+        .with_metrics()
+        .await;
+    }
+}
+
 mod redis_tls_config {
     //! Exercises the `generate_tls_client_config` → `TlsConnector` path that Redis uses.
     //!

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -1606,7 +1606,7 @@ mod connection_timing_metrics {
     use super::*;
     use crate::metrics::FutureMetricsExt;
 
-    /// Verifies that `apollo.router.connection.acquire_duration` fires once per TCP
+    /// Verifies that `apollo.router.connection.acquire.duration` fires once per TCP
     /// connection established, not once per HTTP request.
     ///
     /// Two requests to the same server: the first creates a TCP connection (connector called →
@@ -1654,7 +1654,7 @@ mod connection_timing_metrics {
         .await;
     }
 
-    /// Verifies that `apollo.router.connection.acquire_duration` measures only connection
+    /// Verifies that `apollo.router.connection.acquire.duration` measures only connection
     /// establishment time, not total request time.
     ///
     /// The server delays its response by 200ms. The metric must be recorded before the response

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -244,6 +244,14 @@ Similar to the initial call to Uplink, the router does not record metrics for ca
 
 </Note>
 
+## Connections
+
+- `apollo.router.connection.acquire.duration` - Time in seconds to establish a new TCP or Unix socket connection to a downstream service. Recorded only when the connection pool opens a new connection — pool hits are not recorded. Attributes:
+  - `network.transport`: `tcp` for HTTP connections, `unix` for Unix socket connections
+  - `subgraph.name`: name of the subgraph (subgraph connections only)
+  - `connector.source.name`: name of the connector source (connector connections only)
+  - `coprocessor`: `true` (coprocessor connections only)
+
 ## Subscriptions
 
 <Tip>


### PR DESCRIPTION
## Summary

Adds a new `apollo.router.connection.acquire.duration` histogram that records how long it takes to establish a new TCP or Unix socket connection to a downstream service (subgraph, connector, or coprocessor).

**Motivation:** When diagnosing connection pool latency spikes, there was no way to distinguish TCP/TLS connection establishment time from post-connection server response time — both appeared as `idle_ns` on the `http_request` span. This metric makes connection establishment time directly observable.

## How it works

A new `ConnectionTimingConnector<C>` tower service wrapper intercepts the hyper connector's `call()` method. hyper only calls the connector when it needs to open a **new** connection — pool hits skip the connector entirely — so the metric fires only for new connections, not per-request.

Metric attributes:
- `network.transport`: `tcp` or `unix`
- `subgraph.name`: subgraph name (subgraph connections)
- `connector.source.name`: connector source name (connector connections)
- `coprocessor`: `true` (coprocessor connections)

The `ServiceTarget` enum in `http.rs` captures which kind of service is being connected to and is used both to derive the metric attributes and the service name on `HttpClientService`.

## Changes

- `apollo-router/src/services/http/connection_timing.rs` — new `ConnectionTimingConnector<C>` implementation
- `apollo-router/src/services/http.rs` — new private `ServiceTarget` enum
- `apollo-router/src/services/http/service.rs` — wrap both TCP and Unix connectors; refactor factory methods to pass `ServiceTarget`
- `apollo-router/src/services/http/tests.rs` — two new tests verifying the metric fires per-connection (not per-request) and excludes response time
- `.changesets/feat_caroline_rh_1334_connection_acquire_duration.md` — changeset
- `docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx` — new "Connections" section

## Reviewer notes

- `pub(in crate::services::http)` on `ConnectionTimingConnector::new` is intentional — it matches the visibility of the private `ServiceTarget` parameter and satisfies the `private_interfaces` clippy lint
- The metric uses the `f64_histogram_with_unit!` macro (seconds), consistent with other duration metrics in the router

<!-- [ROUTER-1721] -->

[ROUTER-1721]: https://apollographql.atlassian.net/browse/ROUTER-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ