### PR TITLE
test(harness): integration-harness flake fixes + P11 shutdown-drain race fix (Phase 7)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,55 +13,11 @@
 retries = 2
 filter = '''
    ( binary_id(=apollo-router::integration_tests) & test(#integration::subscriptions::ws_passthrough::*) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::batching::it_batches_with_errors_in_multi_graph) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::batching::it_batches_with_errors_in_single_graph) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::batching::it_handles_cancelled_by_coprocessor) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::batching::it_handles_cancelled_by_rhai) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::batching::it_handles_indefinite_timeouts) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::batching::it_handles_short_timeouts) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::batching::it_handles_single_invalid_graphql) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::batching::it_handles_single_request_cancelled_by_coprocessor) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::batching::it_handles_single_request_cancelled_by_rhai) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::batching::it_supports_multi_subgraph_batching) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::batching::it_supports_single_subgraph_batching) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::connectors::authentication::incompatible_warnings_with_overrides) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::connectors::authentication::test_aws_sig_v4_signing) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::coprocessor::test_coprocessor_response_handling) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::coprocessor::test_error_not_propagated_to_client) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::file_upload::it_fails_incompatible_query_order) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::file_upload::it_fails_invalid_file_order) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::file_upload::it_fails_invalid_multipart_order) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::file_upload::it_fails_upload_without_file) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::file_upload::it_fails_with_file_count_limits) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::file_upload::it_fails_with_file_size_limit) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::file_upload::it_fails_with_no_boundary_in_multipart) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::file_upload::it_supports_compression) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::file_upload::it_supports_nested_file) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::file_upload::it_uploads_file_to_subgraph) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::file_upload::it_uploads_to_multiple_subgraphs) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::introspection::integration) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::metrics::test_jemalloc_metrics_are_emitted) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::operation_limits::test_request_bytes_limit_with_coprocessor) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::operation_limits::test_request_bytes_limit) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::query_planner::context_with_new_qp) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::query_planner::error_paths::test_multi_level_response_failure) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::query_planner::error_paths::test_nested_response_failure) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::query_planner::fed1_schema_with_new_qp) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::query_planner::max_evaluated_plans::reports_evaluated_plans) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::query_planner::valid_schema_with_new_qp_change_to_broken_schema_keeps_old_config) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::rhai::test_rhai_hot_reload_works) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_response::test_invalid_error_locations_contains_negative_one_location) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_response::test_valid_extensions_service_for_subgraph_error) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_response::test_valid_extensions_service_is_preserved_for_subgraph_error) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::callback::test_subscription_callback_pure_error_payload) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::callback::test_subscription_callback) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::supergraph::test_supergraph_errors_on_http1_header_that_does_not_fit_inside_buffer) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::traffic_shaping::test_router_rate_limit) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::traffic_shaping::test_router_timeout_operation_name_in_tracing) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::traffic_shaping::test_router_timeout) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::traffic_shaping::test_subgraph_rate_limit) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::traffic_shaping::test_subgraph_timeout) )
-or ( binary_id(=apollo-router) & test(=plugins::telemetry::config_new::instruments::tests::test_instruments) )
 '''
 
 [profile.ci]
@@ -133,7 +89,6 @@ test-group = 'serial-apollo-telemetry-integration'
 [[profile.default.overrides]]
 filter = '''
    ( binary_id(=apollo-router) & test(/^plugins::telemetry::metrics::apollo::test::apollo_metrics_/) )
-or ( binary_id(=apollo-router) & test(=plugins::telemetry::config_new::instruments::tests::test_instruments) )
 '''
 test-group = 'serial-apollo-metrics-unit'
 

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1195,6 +1195,52 @@ impl IntegrationTest {
                         level: String,
                         message: String,
                     }
+                    // Filter out OpenTelemetry SDK MeterProvider Drop lines
+                    // before strict-struct deserialisation.
+                    //
+                    // Upstream `opentelemetry-0.31.0`'s `otel_error!` macro
+                    // (`src/global/internal_logging.rs:202-228`) expands to
+                    // a `tracing::error!` call that supplies BOTH an empty
+                    // string as the event's display body AND an explicit
+                    // `message = ...` kv field. `tracing-subscriber`'s JSON
+                    // formatter serialises both, producing a JSON object
+                    // with two `"message"` keys. `serde_json::from_str::<Log>`
+                    // rejects duplicate struct fields
+                    // (`serde::de::Error::duplicate_field`), which previously
+                    // panicked the spawn task here, dropped the
+                    // `collect_stdio` `oneshot::Sender`, and made every
+                    // `collect_stdio`-using test fail with
+                    // `RecvError(())`. The triggering emission is gated on
+                    // `MeterProvider::shutdown()` returning `Err` during
+                    // `Drop` — a tokio-runtime-shutdown race in the SDK,
+                    // independent of router behaviour
+                    // (`opentelemetry_sdk-0.31.0/src/metrics/meter_provider.rs:170-175`).
+                    //
+                    // Filtering at the test-harness boundary (rather than
+                    // changing the router-wide JSON formatter) keeps the
+                    // blast radius local to the in-test stdout collector.
+                    //
+                    // The prefix match is `MeterProvider.Drop` (no
+                    // trailing dot) so the filter catches both the
+                    // bare `name="MeterProvider.Drop"` emission from
+                    // `otel_info!` (`meter_provider.rs:166-168`,
+                    // `MeterProvider` dropped without `shutdown_invoked`)
+                    // and the suffixed `name="MeterProvider.Drop.ShutdownFailed"`
+                    // / `name="MeterProvider.Drop.AlreadyShutdown"`
+                    // emissions from `otel_error!` / `otel_debug!`. All
+                    // share the same trailing-`""` Display-body
+                    // expansion at `internal_logging.rs:202-228` (and
+                    // `:42-62` for `otel_info!`) and therefore the
+                    // same duplicate-`message`-key surface.
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line)
+                        && value
+                            .get("name")
+                            .and_then(serde_json::Value::as_str)
+                            .is_some_and(|name| name.starts_with("MeterProvider.Drop"))
+                    {
+                        let _ = stdio_tx.send(line).await;
+                        continue;
+                    }
                     let Ok(log) = serde_json::from_str::<Log>(&line) else {
                         panic!(
                             "line: '{line}' isn't JSON, might you have some debug output in the logging?"
@@ -1526,9 +1572,29 @@ impl IntegrationTest {
         self.assert_shutdown().await;
     }
 
+    /// Like `graceful_shutdown` but lets the caller widen the
+    /// `assert_shutdown` budget. Use only for tests with a documented
+    /// shutdown-drain race that the default 10 s budget cannot beat.
+    /// Prefer fixing the underlying race when possible.
+    #[allow(dead_code)]
+    #[cfg(target_family = "unix")]
+    pub async fn graceful_shutdown_with_deadline(&mut self, deadline: Duration) {
+        unsafe {
+            libc::kill(self.pid(), libc::SIGTERM);
+        }
+        self.assert_shutdown_with_deadline(deadline).await;
+    }
+
     #[cfg(target_os = "windows")]
     pub async fn graceful_shutdown(&mut self) {
         // We don’t have SIGTERM on Windows, so do a non-graceful kill instead
+        self.kill().await
+    }
+
+    #[allow(dead_code)]
+    #[cfg(target_os = "windows")]
+    pub async fn graceful_shutdown_with_deadline(&mut self, _deadline: Duration) {
+        // Windows has no SIGTERM; forward to the non-graceful kill path.
         self.kill().await
     }
 
@@ -1945,9 +2011,25 @@ impl IntegrationTest {
         // a `connection_shutdown_timeout` default to prevent the 60 s
         // production default from hanging tests that hold HTTP/2 client
         // connections open past the response (see `merge_overrides`).
+        self.assert_shutdown_with_deadline(Duration::from_secs(10))
+            .await;
+    }
+
+    /// Variant of `assert_shutdown` that lets a specific test widen the
+    /// shutdown-budget when its shutdown path has a documented drain race
+    /// the default 10 s budget cannot beat.
+    ///
+    /// Used by tests that trip the default 10 s deadline with a known
+    /// fingerprint (typically a hyper-client pool drain race or
+    /// OpenTelemetry SDK shutdown ordering bug, neither of which can be
+    /// pinned without Linux `dump_stack_traces`). Widening the budget
+    /// per-test rather than via the shared default keeps the rest of the
+    /// harness honest about shutdown regressions.
+    #[allow(dead_code)]
+    pub async fn assert_shutdown_with_deadline(&mut self, deadline: Duration) {
         let router = self.router.as_mut().expect("router must have been started");
         let now = Instant::now();
-        while now.elapsed() < Duration::from_secs(10) {
+        while now.elapsed() < deadline {
             match router.try_wait() {
                 Ok(Some(_)) => {
                     self.router = None;

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -17,6 +17,18 @@ use crate::integration::common::Query;
 use crate::integration::common::graph_os_enabled;
 use crate::integration::common::redact_cache_debug_query_hash;
 
+/// Build a `reqwest::Client` that disables HTTP keep-alive so each request
+/// closes its TCP connection on completion.
+/// `test_coprocessor_response_handling` runs many sequential router
+/// processes; any one inheriting an idle inbound connection at SIGTERM
+/// flakes `assert_shutdown` against its 10 s budget.
+fn no_keepalive_reqwest_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()
+        .expect("reqwest client build")
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_error_not_propagated_to_client() -> Result<(), BoxError> {
     if !graph_os_enabled() {
@@ -188,6 +200,7 @@ async fn test_full_pipeline(
             include_str!("fixtures/coprocessor.router.yaml")
                 .replace("<replace>", &coprocessor_address),
         )
+        .reqwest_client(no_keepalive_reqwest_client())
         .build()
         .await;
 
@@ -201,7 +214,14 @@ async fn test_full_pipeline(
         "Failed at stage {stage}"
     );
 
-    router.graceful_shutdown().await;
+    // Widen the shutdown budget to 30 s. With many sequential pipeline
+    // iterations in `test_coprocessor_response_handling`, even a small
+    // per-shot probability of an OTel SDK / pool drain race compounds into
+    // visible flake. Pair with the no-keepalive client above to neutralise
+    // the inbound-connection arm of the race.
+    router
+        .graceful_shutdown_with_deadline(Duration::from_secs(30))
+        .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/apollo-router/tests/integration/subgraph_response.rs
+++ b/apollo-router/tests/integration/subgraph_response.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use serde_json::json;
 use tower::BoxError;
 use wiremock::ResponseTemplate;
@@ -9,6 +11,17 @@ const CONFIG: &str = r#"
 include_subgraph_errors:
   all: true
 "#;
+
+/// Build a `reqwest::Client` that disables HTTP keep-alive so each request
+/// closes its TCP connection on completion. Neutralises the hyper-client
+/// pool drain race that flakes `assert_shutdown` in the harness (see
+/// `IntegrationTest::assert_shutdown_with_deadline` for the full story).
+fn no_keepalive_reqwest_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()
+        .expect("reqwest client build")
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subgraph_returning_data_null() -> Result<(), BoxError> {
@@ -88,8 +101,17 @@ async fn test_subgraph_returning_different_typename_on_query_root() -> Result<()
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_valid_extensions_service_for_subgraph_error() -> Result<(), BoxError> {
+    // This test shares a flake fingerprint with
+    // `coprocessor::test_coprocessor_response_handling`: a shutdown-drain
+    // race that trips the harness's default 10 s `assert_shutdown`
+    // budget. Disable client-side keep-alive so the router's
+    // per-connection task isn't holding an idle inbound TCP socket when
+    // SIGTERM fires, and widen the shutdown budget to give OpenTelemetry
+    // SDK 0.31.0's `MeterProvider.Drop` ordering enough headroom on
+    // slow runners.
     let mut router = IntegrationTest::builder()
         .config(CONFIG)
+        .reqwest_client(no_keepalive_reqwest_client())
         .responder(ResponseTemplate::new(200).set_body_json(json!({
             "data": { "topProducts": null },
             "errors": [{
@@ -125,7 +147,9 @@ async fn test_valid_extensions_service_for_subgraph_error() -> Result<(), BoxErr
         })
     );
 
-    router.graceful_shutdown().await;
+    router
+        .graceful_shutdown_with_deadline(Duration::from_secs(30))
+        .await;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Phase 7 of the flaky-test-fix plan (`flaky-test-phases/phase-7-integration-harness.md`). 47 retry-list entries removed across 6 sub-groups (batching, file_upload, traffic_shaping, query_planner, hermetic in-process, misc), **plus the P11 shutdown-drain-race fix folded in for `test_valid_extensions_service_for_subgraph_error` + `test_coprocessor_response_handling`**.

> **Stacked on Phase 2** (`flake-fix/phase-2-uplink-lift`). Base will switch to `dev` once Phase 2 merges. Phase 2's 3 commits appear in this branch's history.

Phase-7-specific changes (8 commits on top of Phase 2's HEAD `35c953666`, plus 1 P11 commit on top):

- `fix(test-harness)`: surgical 35-LoC `MeterProvider.Drop.*` filter in `collect_stdio` (F4-A).
- 47 retry entries removed across the 6 sub-groups.
- Audit pass-1 findings F1.1–F1.3 addressed in `fb00dd0a5`.
- **P11 fold-in (`2ef3422aa`):** test-local fix for the shutdown-drain race in `test_valid_extensions_service_for_subgraph_error` and `test_coprocessor_response_handling` — both add a no-keepalive `reqwest::Client` (so the router isn't holding an idle inbound TCP socket at SIGTERM) and use a new per-test `graceful_shutdown_with_deadline(30s)` helper (additive to `tests/common.rs`, default 10s budget unchanged for everyone else). Their retry-list entries are NOT removed in this PR pending CI verification.

3 entries **retained** as follow-ups (not part of this PR): `test_aws_sig_v4_signing` (CI verification), `test_valid_extensions_service_for_subgraph_error`, `test_coprocessor_response_handling` (latter two have stability fixes from P11 above; retry-list cleanup deferred to a CI-post-merge follow-up). 19 additional entries deferred to the C10 cross-cutting subgraph-URL-sandboxing work item (PR #9339).

Discovered a 4th unsandboxed egress channel during this work (`*.demo.starstuff.dev`) — split out as the C10 work item.

## Verification

- Audit pass 2 (`7aab892c`) returned `approved`; all 3 pass-1 findings explicitly resolved.
- Independent rhai 50/50 + clippy clean at `fb00dd0a5`.
- Pass-1 spot-check found 4/50 on `test_coprocessor_response_handling` matching the F4-B shape — this is what the P11 fold-in addresses.
- P11 fix: `cargo check --tests` clean. Functional verification (30/30 each) is the CI gate since these tests gate on `graph_os_enabled()`.

## Test plan

- [ ] Phase 2 merges first (rebase / re-target base to `dev`)
- [ ] CI green after rebase
- [ ] 3-day post-merge CI watch
- [ ] If `test_valid_extensions_service_for_subgraph_error` + `test_coprocessor_response_handling` pass on CI under the P11 fix, follow up to remove their retry-list entries.
- [ ] Open follow-ups for `test_aws_sig_v4_signing` + C10 cross-cutting (already #9339)

<!-- jira: ROUTER-1729 -->

<!-- jira: ROUTER-1735 -->
