### PR TITLE
test: comprehensive Phase-1 forward-pass-audit follow-up

### DIFF
--- a/apollo-router/tests/apollo_otel_http_proxy.rs
+++ b/apollo-router/tests/apollo_otel_http_proxy.rs
@@ -351,14 +351,19 @@ async fn test_otlp_http_traces_through_proxy() {
     // Drain the response body so the router can proceed with span export.
     let _ = response.response.into_body().collect().await;
 
-    // Wait up to ~1 s for the OTLP batch to flush.
+    // Poll until the OTLP batch has been flushed through the proxy to the
+    // backend. The previous fixed 10×100 ms (~1 s) window matched what other
+    // OTLP tests had before Phase 1 widened them to 10 s for CI; the same
+    // windowing applies here because the proxy adds an extra hop and the OTLP
+    // batch flush itself can be delayed under load.
     let mut trace_received = false;
-    for _ in 0..10 {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while std::time::Instant::now() < deadline {
         if !reports.lock().await.is_empty() {
             trace_received = true;
             break;
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
     // Clean up env and background tasks before asserting, so any failure message

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -1003,8 +1003,13 @@ async fn test_coprocessor_per_stage_unix_socket_urls() -> Result<(), tower::BoxE
         }
     });
 
-    // Wait a moment for servers to start
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // The UDS sockets are already bound and ready to queue connections — both
+    // `UnixListener::bind` calls above returned synchronously, which is the
+    // moment the kernel starts accepting incoming connections into the listen
+    // backlog. The accept loops in the spawned tasks just drain that backlog.
+    // The previous fixed 100 ms sleep here was a defensive pause with no race
+    // to defend against (and a sibling UDS coprocessor test above does not use
+    // it). Removing the sleep eliminates the slow-CI flake risk.
 
     // Configure router with per-stage Unix socket URLs
     let router_uds_url = format!("unix://{}", router_sock_path.display());
@@ -1145,8 +1150,11 @@ async fn test_coprocessor_mixed_http_and_unix_socket_urls() -> Result<(), tower:
         .mount(&supergraph_mock_server)
         .await;
 
-    // Wait a moment for servers to start
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // The UDS socket is already bound and accepting connections from the
+    // moment `UnixListener::bind` returned above; the wiremock HTTP mock
+    // server is similarly ready to serve the moment `MockServer::start` has
+    // returned. The previous fixed 100 ms sleep was a defensive pause with no
+    // race to defend against. Removing it eliminates the slow-CI flake risk.
 
     // Configure router with MIXED transports: Unix socket for router, HTTP for supergraph
     let router_uds_url = format!("unix://{}", router_sock_path.display());
@@ -1291,8 +1299,11 @@ async fn test_coprocessor_unix_socket_server_closes_connection() -> Result<(), B
         }
     });
 
-    // Wait for server to be ready
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    // The UDS socket is already bound from the synchronous `UnixListener::bind`
+    // above — the kernel queues incoming connections into the listen backlog
+    // until the spawned task accepts them. The previous fixed 100 ms sleep was
+    // a defensive pause with no race to defend against; removing it
+    // eliminates the slow-CI flake risk.
 
     let uds_url = format!("unix://{}", sock_path.display());
     let config = format!(

--- a/apollo-router/tests/integration/response_cache.rs
+++ b/apollo-router/tests/integration/response_cache.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::Instant;
 
 use apollo_router::graphql;
 use apollo_router::services::router;
@@ -12,6 +13,9 @@ use fred::clients::Client;
 use fred::interfaces::ClientLike;
 use fred::interfaces::KeysInterface;
 use fred::types::Builder;
+use fred::types::scan::ScanType;
+use fred::types::scan::Scanner;
+use futures::StreamExt as _;
 use http::HeaderMap;
 use http::HeaderName;
 use http::HeaderValue;
@@ -393,7 +397,8 @@ async fn basic_cache_skips_subgraph_request() {
         return;
     }
 
-    let (mut router, subgraph_request_counters) = harness(base_config(), base_subgraphs()).await;
+    let config = base_config();
+    let (mut router, subgraph_request_counters) = harness(config.clone(), base_subgraphs()).await;
     insta::assert_yaml_snapshot!(subgraph_request_counters, @r"
     products: 0
     reviews: 0
@@ -413,8 +418,13 @@ async fn basic_cache_skips_subgraph_request() {
     products: 1
     reviews: 1
     ");
-    // Needed because insert in the cache is async
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // The cache insert happens in a background tokio task after the response is
+    // returned, so the second request can race the writes. The first request
+    // produces a `products` root cache entry plus one cache entry per reviews
+    // entity (2 entities) → 3 keys minimum. Polling for >= 3 keys proves all
+    // three writes have landed before we issue the cache-hit request below.
+    // Replaces a fixed 100 ms sleep that flaked on CI.
+    wait_for_cache_writes(&config, 3).await;
     let (headers, body) = make_graphql_request(&mut router).await;
     assert!(headers["cache-control"].contains("public"));
     insta::assert_yaml_snapshot!(body, @r"
@@ -440,8 +450,9 @@ async fn private_id_set_at_subgraph_request() {
         return;
     }
 
+    let config = base_config();
     let (mut router, subgraph_request_counters) =
-        harness(base_config(), private_base_subgraphs()).await;
+        harness(config.clone(), private_base_subgraphs()).await;
     insta::assert_yaml_snapshot!(subgraph_request_counters, @r"
     products: 0
     reviews: 0
@@ -482,8 +493,13 @@ async fn private_id_set_at_subgraph_request() {
     products: 2
     reviews: 2
     ");
-    // Needed because insert in the cache is async
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // The cache insert happens in a background tokio task after the response is
+    // returned. The first (no-id) request does not cache; the second
+    // (private_id=123) request produces the first set of cache entries (one
+    // products root + two reviews entities = 3 keys). Poll until those have
+    // landed before issuing the cache-hit request below. Replaces a fixed
+    // 100 ms sleep that flaked on CI.
+    wait_for_cache_writes(&config, 3).await;
     let (headers, body) = makegraphql_request_with_headers(&mut router, headers.clone()).await;
     assert!(headers["cache-control"].contains("private"));
     insta::assert_yaml_snapshot!(body, @r"
@@ -541,7 +557,7 @@ async fn check_cache_tags_from_debugger_data() {
         .and_then(|c| c.as_object_mut())
         .and_then(|c| c.insert("debug".to_string(), true.into()));
 
-    let (mut router, subgraph_request_counters) = harness(config, base_subgraphs()).await;
+    let (mut router, subgraph_request_counters) = harness(config.clone(), base_subgraphs()).await;
     insta::assert_yaml_snapshot!(subgraph_request_counters, @r"
     products: 0
     reviews: 0
@@ -569,8 +585,12 @@ async fn check_cache_tags_from_debugger_data() {
     products: 1
     reviews: 1
     ");
-    // Needed because insert in the cache is async
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // The cache insert happens in a background tokio task after the response is
+    // returned. The first request produces a `products` root cache entry plus
+    // one cache entry per reviews entity (2 entities) → 3 keys minimum. Poll
+    // until those have landed before issuing the cache-hit request below.
+    // Replaces a fixed 100 ms sleep that flaked on CI.
+    wait_for_cache_writes(&config, 3).await;
     let (headers, body) = make_debug_graphql_request(&mut router).await;
     assert!(headers["cache-control"].contains("public"));
     assert!(body.errors.is_empty());
@@ -680,8 +700,10 @@ async fn not_cached_without_cache_control_header() {
     products: 1
     reviews: 1
     ");
-    // Needed because insert in the cache is async
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // No sleep needed: cache-control is no-store, so neither request writes to
+    // the cache and the second request always re-hits the subgraph regardless
+    // of timing. The previous fixed 100 ms sleep was a copy-pasted defensive
+    // pause with no race to defend against.
 
     let (headers, body) = make_graphql_request(&mut router).await;
     assert_eq!(headers["cache-control"], "no-store");
@@ -1132,6 +1154,52 @@ async fn cache_key_exists(
     let key = format!("{namespace}:{cache_key}");
     let count: u32 = client.exists(key).await?;
     Ok(count == 1)
+}
+
+/// Polls Redis until at least `expected_min_keys` cache entries exist under the
+/// `response_cache.subgraph.all.redis.namespace` embedded in `config`, with a
+/// generous deadline. This replaces the previous
+/// `tokio::time::sleep(Duration::from_millis(100))` "Needed because insert in
+/// the cache is async" pattern, which was a fixed timing buffer that raced
+/// under CI load — the cache write happens in a background tokio task after
+/// the response is returned, and 100 ms was simply too tight when the host was
+/// busy. Polling the actual redis state until the writes have landed makes
+/// the test deterministic regardless of system load.
+async fn wait_for_cache_writes(config: &Value, expected_min_keys: usize) {
+    let namespace = config
+        .pointer("/response_cache/subgraph/all/redis/namespace")
+        .and_then(|v| v.as_str())
+        .expect(
+            "wait_for_cache_writes() requires a redis namespace at \
+             config.response_cache.subgraph.all.redis.namespace",
+        )
+        .to_owned();
+    let pattern = format!("{namespace}:*");
+    let client = redis_client()
+        .await
+        .expect("connect to redis at 127.0.0.1:6379");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let mut scanner = client.scan(&pattern, Some(100), Some(ScanType::String));
+        let mut count: usize = 0;
+        while let Some(result) = scanner.next().await {
+            if let Ok(scan_result) = result
+                && let Some(keys) = scan_result.results()
+            {
+                count += keys.len();
+            }
+        }
+        if count >= expected_min_keys {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out after 10s waiting for >= {expected_min_keys} cache key(s) \
+                 under namespace {namespace}; observed {count}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Walks every test under `apollo-router/tests/integration/` and `apollo-router/tests/` outside the namespaces already covered in the Phase 1 deflake effort and its forward-pass follow-ups (PRs #9257, #9334, #9339-#9346), looking for the forward-pass-audit-miss pattern: tests that aren't on the retry list but flake under load due to fixed timing buffers, `try_recv()`-then-assert, or real-network egress.

This PR fixes the matches that surface in scope. The full audit summary follows.

## Tests fixed (8 total across 3 files)

### `apollo-router/tests/integration/response_cache.rs` (4 tests)

Root cause: cache writes happen in a background tokio task after the response is returned. A `tokio::time::sleep(Duration::from_millis(100))` between the populate-cache request and the cache-hit-asserting request was the timing buffer that races under CI load.

- `basic_cache_skips_subgraph_request`
- `private_id_set_at_subgraph_request`
- `check_cache_tags_from_debugger_data`

Fix: introduce `wait_for_cache_writes(&config, n)` helper that scans the redis namespace embedded in the test config until at least `n` cache keys have landed, with a 10 s deadline and a diagnostic panic. Each call site converts to a deadline-bounded poll on the actual redis state.

- `not_cached_without_cache_control_header` — same copy-pasted sleep but cache-control is `no-store` and there is nothing to wait for; sleep removed outright.

### `apollo-router/tests/integration/coprocessor.rs` (3 tests)

Root cause: `tokio::net::UnixListener::bind` returns synchronously with the socket already bound and the kernel already queueing incoming connections. The 100 ms `tokio::time::sleep` after `bind` plus a spawned accept loop is a defensive pause with no race to defend against — but still a fixed timing buffer that risks races under load. A sibling UDS coprocessor test in the same file already runs without it.

- `test_coprocessor_per_stage_unix_socket_urls`
- `test_coprocessor_mixed_http_and_unix_socket_urls`
- `test_coprocessor_unix_socket_server_closes_connection`

Fix: drop the sleeps and replace each with an explanatory comment.

### `apollo-router/tests/apollo_otel_http_proxy.rs` (1 test)

Root cause: `test_otlp_http_traces_through_proxy` polled for an OTLP batch flush with a 10 x 100 ms (~1 s) window. This is the same too-tight window the other OTLP tests had before Phase 1 (PR #9257) widened them to 10 s. A proxy hop only adds latency.

Fix: convert to an `Instant`-deadline poll loop with 10 s deadline and 50 ms tick, matching the canonical pattern from `apollo_otel_traces.rs::get_traces`.

## Verification

Local environment was at 100% disk usage during this audit, so `cargo test` runs were not possible. `cargo check --tests -p apollo-router` passes — the build gate per the task brief, given that all but `test_otlp_http_traces_through_proxy` are graphos-gated and only execute on CI runners with the GraphOS keys. The four `response_cache` tests, the three `coprocessor` UDS tests, and `test_otlp_http_traces_through_proxy` should be exercised on CI to confirm the fixes hold.

## Tests audited but found clean

- `apollo-router/tests/apollo_otel_traces.rs` — non-connector tests; helper `get_traces` already has 10 s deadline + diagnostic panic from PR #9346.
- `apollo-router/tests/apollo_reports.rs` — both helpers have 10 s deadline-bounded poll loops from Phase 1.
- `apollo-router/tests/integration/telemetry/verifier.rs` — `validate_trace`, `validate_metrics` are deadline-bounded.
- `apollo-router/tests/integration/telemetry/otlp/metrics.rs` — `execute_and_validate_metrics` is 15 s deadline-bounded.
- `apollo-router/tests/integration/telemetry/metrics.rs::test_response_cache_metrics` — the 1 s sleep is an intentional TTL-tick verification, not a race.
- `apollo-router/tests/integration/telemetry/metrics.rs::test_prom_reset_on_reload` — uses `update_config(same_yaml)` then `assert_reloaded`; this is the Windows pattern, but PR #9345's `common.rs` fix makes it deterministic.
- `apollo-router/tests/integration/response_cache.rs::cache_control_merging_*` — 2 s sleeps are intentional TTL-countdown verifications.
- `apollo-router/tests/integration/entity_cache.rs::cache_control_merging_*` — same pattern, intentional.
- `apollo-router/tests/integration/oci.rs` — 2 s sleep is a `TEST_APOLLO_OCI_POLL_INTERVAL`-bound delay, intentional.
- `apollo-router/tests/integration/connectors.rs` — no `sleep` / `try_recv` / external network egress.

## Out-of-scope findings (not touched per task rules)

- `apollo-router/tests/integration/entity_cache.rs::test_cache_metrics` (on retry list, in Phase 5/8 scope).
- `apollo-router/tests/integration/entity_cache.rs::test_cache_error_metrics` — has a 3 s `tokio::time::sleep` before `assert_metrics_contains`. The metric assertion expects an exact count of `1`, which depends on the metrics-interval cycle catching exactly one error. This is a deeper timing dependency than the simple forward-pass-audit-miss pattern and risks breaking the assertion if changed naively. Flagged for a follow-up review by the entity_cache owners.

## Test plan

- [ ] CI passes for the modified files on Linux + Windows.
- [ ] Specifically: response_cache, coprocessor, and apollo_otel_http_proxy suites green for 5+ runs under CI load.

<!-- jira: ROUTER-1754 -->