### PR TITLE
test: ensure config writes change bytes for Windows PollWatcher reload (Phase 1 follow-up)

### DIFF
--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::OnceLock;
 use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use buildstructor::buildstructor;
 use flate2::read::GzDecoder;
@@ -941,7 +943,11 @@ impl IntegrationTest {
             .open(&self.test_config_location)
             .await
             .expect("must have been able to open config file");
-        f.write_all("\n#touched\n".as_bytes())
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before UNIX epoch")
+            .as_nanos();
+        f.write_all(format!("\n#touched-{stamp}\n").as_bytes())
             .await
             .expect("must be able to write config file");
     }
@@ -956,12 +962,17 @@ impl IntegrationTest {
             &self.redis_namespace,
             Some(&self.port_replacements),
         );
-        tokio::fs::write(
-            &self.test_config_location,
-            serde_yaml::to_string(&config).unwrap(),
-        )
-        .await
-        .expect("must be able to write config");
+        let mut content = serde_yaml::to_string(&config).unwrap();
+        // Append a unique comment so file content always changes. PollWatcher uses
+        // with_compare_contents(true); identical rewrites may not emit Data events on Windows.
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before UNIX epoch")
+            .as_nanos();
+        content.push_str(&format!("\n# update-{stamp}\n"));
+        tokio::fs::write(&self.test_config_location, content)
+            .await
+            .expect("must be able to write config");
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
## Summary

Cherry-pick of `26593c7aa` (originally authored by @smyrick on the `router-http` feature branch). Append unique nanosecond comments in `update_config` and `touch_config` so Windows' `PollWatcher` (configured with `compare_contents(true)` at `apollo-router/src/files.rs:49`) always observes a content change and emits a `Data(DataChange::Any)` event — required for the router's reload state machine to log "reload complete" and unblock `assert_reloaded()`.

## Root cause

`test_prom_reset_on_reload` (and any other test calling `update_config(same_yaml)`) deadlocks on Windows because:

1. `update_config` writes byte-identical YAML.
2. `PollWatcher` with `compare_contents(true)` doesn't emit a `Data` event for byte-identical writes.
3. Windows' `PollWatcher` is also unreliable on metadata-only events.
4. The router never detects a config change, so it never logs "reload complete".
5. `assert_reloaded()` waits 30s for that log message and panics.

This was hitting **PR #9337's Windows test job** (build 366143) — and any future test that does `update_config(same_yaml)` on the path-agnostic CI matrix.

The diagnosis came from a Phase-1 follow-up audit: `test_prom_reset_on_reload` is not on `.config/nextest.toml`'s retry list, same forward-pass-audit-miss shape as `test_standard_events` (PR #9340) and the connector-namespace tests (PR #9344).

## Verification

- `cargo check --tests --package apollo-router` clean on macOS.
- The fix is platform-agnostic (purely additive — appends a comment to YAML); Linux/macOS behaviour is unchanged.
- Functional verification on Windows is the CI gate (CircleCI's `test-windows_test` job on this PR).

## Sequencing

Independent of all open flake-fix PRs. Lands directly off `dev`. Should unblock #9337 once merged + #9337 rebased.

<!-- jira: ROUTER-1752 -->