### PR TITLE
test(telemetry): deadline-bounded poll for connector-namespace tests (Phase 1 follow-up)

### DIFF
--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -1360,6 +1360,17 @@ async fn test_connector_coprocessor_request_response() -> Result<(), BoxError> {
         .mount(&mock_coprocessor)
         .await;
 
+    // The `connectors.sources.connectors.jsonPlaceholder` stanza is required for the
+    // `IntegrationTest` harness to auto-inject an `override_url` pointing at the local
+    // wiremock subgraph (see `merge_overrides` in `tests/common.rs`: the override is
+    // only inserted if the config already declares `connectors.sources`). Without it
+    // the connector falls through to the schema's `https://jsonplaceholder.typicode.com/`
+    // baseURL and makes a real network request — which on CircleCI's amd_linux_test /
+    // arm_linux_test executors hangs past the router's 30 s subgraph timeout and the
+    // request returns `504 GATEWAY_TIMEOUT`. That was the
+    // `test_connector_coprocessor_request_response` flake on PR #9339's CircleCI build
+    // 366174 (`assertion left == right; left: 504; right: 200`). An empty stanza is
+    // enough — the harness fills in `override_url` per-source.
     let config = format!(
         r#"
         include_subgraph_errors:
@@ -1376,6 +1387,8 @@ async fn test_connector_coprocessor_request_response() -> Result<(), BoxError> {
                         body: true
                         headers: true
                         status_code: true
+        connectors:
+            sources: {{}}
         "#,
         mock_coprocessor.uri()
     );

--- a/apollo-router/tests/integration/telemetry/apollo_otel_metrics.rs
+++ b/apollo-router/tests/integration/telemetry/apollo_otel_metrics.rs
@@ -801,6 +801,18 @@ async fn test_connector_request_emits_histogram() {
     let expected_operation_type = "query";
     let expected_connector_source = "jsonPlaceholder";
 
+    // The `connectors.sources` stanza is required for the `IntegrationTest` harness to
+    // auto-inject `override_url` pointing at the local wiremock subgraph (see
+    // `merge_overrides` in `tests/common.rs`: the override is only inserted if the
+    // config already declares `connectors.sources`). Without it the connector falls
+    // through to the schema's `https://jsonplaceholder.typicode.com/` baseURL and makes
+    // a real network request — which on CircleCI's amd_linux_test / arm_linux_test
+    // executors hangs past the router's 30 s subgraph timeout. The router then emits
+    // an `apollo.router.operations.fetch.duration` datapoint without the `has_errors`
+    // attribute the assertion expects (the early
+    // `apollo.operation.id`-stamped datapoint is the only one that lands within the
+    // poll window). That was the `test_connector_request_emits_histogram` flake on
+    // PR #9339's CircleCI build 366174.
     let mut router = IntegrationTest::builder()
         .telemetry(Telemetry::Otlp { endpoint: None })
         .config(
@@ -815,6 +827,8 @@ async fn test_connector_request_emits_histogram() {
                 subgraph_metrics: true
             include_subgraph_errors:
               all: true
+            connectors:
+              sources: {}
         "#,
         )
         .supergraph(PathBuf::from_iter([
@@ -846,24 +860,20 @@ async fn test_connector_request_emits_histogram() {
         )
         .await;
 
-    let metrics = router
-        .wait_for_emitted_otel_metrics(Duration::from_secs(2))
-        .await;
+    let expected = Metric::builder()
+        .name("apollo.router.operations.fetch.duration".to_string())
+        .attribute("graphql.operation.name", expected_operation_name)
+        .attribute("apollo.client.name", expected_client_name)
+        .attribute("apollo.client.version", expected_client_version)
+        .attribute("subgraph.name", expected_service)
+        .attribute("graphql.operation.type", expected_operation_type)
+        .attribute("has_errors", false)
+        .attribute("connector.source", expected_connector_source)
+        .count(1)
+        .build();
+    let metrics = wait_for_metric_match(&mut router, &expected, Duration::from_secs(5)).await;
     assert!(!metrics.is_empty());
-    assert_metrics_contain(
-        &metrics,
-        Metric::builder()
-            .name("apollo.router.operations.fetch.duration".to_string())
-            .attribute("graphql.operation.name", expected_operation_name)
-            .attribute("apollo.client.name", expected_client_name)
-            .attribute("apollo.client.version", expected_client_version)
-            .attribute("subgraph.name", expected_service)
-            .attribute("graphql.operation.type", expected_operation_type)
-            .attribute("has_errors", false)
-            .attribute("connector.source", expected_connector_source)
-            .count(1)
-            .build(),
-    );
+    assert_metrics_contain(&metrics, expected);
     router.graceful_shutdown().await;
 }
 
@@ -926,35 +936,54 @@ async fn test_failed_connector_request_emits_histogram() {
         )
         .await;
 
-    let metrics = router
-        .wait_for_emitted_otel_metrics(Duration::from_secs(2))
-        .await;
+    let expected = Metric::builder()
+        .name("apollo.router.operations.fetch.duration".to_string())
+        .attribute("graphql.operation.name", expected_operation_name)
+        .attribute("apollo.client.name", expected_client_name)
+        .attribute("apollo.client.version", expected_client_version)
+        .attribute("subgraph.name", expected_service)
+        .attribute("graphql.operation.type", expected_operation_type)
+        .attribute("has_errors", true)
+        .attribute("connector.source", expected_connector_source)
+        .count(1)
+        .build();
+    let metrics = wait_for_metric_match(&mut router, &expected, Duration::from_secs(5)).await;
     assert!(!metrics.is_empty());
-    assert_metrics_contain(
-        &metrics,
-        Metric::builder()
-            .name("apollo.router.operations.fetch.duration".to_string())
-            .attribute("graphql.operation.name", expected_operation_name)
-            .attribute("apollo.client.name", expected_client_name)
-            .attribute("apollo.client.version", expected_client_version)
-            .attribute("subgraph.name", expected_service)
-            .attribute("graphql.operation.type", expected_operation_type)
-            .attribute("has_errors", true)
-            .attribute("connector.source", expected_connector_source)
-            .count(1)
-            .build(),
-    );
+    assert_metrics_contain(&metrics, expected);
     router.graceful_shutdown().await;
 }
 
 /// Assert that the given metric exists in the list of Otel requests. This is a crude attempt at
 /// replicating _some_ assert_counter!() functionality since that test util can't be accessed here.
 fn assert_metrics_contain(actual_metrics: &[ExportMetricsServiceRequest], expected_metric: Metric) {
-    let expected_name = &expected_metric.name.clone();
-    let actual_metric = find_metric(expected_name, actual_metrics)
-        .unwrap_or_else(|| panic!("Metric '{expected_name}' not found"));
+    let (metric_found, observed) = metrics_contain_and_observed(actual_metrics, &expected_metric);
 
-    let actual_metrics: Vec<Metric> = match &actual_metric.data {
+    assert!(
+        metric_found,
+        "Expected metric '{}' but no matching datapoint was found.\nInstead, actual metrics with matching name were:\n{}",
+        expected_metric,
+        observed
+            .iter()
+            .map(|m| m.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+/// Check whether `actual_metrics` contains a datapoint matching `expected_metric`. Returns
+/// `(found, observed_datapoints_for_that_metric_name)` so callers can either assert with a
+/// detailed message (see `assert_metrics_contain`) or loop polling for the metric to land
+/// (see `wait_for_metric_match`).
+fn metrics_contain_and_observed(
+    actual_metrics: &[ExportMetricsServiceRequest],
+    expected_metric: &Metric,
+) -> (bool, Vec<Metric>) {
+    let expected_name = &expected_metric.name;
+    let Some(actual_metric) = find_metric(expected_name, actual_metrics) else {
+        return (false, Vec::new());
+    };
+
+    let observed: Vec<Metric> = match &actual_metric.data {
         Some(metric::Data::Sum(sum)) => sum
             .data_points
             .iter()
@@ -968,7 +997,7 @@ fn assert_metrics_contain(actual_metrics: &[ExportMetricsServiceRequest], expect
         _ => panic!("Metric type for '{expected_name}' is not yet implemented"),
     };
 
-    let metric_found = actual_metrics.iter().any(|m| {
+    let metric_found = observed.iter().any(|m| {
         // Only match values and attributes that are explicitly set
         expected_metric.value.is_none_or(|v| Some(v) == m.value)
             && expected_metric.sum.is_none_or(|s| Some(s) == m.sum)
@@ -976,16 +1005,43 @@ fn assert_metrics_contain(actual_metrics: &[ExportMetricsServiceRequest], expect
             && m.attributes_contain(&expected_metric.attributes)
     });
 
-    assert!(
-        metric_found,
-        "Expected metric '{}' but no matching datapoint was found.\nInstead, actual metrics with matching name were:\n{}",
-        expected_metric,
-        actual_metrics
-            .iter()
-            .map(|m| m.to_string())
-            .collect::<Vec<_>>()
-            .join("\n")
-    );
+    (metric_found, observed)
+}
+
+/// Deadline-bounded poll for a metric matching `expected_metric`.
+///
+/// `IntegrationTest::wait_for_emitted_otel_metrics` returns the first batch of metrics it
+/// receives — but for connector subgraph fetches the router emits more than one batch
+/// for `apollo.router.operations.fetch.duration`: an early datapoint stamped with
+/// `apollo.operation.id` (no `has_errors` yet), and a subsequent datapoint with the
+/// `has_errors` enrichment that the assertion expects. Returning on the first batch races
+/// with the second batch arriving and explains the
+/// `test_connector_request_emits_histogram` flake on PR #9339's CircleCI build 366174
+/// (no datapoint matched the expected attribute set).
+///
+/// Same shape as the deadline-bounded poll Phase 1 applied to
+/// `verifier.rs::validate_*` and `apollo_otel_traces::get_traces` (PR #9257), and the
+/// `events.rs::EventTest::capture_logged_events` poll added in PR #9340 — keep draining
+/// batches into an accumulator until either the expected metric arrives or the deadline
+/// expires. `tests/common.rs::wait_for_emitted_otel_metrics` is owned by the
+/// multi-agent coordinator and intentionally not modified here; the fix lives at the
+/// call site.
+async fn wait_for_metric_match(
+    router: &mut IntegrationTest,
+    expected_metric: &Metric,
+    deadline: Duration,
+) -> Vec<ExportMetricsServiceRequest> {
+    let start = std::time::Instant::now();
+    let per_iter = Duration::from_millis(500);
+    let mut accumulated: Vec<ExportMetricsServiceRequest> = Vec::new();
+    loop {
+        let batch = router.wait_for_emitted_otel_metrics(per_iter).await;
+        accumulated.extend(batch);
+        let (found, _) = metrics_contain_and_observed(&accumulated, expected_metric);
+        if found || start.elapsed() >= deadline {
+            return accumulated;
+        }
+    }
 }
 
 fn find_metric<'a>(


### PR DESCRIPTION
## Context

Phase 1 of the flaky-test-fix project (PR #9257, merged as `b3a0986e0`) widened polling deadlines and replaced fixed sleeps in the telemetry test infrastructure. Phase 1's audit walked the retry list but missed connector-namespace tests added later via `ac17cee6b` (PR #9124, "Implement requestless connectors") that were never on the retry list.

PR #9340 fixed the `test_standard_events` instance of this miss by replacing `try_recv`-then-return with a deadline-bounded poll in `events.rs::EventTest::capture_logged_events`. This PR is the same class of follow-up — fix the four connector-namespace tests flagged as flaking on PR #9339's CircleCI builds 366173 / 366174 (`amd_linux_test` / `arm_linux_test`).

## Tests in scope

1. `apollo-router::integration_tests integration::telemetry::apollo_otel_metrics::test_connector_request_emits_histogram` — fixed
2. `apollo-router::integration_tests integration::coprocessor::test_connector_coprocessor_request_response` — fixed
3. `apollo-router::apollo_otel_traces connector` — out of scope (see below)
4. `apollo-router::apollo_otel_traces connector_error` — out of scope (see below)

## Root cause

Two compounding issues for the two tests we fixed here:

1. **Hardcoded external URL.** The connector source declared in `tests/fixtures/connectors/quickstart.graphql` points at `https://jsonplaceholder.typicode.com/`. The `IntegrationTest` harness already auto-injects an `override_url` per source pointing at the local wiremock subgraph — but only when the user's config already declares a `connectors.sources` map (see `merge_overrides` in `tests/common.rs` lines 1874-1886). Neither test declared one, so the connector fell through to the real URL. On CircleCI's amd_linux_test / arm_linux_test executors that endpoint hung past the router's 30 s subgraph timeout, returning `504 GATEWAY_TIMEOUT` (coprocessor test) or emitting a metric stamped only with `apollo.operation.id` and a 30 s `sum` (histogram test).
2. **First-batch poll.** `wait_for_emitted_otel_metrics` returns the first batch of metrics that arrives. The connector emits multiple batches for `apollo.router.operations.fetch.duration` — an early datapoint stamped with `apollo.operation.id` and no `has_errors`, then a later datapoint with the `has_errors` enrichment. Returning on the first batch races with the second batch arriving.

## Fix

- Both tests: add an empty `connectors.sources: {}` stanza so the harness auto-overrides connector source URLs.
- Histogram test: add a local `wait_for_metric_match` helper that drains batches into an accumulator until either the expected metric arrives or a deadline expires. Same shape as the deadline-bounded poll Phase 1 applied to `verifier.rs::validate_*` and `apollo_otel_traces::get_traces` (PR #9257), and the `events.rs::EventTest::capture_logged_events` poll added in PR #9340.
- `assert_metrics_contain` is split into a pure `metrics_contain_and_observed` plus the existing assert wrapper, so the poll loop can introspect the accumulator without consuming it.
- The fix for `test_failed_connector_request_emits_histogram` is applied symmetrically — same failure mode is latent there even though it didn't flake in the PR #9339 build.
- `tests/common.rs::wait_for_emitted_otel_metrics` is owned by the multi-agent coordinator and intentionally not modified here; the fix lives at the call site.

## Out of scope: `apollo_otel_traces::connector` / `connector_error`

These two tests use `TestHarness::builder().with_subgraph_network_requests()` against `tests/fixtures/supergraph_connect.graphql`, which also points at `https://jsonplaceholder.typicode.com/`. They flake on CI for the same network-dependency reason (build 366174 panic: `reports collected: 0; response had errors: GATEWAY_TIMEOUT`). However:

- The fix would require a localhost mock of jsonplaceholder *and* re-snapshotting both `apollo_otel_traces__connector*.snap` files, because the existing snapshots encode `~50` `connect_request` spans (one per row jsonplaceholder returns), the `apollo.connector.source.detail` baseURL string, and the `connect`/`http_request` span structure.
- A localhost mock that returns 2 posts produces 2 `connect_request` spans, which fails the snapshot.
- Re-snapshotting against a localhost mock with arbitrary canned data would change the test's intent in ways that are harder to review than this PR.

These two tests are reported back to the coordinator as a separate work item — they're a network-dependency flake, not a polling-race / forward-pass-audit-miss flake. Recommended next step is either (a) ship a small canned dataset + re-snapshot, owned by the connector team, or (b) add to the retry list as a temporary mitigation while a proper fix is scoped.

## Verification

- `test_connector_request_emits_histogram`: 5/5 PASS
- `test_failed_connector_request_emits_histogram`: 5/5 PASS
- `test_connector_coprocessor_request_response`: 5/5 PASS
- `test_connector_coprocessor_failure_returns_graphql_error`: 5/5 PASS (companion, no regression)
- 20/20 PASS across batched runs of all four together
- Full `integration::telemetry::apollo_otel_metrics::*` suite (13 tests): green — confirms the `assert_metrics_contain` refactor doesn't regress callers

## Test plan

- [ ] CircleCI `amd_linux_test` and `arm_linux_test` jobs pass
- [ ] No regressions in adjacent `integration::telemetry::*` and `integration::coprocessor::*` suites

## Coordinator note

This branch is off `origin/dev` (`fd463c13f`), not off PR #9340's branch. Both this PR and #9340 modify telemetry test helpers in spirit — but the two patches don't touch the same files (#9340 modifies `events.rs`; this PR modifies `apollo_otel_metrics.rs` and `coprocessor.rs`). No merge conflict expected.

<!-- jira: ROUTER-1751 -->