### PR TITLE
test(subscriptions): replace dedup task.is_finished() race with explicit signaling (Phase 6 Step 3)

### DIFF
--- a/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
+++ b/apollo-router/tests/integration/subscriptions/ws_passthrough.rs
@@ -1017,6 +1017,16 @@ async fn test_subscription_ws_passthrough_dedup_close_early() -> Result<(), BoxE
     let mut multipart = multer::Multipart::new(stream, "graphql");
     let mut multipart_bis = multer::Multipart::new(stream_bis, "graphql");
 
+    // Explicit signal that the primary reader has dropped its multipart stream and is shutting
+    // down. Previously this test relied on `task.is_finished()` ordering, which races the tokio
+    // scheduler: `break` in the primary task only marks the JoinHandle finished after the runtime
+    // gets a chance to poll it again, so the `bis` task could reach the assertion before the
+    // primary task had actually been observed as finished. A `Notify` makes the handoff explicit:
+    // the primary signals the moment it drops its stream, and the `bis` task waits on that signal
+    // before asserting that the primary has fully completed.
+    let primary_closed = Arc::new(tokio::sync::Notify::new());
+    let primary_closed_signal = primary_closed.clone();
+
     // Task for the first (deduplicated) subscription.
     let task = tokio::task::spawn(tokio::time::timeout(Duration::from_secs(30), async move {
         let expected_event = create_expected_user_payload(1);
@@ -1035,6 +1045,12 @@ async fn test_subscription_ws_passthrough_dedup_close_early() -> Result<(), BoxE
             // subscription should continue to receive events...
             break;
         }
+        // Drop the multipart stream explicitly so the underlying connection is closed before
+        // we signal the `bis` task. (Doing this is also what `break` would do implicitly when
+        // the async block returns, but being explicit avoids any future refactor accidentally
+        // introducing work between the break and the drop.)
+        drop(multipart);
+        primary_closed_signal.notify_one();
     }));
     // This the the other connection with the duplicate subscription to the one above.
     // After the subscription above is closed, it should continue to receive events.
@@ -1057,10 +1073,14 @@ async fn test_subscription_ws_passthrough_dedup_close_early() -> Result<(), BoxE
         }
 
         // Make sure that we're actually testing what we think we're testing, i.e. the first task
-        // closed its connection successfully
-        assert!(task.is_finished(), "primary connection should be closed");
+        // closed its connection successfully. Wait for the explicit signal from the primary task
+        // (with a generous timeout in case something has gone wrong) instead of polling
+        // `task.is_finished()`, which races the scheduler.
+        tokio::time::timeout(Duration::from_secs(30), primary_closed.notified())
+            .await
+            .expect("primary connection should have signaled close");
         task.await
-            .expect("asserted that it completes")
+            .expect("primary task should complete after signaling close")
             .expect("should not have timed out");
         assert!(
             expected_events.is_empty(),


### PR DESCRIPTION
## Summary

Phase 6 Step 3 of the flaky-test-fix project. Fixes the scheduler-ordering race in `test_subscription_ws_passthrough_dedup_close_early`.

## The race

The test spawns two tokio tasks consuming concurrent multipart subscription streams. The primary task reads one event and `break`s out of its loop (closing its multipart stream). The `bis` task, after consuming its own events, asserts `task.is_finished()` to verify the primary actually closed.

`JoinHandle::is_finished()` only flips to `true` after the runtime polls the spawned future through to completion. `break` causes the future to return, but if the scheduler hasn't been back to that task yet, the handle still reads as not-finished — even though everything is working correctly. Under load (CI), the `bis` task can reach the assertion before that final poll lands, producing the intermittent failure listed in `.config/nextest.toml`.

## The fix

Add a shared `Arc<tokio::sync::Notify>`. The primary task drops its multipart stream and calls `notify_one()` immediately before returning. The `bis` task waits on `notified()` (with a 30s timeout) instead of polling `is_finished()`, then awaits the JoinHandle as before. The synchronization is now explicit and deterministic.

`Notify` was chosen over `watch::channel` because the signal is single-shot edge-triggered (primary closed: yes/no) — `Notify` matches that shape with less ceremony.

## Verification

- `cargo check --tests --package apollo-router` passes clean.
- The test itself gates on `graph_os_enabled()` (requires `TEST_APOLLO_KEY` / `TEST_APOLLO_GRAPH_REF`), so functional verification is the graphos CI run on this PR.
- `.config/nextest.toml` is intentionally **not** edited here — `ws_passthrough::*` retry-list cleanup is gated on all Phase 6 steps landing + CI verification, in a later commit.

## Test plan

- [ ] graphos CI run on this PR exercises the test with credentials
- [ ] PR runs cleanly without re-introducing flake under CI load

Phase 6 docs: `flaky-test-phases/phase-6-subscriptions.md` (Step 3).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)

<!-- jira: ROUTER-1728 -->