### PR TITLE
fix(composition): fix `EXTENSION_WITH_NO_BASE` validation

### DIFF
--- a/apollo-federation/src/merger/merge_type.rs
+++ b/apollo-federation/src/merger/merge_type.rs
@@ -108,7 +108,11 @@ impl Merger {
                 continue;
             };
 
-            if subgraph.is_orphan_extension_type(element.name()) {
+            let is_orphan = subgraph.is_orphan_extension_type(element.name());
+            let has_extends_directive = subgraph
+                .extends_directive_name()
+                .is_some_and(|extends_name| element.directives().has(extends_name.as_str()));
+            if is_orphan || has_extends_directive {
                 let subgraph_name = subgraph.name.to_string();
                 let element_locations = element.locations(subgraph);
                 subgraphs_with_extension.push((subgraph_name, element_locations));

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -247,9 +247,14 @@ impl SchemaUpgrader {
                             };
                             let extended_type =
                                 type_info.pos.get(other_subgraph.schema().schema())?;
-                            Ok::<bool, FederationError>(
-                                !other_subgraph.is_orphan_extension_type(extended_type.name()),
-                            )
+                            let is_orphan =
+                                other_subgraph.is_orphan_extension_type(extended_type.name());
+                            let has_extends_directive = other_subgraph
+                                .extends_directive_name()
+                                .is_some_and(|extends_name| {
+                                    extended_type.directives().has(extends_name.as_str())
+                                });
+                            Ok::<bool, FederationError>(!is_orphan && !has_extends_directive)
                         })
                 })
                 .unwrap_or(Ok(false))?;

--- a/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
@@ -331,6 +331,77 @@ mod validations {
     }
 
     #[test]
+    fn errors_if_extends_directive_has_no_definition_counterpart() {
+        let subgraph_a = ServiceDefinition {
+            name: "subgraphA",
+            type_defs: r#"
+                type Query {
+                    q: String
+                }
+            "#,
+        };
+
+        let subgraph_b = ServiceDefinition {
+            name: "subgraphB",
+            type_defs: r#"
+                type A @key(fields: "k") @extends {
+                    k: ID!
+                }
+            "#,
+        };
+
+        let result = compose_services(&[subgraph_a, subgraph_b]);
+        assert_composition_errors(
+            &result,
+            &[(
+                "EXTENSION_WITH_NO_BASE",
+                r#"[subgraphB] Type "A" is an extension type, but there is no type definition for "A" in any subgraph."#,
+            )],
+        );
+    }
+
+    #[test]
+    fn errors_if_multiple_subgraphs_all_use_extends_directive_with_no_base() {
+        let subgraph_a = ServiceDefinition {
+            name: "subgraphA",
+            type_defs: r#"
+                type Query {
+                    q: String
+                }
+
+                type Product @key(fields: "id") @extends {
+                    id: ID! @external
+                }
+            "#,
+        };
+
+        let subgraph_b = ServiceDefinition {
+            name: "subgraphB",
+            type_defs: r#"
+                type Product @key(fields: "id") @extends {
+                    id: ID! @external
+                    name: String
+                }
+            "#,
+        };
+
+        let result = compose_services(&[subgraph_a, subgraph_b]);
+        assert_composition_errors(
+            &result,
+            &[
+                (
+                    "EXTENSION_WITH_NO_BASE",
+                    r#"[subgraphA] Type "Product" is an extension type, but there is no type definition for "Product" in any subgraph."#,
+                ),
+                (
+                    "EXTENSION_WITH_NO_BASE",
+                    r#"[subgraphB] Type "Product" is an extension type, but there is no type definition for "Product" in any subgraph."#,
+                ),
+            ],
+        );
+    }
+
+    #[test]
     fn include_pointers_to_fed1_schema_in_errors() {
         let subgraph_a = ServiceDefinition {
             name: "subgraphA",


### PR DESCRIPTION
The `EXTENSION_WITH_NO_BASE` check only detected orphan extensions using `extend type` syntax but missed types declared with the fed1 `@extends` directive (e.g., `type Product @key(fields: "id") @extends`). When all subgraphs used `@extends` with no base definition, the upgrader and merger incorrectly treated them as base types, silently succeeding instead of reporting the error.

Fix both `SchemaUpgrader::pre_upgrade_validations` and `Merger::check_for_extension_with_no_base` to also check for the `@extends` directive via `extends_directive_name()`, matching the JS implementation's `isFederationTypeExtension` which checks `hasAppliedDirective(metadata.extendsDirective())`.

JS reference:
- `isFederationTypeExtension`: https://github.com/apollographql/federation/blob/467a9612/internals-js/src/schemaUpgrader.ts#L301-L308
- `checkForExtensionWithNoBase`: https://github.com/apollographql/federation/blob/467a9612/internals-js/src/schemaUpgrader.ts#L393-L414
- 