### PR TITLE
test(websocket): stabilize heartbeat unit test (Phase 6 Step 5)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -163,7 +163,6 @@ or ( binary_id(=apollo-router) & test(=plugins::include_subgraph_errors::test::i
 or ( binary_id(=apollo-router) & test(=plugins::include_subgraph_errors::test::it_redacts_all_subgraphs_implicit_redact) )
 or ( binary_id(=apollo-router) & test(=plugins::include_subgraph_errors::test::it_returns_valid_response) )
 or ( binary_id(=apollo-router) & test(=plugins::telemetry::config_new::instruments::tests::test_instruments) )
-or ( binary_id(=apollo-router) & test(=protocols::websocket::tests::test_ws_connection_new_proto_with_heartbeat) )
 or ( binary_id(=apollo-router) & test(=router::tests::basic_event_stream_test) )
 or ( binary_id(=apollo-router) & test(=router::tests::schema_update_test) )
 or ( binary_id(=apollo-router) & test(=services::layers::persisted_queries::tests::pq_layer_freeform_graphql_with_safelist_log_unknown_true) )

--- a/apollo-router/src/protocols/websocket.rs
+++ b/apollo-router/src/protocols/websocket.rs
@@ -793,7 +793,18 @@ mod tests {
                        "It should be no pending messages"
                    );
 
-                   tokio::time::sleep(duration).await;
+                   // Use `advance` (deterministic) rather than `sleep` (which can auto-advance
+                   // further while we await network I/O below, firing extra heartbeat ticks
+                   // and racing the "no pending messages" assertion that follows).
+                   tokio::time::advance(duration).await;
+
+                   // Resume real time BEFORE awaiting the network read of the heartbeat ping.
+                   // While paused, awaiting I/O can trigger tokio's idle auto-advance, which
+                   // would cause the client's heartbeat interval to tick again (every 60s of
+                   // virtual time) and produce additional pending messages. Once resumed, the
+                   // next interval tick is 60s of real time away, well past the test lifetime.
+                   tokio::time::resume();
+
                    let ping_message = socket.next().await.unwrap().unwrap();
                    assert_eq!(ping_message, AxumWsMessage::text(
                        serde_json::to_string(&ClientMessage::Ping { payload: None }).unwrap(),
@@ -803,7 +814,6 @@ mod tests {
                        socket.next().now_or_never().is_none(),
                        "It should be no pending messages"
                    );
-                   tokio::time::resume();
                 }
 
                 socket


### PR DESCRIPTION
## Summary

Phase 6 Step 5 from `flaky-test-phases/phase-6-subscriptions.md`. Stabilizes
`apollo-router/src/protocols/websocket.rs::tests::test_ws_connection_new_proto_with_heartbeat`
and removes its entry from `.config/nextest.toml`'s retry list.

## The race

The test simulates a 60-second WebSocket heartbeat with `tokio::time::pause()`
and a fixed-duration sleep. The original sequence on the server side was:

```rust
tokio::time::pause();
assert!(socket.next().now_or_never().is_none(), ...);
tokio::time::sleep(duration).await;          // auto-advances 60s, fires heartbeat
let ping_message = socket.next().await...;   // real-I/O read while still paused
assert!(socket.next().now_or_never().is_none(), ...);
tokio::time::resume();
```

While the test is awaiting real network I/O for the ping (with time still
paused), tokio's runtime can decide everything is idle and **auto-advance
virtual time again**. That fires the client's heartbeat interval at
virtual `t=120s`, producing a second ping that ends up buffered behind the
first. The trailing `now_or_never().is_none()` assertion then sees the
buffered second ping and fails.

This race is shape-rare locally (30/30 PASS pre-fix on this machine) but
plausible enough on CI under load that the test was added to the retry
list back in January 2025.

## The fix

1. Replace `tokio::time::sleep(duration).await` with
   `tokio::time::advance(duration).await`. `advance` moves virtual time
   forward by exactly `duration` and does not auto-advance further.
2. Call `tokio::time::resume()` **before** the real-I/O read of the ping.
   Once real time is back, the client's next interval tick is 60s of
   real time in the future — well past the test's lifetime — so no extra
   pings can race the assertion.

## Verification

- Local: 30/30 PASS (10 baseline + 20 under heavy CPU load via parallel
  `yes > /dev/null` workers).
- Pre-fix: 100/100 PASS on this machine but historically flaky enough to
  be on the retry list. The fix removes the actual mechanism that could
  produce a buffered second ping.

## Retry-list

Removed:
```
or ( binary_id(=apollo-router) & test(=protocols::websocket::tests::test_ws_connection_new_proto_with_heartbeat) )
```

## Test plan

- [x] `cargo nextest run --package apollo-router --lib -E 'test(=protocols::websocket::tests::test_ws_connection_new_proto_with_heartbeat)' --no-fail-fast` — 10/10 PASS
- [x] Same under CPU stress (8x `yes`) — 20/20 PASS
- [ ] CI runs the test without retries and stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- jira: ROUTER-1728 -->