### PR TITLE
fix(composition): add remediation hints to `@key` and `@provides` invalid field errors

### DIFF
--- a/apollo-federation/src/schema/validators/key.rs
+++ b/apollo-federation/src/schema/validators/key.rs
@@ -92,10 +92,16 @@ fn invalid_fields_error_from_diagnostics(
 ) -> FederationError {
     let mut errors = MultipleFederationErrors::new();
     for diagnostic in diagnostics.iter() {
+        let mut message = normalize_diagnostic_message(diagnostic);
+        if message.starts_with("Cannot query field") {
+            message = format!(
+                "{message} (the field should either be added to this subgraph or, if it should not be resolved by this subgraph, you need to add it to this subgraph with @external)."
+            );
+        }
         errors.errors.push(SingleFederationError::KeyInvalidFields {
             target_type: key.target.type_name().clone(),
             application: key.schema_directive.to_string(),
-            message: normalize_diagnostic_message(diagnostic),
+            message,
         })
     }
     errors.into()

--- a/apollo-federation/src/schema/validators/key.rs
+++ b/apollo-federation/src/schema/validators/key.rs
@@ -94,8 +94,9 @@ fn invalid_fields_error_from_diagnostics(
     for diagnostic in diagnostics.iter() {
         let mut message = normalize_diagnostic_message(diagnostic);
         if message.starts_with("Cannot query field") {
+            let base = message.trim_end_matches('.');
             message = format!(
-                "{message} (the field should either be added to this subgraph or, if it should not be resolved by this subgraph, you need to add it to this subgraph with @external)."
+                "{base} (the field should either be added to this subgraph or, if it should not be resolved by this subgraph, you need to add it to this subgraph with @external)."
             );
         }
         errors.errors.push(SingleFederationError::KeyInvalidFields {

--- a/apollo-federation/src/schema/validators/provides.rs
+++ b/apollo-federation/src/schema/validators/provides.rs
@@ -114,12 +114,18 @@ fn invalid_fields_error_from_diagnostics(
 ) -> FederationError {
     let mut errors = MultipleFederationErrors::new();
     for diagnostic in diagnostics.iter() {
+        let mut message = normalize_diagnostic_message(diagnostic);
+        if message.starts_with("Cannot query field") {
+            message = format!(
+                "{message} (if the field is defined in another subgraph, you need to add it to this subgraph with @external)."
+            );
+        }
         errors
             .errors
             .push(SingleFederationError::ProvidesInvalidFields {
                 coordinate: provides.target.coordinate(),
                 application: provides.schema_directive.to_string(),
-                message: normalize_diagnostic_message(diagnostic),
+                message,
             })
     }
     errors.into()

--- a/apollo-federation/src/schema/validators/provides.rs
+++ b/apollo-federation/src/schema/validators/provides.rs
@@ -116,8 +116,9 @@ fn invalid_fields_error_from_diagnostics(
     for diagnostic in diagnostics.iter() {
         let mut message = normalize_diagnostic_message(diagnostic);
         if message.starts_with("Cannot query field") {
+            let base = message.trim_end_matches('.');
             message = format!(
-                "{message} (if the field is defined in another subgraph, you need to add it to this subgraph with @external)."
+                "{base} (if the field is defined in another subgraph, you need to add it to this subgraph with @external)."
             );
         }
         errors

--- a/apollo-federation/src/schema/validators/requires.rs
+++ b/apollo-federation/src/schema/validators/requires.rs
@@ -76,9 +76,10 @@ fn invalid_fields_error_from_diagnostics(
     for diagnostic in diagnostics.iter() {
         let mut message = normalize_diagnostic_message(diagnostic);
         if message.starts_with("Cannot query field") {
+            let base = message.trim_end_matches('.');
             message = format!(
-                "{message} If the field is defined in another subgraph, you need to add it to this subgraph with @external."
-            )
+                "{base} (if the field is defined in another subgraph, you need to add it to this subgraph with @external)."
+            );
         }
         errors
             .errors

--- a/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
+++ b/apollo-federation/tests/subgraph/subgraph_validation_tests.rs
@@ -485,7 +485,51 @@ mod fieldset_based_directives {
             err,
             [(
                 "REQUIRES_INVALID_FIELDS",
-                r#"[S] On field "T.g", for @requires(fields: "f b"): Cannot query field "b" on type "T". If the field is defined in another subgraph, you need to add it to this subgraph with @external."#,
+                r#"[S] On field "T.g", for @requires(fields: "f b"): Cannot query field "b" on type "T" (if the field is defined in another subgraph, you need to add it to this subgraph with @external)."#,
+            )]
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_fields_in_key() {
+        let schema_str = r#"
+            type Query {
+                t: T
+            }
+
+            type T @key(fields: "id unknown") {
+                id: ID!
+            }
+        "#;
+        let err = build_for_errors(schema_str);
+
+        assert_errors!(
+            err,
+            [(
+                "KEY_INVALID_FIELDS",
+                r#"[S] On type "T", for @key(fields: "id unknown"): Cannot query field "unknown" on type "T" (the field should either be added to this subgraph or, if it should not be resolved by this subgraph, you need to add it to this subgraph with @external)."#,
+            )]
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_fields_in_provides() {
+        let schema_str = r#"
+            type Query {
+                t: T @provides(fields: "unknown")
+            }
+
+            type T @key(fields: "id") {
+                id: ID!
+            }
+        "#;
+        let err = build_for_errors(schema_str);
+
+        assert_errors!(
+            err,
+            [(
+                "PROVIDES_INVALID_FIELDS",
+                r#"[S] On field "Query.t", for @provides(fields: "unknown"): Cannot query field "unknown" on type "T" (if the field is defined in another subgraph, you need to add it to this subgraph with @external)."#,
             )]
         );
     }


### PR DESCRIPTION
The `@requires` validator already appended a helpful hint when a "Cannot query field" error was produced, but `@key` and `@provides` did not. This aligns the Rust error messages with the JS composition output.

Ref: https://github.com/apollographql/federation/blob/main/internals-js/src/federation.ts#L2293-L2305
