### PR TITLE
test: Phase 8 unit-test stability (drift cleanup + license_expander pair refactor)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -146,8 +146,6 @@ or ( binary_id(=apollo-router) & test(=services::supergraph::tests::interface_ob
 or ( binary_id(=apollo-router) & test(=services::supergraph::tests::only_query_interface_object_subgraph) )
 or ( binary_id(=apollo-router) & test(=uplink::license_stream::test::license_expander_claim_no_claim) )
 or ( binary_id(=apollo-router) & test(=uplink::license_stream::test::license_expander_claim_pause_claim) )
-or ( binary_id(=apollo-router) & test(=uplink::persisted_queries_manifest_stream::test::integration_test) )
-or ( binary_id(=apollo-router) & test(=uplink::schema_stream::test::integration_test) )
 '''
 
 [profile.ci]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -144,7 +144,6 @@ or ( binary_id(=apollo-router) & test(=services::subgraph_service::tests::test_s
 or ( binary_id(=apollo-router) & test(=services::supergraph::tests::aliased_subgraph_data_rewrites_on_non_root_fetch) )
 or ( binary_id(=apollo-router) & test(=services::supergraph::tests::interface_object_typename_rewrites) )
 or ( binary_id(=apollo-router) & test(=services::supergraph::tests::only_query_interface_object_subgraph) )
-or ( binary_id(=apollo-router) & test(=uplink::license_stream::test::license_expander_claim_no_claim) )
 '''
 
 [profile.ci]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -145,7 +145,6 @@ or ( binary_id(=apollo-router) & test(=services::supergraph::tests::aliased_subg
 or ( binary_id(=apollo-router) & test(=services::supergraph::tests::interface_object_typename_rewrites) )
 or ( binary_id(=apollo-router) & test(=services::supergraph::tests::only_query_interface_object_subgraph) )
 or ( binary_id(=apollo-router) & test(=uplink::license_stream::test::license_expander_claim_no_claim) )
-or ( binary_id(=apollo-router) & test(=uplink::license_stream::test::license_expander_claim_pause_claim) )
 '''
 
 [profile.ci]

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -461,9 +461,20 @@ mod test {
         assert_eq!(events, &[SimpleEvent::UpdateLicense]);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn license_expander_claim_no_claim() {
         // Licenses with no claim do not clear checks as they are ignored if we move from entitled to unentitled, this is handled at the state machine level.
+        //
+        // Use paused virtual time so that the warn/halt boundaries (10ms in the future at the
+        // moment of claim arrival) cannot fire prematurely between the time we enqueue them and
+        // the time the consumer polls `checks.poll_expired`. Under real time, scheduler jitter
+        // could push the boundaries into the past before the upstream `no_claim()` was polled,
+        // taking the early-return branches in `reset_checks_for_licenses` and producing a
+        // different event ordering than the snapshot. Anchoring `to_positive_instant` to
+        // `tokio::time::Instant::now()` (see refactor in this file) means the queue's deadlines
+        // and `Instant::now()` share the same paused clock here, so deadlines only advance when
+        // the test driver decides — `collect::<Vec<_>>().await` auto-advances paused time when
+        // the runtime is otherwise idle, which deterministically fires the warn/halt entries.
         let events_stream =
             futures::stream::iter(vec![license_with_claim(10, 10), license_with_no_claim()])
                 .interleave_pending()

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -9,7 +9,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
-use std::time::Instant;
 use std::time::SystemTime;
 
 use futures::Stream;
@@ -22,6 +21,7 @@ use futures::stream::Zip;
 use graphql_client::GraphQLQuery;
 use pin_project_lite::pin_project;
 use strum::IntoEnumIterator;
+use tokio::time::Instant;
 use tokio_util::time::DelayQueue;
 
 use super::license_enforcement::LicenseLimits;
@@ -221,7 +221,7 @@ fn reset_checks_for_licenses(
             Event::UpdateLicense(Arc::new(LicenseState::LicensedHalt {
                 limits: limits.clone(),
             })),
-            (halt_at).into(),
+            halt_at,
         );
     } else {
         return Poll::Ready(Some(Event::UpdateLicense(Arc::new(
@@ -237,7 +237,7 @@ fn reset_checks_for_licenses(
             Event::UpdateLicense(Arc::new(LicenseState::LicensedWarn {
                 limits: limits.clone(),
             })),
-            (warn_at).into(),
+            warn_at,
         );
     } else {
         return Poll::Ready(Some(Event::UpdateLicense(Arc::new(
@@ -257,8 +257,16 @@ fn reset_checks_for_licenses(
 /// This function exists to generate an approximate Instant from a `SystemTime`. We have externally generated unix timestamps that need to be scheduled, but anything time related to scheduling must be an `Instant`.
 /// The generated instant is only approximate.
 /// Subtracting from instants is not supported on all platforms, so if the calculated instant was in the past we just return now as we don't care about how long ago the instant was, just that it happened already.
+///
+/// Returns a `tokio::time::Instant` (rather than `std::time::Instant`) so that scheduling
+/// respects `tokio::time::pause()` / `tokio::time::advance()` in tests. The downstream
+/// `DelayQueue` reads `tokio::time::Instant::now()` to decide when entries fire; using a
+/// `tokio::time::Instant` here keeps the "now" reference consistent with the queue's clock,
+/// which is required for deterministic virtual-time tests.
 fn to_positive_instant(system_time: SystemTime) -> Instant {
-    // This is approximate as there is no real conversion between SystemTime and Instant
+    // This is approximate as there is no real conversion between SystemTime and Instant.
+    // We use `tokio::time::Instant::now()` so the returned instant is anchored to the same
+    // clock as `DelayQueue`'s scheduler (this clock is virtualized under `tokio::time::pause()`).
     let now_instant = Instant::now();
     let now_system_time = SystemTime::now();
 
@@ -335,11 +343,11 @@ impl<T: Stream<Item = License>> LicenseStreamExt for T {}
 mod test {
     use std::future::ready;
     use std::time::Duration;
-    use std::time::Instant;
     use std::time::SystemTime;
 
     use futures::StreamExt;
     use futures_test::stream::StreamTestExt;
+    use tokio::time::Instant;
     use tracing::instrument::WithSubscriber;
 
     use crate::assert_snapshot_subscriber;
@@ -494,16 +502,27 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(start_paused = true)]
     async fn license_expander_claim_pause_claim() {
+        // Use paused virtual time so the schedule of claim arrivals vs. warn/halt
+        // expirations is deterministic. The previous version of this test used real
+        // `tokio::time::sleep(200ms)` and asserted on event ordering, which raced with
+        // the producer task on slow / loaded systems.
+        //
+        // `to_positive_instant` returns a `tokio::time::Instant` anchored to the same
+        // virtual clock that `DelayQueue` reads, so advancing time here precisely fires
+        // the inserted warn/halt entries.
         let (tx, rx) = tokio::sync::mpsc::channel(10);
         let rx_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
         let events_stream = rx_stream.expand_licenses().map(SimpleEvent::from);
 
         tokio::task::spawn(async move {
-            // This simulates a new claim coming in before in between the warning and halt
+            // Simulate a new claim coming in between the warning and halt of the first.
+            // First claim: warn_at = now + 100ms, halt_at = now + 300ms.
             let _ = tx.send(license_with_claim(100, 300)).await;
+            // Advance past the warn boundary (100ms) but before the halt boundary (300ms).
             tokio::time::sleep(Duration::from_millis(200)).await;
+            // Second claim resets the schedule from "now" (200ms after start).
             let _ = tx.send(license_with_claim(100, 300)).await;
         });
         let events = events_stream.collect::<Vec<_>>().await;


### PR DESCRIPTION
## Summary

Phase 8 unit-test stability work, consolidated. This PR is the umbrella for Phase 8 and contains:

1. **Retry-list drift cleanup** - removed dead Phase 8 entries from `.config/nextest.toml` for tests that no longer flake (or no longer exist) on `dev`.
2. **`license_expander_claim_pause_claim` deflake** (originally PR #9353) - refactor `to_positive_instant` in `apollo-router/src/uplink/license_stream.rs` to return a `tokio::time::Instant` anchored to `tokio::time::Instant::now()` so the `DelayQueue` warn/halt boundaries share a clock with `tokio::time::pause()`. Switch test to `#[tokio::test(start_paused = true)]`.
3. **`license_expander_claim_no_claim` deflake** (originally PR #9356) - applies the same `to_positive_instant` virtual-clock-anchor production fix and `start_paused = true` switch to the sibling test, eliminating the same scheduler-jitter race that pushed warn/halt deadlines into the past before the consumer polled.

## Why a single refactor for two tests

Both tests share the same underlying race: the production code anchored `DelayQueue` deadlines to a `std::time::Instant` derived from `SystemTime::now()`, while the consumer polled `checks.poll_expired` against `tokio::time::Instant::now()`. Under jitter on slow runners, the ~10ms scheduling window could push warn/halt entries into the past before the upstream future was polled, taking early-return branches in `reset_checks_for_licenses` and producing event orderings that didn't match the snapshot.

The fix anchors `to_positive_instant` to `tokio::time::Instant::now()` (delta still computed from `SystemTime` arithmetic, since claims come from outside the process). With `start_paused = true`, `collect::<Vec<_>>().await` auto-advances paused time when the runtime is otherwise idle, deterministically firing warn/halt entries in the expected order.

## Verified

- `license_expander_claim_pause_claim`: 30/30 PASS locally with `cargo nextest run --no-fail-fast --retries 0`.
- `license_expander_claim_no_claim`: 30/30 PASS locally with the same command.
- `cargo check --tests --package apollo-router` clean on the consolidated branch.

## Retry-list entries removed

- All Phase 8 drift entries identified by the original Phase 8 audit (see commit `960c5d0`).
- `uplink::license_stream::test::license_expander_claim_pause_claim` (now deflaked).
- `uplink::license_stream::test::license_expander_claim_no_claim` (now deflaked).

## PR-strategy consolidation

This PR consolidates #9353 and #9356 (both originally separate Phase 8 follow-ups) into the Phase 8 umbrella to reduce review burden, mirroring the consolidations done for Phase 6 (#9342, #9343 → #9341) and Phase 1 follow-ups (#9344, #9345, #9346, #9348, #9354, plus #9335 cancel-races and #9349 Phase 9 → #9340).

<!-- jira: ROUTER-1730 -->
