### PR TITLE
feat(metrics): track experimental features usage (backport #9330)

### DIFF
--- a/.changesets/maint_aaron_instrument_experimental_config_features.md
+++ b/.changesets/maint_aaron_instrument_experimental_config_features.md
@@ -1,0 +1,7 @@
+### Instrument experimental config features with OTLP gauges ([PR #9330](https://github.com/apollographql/router/pull/9330))
+
+Adds `apollo.router.config.experimental_*` OTLP gauge metrics for all customer-facing experimental config flags, using the existing `populate_config_instrument!` pattern in `configuration/metrics.rs`. This enables usage tracking in the data warehouse so that adoption data can inform decisions about which experimental features to promote or remove in future releases.
+
+The following features are now instrumented: `experimental_chaos`, `experimental_type_conditioned_fetching`, `experimental_hoist_orphan_errors`, `experimental_log_on_broken_pipe`, `experimental_plans_limit`, `experimental_paths_limit`, `experimental_reuse_query_plans`, `experimental_cooperative_cancellation`, `experimental_prewarm_query_plan_cache`, `experimental_local_field_metrics`, `experimental_response_trace_id`, `experimental_otlp_endpoint`, `experimental_otlp_tracing_protocol`, `experimental_otlp_metrics_protocol`, `experimental_http2`, `experimental_http2_keep_alive_interval`, `experimental_http2_keep_alive_timeout`, `experimental_mock_subgraphs`, and `experimental.expose_query_plan` (recorded as `apollo.router.config.experimental_expose_query_plan`). The mandatory `experimental_diagnostics` plugin is intentionally excluded because it is loaded on every router and would always report adoption as 100%.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9330

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -468,6 +468,101 @@ impl InstrumentData {
             "$[?(@.subgraphs..sources..max_requests_per_operation)]"
         );
 
+        populate_config_instrument!(
+            apollo.router.config.experimental_chaos,
+            "$.experimental_chaos[?(@.force_schema_reload || @.force_config_reload)]"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_type_conditioned_fetching,
+            "$.experimental_type_conditioned_fetching[?(@==true)]"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_hoist_orphan_errors,
+            "$.experimental_hoist_orphan_errors[?(@.all.enabled==true || @.subgraphs..enabled==true)]"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_log_on_broken_pipe,
+            "$.supergraph.experimental_log_on_broken_pipe[?(@==true)]"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_plans_limit,
+            "$.supergraph.query_planning.experimental_plans_limit"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_paths_limit,
+            "$.supergraph.query_planning.experimental_paths_limit"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_reuse_query_plans,
+            "$.supergraph.query_planning.experimental_reuse_query_plans[?(@==true)]"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_cooperative_cancellation,
+            "$.supergraph.query_planning.experimental_cooperative_cancellation"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_prewarm_query_plan_cache,
+            "$.persisted_queries.experimental_prewarm_query_plan_cache[?(@.on_startup==true)]"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_local_field_metrics,
+            "$.telemetry.apollo.experimental_local_field_metrics[?(@==true)]"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_response_trace_id,
+            "$.telemetry.exporters.tracing.experimental_response_trace_id[?(@.enabled==true)]"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_otlp_endpoint,
+            "$.telemetry.apollo.experimental_otlp_endpoint"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_http2,
+            "$.traffic_shaping[?(@.all.experimental_http2 == 'enable' || @.all.experimental_http2 == 'http2only' || @.subgraphs..experimental_http2 == 'enable' || @.subgraphs..experimental_http2 == 'http2only')]"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_http2_keep_alive_interval,
+            "$..experimental_http2_keep_alive_interval"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_http2_keep_alive_timeout,
+            "$..experimental_http2_keep_alive_timeout"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_otlp_tracing_protocol,
+            "$.telemetry.apollo.experimental_otlp_tracing_protocol"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_otlp_metrics_protocol,
+            "$.telemetry.apollo.experimental_otlp_metrics_protocol"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_mock_subgraphs,
+            "$.experimental_mock_subgraphs"
+        );
+
+        populate_config_instrument!(
+            apollo.router.config.experimental_expose_query_plan,
+            "$.plugins[?(@['experimental.expose_query_plan']==true)]"
+        );
+
         // We need to update the entry we just made because the selected strategy is a named object in the config.
         // The jsonpath spec doesn't include a utility for getting the keys out of an object, so we do it manually.
         if let Some((_, demand_control_attributes)) =

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@apollo_telemetry.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@apollo_telemetry.router.yaml.snap
@@ -21,3 +21,8 @@ expression: "& metrics.non_zero()"
           opt.tracing.batch_processor.max_export_timeout: 30s
           opt.tracing.batch_processor.max_queue_size: 2048
           opt.tracing.batch_processor.scheduled_delay: 5s
+- name: apollo.router.config.experimental_local_field_metrics
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@experimental_features.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@experimental_features.router.yaml.snap
@@ -1,0 +1,139 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+assertion_line: 698
+expression: "& metrics.non_zero()"
+---
+- name: apollo.router.config.apollo_telemetry_options
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.errors.preview_extended_error_metrics: false
+          opt.field_level_instrumentation_sampler: false
+          opt.metrics.otlp.batch_processor.max_export_timeout: false
+          opt.metrics.otlp.batch_processor.scheduled_delay: false
+          opt.metrics.usage_reports.batch_processor.max_concurrent_exports: false
+          opt.metrics.usage_reports.batch_processor.max_export_timeout: false
+          opt.metrics.usage_reports.batch_processor.scheduled_delay: false
+          opt.metrics_reference_mode: false
+          opt.signature_normalization_algorithm: false
+          opt.tracing.batch_processor.max_concurrent_exports: false
+          opt.tracing.batch_processor.max_export_batch_size: false
+          opt.tracing.batch_processor.max_export_timeout: false
+          opt.tracing.batch_processor.max_queue_size: false
+          opt.tracing.batch_processor.scheduled_delay: false
+- name: apollo.router.config.experimental_chaos
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_cooperative_cancellation
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_expose_query_plan
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_hoist_orphan_errors
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_http2
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_http2_keep_alive_interval
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_http2_keep_alive_timeout
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_local_field_metrics
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_log_on_broken_pipe
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_mock_subgraphs
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_otlp_endpoint
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_otlp_metrics_protocol
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_otlp_tracing_protocol
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_paths_limit
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_plans_limit
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_prewarm_query_plan_cache
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_response_trace_id
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_reuse_query_plans
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.experimental_type_conditioned_fetching
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
+- name: apollo.router.config.persisted_queries
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.log_unknown: false
+          opt.safelist.enabled: false
+          opt.safelist.require_id: false
+- name: apollo.router.config.traffic_shaping
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.router.rate_limit: false
+          opt.router.timeout: false
+          opt.subgraph.compression: false
+          opt.subgraph.deduplicate_query: false
+          opt.subgraph.http2: true
+          opt.subgraph.rate_limit: false
+          opt.subgraph.timeout: false

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@traffic_shaping.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@traffic_shaping.router.yaml.snap
@@ -1,7 +1,13 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
+assertion_line: 698
 expression: "& metrics.non_zero()"
 ---
+- name: apollo.router.config.experimental_http2
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
 - name: apollo.router.config.traffic_shaping
   data:
     datapoints:

--- a/apollo-router/src/configuration/testdata/metrics/experimental_features.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/experimental_features.router.yaml
@@ -1,0 +1,47 @@
+experimental_type_conditioned_fetching: true
+
+experimental_hoist_orphan_errors:
+  all:
+    enabled: true
+
+experimental_chaos:
+  force_schema_reload: 10s
+
+experimental_mock_subgraphs:
+  test_subgraph:
+    query:
+      hello: "world"
+
+traffic_shaping:
+  all:
+    experimental_http2: enable
+    experimental_http2_keep_alive_interval: 30s
+    experimental_http2_keep_alive_timeout: 20s
+
+supergraph:
+  experimental_log_on_broken_pipe: true
+  query_planning:
+    experimental_plans_limit: 10
+    experimental_paths_limit: 10
+    experimental_reuse_query_plans: true
+    experimental_cooperative_cancellation:
+      enabled: true
+
+persisted_queries:
+  enabled: true
+  experimental_prewarm_query_plan_cache:
+    on_startup: true
+
+telemetry:
+  apollo:
+    experimental_local_field_metrics: true
+    experimental_otlp_endpoint: "https://custom.example.com/otlp"
+    experimental_otlp_tracing_protocol: grpc
+    experimental_otlp_metrics_protocol: http
+  exporters:
+    tracing:
+      experimental_response_trace_id:
+        enabled: true
+
+plugins:
+  experimental.expose_query_plan: true


### PR DESCRIPTION



## Summary

- Adds `apollo.router.config.experimental_*` OTLP gauge metrics for all 12 customer-facing experimental config flags
- These flow through the existing telemetry pipeline into the data warehouse, enabling usage tracking via Omni
- Follows the existing `populate_config_instrument!` pattern in `configuration/metrics.rs`

Features instrumented: `experimental_chaos`, `experimental_type_conditioned_fetching`, `experimental_hoist_orphan_errors`, `experimental_log_on_broken_pipe`, `experimental_plans_limit`, `experimental_paths_limit`, `experimental_reuse_query_plans`, `experimental_cooperative_cancellation`, `experimental_prewarm_query_plan_cache`, `experimental_local_field_metrics`, `experimental_response_trace_id`, `experimental_otlp_endpoint`

Note: `experimental_http2` is already tracked as `opt.subgraph.http2` inside the existing `apollo.router.config.traffic_shaping` instrument.

## Context

This is Phase 1 of a plan to gather usage data on experimental features to inform decisions about what to remove vs. promote in the next major version. A companion dbt PR (in `mdg-private/data/dbt`) is needed to surface these new metric names as columns in `mart_studio__graph_ref_activity_daily`.

## Test plan

- [ ] `cargo test -p apollo-router --lib configuration::metrics::test::test_metrics` passes
- [ ] New snapshot `experimental_features.router.yaml.snap` shows all 12 instruments firing with `value: 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)<hr>This is an automatic backport of pull request #9330 done by [Mergify](https://mergify.com).

<!-- jira: GRAPHOS-271 -->