### PR TITLE
Backport automation label for v2.10.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,12 +1,12 @@
 pull_request_rules:
-  - name: backport 1.x
-    description: Add a label to backport to 1.x
+  - name: backport v2.10.x
+    description: Add a label to backport to 2.10.x
     conditions:
-      - label = backport-1.x
+      - label = backport-2.10.x
     actions:
       backport:
         branches:
-          - 1.x
+          - dev-v2.10.x
         assignees:
           - "{{ author }}"
         bot_account: "{{ author }}"


### PR DESCRIPTION
Added a rule to backport changes to version 2.10.x, not unlike the existing label option which now removed for 1.x.

This just saves the `@mergifyio backport <branch>` thing, but that still works too if you want.
