### PR TITLE
fix(composition): filter fake externals to only field-level `@external`

### DIFF
--- a/apollo-federation/src/schema/subgraph_metadata.rs
+++ b/apollo-federation/src/schema/subgraph_metadata.rs
@@ -397,7 +397,7 @@ impl ExternalMetadata {
     ) -> Result<Self, FederationError> {
         let external_fields = Self::collect_external_fields(federation_spec_definition, schema)?;
         let fake_external_fields =
-            Self::collect_fake_externals(federation_spec_definition, schema)?;
+            Self::collect_fake_externals(federation_spec_definition, schema, &external_fields)?;
         // We do not collect @external on types for Fed 1 schemas since those will be discarded by
         // the schema upgrader. The schema upgrader, through calls to `is_external()`, relies on the
         // populated `fields_on_external_types` set to inform when @shareable should be
@@ -478,6 +478,7 @@ impl ExternalMetadata {
     fn collect_fake_externals(
         federation_spec_definition: &'static FederationSpecDefinition,
         schema: &FederationSchema,
+        external_fields: &IndexSet<FieldDefinitionPosition>,
     ) -> Result<IndexSet<FieldDefinitionPosition>, FederationError> {
         let mut fake_external_fields = IndexSet::default();
         let (Ok(extends_directive_definition), Ok(key_directive_applications)) = (
@@ -503,12 +504,16 @@ impl ExternalMetadata {
                     .extension_id()
                     .is_some()
             {
-                fake_external_fields.extend(collect_target_fields_from_field_set(
-                    unwrap_schema(schema),
-                    key_directive.target.type_name().clone(),
-                    key_directive.arguments.fields,
-                    false,
-                )?);
+                fake_external_fields.extend(
+                    collect_target_fields_from_field_set(
+                        unwrap_schema(schema),
+                        key_directive.target.type_name().clone(),
+                        key_directive.arguments.fields,
+                        false,
+                    )?
+                    .into_iter()
+                    .filter(|field| external_fields.contains(field)),
+                );
             }
         }
         Ok(fake_external_fields)
@@ -719,5 +724,71 @@ mod tests {
             type_name: Name::new_unchecked(type_name),
             field_name: Name::new_unchecked(field_name),
         })
+    }
+
+    /// Regression test: type-level @external fields should NOT be fake-external.
+    ///
+    /// When type T has `@key(fields: "id") @external` and another type S has
+    /// `@key(fields: "t { id }") @extends`, the key field set traversal for S
+    /// reaches T.id. `collect_fake_externals` must filter these to only include
+    /// fields with field-level @external (matching JS `collectTargetFields(...)
+    /// .filter(f => f.hasAppliedDirective(@external))`).
+    #[test]
+    fn type_level_external_field_not_fake_external() {
+        use crate::subgraph::typestate::Subgraph;
+
+        let subgraph = Subgraph::parse(
+            "s1",
+            "http://s1",
+            r#"
+                extend schema
+                  @link(url: "https://specs.apollo.dev/link/v1.0")
+                  @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@external", "@extends", "@requires"])
+
+                directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+                directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+                directive @external on OBJECT | FIELD_DEFINITION
+                directive @extends on OBJECT | INTERFACE
+                directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+                enum link__Purpose { SECURITY EXECUTION }
+                scalar link__Import
+                scalar federation__FieldSet
+
+                type Query {
+                    ss: [S!]!
+                }
+
+                type T @key(fields: "id") @external {
+                    id: ID!
+                }
+
+                type S @key(fields: "t { id }") @extends {
+                    t: T! @external
+                    x: ID @external
+                    y: [String!] @requires(fields: "x")
+                }
+            "#,
+        )
+        .expect("parses schema")
+        .expand_links()
+        .expect("expands schema");
+
+        let meta = subgraph.metadata();
+        let t_id = field("T", "id");
+
+        // T.id should be external (inherited from type-level @external)
+        assert!(
+            meta.is_field_external(&t_id),
+            "T.id should be external (inherited from type-level @external). \
+             collect_fake_externals must filter traversed fields to only include \
+             those with field-level @external."
+        );
+
+        assert!(
+            !meta.external_metadata().is_fake_external(&t_id),
+            "T.id should NOT be fake-external: only the parent type has @external, \
+             not the field itself."
+        );
     }
 }

--- a/apollo-federation/tests/composition/compose_set_context.rs
+++ b/apollo-federation/tests/composition/compose_set_context.rs
@@ -1487,34 +1487,18 @@ fn from_context_field_in_all_subgraphs_preserves_join_field() {
     .unwrap();
 
     let supergraph = compose(vec![s1, s2]).expect("composition should succeed");
-    let sdl = supergraph.schema().schema().to_string();
+    insta::assert_snapshot!(supergraph.schema().schema().to_string());
 
-    // U.f must have @join__field with contextArguments for s1.
-    // The bug caused needs_join_field to return false, dropping all @join__field.
-    let u_section: String = sdl
-        .lines()
-        .skip_while(|line| !line.starts_with("type U "))
-        .take_while(|line| !line.starts_with('}'))
-        .chain(std::iter::once("}"))
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    // The f field must have @join__field (not be bare)
-    let f_line = sdl
-        .lines()
-        .find(|line| line.trim_start().starts_with("f") && u_section.contains(line.trim()));
-
-    assert!(
-        f_line.is_some_and(|l| l.contains("@join__field")),
-        "U.f should have @join__field directives (including contextArguments for s1) \
-         but the composed supergraph U section is:\n{}",
-        u_section
-    );
-
-    assert!(
-        f_line.is_some_and(|l| l.contains("contextArguments")),
-        "U.f should have @join__field with contextArguments for s1 \
-         but the composed supergraph U section is:\n{}",
-        u_section
-    );
+    let type_u = supergraph
+        .schema()
+        .schema()
+        .types
+        .get("U")
+        .expect("U exists in the schema");
+    insta::assert_snapshot!(type_u.to_string(), @r#"
+    type U @join__type(graph: S1, key: "id") @join__type(graph: S2, key: "id") {
+      id: ID!
+      f: Int! @join__field(graph: S1, contextArguments: [{context: "s1__ctx", name: "a", type: "String", selection: "{ prop }"}]) @join__field(graph: S2)
+    }
+    "#);
 }

--- a/apollo-federation/tests/composition/external.rs
+++ b/apollo-federation/tests/composition/external.rs
@@ -7,8 +7,9 @@ use super::compose_as_fed2_subgraphs;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use apollo_federation::subgraph::typestate::Subgraph;
+
+    use super::*;
 
     #[test]
     fn errors_on_incompatible_types_with_external() {

--- a/apollo-federation/tests/composition/external.rs
+++ b/apollo-federation/tests/composition/external.rs
@@ -288,29 +288,6 @@ mod tests {
         .unwrap();
 
         let supergraph = compose(vec![s1, s2, s3]).expect("composition should succeed");
-        let sdl = supergraph.schema().schema().to_string();
-
-        // Extract the T type section from the supergraph SDL
-        let t_section: String = sdl
-            .lines()
-            .skip_while(|line| !line.starts_with("type T "))
-            .take_while(|line| !line.starts_with('}'))
-            .chain(std::iter::once("}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        assert!(
-            t_section.contains("@join__field") && t_section.contains("id: ID!"),
-            "T.id should have @join__field directives (including external: true for s3) \
-             but the composed supergraph T section is:\n{}",
-            t_section
-        );
-
-        assert!(
-            t_section.contains("external: true"),
-            "T.id should have @join__field(graph: S3, external: true) \
-             but the composed supergraph T section is:\n{}",
-            t_section
-        );
+        assert_snapshot!(supergraph.schema().schema().to_string());
     }
 }

--- a/apollo-federation/tests/composition/external.rs
+++ b/apollo-federation/tests/composition/external.rs
@@ -2,11 +2,13 @@ use insta::assert_snapshot;
 
 use super::ServiceDefinition;
 use super::assert_composition_errors;
+use super::compose;
 use super::compose_as_fed2_subgraphs;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use apollo_federation::subgraph::typestate::Subgraph;
 
     #[test]
     fn errors_on_incompatible_types_with_external() {
@@ -183,5 +185,131 @@ mod tests {
           d: Int
         }
         "###);
+    }
+
+    /// Regression test: when a Fed v2 subgraph uses type-level @external
+    /// (e.g., `type T @key(fields: "id") @external { id: ID! }`), the composed
+    /// supergraph must emit `@join__field(graph: ..., external: true)` for the
+    /// key field — not drop all @join__field directives.
+    #[test]
+    fn type_level_external_preserves_join_field_with_external_arg() {
+        // s1: owns T, provides field a
+        let s1 = Subgraph::parse(
+            "s1",
+            "http://s1",
+            r#"
+                extend schema
+                  @link(url: "https://specs.apollo.dev/link/v1.0")
+                  @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@external", "@requires"])
+
+                directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+                directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+                directive @external on OBJECT | FIELD_DEFINITION
+                directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+                enum link__Purpose { SECURITY EXECUTION }
+                scalar link__Import
+                scalar federation__FieldSet
+
+                type Query {
+                    ts: [T!]!
+                }
+
+                type T @key(fields: "id") {
+                    id: ID!
+                    a: String!
+                }
+
+                type S @key(fields: "t { id }") {
+                    t: T!
+                    x: ID
+                }
+            "#,
+        )
+        .unwrap();
+
+        // s2: also owns T, provides field b
+        let s2 = Subgraph::parse(
+            "s2",
+            "http://s2",
+            r#"
+                extend schema
+                  @link(url: "https://specs.apollo.dev/link/v1.0")
+                  @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@external"])
+
+                directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+                directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+                directive @external on OBJECT | FIELD_DEFINITION
+
+                enum link__Purpose { SECURITY EXECUTION }
+                scalar link__Import
+                scalar federation__FieldSet
+
+                type T @key(fields: "id") {
+                    id: ID!
+                    b: String!
+                }
+            "#,
+        )
+        .unwrap();
+
+        // s3: references T as an external stub (type-level @external).
+        // Extends S from s1 and uses @requires on x.
+        let s3 = Subgraph::parse(
+            "s3",
+            "http://s3",
+            r#"
+                extend schema
+                  @link(url: "https://specs.apollo.dev/link/v1.0")
+                  @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@external", "@extends", "@requires"])
+
+                directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+                directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+                directive @external on OBJECT | FIELD_DEFINITION
+                directive @extends on OBJECT | INTERFACE
+                directive @requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+                enum link__Purpose { SECURITY EXECUTION }
+                scalar link__Import
+                scalar federation__FieldSet
+
+                type T @key(fields: "id") @external {
+                    id: ID!
+                }
+
+                type S @key(fields: "t { id }") @extends {
+                    t: T! @external
+                    x: ID @external
+                    y: [String!] @requires(fields: "x")
+                }
+            "#,
+        )
+        .unwrap();
+
+        let supergraph = compose(vec![s1, s2, s3]).expect("composition should succeed");
+        let sdl = supergraph.schema().schema().to_string();
+
+        // Extract the T type section from the supergraph SDL
+        let t_section: String = sdl
+            .lines()
+            .skip_while(|line| !line.starts_with("type T "))
+            .take_while(|line| !line.starts_with('}'))
+            .chain(std::iter::once("}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            t_section.contains("@join__field") && t_section.contains("id: ID!"),
+            "T.id should have @join__field directives (including external: true for s3) \
+             but the composed supergraph T section is:\n{}",
+            t_section
+        );
+
+        assert!(
+            t_section.contains("external: true"),
+            "T.id should have @join__field(graph: S3, external: true) \
+             but the composed supergraph T section is:\n{}",
+            t_section
+        );
     }
 }

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_set_context__from_context_field_in_all_subgraphs_preserves_join_field.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_set_context__from_context_field_in_all_subgraphs_preserves_join_field.snap
@@ -1,0 +1,75 @@
+---
+source: apollo-federation/tests/composition/compose_set_context.rs
+expression: supergraph.schema().schema().to_string()
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/context/v0.1", for: SECURITY) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  S1 @join__graph(name: "s1", url: "http://s1")
+  S2 @join__graph(name: "s2", url: "http://s2")
+}
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar context__ContextFieldValue
+
+type Query @join__type(graph: S1) @join__type(graph: S2) {
+  t: T! @join__field(graph: S1)
+}
+
+type T @join__type(graph: S1, key: "id") @context(name: "s1__ctx") {
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+type U @join__type(graph: S1, key: "id") @join__type(graph: S2, key: "id") {
+  id: ID!
+  f: Int! @join__field(graph: S1, contextArguments: [{context: "s1__ctx", name: "a", type: "String", selection: "{ prop }"}]) @join__field(graph: S2)
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__external__tests__type_level_external_preserves_join_field_with_external_arg.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__external__tests__type_level_external_preserves_join_field_with_external_arg.snap
@@ -1,0 +1,58 @@
+---
+source: apollo-federation/tests/composition/external.rs
+expression: supergraph.schema().schema().to_string()
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  S1 @join__graph(name: "s1", url: "http://s1")
+  S2 @join__graph(name: "s2", url: "http://s2")
+  S3 @join__graph(name: "s3", url: "http://s3")
+}
+
+scalar join__FieldSet
+
+type Query @join__type(graph: S1) @join__type(graph: S2) @join__type(graph: S3) {
+  ts: [T!]! @join__field(graph: S1)
+}
+
+type T @join__type(graph: S1, key: "id") @join__type(graph: S2, key: "id") @join__type(graph: S3, key: "id") {
+  id: ID! @join__field(graph: S1) @join__field(graph: S2) @join__field(graph: S3, external: true)
+  a: String! @join__field(graph: S1)
+  b: String! @join__field(graph: S2)
+}
+
+type S @join__type(graph: S1, key: "t { id }") @join__type(graph: S3, key: "t { id }", extension: true) {
+  t: T!
+  x: ID @join__field(graph: S1) @join__field(graph: S3, external: true)
+  y: [String!] @join__field(graph: S3, requires: "x")
+}


### PR DESCRIPTION
`collect_fake_externals` traverses compound `@key` field sets (e.g., `@key(fields: "t { id }")`) and adds all reached fields to `fake_external_fields`. When a type stub uses type-level `@external` (e.g., `type T @key(fields: "id") @external { id: ID! }`), the traversal reaches `T.id` and incorrectly marks it as fake-external. This cancels out `fields_on_external_types` in `is_external()`, causing `needs_join_field()` to return false and drop all `@join__field` directives — including `external: true` — from the supergraph.

The JS implementation filters the traversal result:

    collectTargetFields({...})
      .filter((field) => field.hasAppliedDirective(this.externalDirective))
      .forEach((field) => this.fakeExternalFields.add(field.coordinate));

    // federation/internals-js/src/federation.ts — collectFakeExternals, line 2709
    // https://github.com/apollographql/federation/blob/main/internals-js/src/federation.ts#L2709

The Rust `collect_fake_externals` was missing this filter — it added all fields from `collect_target_fields_from_field_set` unconditionally.

The fix adds `.filter(|field| external_fields.contains(field))` to only include fields that have field-level `@external` applied directly, matching the JS behavior.