### PR TITLE
fix(composition): add subgraph location to FROM_SUBGRAPH_DOES_NOT_EXIST hint

### DIFF
--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -17,6 +17,7 @@ use apollo_compiler::ast::Type;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::name;
+use apollo_compiler::parser::LineColumn;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::ComponentName;
 use apollo_compiler::schema::ComponentOrigin;
@@ -1238,13 +1239,17 @@ impl Merger {
                 result.set_override_with_unknown_target(idx);
                 let suggestions = suggestion_list(&source_subgraph_name, self.names.clone());
                 let extra_msg = did_you_mean(suggestions);
+                let default_range = LineColumn { line: 0, column: 0 }..LineColumn { line: 0, column: 0 };
                 self.error_reporter.add_hint(CompositionHint {
                     definition: HintCode::FromSubgraphDoesNotExist.definition(),
                     message: format!(
                         "Source subgraph \"{}\" for field \"{}\" on subgraph \"{}\" does not exist.{extra_msg}",
                         source_subgraph_name, dest, subgraph_name
                     ),
-                    locations: Default::default(),
+                    locations: vec![SubgraphLocation {
+                        subgraph: subgraph_name.clone(),
+                        range: default_range,
+                    }],
                 });
             } else if source_subgraph_name == *subgraph_name {
                 // error: source and destination are the same

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1239,7 +1239,8 @@ impl Merger {
                 result.set_override_with_unknown_target(idx);
                 let suggestions = suggestion_list(&source_subgraph_name, self.names.clone());
                 let extra_msg = did_you_mean(suggestions);
-                let default_range = LineColumn { line: 0, column: 0 }..LineColumn { line: 0, column: 0 };
+                let default_range =
+                    LineColumn { line: 0, column: 0 }..LineColumn { line: 0, column: 0 };
                 self.error_reporter.add_hint(CompositionHint {
                     definition: HintCode::FromSubgraphDoesNotExist.definition(),
                     message: format!(

--- a/apollo-federation/tests/composition/compose_basic.rs
+++ b/apollo-federation/tests/composition/compose_basic.rs
@@ -546,3 +546,51 @@ fn override_from_nonexistent_subgraph_hint_has_no_empty_did_you_mean() {
         "Hint message should end with 'does not exist.', got: {message}"
     );
 }
+
+#[test]
+fn override_from_nonexistent_subgraph_hint_has_subgraph_location() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          product: Product
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+          name: String! @override(from: "nonExistent") @shareable
+        }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+        type Product @key(fields: "id") {
+          id: ID!
+          name: String! @shareable
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+    let supergraph = result.expect("Expected composition to succeed");
+
+    let from_subgraph_hints: Vec<_> = supergraph
+        .hints()
+        .iter()
+        .filter(|h| h.code() == "FROM_SUBGRAPH_DOES_NOT_EXIST")
+        .collect();
+
+    assert_eq!(from_subgraph_hints.len(), 1);
+    let hint = &from_subgraph_hints[0];
+    assert_eq!(
+        hint.locations.len(),
+        1,
+        "Hint should have exactly one location"
+    );
+    assert_eq!(
+        hint.locations[0].subgraph, "subgraphA",
+        "Hint location should reference the subgraph with @override"
+    );
+}


### PR DESCRIPTION
The hint was missing a SubgraphLocation, so when converted to a BuildMessage the `[subgraph-name]` prefix was not prepended. JS composition passes the field's AST node which carries the subgraph, producing the prefix. Now RS populates the location with the subgraph name so `maybe_prepend_subgraph` can add the prefix to match JS output.