### PR TITLE
fix(composition): fix `@interfaceObject` type kind mismatch

### DIFF
--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -474,6 +474,18 @@ impl Merger {
         self.add_types_shallow()?;
         self.add_directives_shallow()?;
 
+        // Type kind mismatches (e.g. Object vs Interface) leave the merged schema in an
+        // inconsistent state that causes later stages to fail with internal errors. Bail
+        // early so the user sees the real TYPE_KIND_MISMATCH errors instead.
+        if self.error_reporter.has_errors() {
+            let (errors, hints) = self.error_reporter.into_errors_and_hints();
+            return Ok(MergeResult {
+                supergraph: None,
+                errors,
+                hints,
+            });
+        }
+
         let object_types = self.get_merged_object_type_names();
         let interface_types = self.get_merged_interface_type_names();
         let union_types = self.get_merged_union_type_names();
@@ -702,11 +714,11 @@ impl Merger {
     }
 
     fn add_types_shallow(&mut self) -> Result<(), FederationError> {
-        let mut mismatched_types = IndexSet::new();
-        // A mapping of Ty -> [SubgraphA, SubgraphB] where Ty is a interface object in those
-        // subgraphs
-        let mut subgraphs_with_interface_obj =
-            MultiIndexMap::<TypeDefinitionPosition, String>::new();
+        let mut mismatched_types: IndexSet<Name> = IndexSet::new();
+        // A mapping of type name -> [SubgraphA, SubgraphB] where the type uses @interfaceObject
+        // in those subgraphs. Keyed by Name (not TypeDefinitionPosition) to match JS behavior
+        // where lookups use plain type name strings regardless of kind.
+        let mut subgraphs_with_interface_obj = MultiIndexMap::<Name, String>::new();
 
         for subgraph in &self.subgraphs {
             for pos in subgraph.schema().get_types() {
@@ -717,19 +729,17 @@ impl Merger {
                 let mut expects_interface = false;
                 if subgraph.is_interface_object_type(&pos) {
                     expects_interface = true;
-                    let itf_pos = InterfaceTypeDefinitionPosition {
-                        type_name: pos.type_name().clone(),
-                    };
-                    subgraphs_with_interface_obj.insert(itf_pos.into(), subgraph.name.clone());
+                    subgraphs_with_interface_obj
+                        .insert(pos.type_name().clone(), subgraph.name.clone());
                 }
                 if let Ok(previous) = self.merged.get_type(pos.type_name().clone()) {
                     if expects_interface
                         && !matches!(previous, TypeDefinitionPosition::Interface(_))
                     {
-                        mismatched_types.insert(previous.clone());
+                        mismatched_types.insert(pos.type_name().clone());
                     }
                     if !expects_interface && previous != pos {
-                        mismatched_types.insert(previous.clone());
+                        mismatched_types.insert(pos.type_name().clone());
                     }
                 } else if expects_interface {
                     let itf_pos = InterfaceTypeDefinitionPosition {
@@ -744,26 +754,28 @@ impl Merger {
             }
         }
 
-        for mismatched_type in mismatched_types.iter() {
+        for type_name in mismatched_types.iter() {
             let subgraphs = subgraphs_with_interface_obj
-                .get(mismatched_type)
+                .get(type_name)
                 .cloned()
                 .unwrap_or_default();
-            self.report_mismatched_type_definitions(mismatched_type, &subgraphs);
+            if let Ok(mismatched_type) = self.merged.get_type(type_name.clone()) {
+                self.report_mismatched_type_definitions(&mismatched_type, &subgraphs);
+            }
         }
 
         // Most invalid use of @interfaceObject are reported as a mismatch above, but one exception is the
         // case where a type is used only with @interfaceObject, but there is no corresponding interface
         // definition in any subgraph.
-        for type_ in subgraphs_with_interface_obj.keys() {
-            if mismatched_types.contains(type_) {
+        for type_name in subgraphs_with_interface_obj.keys() {
+            if mismatched_types.contains(type_name) {
                 continue;
             }
 
             let mut found_interface = false;
             let mut subgraphs_with_type = IndexSet::new();
             for subgraph in &self.subgraphs {
-                let type_in_subgraph = subgraph.schema().get_type(type_.type_name().clone());
+                let type_in_subgraph = subgraph.schema().get_type(type_name.clone());
                 if matches!(type_in_subgraph, Ok(TypeDefinitionPosition::Interface(_))) {
                     found_interface = true;
                     break;
@@ -780,7 +792,7 @@ impl Merger {
             if !found_interface {
                 self.error_reporter.add_error(CompositionError::InterfaceObjectUsageError {message: format!(
                     "Type \"{}\" is declared with @interfaceObject in all the subgraphs in which it is defined (it is defined in {} but should be defined as an interface in at least one subgraph)",
-                    type_.type_name(),
+                    type_name,
                     human_readable_subgraph_names(subgraphs_with_type.iter())
                 ) });
             }

--- a/apollo-federation/tests/composition/compose_interface_object.rs
+++ b/apollo-federation/tests/composition/compose_interface_object.rs
@@ -937,3 +937,56 @@ fn interface_object_partial_overlap_needs_join_field() {
          but has {partial_join_count}"
     );
 }
+
+#[test]
+fn interface_object_type_kind_mismatch_labels_correctly_when_object_processed_first() {
+    // Regression test for a bug where `mismatched_types` and `subgraphs_with_interface_obj`
+    // used TypeDefinitionPosition (kind-carrying enum) as keys. When a plain object subgraph
+    // was processed before an @interfaceObject subgraph, the merged schema stored Object("I")
+    // but the @interfaceObject map was keyed by Interface("I"), causing lookup failures.
+    // This produced: (1) wrong labels in TYPE_KIND_MISMATCH (both subgraphs shown as
+    // "Object Type"), and (2) a spurious INTERFACE_OBJECT_USAGE_ERROR because the
+    // mismatch-suppression check also failed.
+
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          iFromA: I
+        }
+
+        type I @key(fields: "id") {
+          id: ID!
+          x: Int
+        }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+        type Query {
+          iFromB: I
+        }
+
+        type I @interfaceObject @key(fields: "id") {
+          id: ID!
+          y: Int
+        }
+        "#,
+    };
+
+    // Compose with the plain object subgraph processed first (alphabetical ordering).
+    // Before the fix, this produced:
+    // 1. TYPE_KIND_MISMATCH with wrong label (both shown as "Object Type")
+    // 2. Spurious INTERFACE_OBJECT_USAGE_ERROR
+    // After the fix, only TYPE_KIND_MISMATCH with correct labeling is produced.
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+    assert_composition_errors(
+        &result,
+        &[(
+            "TYPE_KIND_MISMATCH",
+            r#"Type "I" has mismatched kind: it is defined as Object Type in subgraph "subgraphA" but Interface Object Type (Object Type with @interfaceObject) in subgraph "subgraphB""#,
+        )],
+    );
+}


### PR DESCRIPTION
`add_types_shallow` used `TypeDefinitionPosition` (a kind-carrying enum) as keys in `mismatched_types` and `subgraphs_with_interface_obj`. When a non-`@interfaceObject` subgraph was processed first, the merged schema stored `Object("Foo")` but the `@interfaceObject` map was keyed by `Interface("Foo")`, causing two lookup failures:

1. `.get()` for label lookup failed — `@interfaceObject` subgraphs were mislabeled as plain "Object Type" in `TYPE_KIND_MISMATCH` errors
2. `.contains()` for error suppression failed — a spurious `INTERFACE_OBJECT_USAGE_ERROR` was emitted

Fix: change both `mismatched_types` and `subgraphs_with_interface_obj` to use `Name` (plain type name) as keys, matching JS which uses `Set<string>` for both `mismatchedTypes` (L839) and `typesWithInterfaceObject` (L840):
https://github.com/apollographql/federation/blob/main/composition-js/src/merging/merge.ts#L838-L863

Also add early bail after `add_types_shallow` when errors exist, since type kind mismatches leave the merged schema in an inconsistent state that causes later stages to fail with internal errors that swallow the real `TYPE_KIND_MISMATCH` errors. JS avoids this by filtering mismatched types in `subgraphsTypes()` (L954-L957):
https://github.com/apollographql/federation/blob/main/composition-js/src/merging/merge.ts#L944-L961

JS `reportMismatchedTypeDefinitions` checks `isInterfaceObjectType()` directly on each source type (L929) rather than relying on a separate map lookup:
https://github.com/apollographql/federation/blob/main/composition-js/src/merging/merge.ts#L925-L942
