### PR TITLE
refactor(license_expander): tokio::time::pause()-friendly to_positive_instant + deflake claim_pause_claim test (Phase 8)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -172,7 +172,6 @@ or ( binary_id(=apollo-router) & test(=services::supergraph::tests::aliased_subg
 or ( binary_id(=apollo-router) & test(=services::supergraph::tests::interface_object_typename_rewrites) )
 or ( binary_id(=apollo-router) & test(=services::supergraph::tests::only_query_interface_object_subgraph) )
 or ( binary_id(=apollo-router) & test(=uplink::license_stream::test::license_expander_claim_no_claim) )
-or ( binary_id(=apollo-router) & test(=uplink::license_stream::test::license_expander_claim_pause_claim) )
 or ( binary_id(=apollo-router) & test(=uplink::persisted_queries_manifest_stream::test::integration_test) )
 or ( binary_id(=apollo-router) & test(=uplink::schema_stream::test::integration_test) )
 '''

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -9,7 +9,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
-use std::time::Instant;
 use std::time::SystemTime;
 
 use futures::Stream;
@@ -22,6 +21,7 @@ use futures::stream::Zip;
 use graphql_client::GraphQLQuery;
 use pin_project_lite::pin_project;
 use strum::IntoEnumIterator;
+use tokio::time::Instant;
 use tokio_util::time::DelayQueue;
 
 use super::license_enforcement::LicenseLimits;
@@ -221,7 +221,7 @@ fn reset_checks_for_licenses(
             Event::UpdateLicense(Arc::new(LicenseState::LicensedHalt {
                 limits: limits.clone(),
             })),
-            (halt_at).into(),
+            halt_at,
         );
     } else {
         return Poll::Ready(Some(Event::UpdateLicense(Arc::new(
@@ -237,7 +237,7 @@ fn reset_checks_for_licenses(
             Event::UpdateLicense(Arc::new(LicenseState::LicensedWarn {
                 limits: limits.clone(),
             })),
-            (warn_at).into(),
+            warn_at,
         );
     } else {
         return Poll::Ready(Some(Event::UpdateLicense(Arc::new(
@@ -257,8 +257,16 @@ fn reset_checks_for_licenses(
 /// This function exists to generate an approximate Instant from a `SystemTime`. We have externally generated unix timestamps that need to be scheduled, but anything time related to scheduling must be an `Instant`.
 /// The generated instant is only approximate.
 /// Subtracting from instants is not supported on all platforms, so if the calculated instant was in the past we just return now as we don't care about how long ago the instant was, just that it happened already.
+///
+/// Returns a `tokio::time::Instant` (rather than `std::time::Instant`) so that scheduling
+/// respects `tokio::time::pause()` / `tokio::time::advance()` in tests. The downstream
+/// `DelayQueue` reads `tokio::time::Instant::now()` to decide when entries fire; using a
+/// `tokio::time::Instant` here keeps the "now" reference consistent with the queue's clock,
+/// which is required for deterministic virtual-time tests.
 fn to_positive_instant(system_time: SystemTime) -> Instant {
-    // This is approximate as there is no real conversion between SystemTime and Instant
+    // This is approximate as there is no real conversion between SystemTime and Instant.
+    // We use `tokio::time::Instant::now()` so the returned instant is anchored to the same
+    // clock as `DelayQueue`'s scheduler (this clock is virtualized under `tokio::time::pause()`).
     let now_instant = Instant::now();
     let now_system_time = SystemTime::now();
 
@@ -335,11 +343,11 @@ impl<T: Stream<Item = License>> LicenseStreamExt for T {}
 mod test {
     use std::future::ready;
     use std::time::Duration;
-    use std::time::Instant;
     use std::time::SystemTime;
 
     use futures::StreamExt;
     use futures_test::stream::StreamTestExt;
+    use tokio::time::Instant;
     use tracing::instrument::WithSubscriber;
 
     use crate::assert_snapshot_subscriber;
@@ -494,16 +502,27 @@ mod test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(start_paused = true)]
     async fn license_expander_claim_pause_claim() {
+        // Use paused virtual time so the schedule of claim arrivals vs. warn/halt
+        // expirations is deterministic. The previous version of this test used real
+        // `tokio::time::sleep(200ms)` and asserted on event ordering, which raced with
+        // the producer task on slow / loaded systems.
+        //
+        // `to_positive_instant` returns a `tokio::time::Instant` anchored to the same
+        // virtual clock that `DelayQueue` reads, so advancing time here precisely fires
+        // the inserted warn/halt entries.
         let (tx, rx) = tokio::sync::mpsc::channel(10);
         let rx_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
         let events_stream = rx_stream.expand_licenses().map(SimpleEvent::from);
 
         tokio::task::spawn(async move {
-            // This simulates a new claim coming in before in between the warning and halt
+            // Simulate a new claim coming in between the warning and halt of the first.
+            // First claim: warn_at = now + 100ms, halt_at = now + 300ms.
             let _ = tx.send(license_with_claim(100, 300)).await;
+            // Advance past the warn boundary (100ms) but before the halt boundary (300ms).
             tokio::time::sleep(Duration::from_millis(200)).await;
+            // Second claim resets the schedule from "now" (200ms after start).
             let _ = tx.send(license_with_claim(100, 300)).await;
         });
         let events = events_stream.collect::<Vec<_>>().await;


### PR DESCRIPTION
## Summary

- **Production refactor:** `to_positive_instant` in `apollo-router/src/uplink/license_stream.rs` now returns a `tokio::time::Instant` (anchored to `tokio::time::Instant::now()`) instead of a `std::time::Instant`. The downstream `DelayQueue` consumes the result via `insert_at` and reads `tokio::time::Instant::now()` to decide when entries fire - so anchoring to the same clock is what makes virtual-time tests deterministic.
- **Test rewrite:** `license_expander_claim_pause_claim` now uses `#[tokio::test(start_paused = true)]` instead of `#[tokio::test(flavor = \"multi_thread\")]` + `tokio::time::sleep(200ms)`. With paused virtual time and a clock-aligned `to_positive_instant`, claim arrivals vs. warn/halt boundaries are deterministic.
- **Retry-list cleanup:** removed the `license_expander_claim_pause_claim` entry from `.config/nextest.toml`.

## Diagnosis

The original test ran a producer task that sent a claim, slept 200ms in real time, then sent a second claim. The first claim's `warn_at` was `now + 100ms` and `halt_at` was `now + 300ms`. The expected event sequence was `Update, Warn, Update, Warn, Halt`.

Two pieces had to align for that sequence to happen reliably:
1. The 100ms warn boundary had to fire before the producer woke from its 200ms sleep.
2. `to_positive_instant` had to schedule that warn boundary on the same clock the `DelayQueue` was reading.

In practice (1) was racy under load and (2) silently almost-worked because both `std::time::Instant` and `tokio::time::Instant` advance the same way in the absence of `pause()`. But the moment we wanted to fix (1) with `tokio::time::pause()`, the mismatch in (2) became blocking - the queue would read virtual-frozen time while the scheduled targets were anchored to real wall-clock.

## Refactor approach

Mirrors the Phase-6 canonical pattern from PR #9343 (`test_ws_connection_new_proto_with_heartbeat`). Change `to_positive_instant`'s anchor from `std::time::Instant::now()` to `tokio::time::Instant::now()`. The `SystemTime` arithmetic stays unchanged because the *delta* is real-world wall-clock-derived (claims come from outside the process); only the *anchor* needs to match the scheduler's clock. Updated the existing `test_to_instant` import set so it uses `tokio::time::Instant` for comparison too.

## Test plan

- [x] `cargo nextest run --lib -E 'test(/uplink::license_stream::test::/)'` -> 14/14 passed (no regressions in the suite, including `test_to_instant`)
- [x] `cargo nextest run --lib -E 'test(=uplink::license_stream::test::license_expander_claim_pause_claim)'` x **30 iterations -> 30 passed / 0 failed** (baseline)
- [ ] CI green on dev

## Notes

- `to_positive_instant` is private to `license_stream.rs` (only consumers are inside the module + the test module), so the type change has no external blast radius.
- Scope intentionally narrow: only this one test from the Phase 8 deferred set is addressed here.