### PR TITLE
docs: update discontinuation notice for cloud routers

### DIFF
--- a/docs/shared/cloud-router-discontinuation-notice.mdx
+++ b/docs/shared/cloud-router-discontinuation-notice.mdx
@@ -1,9 +1,9 @@
-<Caution>
+<Warning>
 
-Apollo is discontinuing Serverless and Dedicated plans, which use cloud routers. Serverless plans end on February 1, 2026, and serverless cloud routers are not available after February 15, 2026. Dedicated plans end on March 15, 2026, and dedicated cloud routers are not available after March 15, 2026.
+Cloud routers are discontinued. You cannot create or use cloud routers.
 
-<br/><br/>
+Use a self-hosted router instead. [See the quickstart](/graphos/routing/quickstart) for step-by-step instructions.
 
-If you're currently on a Serverless or Dedicated plan, migrate your graphs to use self-hosted routers. [See the migration guide](/graphos/routing/cloud/migrate-to-self-hosted) for step-by-step instructions.
+If you are migrating from a Serverless or Dedicated plan, [see the Migration Guide](/graphos/routing/cloud/migrate-to-self-hosted).
 
-</Caution>
+</Warning>

--- a/docs/shared/cloud-router-discontinuation-notice.mdx
+++ b/docs/shared/cloud-router-discontinuation-notice.mdx
@@ -1,9 +1,11 @@
-<Warning>
+<Caution>
 
 Cloud routers are discontinued. You cannot create or use cloud routers.
 
+<br/><br/>
 Use a self-hosted router instead. [See the quickstart](/graphos/routing/quickstart) for step-by-step instructions.
 
+<br/><br/>
 If you are migrating from a Serverless or Dedicated plan, [see the Migration Guide](/graphos/routing/cloud/migrate-to-self-hosted).
 
-</Warning>
+</Caution>


### PR DESCRIPTION
We're past the dates of discontinuation in the original notice so I've updated to remove the dates and link out to appropriate paths.