### PR TITLE
fix(composition): emit schema definition in supergraph SDL

### DIFF
--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1698,7 +1698,8 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                         "Setting supergraph root {} to type named {} (from subgraph {})",
                         root_kind, root_type, subgraph.name
                     );
-                    dest.set_root_type(&mut self.merged, root_kind, root_type.clone())?;
+                    let root_type = ComponentName::from(root_type.name.clone());
+                    dest.set_root_type(&mut self.merged, root_kind, root_type)?;
                     break;
                 }
             }

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -100,10 +100,7 @@ impl Supergraph<Merged> {
     }
 
     pub fn parse(schema_str: &str) -> Result<Self, FederationError> {
-        let mut schema = Schema::builder()
-            .adopt_orphan_extensions()
-            .parse(schema_str, "schema.graphql")
-            .build()?;
+        let mut schema = Schema::parse_and_validate(schema_str, "schema.graphql")?.into_inner();
         crate::compat::coerce_schema_default_values(&mut schema);
         let schema = schema.validate()?;
         Ok(Self {

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -100,7 +100,10 @@ impl Supergraph<Merged> {
     }
 
     pub fn parse(schema_str: &str) -> Result<Self, FederationError> {
-        let mut schema = Schema::parse_and_validate(schema_str, "schema.graphql")?.into_inner();
+        let mut schema = Schema::builder()
+            .adopt_orphan_extensions()
+            .parse(schema_str, "schema.graphql")
+            .build()?;
         crate::compat::coerce_schema_default_values(&mut schema);
         let schema = schema.validate()?;
         Ok(Self {

--- a/apollo-federation/tests/composition/compose_basic.rs
+++ b/apollo-federation/tests/composition/compose_basic.rs
@@ -1,9 +1,12 @@
 use apollo_compiler::coord;
+use apollo_federation::subgraph::typestate::Subgraph;
+use apollo_federation::supergraph::Supergraph;
 use insta::assert_snapshot;
 use test_log::test;
 
 use super::ServiceDefinition;
 use super::assert_composition_errors;
+use super::compose;
 use super::compose_as_fed2_subgraphs;
 use super::extract_subgraphs_from_supergraph_result;
 
@@ -593,4 +596,77 @@ fn override_from_nonexistent_subgraph_hint_has_subgraph_location() {
         hint.locations[0].subgraph, "subgraphA",
         "Hint location should reference the subgraph with @override"
     );
+}
+
+/// Regression test: when subgraphs use `extend schema { query: Query }`,
+/// the supergraph SDL must be re-parseable without "duplicate definitions
+/// for the `query` root operation type" errors.
+#[test]
+fn supergraph_sdl_is_reparseable_when_subgraphs_use_extend_schema() {
+    let sub1 = Subgraph::parse(
+        "s1",
+        "http://s1",
+        r#"
+            extend schema
+              @link(url: "https://specs.apollo.dev/link/v1.0")
+              @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key", "@shareable"])
+            {
+              query: Query
+              mutation: Mutation
+            }
+
+            directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+            directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+            directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+
+            enum link__Purpose { SECURITY EXECUTION }
+            scalar link__Import
+            scalar federation__FieldSet
+
+            type Query {
+              hello: String
+            }
+
+            type Mutation {
+              doThing: String
+            }
+        "#,
+    )
+    .unwrap();
+
+    let sub2 = Subgraph::parse(
+        "s2",
+        "http://s2",
+        r#"
+            extend schema
+              @link(url: "https://specs.apollo.dev/link/v1.0")
+              @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key", "@shareable"])
+            {
+              query: Query
+              mutation: Mutation
+            }
+
+            directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+            directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+            directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+
+            enum link__Purpose { SECURITY EXECUTION }
+            scalar link__Import
+            scalar federation__FieldSet
+
+            type Query {
+              world: String
+            }
+
+            type Mutation {
+              doOther: String
+            }
+        "#,
+    )
+    .unwrap();
+
+    let supergraph = compose(vec![sub1, sub2]).expect("composition should succeed");
+    let sdl = supergraph.schema().schema().to_string();
+
+    Supergraph::parse(&sdl).expect("supergraph SDL should be re-parseable");
 }


### PR DESCRIPTION
When subgraphs use `extend schema { query: Query }`, the merger preserved the extension origin on root operation `ComponentNames`, causing the serializer to emit `extend schema` blocks. Re-parsing this SDL then failed with `duplicate definitions for the query root operation type` because implicit root types from `Query`/`Mutation` type names conflicted with the extension.

Fixed merger to create fresh `ComponentNames` with `Definition` origin.
