### PR TITLE
fix(composition): include `@requires` directive location in error locations

### DIFF
--- a/apollo-federation/src/schema/validators/merged.rs
+++ b/apollo-federation/src/schema/validators/merged.rs
@@ -140,6 +140,7 @@ pub(crate) fn validate_merged_schema(
             else {
                 bail!("@requires unexpectedly missing from field that references it");
             };
+            let requires_directive_locations = requires_directive.locations(subgraph);
             let requires_arguments = &subgraph
                 .metadata()
                 .federation_spec_definition()
@@ -229,6 +230,7 @@ pub(crate) fn validate_merged_schema(
                     add_requires_error(
                         parent_field_pos,
                         requires_directive,
+                        &requires_directive_locations,
                         &subgraph.name,
                         type_name,
                         field_name,
@@ -260,6 +262,7 @@ pub(crate) fn validate_merged_schema(
                     add_requires_error(
                         parent_field_pos,
                         requires_directive,
+                        &requires_directive_locations,
                         &subgraph.name,
                         type_name,
                         field_name,
@@ -311,6 +314,7 @@ static APOLLO_COMPILER_REQUIRED_ARGUMENT_PATTERN: LazyLock<Regex> = LazyLock::ne
 fn add_requires_error(
     requires_parent_field_pos: &ObjectFieldDefinitionPosition,
     requires_application: &Directive,
+    requires_directive_locations: &Locations,
     subgraph_name: &str,
     type_name: &str,
     field_name: &str,
@@ -323,7 +327,8 @@ fn add_requires_error(
     let type_name = Name::new(type_name)?;
     let field_name = Name::new(field_name)?;
     let argument_name = Name::new(argument_name)?;
-    let mut locations = Vec::with_capacity(subgraphs.len());
+    let mut locations = Vec::with_capacity(subgraphs.len() + requires_directive_locations.len());
+    locations.extend_from_slice(requires_directive_locations);
     let incompatible_subgraph_names = subgraphs
         .iter()
         .map(|other_subgraph| {

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -1,5 +1,4 @@
 use test_log::test;
-
 use super::ServiceDefinition;
 use super::assert_composition_errors;
 use super::compose_as_fed2_subgraphs;
@@ -678,4 +677,52 @@ fn interface_field_no_implem_error_includes_source_locations() {
     );
     assert_eq!(locs[0].subgraph, "subgraphA");
     assert_eq!(locs[1].subgraph, "subgraphB");
+}
+
+#[test]
+fn requires_error_locations_include_requires_directive_and_incompatible_fields() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y: Int @requires(fields: "x(arg: 42)")
+        }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+        type T @key(fields: "id") {
+          id: ID!
+          x: Int
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+    assert_composition_errors(
+        &result,
+        &[(
+            "REQUIRES_INVALID_FIELDS",
+            r#"[subgraphA] On field "T.y", for @requires(fields: "x(arg: 42)"): cannot provide a value for argument "arg" of field "T.x" as argument "arg" is not defined in subgraph "subgraphB""#,
+        )],
+    );
+    let failure = result.unwrap_err();
+    let locations = failure.errors[0].locations();
+    assert_eq!(
+        locations.len(),
+        2,
+        "Expected 2 locations (the @requires directive and the incompatible field), got {}: {:?}",
+        locations.len(),
+        locations,
+    );
+    assert_eq!(locations[0].subgraph, "subgraphA");
+    assert_eq!(locations[1].subgraph, "subgraphB");
 }

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -1,4 +1,5 @@
 use test_log::test;
+
 use super::ServiceDefinition;
 use super::assert_composition_errors;
 use super::compose_as_fed2_subgraphs;


### PR DESCRIPTION
Previously, `REQUIRES_INVALID_FIELDS` errors only included source locations for the incompatible fields in other subgraphs. This aligns with the JS implementation by also including the `@requires` directive's own source location, matching the JS pattern:
`const nodes = requireAST.concat(incompatibleSubgraphs.map(...))`

JS references:
- `@requires` directive node captured: https://github.com/apollographql/federation/blob/main/composition-js/src/merging/merge.ts#L3808
- Error locations built with `requireAST.concat(...)`: https://github.com/apollographql/federation/blob/main/composition-js/src/merging/merge.ts#L3833
