### PR TITLE
chore(nextest): drop apollo-router-benchmarks::tests::test retry-list entry (Phase 9 follow-up)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,8 +12,7 @@
 # module, as they have a high failure rate, in general.
 retries = 2
 filter = '''
-   ( binary_id(=apollo-router-benchmarks) & test(=tests::test) )
-or ( binary_id(=apollo-router::integration_tests) & test(#integration::subscriptions::ws_passthrough::*) )
+   ( binary_id(=apollo-router::integration_tests) & test(#integration::subscriptions::ws_passthrough::*) )
 or ( binary_id(=apollo-router::integration_tests) & test(=api_schema_hides_field) )
 or ( binary_id(=apollo-router::integration_tests) & test(=automated_persisted_queries) )
 or ( binary_id(=apollo-router::integration_tests) & test(=defer_default_variable) )


### PR DESCRIPTION
## Summary

Tiny Phase 9 follow-up. PR #9349 deferred `apollo-router-benchmarks::tests::test` because the host hit 100% disk during verification. With disk healthy now (86G free post-cleanup), the verification ran clean.

## Verification

**30/30 PASS locally**, sub-second runs each. The test is hermetic by construction:

- Uses `apollo_router::MockedSubgraphs` (no network egress).
- Asserts exact equality against a static `EXPECTED_RESPONSE` (`once_cell::sync::Lazy<Response>`).
- Mocks all 3 subgraphs (accounts / reviews / products) with `MockSubgraph::with_json` matchers covering exactly the queries the planner emits.

Same paper-tiger shape as the rest of Phase 9 — see [PR #9349](https://github.com/apollographql/router/pull/9349) and `flaky-test-phases/blog-details.md` Arc 6d ("Phase 9 was a paper tiger") for context.

## Diff

```
.config/nextest.toml | 3 +--
1 file changed, 1 insertion(+), 2 deletions(-)
```

Removed:

```
   ( binary_id(=apollo-router-benchmarks) & test(=tests::test) )
or
```

## Sequencing

Independent of all open flake-fix PRs. Lands directly off `dev`.