### PR TITLE
fix(composition): use IndexMap when merging input fields and intf objects

### DIFF
--- a/apollo-federation/src/merger/merge_input.rs
+++ b/apollo-federation/src/merger/merge_input.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
-use std::collections::HashSet;
-
 use apollo_compiler::Node;
 use apollo_compiler::ast::InputValueDefinition;
 use apollo_compiler::ast::Type;
 use apollo_compiler::collections::IndexMap;
+use apollo_compiler::collections::IndexSet;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::InputObjectType;
 use tracing::instrument;
@@ -185,9 +183,9 @@ impl Merger {
             InputObjectFieldDefinitionPosition,
             Sources<InputObjectFieldDefinitionPosition>,
         > = Default::default();
-        let mut fields_to_add: HashMap<usize, HashSet<InputObjectFieldDefinitionPosition>> =
+        let mut fields_to_add: IndexMap<usize, IndexSet<InputObjectFieldDefinitionPosition>> =
             Default::default();
-        let mut field_types: HashMap<InputObjectFieldDefinitionPosition, Node<Type>> =
+        let mut field_types: IndexMap<InputObjectFieldDefinitionPosition, Node<Type>> =
             Default::default();
         let mut extra_sources: Sources<InputObjectFieldDefinitionPosition> = Default::default();
 

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1744,8 +1744,8 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
     fn add_missing_interface_object_fields_to_implementations(
         &mut self,
     ) -> Result<(), FederationError> {
-        let mut fields_to_insert: HashMap<ObjectFieldDefinitionPosition, FieldDefinition> =
-            HashMap::new();
+        let mut fields_to_insert: IndexMap<ObjectFieldDefinitionPosition, FieldDefinition> =
+            IndexMap::default();
 
         let access_control_directive_names: IndexSet<Name> = self
             .access_control_directives_in_supergraph


### PR DESCRIPTION
Update merge logic to use `IndexMap` instead of `HashMap` when merging input object fields and propagating interface object fields to their implementations.