### PR TITLE
chore(deps): update multimap to 0.10.0 in next major

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
  "line-col",
  "mime",
  "multi_try",
- "multimap 0.10.1",
+ "multimap",
  "nom 8.0.0",
  "nom_locate",
  "parking_lot",
@@ -363,7 +363,7 @@ dependencies = [
  "mime",
  "mockall",
  "multer",
- "multimap 0.9.1",
+ "multimap",
  "notify",
  "nu-ansi-term",
  "num-traits",
@@ -2476,7 +2476,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
- "multimap 0.9.1",
+ "multimap",
  "schemars",
  "serde",
  "serde_json",
@@ -4348,15 +4348,6 @@ checksum = "b42256e8ab5f19108cf42e2762786052ae4660635f6fe76134d2cab37068ee8a"
 
 [[package]]
 name = "multimap"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a5d38b9b352dbd913288736af36af41c48d61b1a8cd34bcecd727561b7d511"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
@@ -5361,7 +5352,7 @@ dependencies = [
  "heck",
  "itertools 0.14.0",
  "log",
- "multimap 0.10.1",
+ "multimap",
  "petgraph",
  "prettyplease",
  "prost",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -146,7 +146,7 @@ mediatype = "0.21.0"
 mockall = "0.14.0"
 mime = "0.3.17"
 multer = "3.1.0"
-multimap = "0.9.1" # Warning: part of the public API
+multimap = "0.10.0" # Warning: part of the public API
 # To avoid tokio issues
 notify = { version = "8.0.0", default-features = false, features = [
     "macos_kqueue",

--- a/examples/coprocessor-subgraph/rust/Cargo.toml
+++ b/examples/coprocessor-subgraph/rust/Cargo.toml
@@ -13,7 +13,7 @@ bytes = "1.6.0"
 futures = "0.3"
 http = "1.2.0"
 http-body-util = "0.1.2"
-multimap = "0.9.0"
+multimap = "0.10.0"
 schemars = { version = "1.0.0", features = ["url2"] }
 serde = "1"
 serde_json = "1"


### PR DESCRIPTION
Since this type is used in part of the public plugin API, this update is going into 3.0

<!-- start metadata -->

<!-- [ROUTER-1684] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1684]: https://apollographql.atlassian.net/browse/ROUTER-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ