### PR TITLE
fix(composition): return empty string from did_you_mean with no suggestions

### DIFF
--- a/apollo-federation/src/error/suggestion.rs
+++ b/apollo-federation/src/error/suggestion.rs
@@ -31,7 +31,7 @@ const MAX_SUGGESTIONS: usize = 5;
 /// Given [ A, B ], returns "Did you mean A or B?".
 /// Given [ A, B, C ], returns "Did you mean A, B, or C?".
 pub(crate) fn did_you_mean(suggestions: impl IntoIterator<Item = String>) -> String {
-    const MESSAGE: &str = "Did you mean ";
+    const MESSAGE: &str = " Did you mean ";
     let suggestions = suggestions
         .into_iter()
         .take(MAX_SUGGESTIONS)
@@ -70,7 +70,7 @@ mod tests {
     fn did_you_mean_with_one_suggestion() {
         assert_eq!(
             did_you_mean(vec!["foo".to_string()]),
-            r#"Did you mean "foo"?"#
+            r#" Did you mean "foo"?"#
         );
     }
 
@@ -78,7 +78,7 @@ mod tests {
     fn did_you_mean_with_two_suggestions() {
         assert_eq!(
             did_you_mean(vec!["foo".to_string(), "bar".to_string()]),
-            r#"Did you mean "foo" or "bar"?"#
+            r#" Did you mean "foo" or "bar"?"#
         );
     }
 
@@ -90,7 +90,7 @@ mod tests {
                 "bar".to_string(),
                 "baz".to_string()
             ]),
-            r#"Did you mean "foo", "bar", or "baz"?"#
+            r#" Did you mean "foo", "bar", or "baz"?"#
         );
     }
 }

--- a/apollo-federation/src/error/suggestion.rs
+++ b/apollo-federation/src/error/suggestion.rs
@@ -37,6 +37,9 @@ pub(crate) fn did_you_mean(suggestions: impl IntoIterator<Item = String>) -> Str
         .take(MAX_SUGGESTIONS)
         .map(|s| format!("\"{s}\""))
         .collect_vec();
+    if suggestions.is_empty() {
+        return String::new();
+    }
     let last_separator = if suggestions.len() > 2 {
         Some(", or ")
     } else {
@@ -52,4 +55,42 @@ pub(crate) fn did_you_mean(suggestions: impl IntoIterator<Item = String>) -> Str
         },
     );
     format!("{MESSAGE}{suggestion_str}?")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn did_you_mean_returns_empty_string_for_no_suggestions() {
+        assert_eq!(did_you_mean(Vec::<String>::new()), "");
+    }
+
+    #[test]
+    fn did_you_mean_with_one_suggestion() {
+        assert_eq!(
+            did_you_mean(vec!["foo".to_string()]),
+            r#"Did you mean "foo"?"#
+        );
+    }
+
+    #[test]
+    fn did_you_mean_with_two_suggestions() {
+        assert_eq!(
+            did_you_mean(vec!["foo".to_string(), "bar".to_string()]),
+            r#"Did you mean "foo" or "bar"?"#
+        );
+    }
+
+    #[test]
+    fn did_you_mean_with_three_suggestions() {
+        assert_eq!(
+            did_you_mean(vec![
+                "foo".to_string(),
+                "bar".to_string(),
+                "baz".to_string()
+            ]),
+            r#"Did you mean "foo", "bar", or "baz"?"#
+        );
+    }
 }

--- a/apollo-federation/src/merger/compose_directive_manager.rs
+++ b/apollo-federation/src/merger/compose_directive_manager.rs
@@ -724,11 +724,12 @@ impl ErrorReporter {
                 .keys()
                 .map(|d| format!("@{d}")),
         );
+        let suggestion = did_you_mean(words);
+        let separator = if suggestion.is_empty() { "" } else { " " };
         self.add_error(CompositionError::DirectiveCompositionError {
             message: format!(
-                "Could not find matching directive definition for argument to @composeDirective \"{name}\" in subgraph \"{}\". {}",
+                "Could not find matching directive definition for argument to @composeDirective \"{name}\" in subgraph \"{}\".{separator}{suggestion}",
                 subgraph.name,
-                did_you_mean(words),
             ),
         });
     }

--- a/apollo-federation/src/merger/compose_directive_manager.rs
+++ b/apollo-federation/src/merger/compose_directive_manager.rs
@@ -724,12 +724,11 @@ impl ErrorReporter {
                 .keys()
                 .map(|d| format!("@{d}")),
         );
-        let suggestion = did_you_mean(words);
-        let separator = if suggestion.is_empty() { "" } else { " " };
         self.add_error(CompositionError::DirectiveCompositionError {
             message: format!(
-                "Could not find matching directive definition for argument to @composeDirective \"{name}\" in subgraph \"{}\".{separator}{suggestion}",
+                "Could not find matching directive definition for argument to @composeDirective \"{name}\" in subgraph \"{}\".{}",
                 subgraph.name,
+                did_you_mean(words),
             ),
         });
     }

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1238,11 +1238,10 @@ impl Merger {
                 result.set_override_with_unknown_target(idx);
                 let suggestions = suggestion_list(&source_subgraph_name, self.names.clone());
                 let extra_msg = did_you_mean(suggestions);
-                let separator = if extra_msg.is_empty() { "" } else { " " };
                 self.error_reporter.add_hint(CompositionHint {
                     definition: HintCode::FromSubgraphDoesNotExist.definition(),
                     message: format!(
-                        "Source subgraph \"{}\" for field \"{}\" on subgraph \"{}\" does not exist.{separator}{extra_msg}",
+                        "Source subgraph \"{}\" for field \"{}\" on subgraph \"{}\" does not exist.{extra_msg}",
                         source_subgraph_name, dest, subgraph_name
                     ),
                     locations: Default::default(),

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1238,10 +1238,11 @@ impl Merger {
                 result.set_override_with_unknown_target(idx);
                 let suggestions = suggestion_list(&source_subgraph_name, self.names.clone());
                 let extra_msg = did_you_mean(suggestions);
+                let separator = if extra_msg.is_empty() { "" } else { " " };
                 self.error_reporter.add_hint(CompositionHint {
                     definition: HintCode::FromSubgraphDoesNotExist.definition(),
                     message: format!(
-                        "Source subgraph \"{}\" for field \"{}\" on subgraph \"{}\" does not exist. {extra_msg}",
+                        "Source subgraph \"{}\" for field \"{}\" on subgraph \"{}\" does not exist.{separator}{extra_msg}",
                         source_subgraph_name, dest, subgraph_name
                     ),
                     locations: Default::default(),

--- a/apollo-federation/tests/composition/compose_basic.rs
+++ b/apollo-federation/tests/composition/compose_basic.rs
@@ -499,3 +499,50 @@ fn enum_value_mismatch_detected_with_multiple_input_fields() {
         )],
     );
 }
+
+#[test]
+fn override_from_nonexistent_subgraph_hint_has_no_empty_did_you_mean() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          product: Product
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+          name: String! @override(from: "nonExistent") @shareable
+        }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+        type Product @key(fields: "id") {
+          id: ID!
+          name: String! @shareable
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+    let supergraph = result.expect("Expected composition to succeed");
+
+    let from_subgraph_hints: Vec<_> = supergraph
+        .hints()
+        .iter()
+        .filter(|h| h.code() == "FROM_SUBGRAPH_DOES_NOT_EXIST")
+        .collect();
+
+    assert_eq!(from_subgraph_hints.len(), 1);
+    let message = &from_subgraph_hints[0].message;
+    assert!(
+        !message.contains("Did you mean"),
+        "Hint message should not contain empty 'Did you mean' suggestion, got: {message}"
+    );
+    assert!(
+        message.ends_with("does not exist."),
+        "Hint message should end with 'does not exist.', got: {message}"
+    );
+}

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -883,7 +883,7 @@ mod custom_error_message_for_misnamed_directives {
    │                            ─────────┬─────────
    │                                     ╰─────────── directive not defined
 ───╯
-Did you mean "@key"?"#,
+ Did you mean "@key"?"#,
                     ),
                     (
                         "INVALID_GRAPHQL",
@@ -905,7 +905,7 @@ Did you mean "@key"?"#,
    │                                     ────┬────
    │                                         ╰────── directive not defined
 ───╯
-Did you mean "@shareable"?{}"#,
+ Did you mean "@shareable"?{}"#,
                             fed_ver.extra_msg
                         ),
                     ),


### PR DESCRIPTION
The `did_you_mean` function was returning `"Did you mean ?"` when called with an empty suggestion list, producing hint messages like `Type does not exist. Did you mean ?`. Now returns an empty string for zero suggestions, matching the JS composer behavior.