### PR TITLE
test: deflake Phase-8 deferred-review entries (Phase 8 follow-up)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -171,7 +171,6 @@ or ( binary_id(=apollo-router) & test(=services::subgraph_service::tests::test_s
 or ( binary_id(=apollo-router) & test(=services::supergraph::tests::aliased_subgraph_data_rewrites_on_non_root_fetch) )
 or ( binary_id(=apollo-router) & test(=services::supergraph::tests::interface_object_typename_rewrites) )
 or ( binary_id(=apollo-router) & test(=services::supergraph::tests::only_query_interface_object_subgraph) )
-or ( binary_id(=apollo-router) & test(=uplink::license_stream::test::license_expander_claim_no_claim) )
 or ( binary_id(=apollo-router) & test(=uplink::license_stream::test::license_expander_claim_pause_claim) )
 or ( binary_id(=apollo-router) & test(=uplink::persisted_queries_manifest_stream::test::integration_test) )
 or ( binary_id(=apollo-router) & test(=uplink::schema_stream::test::integration_test) )

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -9,7 +9,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
-use std::time::Instant;
 use std::time::SystemTime;
 
 use futures::Stream;
@@ -22,6 +21,7 @@ use futures::stream::Zip;
 use graphql_client::GraphQLQuery;
 use pin_project_lite::pin_project;
 use strum::IntoEnumIterator;
+use tokio::time::Instant;
 use tokio_util::time::DelayQueue;
 
 use super::license_enforcement::LicenseLimits;
@@ -221,7 +221,7 @@ fn reset_checks_for_licenses(
             Event::UpdateLicense(Arc::new(LicenseState::LicensedHalt {
                 limits: limits.clone(),
             })),
-            (halt_at).into(),
+            halt_at,
         );
     } else {
         return Poll::Ready(Some(Event::UpdateLicense(Arc::new(
@@ -237,7 +237,7 @@ fn reset_checks_for_licenses(
             Event::UpdateLicense(Arc::new(LicenseState::LicensedWarn {
                 limits: limits.clone(),
             })),
-            (warn_at).into(),
+            warn_at,
         );
     } else {
         return Poll::Ready(Some(Event::UpdateLicense(Arc::new(
@@ -257,8 +257,16 @@ fn reset_checks_for_licenses(
 /// This function exists to generate an approximate Instant from a `SystemTime`. We have externally generated unix timestamps that need to be scheduled, but anything time related to scheduling must be an `Instant`.
 /// The generated instant is only approximate.
 /// Subtracting from instants is not supported on all platforms, so if the calculated instant was in the past we just return now as we don't care about how long ago the instant was, just that it happened already.
+///
+/// Returns a `tokio::time::Instant` (rather than `std::time::Instant`) so that scheduling
+/// respects `tokio::time::pause()` / `tokio::time::advance()` in tests. The downstream
+/// `DelayQueue` reads `tokio::time::Instant::now()` to decide when entries fire; using a
+/// `tokio::time::Instant` here keeps the "now" reference consistent with the queue's clock,
+/// which is required for deterministic virtual-time tests.
 fn to_positive_instant(system_time: SystemTime) -> Instant {
-    // This is approximate as there is no real conversion between SystemTime and Instant
+    // This is approximate as there is no real conversion between SystemTime and Instant.
+    // We use `tokio::time::Instant::now()` so the returned instant is anchored to the same
+    // clock as `DelayQueue`'s scheduler (this clock is virtualized under `tokio::time::pause()`).
     let now_instant = Instant::now();
     let now_system_time = SystemTime::now();
 
@@ -335,11 +343,11 @@ impl<T: Stream<Item = License>> LicenseStreamExt for T {}
 mod test {
     use std::future::ready;
     use std::time::Duration;
-    use std::time::Instant;
     use std::time::SystemTime;
 
     use futures::StreamExt;
     use futures_test::stream::StreamTestExt;
+    use tokio::time::Instant;
     use tracing::instrument::WithSubscriber;
 
     use crate::assert_snapshot_subscriber;
@@ -453,9 +461,20 @@ mod test {
         assert_eq!(events, &[SimpleEvent::UpdateLicense]);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn license_expander_claim_no_claim() {
         // Licenses with no claim do not clear checks as they are ignored if we move from entitled to unentitled, this is handled at the state machine level.
+        //
+        // Use paused virtual time so that the warn/halt boundaries (10ms in the future at the
+        // moment of claim arrival) cannot fire prematurely between the time we enqueue them and
+        // the time the consumer polls `checks.poll_expired`. Under real time, scheduler jitter
+        // could push the boundaries into the past before the upstream `no_claim()` was polled,
+        // taking the early-return branches in `reset_checks_for_licenses` and producing a
+        // different event ordering than the snapshot. Anchoring `to_positive_instant` to
+        // `tokio::time::Instant::now()` (see refactor in this file) means the queue's deadlines
+        // and `Instant::now()` share the same paused clock here, so deadlines only advance when
+        // the test driver decides — `collect::<Vec<_>>().await` auto-advances paused time when
+        // the runtime is otherwise idle, which deterministically fires the warn/halt entries.
         let events_stream =
             futures::stream::iter(vec![license_with_claim(10, 10), license_with_no_claim()])
                 .interleave_pending()


### PR DESCRIPTION
## Summary

Phase-8 deferred-review triage of the 27 live retry-list entries that PR
#9350 conservatively deferred (after excluding `license_expander_claim_pause_claim`
which is on PR #9353, `notification::tests::it_test_ttl` which is on a separate
blocked branch, and `pq_layer_freeform_graphql_with_safelist_log_unknown_true` /
`persisted_queries_manifest_stream` which were already removed by #9350 / #9353).

Identified **1** entry with the same `to_positive_instant` shape as the canonical
PR #9353 fix; deflaked it; left the remaining **26** as documented Category C/D.

## Triage table

| Test | Category | Reason |
|------|----------|--------|
| `uplink::license_stream::test::license_expander_claim_no_claim` | **A** | `std::time::Instant` anchor vs `DelayQueue`'s `tokio::time::Instant` clock - **fixed in this PR** |
| `uplink::schema_stream::test::integration_test` | D | env-gated on `TEST_APOLLO_KEY` / `TEST_APOLLO_GRAPH_REF`; no-op locally |
| `axum_factory::axum_http_server_factory::tests::request_cancel_log` | C | already-being-fixed on `flake-fix/phase-4-axum-cancel-races` |
| `axum_factory::axum_http_server_factory::tests::request_cancel_no_log` | C | already-being-fixed on `flake-fix/phase-4-axum-cancel-races` |
| `axum_factory::tests::cors_origin_default` | C | port-binding race, not virtual-clock-fixable |
| `axum_factory::tests::cors_origin_list` | C | port-binding race |
| `axum_factory::tests::cors_origin_regex` | C | port-binding race |
| `axum_factory::tests::it_answers_to_custom_endpoint` | C | port-binding race |
| `axum_factory::tests::it_compress_response_body` | C | port-binding race |
| `axum_factory::tests::response` | C | port-binding race |
| `axum_factory::tests::response_with_custom_endpoint` | C | port-binding race |
| `axum_factory::tests::response_with_custom_endpoint_wildcard` | C | port-binding race |
| `axum_factory::tests::response_with_custom_prefix_endpoint` | C | port-binding race |
| `axum_factory::tests::response_with_root_wildcard` | C | port-binding race |
| `cache::metrics::tests::test_redis_storage_with_mocks` | C | cross-test global `AtomicU64` contamination on `apollo.router.cache.redis.clients` |
| `layers::map_first_graphql_response::tests::test_map_first_graphql_response` | C | TestHarness-build race; no timing assertions |
| `plugins::authentication::subgraph::test::test_credentials_provider_refresh_on_stale` | C | `next_refresh_timer` keys off `SystemTime`, not `Instant`; refactor cross-cuts AWS SDK boundary, >50 LoC out of scope |
| `plugins::connectors::tests::connect_on_type::batch_with_max_size_over_batch_size` | C | wiremock startup race |
| `plugins::connectors::tests::quickstart::query_4` | C | wiremock startup race |
| `plugins::connectors::tests::test_entity_references` | C | wiremock startup race |
| `plugins::connectors::tests::test_interface_object` | C | wiremock startup race |
| `plugins::expose_query_plan::tests::it_expose_query_plan` | C | TestHarness-build race |
| `plugins::include_subgraph_errors::test::it_does_not_redact_all_explicit_allow_account_explict_redact_for_product_query` | C | PluginTestHarness/snapshot |
| `plugins::include_subgraph_errors::test::it_does_not_redact_all_explicit_allow_review_explict_redact_for_product_query` | C | PluginTestHarness/snapshot |
| `plugins::include_subgraph_errors::test::it_does_not_redact_all_implicit_redact_product_explict_allow_for_product_query` | C | PluginTestHarness/snapshot |
| `plugins::include_subgraph_errors::test::it_does_redact_all_explicit_allow_account_explict_redact_for_account_query` | C | PluginTestHarness/snapshot |
| `plugins::include_subgraph_errors::test::it_does_redact_all_explicit_allow_product_explict_redact_for_product_query` | C | PluginTestHarness/snapshot |
| `plugins::include_subgraph_errors::test::it_redacts_all_subgraphs_implicit_redact` | C | PluginTestHarness/snapshot |
| `plugins::include_subgraph_errors::test::it_returns_valid_response` | C | PluginTestHarness/snapshot |
| `plugins::telemetry::config_new::instruments::tests::test_instruments` | C | data-driven YAML fixture suite; no virtual-clock boundary |
| `protocols::websocket::tests::test_ws_connection_new_proto_with_heartbeat` | C | already deflaked by PR #9343 (commit `e1e8cf93d` removed it from retry list); entry on `dev` is stale - drift |
| `router::tests::basic_event_stream_test` | C | TestRouterHttpServer port-bind race |
| `router::tests::schema_update_test` | C | TestRouterHttpServer port-bind race |
| `services::subgraph_service::tests::test_subgraph_service_websocket_with_error` | C | TCP bind + WebSocket startup race |
| `services::supergraph::tests::aliased_subgraph_data_rewrites_on_non_root_fetch` | C | TestHarness/snapshot |
| `services::supergraph::tests::interface_object_typename_rewrites` | C | TestHarness/snapshot |
| `services::supergraph::tests::only_query_interface_object_subgraph` | C | TestHarness/snapshot |

**Summary:** 1 in A, 0 in B, 35 in C, 1 in D. (Counts include the 9 axum + 7 include_subgraph_errors batches above.)

## Fixes applied

**`license_expander_claim_no_claim`** (Category A)

1. Production: switched `to_positive_instant` to return a `tokio::time::Instant`
   anchored to `tokio::time::Instant::now()` so it matches the `DelayQueue`'s
   scheduler clock (this clock is virtualized under `tokio::time::pause()`).
2. Production: dropped the now-unnecessary `.into()` conversions at the
   `DelayQueue::insert_at` call sites.
3. Test: switched to `#[tokio::test(start_paused = true)]` so the warn/halt
   boundaries cannot fire prematurely between scheduling and consumer polling.

This is the same production-side refactor used by PR #9353 to deflake the
sibling `license_expander_claim_pause_claim` test. Both PRs touch the same
production code with identical changes, so they will merge cleanly into `dev`
in any order; each PR removes a different retry-list entry and rewrites a
different test.

## Verification

- `license_expander_claim_no_claim`: **30/30 PASS** locally
- All 7 sibling `license_expander_*` tests: 7/7 PASS in a single run
- `test_to_instant`: PASS (verifies the `tokio::time::Instant::now()` change
  works outside a runtime context too)

## Retry-list entries removed

- `uplink::license_stream::test::license_expander_claim_no_claim` (1 entry)

## Not addressed (out of scope)

- `notification::tests::it_test_ttl` - on a separate blocked branch, per the brief.
- The 35 Category-C entries above - real-time / port-binding / global-state races
  that would require a different deflake pattern (or are already in flight on
  another branch).
- The Category-D `schema_stream::integration_test` - env-gated network test;
  needs CI reproducer log to debug further.

## Test plan

- [x] `cargo nextest run` of `license_expander_claim_no_claim`, 30 iterations, 30/30 PASS
- [x] `cargo nextest run` of all `license_expander_*` siblings, 7/7 PASS
- [ ] CI green
- [ ] Coordinator confirms 30/30 from the agreed CI verification gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)