### PR TITLE
fix(composition): prefer query witness over mutation 

### DIFF
--- a/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
+++ b/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
@@ -113,6 +113,15 @@ pub(super) fn shareable_field_mismatched_runtime_types_hint(
     runtime_types_per_subgraphs: &IndexMap<Arc<str>, Arc<BTreeSet<Name>>>,
     hints: &mut Vec<CompositionHint>,
 ) -> Result<(), FederationError> {
+    let field_coord = field_definition_position.to_string();
+    let already_reported = hints.iter().any(|h| {
+        h.code() == "INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN"
+            && h.message()
+                .contains(&format!("Shared field \"{}\"", field_coord))
+    });
+    if already_reported {
+        return Ok(());
+    }
     let witness = build_witness_operation(state.supergraph_path())?;
     let operation = witness.to_string();
     let all_subgraphs = state.current_subgraph_names()?;

--- a/apollo-federation/src/composition/satisfiability/validation_traversal.rs
+++ b/apollo-federation/src/composition/satisfiability/validation_traversal.rs
@@ -113,7 +113,7 @@ impl ValidationTraversal {
                 .max_validation_subgraph_paths
                 .unwrap_or(Self::DEFAULT_MAX_VALIDATION_SUBGRAPH_PATHS),
         };
-        for kind in api_schema_query_graph.root_kinds_to_nodes()?.keys() {
+        for kind in api_schema_query_graph.root_kinds_to_nodes()?.keys().rev() {
             validation_traversal.push_stack(ValidationState::new(
                 api_schema_query_graph.clone(),
                 federated_query_graph.clone(),

--- a/apollo-federation/tests/composition/hints.rs
+++ b/apollo-federation/tests/composition/hints.rs
@@ -1705,6 +1705,99 @@ Since a shared field must be resolved the same way in all subgraphs, make sure t
 Otherwise the @shareable contract will be broken."#,
         );
     }
+
+    #[test]
+    fn witness_prefers_query_over_mutation() {
+        // When a shareable field with inconsistent runtime types is reachable via both
+        // a Query path and a Mutation path, the witness operation in the hint message
+        // should use a query, not a mutation.
+        let subgraph_a = ServiceDefinition {
+            name: "A",
+            type_defs: r#"
+                type Query {
+                    entity: E! @shareable
+                }
+
+                type Mutation {
+                    updateEntity: E! @shareable
+                }
+
+                type E @key(fields: "id") {
+                    id: ID!
+                    result: R! @shareable
+                }
+
+                union R = Success | Failure
+
+                type Success @shareable {
+                    value: String
+                }
+
+                type Failure @shareable {
+                    error: String
+                }
+            "#,
+        };
+
+        let subgraph_b = ServiceDefinition {
+            name: "B",
+            type_defs: r#"
+                type Query {
+                    entity: E! @shareable
+                }
+
+                type Mutation {
+                    updateEntity: E! @shareable
+                }
+
+                type E @key(fields: "id") {
+                    id: ID!
+                    result: R! @shareable
+                }
+
+                union R = Success | Failure | Pending
+
+                type Success @shareable {
+                    value: String
+                }
+
+                type Failure @shareable {
+                    error: String
+                }
+
+                type Pending {
+                    status: String
+                }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]).unwrap();
+        let hints: Vec<_> = result
+            .hints()
+            .iter()
+            .filter(|h| h.code() == "INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN")
+            .collect();
+
+        assert!(
+            !hints.is_empty(),
+            "Expected INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN hint"
+        );
+
+        assert_eq!(
+            hints.len(),
+            1,
+            "Expected exactly one INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN hint (deduplicated across root kinds), got {}",
+            hints.len()
+        );
+
+        for hint in &hints {
+            assert!(
+                hint.message().contains("{\n  entity {"),
+                "Witness operation should use a query path (via 'entity'), not a mutation path (via 'updateEntity').\nActual message:\n{}",
+                hint.message()
+            );
+        }
+    }
 }
 
 mod implicit_federation_upgrades {


### PR DESCRIPTION
When a shareable field with inconsistent runtime types is reachable via both Query and Mutation paths, the satisfiability validator was emitting duplicate hints and arbitrarily picking mutation-rooted witness queries. This caused unnecessary hint mismatches between JS and RS composers.

Reverse the root kind iteration order so Query is processed first (DFS on a stack), and deduplicate INCONSISTENT_RUNTIME_TYPES_FOR_SHAREABLE_RETURN hints by field coordinate so only the first (query-rooted) witness is kept.

<!-- [FED-962] -->


[FED-962]: https://apollographql.atlassian.net/browse/FED-962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ