### PR TITLE
fix(file_uploads): enforce http_max_request_bytes on operations field via multer SizeLimit

### DIFF
--- a/.changesets/fix_caroline_router_1695.md
+++ b/.changesets/fix_caroline_router_1695.md
@@ -1,7 +1,7 @@
-### fix(file_uploads): apply `http_max_request_bytes` only to the operations field, not file streams ([PR #9226](https://github.com/apollographql/router/pull/9226))
+### fix(file_uploads): apply `http_max_request_bytes` only to the operations field, not file streams ([PR #9226](https://github.com/apollographql/router/pull/9226), [PR #9327](https://github.com/apollographql/router/pull/9327))
 
 Previously, `limits.http_max_request_bytes` (default 2 MB) was applied to the entire multipart body of file upload requests, causing large file uploads to be rejected even when `preview_file_uploads.protocols.multipart.limits.max_file_size` was configured to allow them.
 
 The limit now applies only to the GraphQL operations field (the query and variables). File data is bounded separately by `max_file_size`, enforced by the multer parser.
 
-By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9226
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9226 and https://github.com/apollographql/router/pull/9327

--- a/apollo-router/src/plugins/file_uploads/error.rs
+++ b/apollo-router/src/plugins/file_uploads/error.rs
@@ -1,4 +1,5 @@
 use bytesize::ByteSize;
+use http::StatusCode;
 use thiserror::Error;
 
 use crate::graphql;
@@ -61,6 +62,19 @@ pub(super) enum FileUploadError {
 
     #[error("{0}")]
     AxumError(#[from] axum::Error),
+}
+
+impl FileUploadError {
+    pub(super) fn http_status_code(&self) -> StatusCode {
+        match self {
+            // Only "operations" and "map" have multer SizeLimits configured; file parts are
+            // checked separately in SubgraphFileProxyStream and return MaxFileSizeLimitExceeded.
+            FileUploadError::InvalidMultipartRequest(multer::Error::FieldSizeExceeded {
+                ..
+            }) => StatusCode::PAYLOAD_TOO_LARGE,
+            _ => StatusCode::BAD_REQUEST,
+        }
+    }
 }
 
 impl From<FileUploadError> for graphql::Error {

--- a/apollo-router/src/plugins/file_uploads/mod.rs
+++ b/apollo-router/src/plugins/file_uploads/mod.rs
@@ -89,6 +89,7 @@ impl PluginPrivate for FileUploadsPlugin {
                         Ok(req) => ControlFlow::Continue(req),
                         Err(err) => ControlFlow::Break(
                             router::Response::error_builder()
+                                .status_code(err.http_status_code())
                                 .errors(vec![err.into()])
                                 .context(context)
                                 .build()?,
@@ -211,7 +212,28 @@ async fn router_layer(
 
         let (mut request_parts, request_body) = req.router_request.into_parts();
 
-        let mut multipart = MultipartRequest::new(request_body, boundary, limits);
+        // Disable the global stream-level limit before multer reads anything.
+        // limited::poll_frame fires when a single HTTP frame exceeds the remaining budget, but
+        // hyper can deliver large frames on the first read (e.g. the entire multipart body). That
+        // would trigger a spurious 413 before multer has extracted the small operations field.
+        // Instead, we enforce http_max_request_bytes via multer's per-field SizeLimit on the
+        // "operations" field (passed as operations_size_limit below), which counts content bytes
+        // incrementally during streaming.
+        let operations_size_limit = request_parts
+            .extensions
+            .get::<BodyLimitControl>()
+            .and_then(|control| {
+                let limit = control.limit();
+                // update_limit asserts new > current, so skip if already at usize::MAX.
+                if limit < usize::MAX {
+                    control.update_limit(usize::MAX);
+                }
+                u64::try_from(limit).ok()
+            })
+            .unwrap_or(u64::MAX);
+
+        let mut multipart =
+            MultipartRequest::new(request_body, boundary, limits, operations_size_limit);
         let operations_stream = multipart.operations_field().await?;
 
         req.context
@@ -228,30 +250,10 @@ async fn router_layer(
         request_parts.headers.insert(CONTENT_TYPE, content_type);
         request_parts.headers.remove(CONTENT_LENGTH);
 
-        // Buffer the operations field so http_max_request_bytes applies to it specifically.
-        // The underlying Limited<Body> enforces the limit while we read here. Once buffered,
-        // disable the global limit so file streams aren't constrained by it; per-file size
-        // limits (max_file_size) still apply via the multer parser.
-        //
-        // Buffering is not wasteful: the downstream supergraph service reads the entire
-        // operations body into memory anyway for JSON parsing, and the operations field is
-        // bounded by http_max_request_bytes (default 2 MB), so peak memory usage is unchanged.
-        //
-        // If the operations field exceeds http_max_request_bytes, this never returns an Err:
-        // Limited<Body> stalls (returns Poll::Pending forever) and the RequestBodyLimitLayer's
-        // abort semaphore fires a 413 that cancels this future before .bytes() can resolve.
-        // The only errors that reach map_err here are genuine multer errors (bad encoding, etc.).
         let operations_bytes = operations_stream
             .bytes()
             .await
             .map_err(FileUploadError::InvalidMultipartRequest)?;
-        if let Some(control) = request_parts.extensions.get::<BodyLimitControl>() {
-            // update_limit asserts new > current, so skip if already at usize::MAX
-            // (only possible if http_max_request_bytes was explicitly set to usize::MAX).
-            if control.limit() < usize::MAX {
-                control.update_limit(usize::MAX);
-            }
-        }
 
         let request_body = router::body::from_bytes(operations_bytes);
         return Ok(router::Request::from((

--- a/apollo-router/src/plugins/file_uploads/multipart_request.rs
+++ b/apollo-router/src/plugins/file_uploads/multipart_request.rs
@@ -73,11 +73,16 @@ impl MultipartRequest {
         request_body: RouterBody,
         boundary: String,
         limits: MultipartRequestLimits,
+        operations_size_limit: u64,
     ) -> Self {
         let multer = Multipart::with_constraints(
             request_body.into_data_stream(),
             boundary,
-            Constraints::new().size_limit(SizeLimit::new().for_field("map", MAP_SIZE_LIMIT)),
+            Constraints::new().size_limit(
+                SizeLimit::new()
+                    .for_field("map", MAP_SIZE_LIMIT)
+                    .for_field("operations", operations_size_limit),
+            ),
         );
         Self {
             state: Arc::new(Mutex::new(MultipartRequestState {

--- a/apollo-router/tests/fixtures/file_upload/small_body_limit.router.yaml
+++ b/apollo-router/tests/fixtures/file_upload/small_body_limit.router.yaml
@@ -1,0 +1,17 @@
+preview_file_uploads:
+  enabled: true
+  protocols:
+    multipart:
+      enabled: true
+      mode: stream
+      limits:
+        max_file_size: 1kb
+        max_files: 5
+# 500 bytes: large enough for the operations field JSON (~150 bytes), but far smaller
+# than a typical file. This is used to test that http_max_request_bytes is enforced
+# at the content level (operations field only), not at the HTTP frame level.
+limits:
+  router:
+    http_max_request_bytes: 500
+include_subgraph_errors:
+  all: true

--- a/apollo-router/tests/integration/file_upload.rs
+++ b/apollo-router/tests/integration/file_upload.rs
@@ -1120,6 +1120,192 @@ async fn it_rejects_operations_field_larger_than_http_max_request_bytes() -> Res
         .await
 }
 
+mod body_limits {
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+    use std::net::SocketAddr;
+    use std::path::PathBuf;
+
+    use axum::Router;
+    use bytes::Bytes;
+    use http::StatusCode;
+    use http::header::CONTENT_TYPE;
+    use rstest::rstest;
+    use serde_json::Value;
+    use tokio::net::TcpListener;
+    use tower::BoxError;
+
+    use crate::integration::IntegrationTest;
+    use crate::integration::common::graph_os_enabled;
+
+    const CONFIG: &str = include_str!("../fixtures/file_upload/small_body_limit.router.yaml");
+    const BOUNDARY: &str = "testboundary";
+
+    fn build_multipart_body(operations: &str, file_data: &[u8]) -> Vec<u8> {
+        let map = r#"{"0":["variables.file"]}"#;
+        let mut body = Vec::new();
+        for (name, content) in [
+            ("operations", operations.as_bytes()),
+            ("map", map.as_bytes()),
+        ] {
+            body.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+            body.extend_from_slice(
+                format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+            );
+            body.extend_from_slice(content);
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"0\"; filename=\"test.bin\"\r\n\r\n",
+        );
+        body.extend_from_slice(file_data);
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{BOUNDARY}--\r\n").as_bytes());
+        body
+    }
+
+    /// Send `body_bytes` to a router backed by a real subgraph handler.
+    /// `chunk_size` controls HTTP chunking: `None` sends the entire body as one frame
+    /// (reproducing curl's default chunked-upload behavior), `Some(n)` splits into n-byte chunks.
+    async fn run(body_bytes: Vec<u8>, chunk_size: Option<usize>) -> (StatusCode, Value) {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+        let bound = TcpListener::bind(addr).await.unwrap();
+        let bound_url = format!("http://{}", bound.local_addr().unwrap());
+
+        let mut router = IntegrationTest::builder()
+            .config(CONFIG)
+            .subgraph_overrides([("uploads".to_string(), format!("{bound_url}/"))].into())
+            .supergraph(PathBuf::from_iter([
+                "tests",
+                "fixtures",
+                "file_upload",
+                "schema.graphql",
+            ]))
+            .build()
+            .await;
+        router.start().await;
+        router.assert_started().await;
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let handler = Router::new().route(
+            "/",
+            axum::routing::post(crate::integration::file_upload::helper::echo_single_file),
+        );
+        tokio::spawn(async {
+            axum::serve(bound, handler.into_make_service())
+                .with_graceful_shutdown(async {
+                    shutdown_rx.await.ok();
+                })
+                .await
+                .unwrap()
+        });
+
+        let body: reqwest::Body = match chunk_size {
+            None => reqwest::Body::wrap_stream(tokio_stream::once(Ok::<_, std::io::Error>(
+                Bytes::from(body_bytes),
+            ))),
+            Some(n) => {
+                let chunks: Vec<Result<Bytes, std::io::Error>> = body_bytes
+                    .chunks(n)
+                    .map(|c| Ok(Bytes::copy_from_slice(c)))
+                    .collect();
+                reqwest::Body::wrap_stream(tokio_stream::iter(chunks))
+            }
+        };
+
+        let url = format!("http://{}", router.bind_address());
+        let response = reqwest::Client::new()
+            .post(url)
+            .header(
+                CONTENT_TYPE,
+                format!("multipart/form-data; boundary={BOUNDARY}"),
+            )
+            .header("apollo-require-preflight", "true")
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let body = response.json().await.unwrap_or_default();
+        shutdown_tx.send(()).unwrap();
+        router.graceful_shutdown().await;
+        (status, body)
+    }
+
+    const OPS: &str = r#"{"query":"mutation ($file: Upload) { file0: singleUpload(file: $file) { filename body } }","variables":{"file":null}}"#;
+
+    /// A file larger than http_max_request_bytes but within max_file_size should succeed,
+    /// regardless of how many HTTP frames the body arrives in.
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn succeeds_when_file_larger_than_http_limit(
+        #[values(None, Some(100))] chunk_size: Option<usize>,
+    ) -> Result<(), BoxError> {
+        if !graph_os_enabled() {
+            return Ok(());
+        }
+
+        let body_bytes = build_multipart_body(OPS, &vec![0xBBu8; 500]);
+        let (status, body) = run(body_bytes, chunk_size).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(body["errors"].is_null());
+
+        Ok(())
+    }
+
+    /// A file larger than max_file_size should be rejected with a GraphQL error,
+    /// regardless of how many HTTP frames the body arrives in.
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rejects_file_exceeding_max_file_size(
+        #[values(None, Some(100))] chunk_size: Option<usize>,
+    ) -> Result<(), BoxError> {
+        if !graph_os_enabled() {
+            return Ok(());
+        }
+
+        let body_bytes = build_multipart_body(OPS, &vec![0xBBu8; 2000]);
+        let (status, body) = run(body_bytes, chunk_size).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(!body["errors"].is_null());
+
+        assert!(
+            body["errors"][0].is_object(),
+            "expected an error for oversized file but got: {body}"
+        );
+
+        Ok(())
+    }
+
+    /// An operations field larger than http_max_request_bytes should be rejected with 413,
+    /// regardless of how many HTTP frames the body arrives in.
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rejects_oversized_operations_field(
+        #[values(None, Some(100))] chunk_size: Option<usize>,
+    ) -> Result<(), BoxError> {
+        if !graph_os_enabled() {
+            return Ok(());
+        }
+
+        // Operations content that exceeds http_max_request_bytes = 500
+        let large_ops = format!(
+            r#"{{"query":"mutation ($file: Upload) {{ file0: singleUpload(file: $file) {{ filename body }} }}","variables":{{"file":null,"pad":"{}"}}}}"#,
+            "x".repeat(600),
+        );
+        let body_bytes = build_multipart_body(&large_ops, b"tiny");
+        let (status, _body) = run(body_bytes, chunk_size).await;
+
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+
+        Ok(())
+    }
+}
+
 mod operation_body_timeout {
     use std::time::Duration;
 


### PR DESCRIPTION
<!-- [ROUTER-1740] -->

## Summary

Fix for #9226

The `http_max_request_bytes` limit was incorrectly firing with 413 on multipart file upload requests even when the operations field (GraphQL query + variables) was well within the limit and the file was within `max_file_size`.

**Root cause:** `limited.rs::poll_frame` compares a single HTTP frame's size against the remaining byte budget. With chunked transfer encoding, hyper can deliver the entire multipart body as one large frame on the first read. This caused a spurious 413 before multer had a chance to extract the small `operations` field — the very first `multer.next_field().await` never returned.

**Fix (two parts):**
1. Disable the global stream-level limit _before_ any body read, so `limited.rs` never fires on a large frame during multipart parsing.
2. Re-enforce `http_max_request_bytes` on the `"operations"` field via multer's per-field `SizeLimit`, which counts content bytes incrementally during streaming. An oversized operations field now returns 413 (`PAYLOAD_TOO_LARGE`) via `FileUploadError::http_status_code()`.

The `"map"` field retains its existing 10 KB multer limit. Per-file size enforcement via `SubgraphFileProxyStream` is unchanged and returns a GraphQL error in a 200 response.

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible
- [ ] Documentation completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added and documented
- Tests added and passing
    - [x] Integration tests (`mod body_limits` in `file_upload.rs` — 6 parameterized tests covering one-chunk and many-chunk delivery for all three limit scenarios)
    - [ ] Manual tests, as necessary


[ROUTER-1740]: https://apollographql.atlassian.net/browse/ROUTER-1740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ