### PR TITLE
test(entity_cache): stabilize test_cache_error_metrics

### DIFF
--- a/apollo-router/tests/integration/entity_cache.rs
+++ b/apollo-router/tests/integration/entity_cache.rs
@@ -579,14 +579,20 @@ async fn test_cache_error_metrics() {
         assert_eq!(response.status(), 200);
     }
 
-    // Wait for metrics to be collected
-    tokio::time::sleep(std::time::Duration::from_millis(3000)).await;
-
-    // Assert that Redis error metrics are emitted when Redis operations fail
-    // We expect an IO error when connecting to an invalid Redis port
+    // Assert that Redis error metrics are emitted when Redis operations fail.
+    // We expect at least one IO error when connecting to an invalid Redis port.
+    //
+    // Use `assert_metric_non_zero` (which already polls up to 15s) instead of an
+    // exact-count assertion: the underlying `apollo.router.cache.redis.errors`
+    // counter is incremented per failed Redis operation (connect, query, client
+    // event, heartbeat). The exact number that lands depends on how many connect
+    // retries `fred` has performed, the 100ms metrics interval, and how many
+    // subgraph requests fanned out — none of which are deterministic in this
+    // test. The semantic we actually care about is "Redis IO errors are
+    // recorded when Redis is unreachable", which `non_zero` captures correctly.
     router
-        .assert_metrics_contains(
-            r#"apollo_router_cache_redis_errors_total{error_type="io",kind="entity",otel_scope_name="apollo/router"} 1"#,
+        .assert_metric_non_zero(
+            r#"apollo_router_cache_redis_errors_total{error_type="io",kind="entity",otel_scope_name="apollo/router"}"#,
             None,
         )
         .await;


### PR DESCRIPTION
## Summary

`apollo-router/tests/integration/entity_cache.rs::test_cache_error_metrics` had a classic timing-race pattern flagged by the Phase-1 forward-pass audit (PR #9348): a hard-coded 3 s `tokio::sleep` followed by an *exact-count* metric assertion (`} 1`). This PR replaces both with a deadline-bounded poll that asserts the metric is non-zero.

## The race

The test points entity-cache's Redis at port `9999` (intentionally invalid) and runs 3 mutation queries, expecting `apollo_router_cache_redis_errors_total{error_type="io",kind="entity",...}` to be exactly `1`.

Two problems:

1. **The 3 s sleep was a guess** at when the metrics pipeline would have observed the first error. Too short = metric is still `0`; too long = wasted CI time.
2. **The exact-count `} 1` assertion was racing more incoming errors.** The counter is bumped per failed Redis op (connect, query, client event, heartbeat). With 3 queries, `fred`'s connect-retry loop, and the configured `metrics_interval: 100ms`, the value can land at 1, 2, 3, or higher — none of which the test could predict.

## Fix (Pattern B+C)

Use `assert_metric_non_zero`, which:
- Already polls the Prometheus endpoint for up to 15 s (so the 3 s sleep is gone).
- Matches any positive value (so the value drift is irrelevant).

This is the same pattern already used by `test_redis_emits_configuration_error_metric` in `redis.rs` for the same metric family — exactly the right precedent.

The semantic the test actually wants ("Redis IO errors are recorded when Redis is unreachable") is preserved; the brittle exact-count coupling and the wasteful sleep are removed.

## Verification

- 30 / 30 runs passed locally (`cargo test -p apollo-router --test integration_tests -- integration::entity_cache::test_cache_error_metrics --exact`).
- Per-run wall time: 3.4 - 4.1 s (down from the 4-5 s+ floor imposed by the prior mandatory 3 s sleep).
- The test was not on the `.config/nextest.toml` retry list (Phase-1 flagged it as a *latent* flake, not a known retrying entry); no retry-list change needed.

## Test plan

- [x] `cargo check -p apollo-router --tests` clean
- [x] 30 / 30 sequential `cargo test` passes locally with `TEST_APOLLO_KEY` / `TEST_APOLLO_GRAPH_REF` set
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)