### PR TITLE
fix(deps): update ctor usage for v1 unsafe requirement

### DIFF
--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -2118,7 +2118,7 @@ pub fn graph_os_enabled() -> bool {
 }
 
 /// Automatic tracing initialization using ctor for integration tests
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init_integration_test_tracing() {
     // Initialize tracing for integration tests
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()


### PR DESCRIPTION
## Summary

- `ctor` v1 requires `#[ctor(unsafe)]` instead of bare `#[ctor]` to acknowledge that constructor functions run before `main` and must be sound.
- Fixes the lint failure in [PR #9324](https://github.com/apollographql/router/pull/9324) (the Renovate bump of `ctor` to `v1`).

## Test plan

- [x] `cargo xtask lint` passes locally
- [x] `cargo fmt --check` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)