### PR TITLE
fix(composition): add source locations to `INTERFACE_FIELD_NO_IMPLEM` errors

### DIFF
--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -285,7 +285,10 @@ pub enum CompositionError {
         locations: Locations,
     },
     #[error("{message}")]
-    InterfaceFieldNoImplem { message: String },
+    InterfaceFieldNoImplem {
+        message: String,
+        locations: Locations,
+    },
 }
 
 impl CompositionError {
@@ -479,8 +482,9 @@ impl CompositionError {
                     locations,
                 }
             }
-            Self::InterfaceFieldNoImplem { message } => Self::InterfaceFieldNoImplem {
+            Self::InterfaceFieldNoImplem { message, locations } => Self::InterfaceFieldNoImplem {
                 message: format!("{message}{appendix}"),
+                locations,
             },
             // Remaining errors do not have an obvious way to appending a message, so we just return self.
             Self::SubgraphError { .. }
@@ -533,7 +537,8 @@ impl CompositionError {
             | Self::InvalidFieldSharing { locations, .. }
             | Self::MergeError { locations, .. }
             | Self::ArgumentDefaultMismatch { locations, .. }
-            | Self::InputFieldDefaultMismatch { locations, .. } => locations,
+            | Self::InputFieldDefaultMismatch { locations, .. }
+            | Self::InterfaceFieldNoImplem { locations, .. } => locations,
             _ => &[],
         }
     }

--- a/apollo-federation/src/schema/validators/merged.rs
+++ b/apollo-federation/src/schema/validators/merged.rs
@@ -14,6 +14,7 @@ use crate::ensure;
 use crate::error::CompositionError;
 use crate::error::FederationError;
 use crate::error::HasLocations;
+use crate::error::Locations;
 use crate::error::SingleFederationError;
 use crate::schema::FederationSchema;
 use crate::schema::position::CompositeTypeDefinitionPosition;
@@ -59,14 +60,18 @@ pub(crate) fn validate_merged_schema(
                 if field_pos.get(supergraph_schema.schema()).is_err() {
                     // This means that the type was defined (or at least implemented the interface)
                     // only in subgraphs where the interface didn't have that field.
-                    let subgraphs_with_interface_field = subgraphs
+                    let mut locations: Locations = Vec::new();
+                    let subgraphs_with_interface_field: Vec<_> = subgraphs
                         .iter()
                         .filter(|subgraph| {
                             interface_field_pos.get(subgraph.schema().schema()).is_ok()
                         })
+                        .inspect(|subgraph| {
+                            locations.extend(interface_field_pos.locations(subgraph));
+                        })
                         .map(|subgraph| subgraph.name.clone())
-                        .collect::<Vec<_>>();
-                    let subgraphs_with_type_implementing_interface = subgraphs
+                        .collect();
+                    let subgraphs_with_type_implementing_interface: Vec<_> = subgraphs
                         .iter()
                         .filter(|subgraph| {
                             let Some(subgraph_type) =
@@ -84,8 +89,11 @@ pub(crate) fn validate_merged_schema(
                                 _ => false,
                             }
                         })
+                        .inspect(|subgraph| {
+                            locations.extend(type_pos.locations(subgraph));
+                        })
                         .map(|subgraph| subgraph.name.clone())
-                        .collect::<Vec<_>>();
+                        .collect();
                     errors.push(CompositionError::InterfaceFieldNoImplem {
                         message: format!(
                             "Interface field \"{}\" is declared in {} but type \"{}\", which implements \"{}\" only in {} does not have field \"{}\".",
@@ -95,7 +103,8 @@ pub(crate) fn validate_merged_schema(
                             interface_name,
                             human_readable_subgraph_names(subgraphs_with_type_implementing_interface.iter()),
                             interface_field_pos.field_name,
-                        )
+                        ),
+                        locations,
                     });
                 }
 

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -626,3 +626,56 @@ fn satisfiability_validation_handles_indirectly_reachable_keys() {
     let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b, subgraph_c]);
     let _supergraph = result.expect("Expected composition to succeed - satisfiability should pass");
 }
+
+#[test]
+fn interface_field_no_implem_error_includes_source_locations() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          I: [I!]
+        }
+
+        interface I {
+          a: Int
+        }
+
+        type A implements I {
+          a: Int
+          b: Int
+        }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+        interface I {
+          b: Int
+        }
+
+        type B implements I {
+          b: Int
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+    assert_composition_errors(
+        &result,
+        &[(
+            "INTERFACE_FIELD_NO_IMPLEM",
+            r#"Interface field "I.a" is declared in subgraph "subgraphA" but type "B", which implements "I" only in subgraph "subgraphB" does not have field "a"."#,
+        )],
+    );
+
+    let errors = result.expect_err("Expected composition to fail").errors;
+    let locs = errors[0].locations();
+    assert_eq!(
+        locs.len(),
+        2,
+        "Expected 2 locations (interface field def + implementing type def), got {locs:#?}"
+    );
+    assert_eq!(locs[0].subgraph, "subgraphA");
+    assert_eq!(locs[1].subgraph, "subgraphB");
+}


### PR DESCRIPTION
Collect source locations from interface field definitions and implementing type definitions when building `InterfaceFieldNoImplem` errors, matching the JS composition behavior.

JS reference:
https://github.com/apollographql/federation/blob/main/composition-js/src/merging/merge.ts#L3733-L3742
