### PR TITLE
fix(federation): fix @fromContext positions for join__field

### DIFF
--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -301,6 +301,15 @@ impl Merger {
         linked_federation_version
     }
 
+    /// Collect fields that have arguments with `@fromContext`.
+    ///
+    /// `@fromContext` is applied to field **arguments**, so `DirectiveReferencers`
+    /// puts them in `object_field_arguments` / `interface_field_arguments`. But
+    /// `needs_join_field` checks `object_fields` / `interface_fields`. We map
+    /// argument positions to their parent field positions to match the JS behavior:
+    ///
+    ///     // composition-js/src/merging/merge.ts — getFieldsWithFromContextDirective
+    ///     const field = application.parent.parent; // argument → field
     fn get_fields_with_from_context_directive(
         subgraphs: &[Subgraph<Validated>],
     ) -> DirectiveReferencers {
@@ -313,7 +322,14 @@ impl Merger {
                         .referencers()
                         .get_directive(&directive_name);
                     if !referencers.is_empty() {
-                        acc.extend(referencers);
+                        // Map argument positions to their parent field positions,
+                        // since needs_join_field checks object_fields/interface_fields.
+                        for arg_pos in &referencers.object_field_arguments {
+                            acc.object_fields.insert(arg_pos.parent());
+                        }
+                        for arg_pos in &referencers.interface_field_arguments {
+                            acc.interface_fields.insert(arg_pos.parent());
+                        }
                     }
                 }
                 acc

--- a/apollo-federation/tests/composition/compose_set_context.rs
+++ b/apollo-federation/tests/composition/compose_set_context.rs
@@ -1,6 +1,7 @@
 use test_log::test;
 
 use super::ServiceDefinition;
+use super::compose;
 use super::compose_as_fed2_subgraphs;
 
 #[test]
@@ -1404,5 +1405,116 @@ fn nullability_mismatch_is_not_ok_if_argument_is_non_nullable() {
         "[Subgraph1] Context \"context\" is used in \"U.field(a:)\" but the selection is invalid: the type of the selection \"String\" does not match the expected type \"String!\"",
         "Expected error message about type mismatch, but got: {}",
         error_message
+    );
+}
+
+/// Regression test: when a field has `@fromContext` on an argument and the
+/// same field exists in multiple subgraphs with the same type, `needs_join_field`
+/// must still return true so `@join__field` (with `contextArguments`) is emitted.
+///
+/// The bug: `@fromContext` is applied to field **arguments**, so `DirectiveReferencers`
+/// stores them in `object_field_arguments`. But `needs_join_field` checked
+/// `object_fields` — the wrong set. JS avoids this by navigating `.parent.parent`
+/// (argument → field) when collecting `fieldsWithFromContext`.
+///
+///     // composition-js/src/merging/merge.ts — getFieldsWithFromContextDirective
+///     const field = application.parent.parent; // argument → field
+#[test]
+fn from_context_field_in_all_subgraphs_preserves_join_field() {
+    use apollo_federation::subgraph::typestate::Subgraph;
+
+    // s1: owns T with @context, U.f has @fromContext on its argument
+    let s1 = Subgraph::parse(
+        "s1",
+        "http://s1",
+        r#"
+            extend schema
+              @link(url: "https://specs.apollo.dev/link/v1.0")
+              @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key", "@shareable", "@context", "@fromContext"])
+
+            directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+            directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+            directive @shareable on OBJECT | FIELD_DEFINITION
+            directive @context(name: String!) repeatable on OBJECT | INTERFACE | UNION
+            directive @fromContext(field: federation__ContextFieldValue) on ARGUMENT_DEFINITION
+
+            enum link__Purpose { SECURITY EXECUTION }
+            scalar link__Import
+            scalar federation__FieldSet
+            scalar federation__ContextFieldValue
+
+            type Query {
+                t: T!
+            }
+
+            type T @key(fields: "id") @context(name: "ctx") {
+                id: ID!
+                u: U!
+                prop: String!
+            }
+
+            type U @key(fields: "id") {
+                id: ID!
+                f(a: String @fromContext(field: "$ctx { prop }")): Int! @shareable
+            }
+        "#,
+    )
+    .unwrap();
+
+    // s2: also has U.f with same type but no @fromContext
+    let s2 = Subgraph::parse(
+        "s2",
+        "http://s2",
+        r#"
+            extend schema
+              @link(url: "https://specs.apollo.dev/link/v1.0")
+              @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key", "@shareable"])
+
+            directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+            directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+            directive @shareable on OBJECT | FIELD_DEFINITION
+
+            enum link__Purpose { SECURITY EXECUTION }
+            scalar link__Import
+            scalar federation__FieldSet
+
+            type U @key(fields: "id") {
+                id: ID!
+                f: Int! @shareable
+            }
+        "#,
+    )
+    .unwrap();
+
+    let supergraph = compose(vec![s1, s2]).expect("composition should succeed");
+    let sdl = supergraph.schema().schema().to_string();
+
+    // U.f must have @join__field with contextArguments for s1.
+    // The bug caused needs_join_field to return false, dropping all @join__field.
+    let u_section: String = sdl
+        .lines()
+        .skip_while(|line| !line.starts_with("type U "))
+        .take_while(|line| !line.starts_with('}'))
+        .chain(std::iter::once("}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // The f field must have @join__field (not be bare)
+    let f_line = sdl
+        .lines()
+        .find(|line| line.trim_start().starts_with("f") && u_section.contains(line.trim()));
+
+    assert!(
+        f_line.is_some_and(|l| l.contains("@join__field")),
+        "U.f should have @join__field directives (including contextArguments for s1) \
+         but the composed supergraph U section is:\n{}",
+        u_section
+    );
+
+    assert!(
+        f_line.is_some_and(|l| l.contains("contextArguments")),
+        "U.f should have @join__field with contextArguments for s1 \
+         but the composed supergraph U section is:\n{}",
+        u_section
     );
 }


### PR DESCRIPTION
`@fromContext` is applied to field **arguments**, so `DirectiveReferencers` stores them in `object_field_arguments` / `interface_field_arguments`. However, `needs_join_field` checks `object_fields` / `interface_fields`, causing it to miss fields that need `@join__field` with `contextArguments`.

When a field with `@fromContext` exists in all subgraphs with the same return type and no other special directives, `needs_join_field` incorrectly returned false, dropping the `@join__field` directive entirely—including the `contextArguments` data needed at runtime.

The fix maps argument positions to their parent field positions in `get_fields_with_from_context_directive`, matching the JS implementation:

    // composition-js/src/merging/merge.ts:4037 — getFieldsWithFromContextDirective
    const field = application.parent.parent; // argument → field

https://github.com/apollographql/federation/blob/main/composition-js/src/merging/merge.ts#L4033-L4042
