### PR TITLE
fix(composition): interface cannot be a subtype of a union

### DIFF
--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -2221,10 +2221,6 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
             (ExtendedType::Object(_), ExtendedType::Union(union_type)) => {
                 Ok(union_type.members.contains(potential_subtype))
             }
-            // Interface that is a member of a union (if supported)
-            (ExtendedType::Interface(_), ExtendedType::Union(union_type)) => {
-                Ok(union_type.members.contains(potential_subtype))
-            }
             _ => Ok(false),
         }
     }


### PR DESCRIPTION
Union can only reference objects. While it is possible for a subgraph to define an `@interfaceObject` in the schema, in the merged supergraph it would still be represented as interface in the supergraph. `union_type.members` will never contain the target `interface` so the check would never succeed. `apollo-compiler` also correctly validates this so we wouldn't generate invalid schema.

This PR just cleans this incorrect logic but this should have no effect on the merged supergraph (this check would always fail).

Allowing unions to include interfaces/other unions is an old issue (https://github.com/graphql/graphql-spec/issues/711).