### PR TITLE
fix(composition): Add early return in `hint_on_inconsistent_output_enum_value`

### DIFF
--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -281,6 +281,7 @@ impl Merger {
                     false,
                     false,
                 );
+                return;
             }
         }
     }

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -257,32 +257,32 @@ impl Merger {
         dest_name: &Name,
         value_name: &Name,
     ) {
-        // As soon as we find a subgraph that has the type but not the member, we hint.
-        for enum_type in sources.values().flatten() {
-            if !enum_type.values.contains_key(value_name) {
-                self.error_reporter.report_mismatch_hint(
-                    HintCode::InconsistentEnumValueForOutputEnum,
-                    format!(
-                        "Value \"{value_name}\" of enum type \"{dest_name}\" has been added to the supergraph but is only defined in a subset of the subgraphs defining \"{dest_name}\": ",
-                    ),
-                    dest_name,
-                    sources,
-                    &self.subgraphs,
-                    |_| Some("yes".to_string()),
-                    |source, _| {
-                        if source.values.contains_key(value_name) {
-                            Some("yes".to_string())
-                        } else {
-                            Some("no".to_string())
-                        }
-                    },
-                    |_, subgraphs| format!("\"{}\" is defined in {}", value_name, subgraphs.unwrap_or_else(|| "no subgraphs".to_string())),
-                    |_, subgraphs| format!(" but not in {subgraphs}"),
-                    false,
-                    false,
-                );
-                return;
-            }
+        if sources
+            .values()
+            .flatten()
+            .any(|e| !e.values.contains_key(value_name))
+        {
+            self.error_reporter.report_mismatch_hint(
+                HintCode::InconsistentEnumValueForOutputEnum,
+                format!(
+                    "Value \"{value_name}\" of enum type \"{dest_name}\" has been added to the supergraph but is only defined in a subset of the subgraphs defining \"{dest_name}\": ",
+                ),
+                dest_name,
+                sources,
+                &self.subgraphs,
+                |_| Some("yes".to_string()),
+                |source, _| {
+                    if source.values.contains_key(value_name) {
+                        Some("yes".to_string())
+                    } else {
+                        Some("no".to_string())
+                    }
+                },
+                |_, subgraphs| format!("\"{}\" is defined in {}", value_name, subgraphs.unwrap_or_else(|| "no subgraphs".to_string())),
+                |_, subgraphs| format!(" but not in {subgraphs}"),
+                false,
+                false,
+            );
         }
     }
 }

--- a/apollo-federation/tests/composition/hints.rs
+++ b/apollo-federation/tests/composition/hints.rs
@@ -689,16 +689,7 @@ mod enum_hints {
             "INCONSISTENT_ENUM_VALUE_FOR_OUTPUT_ENUM",
             "Value \"V2\" of enum type \"T\" has been added to the supergraph but is only defined in a subset of the subgraphs defining \"T\": \"V2\" is defined in subgraph \"Subgraph1\" but not in subgraphs \"Subgraph2\" and \"Subgraph3\".",
         );
-        let hint_count = result
-            .hints()
-            .iter()
-            .filter(|h| h.code() == "INCONSISTENT_ENUM_VALUE_FOR_OUTPUT_ENUM")
-            .count();
-        assert_eq!(
-            hint_count,
-            1,
-            "Expected exactly 1 hint but got {hint_count}"
-        );
+        assert_eq!(result.hints().len(), 1, "Expected exactly 1 hint");
     }
 }
 

--- a/apollo-federation/tests/composition/hints.rs
+++ b/apollo-federation/tests/composition/hints.rs
@@ -643,6 +643,60 @@ mod enum_hints {
             "Value \"V2\" of enum type \"T\" has been added to the supergraph but is only defined in a subset of the subgraphs defining \"T\": \"V2\" is defined in subgraph \"Subgraph1\" but not in subgraph \"Subgraph2\".",
         );
     }
+
+    #[test]
+    fn hints_on_output_enum_value_emits_single_hint_when_multiple_subgraphs_missing_value() {
+        // Regression test: before the fix, hint_on_inconsistent_output_enum_value was missing
+        // an early return after emitting the hint. Since report_mismatch_hint already examines
+        // all sources internally, the loop would emit duplicate identical hints — one per
+        // subgraph missing the value.
+
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+                type Query {
+                    t: T
+                }
+
+                enum T {
+                    V1
+                    V2
+                }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+                enum T {
+                    V1
+                }
+            "#,
+        };
+
+        let subgraph3 = ServiceDefinition {
+            name: "Subgraph3",
+            type_defs: r#"
+                enum T {
+                    V1
+                }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2, subgraph3]).unwrap();
+        let hints = result.hints();
+        let matching: Vec<_> = hints
+            .iter()
+            .filter(|h| h.code() == "INCONSISTENT_ENUM_VALUE_FOR_OUTPUT_ENUM")
+            .collect();
+        assert_eq!(
+            matching.len(),
+            1,
+            "Expected exactly 1 INCONSISTENT_ENUM_VALUE_FOR_OUTPUT_ENUM hint but got {}: {:?}",
+            matching.len(),
+            matching.iter().map(|h| h.message()).collect::<Vec<_>>()
+        );
+    }
 }
 
 mod executable_directives {

--- a/apollo-federation/tests/composition/hints.rs
+++ b/apollo-federation/tests/composition/hints.rs
@@ -684,17 +684,20 @@ mod enum_hints {
         };
 
         let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2, subgraph3]).unwrap();
-        let hints = result.hints();
-        let matching: Vec<_> = hints
+        assert_has_hint(
+            &result,
+            "INCONSISTENT_ENUM_VALUE_FOR_OUTPUT_ENUM",
+            "Value \"V2\" of enum type \"T\" has been added to the supergraph but is only defined in a subset of the subgraphs defining \"T\": \"V2\" is defined in subgraph \"Subgraph1\" but not in subgraphs \"Subgraph2\" and \"Subgraph3\".",
+        );
+        let hint_count = result
+            .hints()
             .iter()
             .filter(|h| h.code() == "INCONSISTENT_ENUM_VALUE_FOR_OUTPUT_ENUM")
-            .collect();
+            .count();
         assert_eq!(
-            matching.len(),
+            hint_count,
             1,
-            "Expected exactly 1 INCONSISTENT_ENUM_VALUE_FOR_OUTPUT_ENUM hint but got {}: {:?}",
-            matching.len(),
-            matching.iter().map(|h| h.message()).collect::<Vec<_>>()
+            "Expected exactly 1 hint but got {hint_count}"
         );
     }
 }


### PR DESCRIPTION
`hint_on_inconsistent_output_enum_value` was missing a `return` after emitting the hint. Since `report_mismatch_hint` already examines all sources internally, the loop emitted duplicate identical hints — one per subgraph missing the value.

JS returns immediately after the first match (L2732): https://github.com/apollographql/federation/blob/main/composition-js/src/merging/merge.ts#L2713-L2735

The existing comment on L260 ("As soon as we find a subgraph that has the type but not the member, we hint") already described the intended behavior — the `return` was simply missing.
