### PR TITLE
fix(composition): remove invalid executable directive from supergraph 

### DIFF
--- a/apollo-federation/src/merger/merge_directive.rs
+++ b/apollo-federation/src/merger/merge_directive.rs
@@ -546,6 +546,7 @@ impl Merger {
                     self.subgraphs[*idx].name, locations
                 );
                 if locations.is_empty() {
+                    dest.remove(&mut self.merged)?;
                     self.error_reporter.report_mismatch_hint(
                         HintCode::NoExecutableDirectiveLocationsIntersection,
                         format!("Executable directive \"@{name}\" has no location that is common to all subgraphs: "),
@@ -560,6 +561,7 @@ impl Merger {
                         false,
                         false,
                     );
+                    return Ok(());
                 }
             }
         }

--- a/apollo-federation/tests/composition/hints.rs
+++ b/apollo-federation/tests/composition/hints.rs
@@ -662,6 +662,15 @@ mod executable_directives {
             "NO_EXECUTABLE_DIRECTIVE_LOCATIONS_INTERSECTION",
             r#"Executable directive "@t" has no location that is common to all subgraphs: it will not appear in the supergraph as there no intersection between location "QUERY" in subgraph "Subgraph1" and location "FIELD" in subgraph "Subgraph2"."#,
         );
+
+        assert!(
+            !composition_result
+                .schema()
+                .schema()
+                .directive_definitions
+                .contains_key("t"),
+            "Directive @t should be removed from the supergraph when locations have no intersection"
+        );
     }
 
     #[test]


### PR DESCRIPTION
When an executable directive has no locations common to all subgraphs, the JS composition removes it from the supergraph and returns early. The Rust implementation reported the hint but left the directive in the supergraph with zero locations and continued merging its properties.

This adds `dest.remove()` and an early return to match the JS behavior, preventing an invalid directive definition with empty locations from appearing in the supergraph.

JS reference: `mergeExecutableDirectiveDefinition` in `merge.ts` https://github.com/apollographql/federation/blob/d4969572/composition-js/src/merging/merge.ts#L2948-L2962
