### PR TITLE
fix(composition): remove @provides/@requires from all intf fields during fed1 upgrade

### DIFF
--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -608,16 +608,27 @@ impl SchemaUpgrader {
             {
                 interface_key_types.insert(pos.type_name.clone());
                 pos.remove_directive_name(schema, key);
+            }
+        }
 
-                let fields: Vec<_> = pos.fields(schema.schema())?.collect();
-                for field in fields {
-                    if let Some(provides) = &upgrade_metadata.provides_directive_name {
-                        field.remove_directive_name(schema, provides);
-                    }
-                    if let Some(requires) = &upgrade_metadata.requires_directive_name {
-                        field.remove_directive_name(schema, requires);
-                    }
-                }
+        if let Some(provides) = &upgrade_metadata.provides_directive_name {
+            for field in schema
+                .referencers()
+                .get_directive(provides)
+                .interface_fields
+                .clone()
+            {
+                field.remove_directive_name(schema, provides);
+            }
+        }
+        if let Some(requires) = &upgrade_metadata.requires_directive_name {
+            for field in schema
+                .referencers()
+                .get_directive(requires)
+                .interface_fields
+                .clone()
+            {
+                field.remove_directive_name(schema, requires);
             }
         }
 
@@ -2701,6 +2712,52 @@ scalar _FieldSet
 
                 scalar link__Import
             "###
+        );
+    }
+
+    #[test]
+    fn removes_provides_and_requires_from_interface_fields_without_key() {
+        let s1 = Subgraph::parse(
+            "s1",
+            "",
+            r#"
+            directive @key(fields: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+            directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+            directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+            directive @external(reason: String) on OBJECT | FIELD_DEFINITION
+            directive @extends on OBJECT | INTERFACE
+
+            scalar _FieldSet
+
+            type Query {
+              product: Product
+            }
+
+            type Author @key(fields: "id") {
+              id: ID! @external
+              name: String
+            }
+
+            interface Product {
+              id: ID!
+              author: Author @provides(fields: "id")
+            }
+
+            type Book implements Product @key(fields: "id") {
+              id: ID!
+              author: Author @provides(fields: "id")
+            }
+            "#,
+        )
+        .expect("parses schema")
+        .expand_links()
+        .expect("expands schema");
+
+        let result = upgrade_subgraphs_if_necessary(vec![s1]);
+        assert!(
+            result.is_ok(),
+            "Expected upgrade to succeed but got: {:?}",
+            result.err()
         );
     }
 }


### PR DESCRIPTION
The schema upgrader only removed `@provides` and `@requires` from interface fields when the interface had `@key`. JS removes them from all interface fields regardless of `@key` presence, since these directives on interface fields were ignored in federation 0.x. This caused `PROVIDES_UNSUPPORTED_ON_INTERFACE` errors for fed1 schemas with `@provides` on interface fields without `@key`.

Link to JS logic -> https://github.com/apollographql/federation/blob/main/internals-js/src/schemaUpgrader.ts#L699-L706

<!-- [FED-876] -->

[FED-876]: https://apollographql.atlassian.net/browse/FED-876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ