### PR TITLE
test(axum_factory): fix request_cancel_* nanosecond races (Phase 4)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -134,8 +134,6 @@ or ( binary_id(=apollo-router::type_conditions) & test(=test_type_conditions_dis
 or ( binary_id(=apollo-router::type_conditions) & test(=test_type_conditions_enabled_generate_query_fragments) )
 or ( binary_id(=apollo-router::type_conditions) & test(=test_type_conditions_enabled_list_of_list) )
 or ( binary_id(=apollo-router::type_conditions) & test(=test_type_conditions_enabled) )
-or ( binary_id(=apollo-router) & test(=axum_factory::axum_http_server_factory::tests::request_cancel_log) )
-or ( binary_id(=apollo-router) & test(=axum_factory::axum_http_server_factory::tests::request_cancel_no_log) )
 or ( binary_id(=apollo-router) & test(=axum_factory::tests::cors_origin_default) )
 or ( binary_id(=apollo-router) & test(=axum_factory::tests::cors_origin_list) )
 or ( binary_id(=apollo-router) & test(=axum_factory::tests::cors_origin_regex) )

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -751,12 +751,16 @@ mod tests {
             ))
             .unwrap();
 
-        let call_fut = http_router.call(request);
-        tokio::pin!(call_fut);
+        // `HttpService::call` already returns a `Pin<Box<dyn Future + Send>>`, so we can
+        // poll it via `.as_mut()` and explicitly drop it without `tokio::pin!` (which would
+        // shadow the binding with a `Pin<&mut _>` and make the subsequent `drop` a no-op
+        // on the underlying boxed future).
+        let mut call_fut = http_router.call(request);
 
         // First poll drives the router synchronously through `CancelHandler::new` into the
         // inner `tokio::task::spawn(task).await`, which returns `Pending`. After this point
-        // dropping the future will run `CancelHandler::Drop` with `got_first_response == false`.
+        // dropping the future will run `CancelHandler::Drop` with
+        // `got_first_response == false`.
         let first = futures::poll!(call_fut.as_mut());
         assert!(
             matches!(first, Poll::Pending),

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -680,9 +680,15 @@ mod tests {
         assert_eq!(mode, SpanMode::Deprecated);
     }
 
-    // Perform a short wait, (100ns) which is intended to complete before the http router call. If
-    // it does complete first, then the http router call will be cancelled and we'll see an error
-    // log in our assert.
+    // Drive the http router call into its cancellation-handling path (where `CancelHandler`
+    // is constructed) and then deterministically cancel it before completion. With
+    // `experimental_log_on_broken_pipe = true`, dropping `CancelHandler` without an
+    // intervening `on_response` is what emits the "broken pipe" error log asserted on below.
+    //
+    // Historical note: this used to race a `Duration::from_nanos(100)` timeout against the
+    // call. Whether the future was polled even once before the timeout fired was a function
+    // of scheduler timing, not test logic, so the assertion was inherently flaky. See
+    // `flaky-test-fixes.md` (nanosecond-timeout-race anti-pattern).
     #[tokio::test(flavor = "multi_thread")]
     async fn request_cancel_log() {
         let mut http_router = crate::TestHarness::builder()
@@ -694,21 +700,7 @@ mod tests {
             .unwrap();
 
         async {
-            let _res = tokio::time::timeout(
-                std::time::Duration::from_nanos(100),
-                http_router.call(
-                    http::Request::builder()
-                        .method("POST")
-                        .uri("/")
-                        .header(ACCEPT, "application/json")
-                        .header(CONTENT_TYPE, "application/json")
-                        .body(router::body::from_bytes(
-                            r#"{"query":"query { me { name }}"}"#,
-                        ))
-                        .unwrap(),
-                ),
-            )
-            .await;
+            cancel_after_first_poll(&mut http_router).await;
         }
         .with_subscriber(assert_snapshot_subscriber!(
             tracing_core::LevelFilter::ERROR
@@ -716,9 +708,8 @@ mod tests {
         .await
     }
 
-    // Perform a short wait, (100ns) which is intended to complete before the http router call. If
-    // it does complete first, then the http router call will be cancelled and we'll not see an
-    // error log in our assert.
+    // Same shape as `request_cancel_log`, but with `experimental_log_on_broken_pipe = false`,
+    // so the snapshot asserts that no error log is emitted on cancellation.
     #[tokio::test(flavor = "multi_thread")]
     async fn request_cancel_no_log() {
         let mut http_router = crate::TestHarness::builder()
@@ -730,25 +721,50 @@ mod tests {
             .unwrap();
 
         async {
-            let _res = tokio::time::timeout(
-                std::time::Duration::from_nanos(100),
-                http_router.call(
-                    http::Request::builder()
-                        .method("POST")
-                        .uri("/")
-                        .header(ACCEPT, "application/json")
-                        .header(CONTENT_TYPE, "application/json")
-                        .body(router::body::from_bytes(
-                            r#"{"query":"query { me { name }}"}"#,
-                        ))
-                        .unwrap(),
-                ),
-            )
-            .await;
+            cancel_after_first_poll(&mut http_router).await;
         }
         .with_subscriber(assert_snapshot_subscriber!(
             tracing_core::LevelFilter::ERROR
         ))
         .await
+    }
+
+    // Drive `http_router.call(...)` to its first `Pending` (which is what constructs the
+    // request's `CancelHandler` inside the production code path) and then drop the future to
+    // cancel it. Using `futures::poll!` instead of a `tokio::time::timeout` race makes
+    // "polled then cancelled" deterministic regardless of scheduler timing.
+    //
+    // The phase doc sketched a `tokio::sync::oneshot` + `tokio::select!` cancellation, which
+    // is the same shape any caller would use to cancel a real request; this helper is the
+    // synchronous-equivalent collapsed into a test-only single-task form because we don't
+    // need to `tokio::spawn` to observe cancellation here.
+    async fn cancel_after_first_poll(http_router: &mut crate::test_harness::HttpService) {
+        use std::task::Poll;
+
+        let request = http::Request::builder()
+            .method("POST")
+            .uri("/")
+            .header(ACCEPT, "application/json")
+            .header(CONTENT_TYPE, "application/json")
+            .body(router::body::from_bytes(
+                r#"{"query":"query { me { name }}"}"#,
+            ))
+            .unwrap();
+
+        let call_fut = http_router.call(request);
+        tokio::pin!(call_fut);
+
+        // First poll drives the router synchronously through `CancelHandler::new` into the
+        // inner `tokio::task::spawn(task).await`, which returns `Pending`. After this point
+        // dropping the future will run `CancelHandler::Drop` with `got_first_response == false`.
+        let first = futures::poll!(call_fut.as_mut());
+        assert!(
+            matches!(first, Poll::Pending),
+            "expected first poll of the router call to be Pending so the request enters \
+             the cancellation-handling path; got {:?}",
+            first
+        );
+
+        drop(call_fut);
     }
 }


### PR DESCRIPTION
## Summary

Phase 4 of the flaky-test-fix plan (`flaky-test-phases/phase-4-axum-cancel-races.md`). Replaces the inherently non-deterministic timeout-vs-completion race in `axum_factory::request_cancel_{log,no_log}` with a deterministic cancel.

- Drops the pinned `Box` future directly in the cancel helper.
- Removes `request_cancel_log` / `request_cancel_no_log` from the retry list.

## Verification

- **240 / 240** verified across worker + auditor reproduction.
- Audit pass 1 (`8b8f1cd6`) returned `approved` with 1 `note`-severity finding (F1.1).

## Test plan

- [ ] CI green
- [ ] 3-day post-merge CI watch

<!-- jira: ROUTER-1726 -->