### PR TITLE
fix(QP-execution): propagate missing-required-field signal through execute_selection_set

### DIFF
--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -200,7 +200,12 @@ impl Variables {
                     context.execute_on_path(path);
                 }
 
-                let mut value = execute_selection_set(value, requires, schema, None);
+                let (mut value, had_errors) = execute_selection_set(value, requires, schema, None);
+                // If a non-nullable required field was missing, the representation is incomplete;
+                // skip the entity rather than sending a malformed representation to the subgraph.
+                if had_errors {
+                    return;
+                }
                 if value.as_object().map(|o| !o.is_empty()).unwrap_or(false) {
                     rewrites::apply_rewrites(schema, &mut value, input_rewrites);
                     match values.get_index_of(&value) {

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -11,11 +11,35 @@ use crate::json_ext::ValueExt;
 use crate::spec::Schema;
 use crate::spec::TYPENAME;
 
+/// Executes a selection set against the input data, extracting fields specified by the selections.
+/// Returns `(value, had_errors)` where `had_errors` is true if a non-nullable field was missing
+/// and an error null was evaluated for it.
+/// Note: Unlike the GraphQL spec execution, this function does not bubble up error nulls to the
+///       nearest nullable parent, but instead it indicates the presence of such errors via the
+///       `had_errors` flag.
 pub(crate) fn execute_selection_set<'a>(
     input_content: &'a Value,
     selections: &[Selection],
     schema: &Schema,
+    current_type: Option<&'a str>,
+) -> (Value, bool) {
+    let mut had_errors = false;
+    let value = execute_selection_set_inner(
+        input_content,
+        selections,
+        schema,
+        current_type,
+        &mut had_errors,
+    );
+    (value, had_errors)
+}
+
+fn execute_selection_set_inner<'a>(
+    input_content: &'a Value,
+    selections: &[Selection],
+    schema: &Schema,
     mut current_type: Option<&'a str>,
+    had_errors: &mut bool,
 ) -> Value {
     let content = match input_content.as_object() {
         Some(o) => o,
@@ -76,6 +100,7 @@ pub(crate) fn execute_selection_set<'a>(
                         {
                             output.insert(ByteString::from(selection_name.to_owned()), Value::Null);
                         } else {
+                            *had_errors = true;
                             return Value::Null;
                         }
                     }
@@ -85,13 +110,14 @@ pub(crate) fn execute_selection_set<'a>(
                                 .iter()
                                 .map(|element| {
                                     if !selections.is_empty() {
-                                        execute_selection_set(
+                                        execute_selection_set_inner(
                                             element,
                                             selections,
                                             schema,
                                             field_type
                                                 .as_ref()
                                                 .map(|ty| ty.inner_named_type().as_str()),
+                                            had_errors,
                                         )
                                     } else {
                                         element.clone()
@@ -102,11 +128,12 @@ pub(crate) fn execute_selection_set<'a>(
                         } else if !selections.is_empty() {
                             output.insert(
                                 key.clone(),
-                                execute_selection_set(
+                                execute_selection_set_inner(
                                     value,
                                     selections,
                                     schema,
                                     field_type.as_ref().map(|ty| ty.inner_named_type().as_str()),
+                                    had_errors,
                                 ),
                             );
                         } else {
@@ -121,17 +148,23 @@ pub(crate) fn execute_selection_set<'a>(
             }) => match type_condition {
                 None => continue,
                 Some(condition) => {
-                    if type_condition_matches(schema, current_type, condition)
-                        && let Value::Object(selected) =
-                            execute_selection_set(input_content, selections, schema, current_type)
-                    {
-                        for (key, value) in selected.into_iter() {
-                            match output.entry(key) {
-                                Entry::Vacant(e) => {
-                                    e.insert(value);
-                                }
-                                Entry::Occupied(e) => {
-                                    e.into_mut().type_aware_deep_merge(value, schema);
+                    if type_condition_matches(schema, current_type, condition) {
+                        let inner = execute_selection_set_inner(
+                            input_content,
+                            selections,
+                            schema,
+                            current_type,
+                            had_errors,
+                        );
+                        if let Value::Object(selected) = inner {
+                            for (key, value) in selected.into_iter() {
+                                match output.entry(key) {
+                                    Entry::Vacant(e) => {
+                                        e.insert(value);
+                                    }
+                                    Entry::Occupied(e) => {
+                                        e.into_mut().type_aware_deep_merge(value, schema);
+                                    }
                                 }
                             }
                         }
@@ -152,7 +185,7 @@ pub(crate) fn execute_selection_set<'a>(
 /// <https://spec.graphql.org/October2021/#DoesFragmentTypeApply()>
 /// <https://spec.graphql.org/October2021/#CompleteValue()>
 /// <https://spec.graphql.org/October2021/#ResolveAbstractType()>
-fn type_condition_matches(
+pub(crate) fn type_condition_matches(
     schema: &Schema,
     current_type: Option<&str>,
     type_condition: &str,
@@ -240,7 +273,7 @@ mod tests {
         Ok(Value::Array(
             values
                 .into_iter()
-                .map(|value| execute_selection_set(value, selections, schema, None))
+                .map(|value| execute_selection_set(value, selections, schema, None).0)
                 .collect::<Vec<_>>(),
         ))
     }
@@ -388,7 +421,7 @@ mod tests {
         ]);
         let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
 
-        let value = execute_selection_set(&response, &selection, &schema, None);
+        let (value, _had_errors) = execute_selection_set(&response, &selection, &schema, None);
         println!(
             "response\n{}\nand selection\n{:?}\n returns:\n{}",
             serde_json::to_string_pretty(&response).unwrap(),
@@ -653,7 +686,7 @@ mod tests {
 
         let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
 
-        let value = execute_selection_set(&response, &selection, &schema, None);
+        let (value, _had_errors) = execute_selection_set(&response, &selection, &schema, None);
 
         assert_eq!(
             value,
@@ -679,6 +712,255 @@ mod tests {
                 },
                 "id": 1780384,
             })
+        );
+    }
+
+    /// Test for the nested non-null field missing bug.
+    ///
+    /// When `@requires(fields: "data { a b }")` and `b` is non-null but missing,
+    /// `execute_selection_set` should return `Value::Null` so the entity is skipped.
+    /// Currently it returns `{ "data": null }` (a non-empty object), which causes the
+    /// entity to NOT be skipped in `Variables::new` (fetch.rs), leading to an invalid
+    /// representation being sent to the subgraph.
+    #[test]
+    fn test_nested_non_null_missing_field_should_nullify_parent() {
+        let schema = with_supergraph_boilerplate(
+            "type Query @join__type(graph: TEST) { me: String @join__field(graph: TEST) }
+            type Entity { data: NestedData! }
+            type NestedData { a: String! b: String! }",
+        );
+        let schema = Schema::parse(&schema, &Default::default()).unwrap();
+
+        // Simulates @requires(fields: "data { a b }") where `b` is missing
+        let response = bjson!({
+            "__typename": "Entity",
+            "data": {
+                "a": "value_a"
+                // "b" is missing — it's non-null (String!), so this should fail
+            }
+        });
+
+        // Selection: ... on Entity { __typename data { a b } }
+        let requires = json!([
+            {
+                "kind": "InlineFragment",
+                "typeCondition": "Entity",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": "__typename",
+                    },
+                    {
+                        "kind": "Field",
+                        "name": "data",
+                        "selections": [
+                            {
+                                "kind": "Field",
+                                "name": "a",
+                            },
+                            {
+                                "kind": "Field",
+                                "name": "b",
+                            }
+                        ],
+                    }
+                ],
+            },
+        ]);
+        let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
+
+        let (value, had_errors) = execute_selection_set(&response, &selection, &schema, None);
+
+        // `execute_selection_set` returns `{ "__typename": "Entity", "data": null }` because
+        // null-bubbling stops at the `data` field level. The `had_errors` flag is what
+        // fetch.rs uses to skip this entity from the downstream fetch.
+        assert!(
+            had_errors,
+            "Expected had_errors=true for missing non-null field"
+        );
+        assert_eq!(
+            value,
+            bjson!({"__typename": "Entity", "data": null}),
+            "Expected data to be nullified due to missing non-null field `b`"
+        );
+    }
+
+    /// Same as above but with a nullable parent field.
+    /// Even when the parent field (`data`) is nullable, if a nested non-null field is
+    /// missing, the representation is incomplete and should not be sent.
+    #[test]
+    fn test_nested_non_null_missing_field_nullable_parent_should_nullify() {
+        let schema = with_supergraph_boilerplate(
+            "type Query @join__type(graph: TEST) { me: String @join__field(graph: TEST) }
+            type Entity { data: NestedData }
+            type NestedData { a: String! b: String! }",
+        );
+        let schema = Schema::parse(&schema, &Default::default()).unwrap();
+
+        // `data` is present (non-null object), but inner field `b` is missing
+        let response = bjson!({
+            "__typename": "Entity",
+            "data": {
+                "a": "value_a"
+            }
+        });
+
+        let requires = json!([
+            {
+                "kind": "InlineFragment",
+                "typeCondition": "Entity",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": "__typename",
+                    },
+                    {
+                        "kind": "Field",
+                        "name": "data",
+                        "selections": [
+                            {
+                                "kind": "Field",
+                                "name": "a",
+                            },
+                            {
+                                "kind": "Field",
+                                "name": "b",
+                            }
+                        ],
+                    }
+                ],
+            },
+        ]);
+        let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
+
+        let (value, had_errors) = execute_selection_set(&response, &selection, &schema, None);
+
+        // `execute_selection_set` returns `{ "__typename": "Entity", "data": null }` because
+        // null-bubbling nullifies the `data` field. The `had_errors` flag is what fetch.rs
+        // uses to skip this entity from the downstream fetch.
+        assert!(
+            had_errors,
+            "Expected had_errors=true for missing non-null field"
+        );
+        assert_eq!(
+            value,
+            bjson!({"__typename": "Entity", "data": null}),
+            "Expected data to be nullified due to missing non-null field `b`"
+        );
+    }
+
+    /// Verify that when all nested fields are present, the selection works correctly.
+    #[test]
+    fn test_nested_fields_all_present() {
+        let schema = with_supergraph_boilerplate(
+            "type Query @join__type(graph: TEST) { me: String @join__field(graph: TEST) }
+            type Entity { data: NestedData! }
+            type NestedData { a: String! b: String! }",
+        );
+        let schema = Schema::parse(&schema, &Default::default()).unwrap();
+
+        let response = bjson!({
+            "__typename": "Entity",
+            "data": {
+                "a": "value_a",
+                "b": "value_b"
+            }
+        });
+
+        let requires = json!([
+            {
+                "kind": "InlineFragment",
+                "typeCondition": "Entity",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": "__typename",
+                    },
+                    {
+                        "kind": "Field",
+                        "name": "data",
+                        "selections": [
+                            {
+                                "kind": "Field",
+                                "name": "a",
+                            },
+                            {
+                                "kind": "Field",
+                                "name": "b",
+                            }
+                        ],
+                    }
+                ],
+            },
+        ]);
+        let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
+
+        let (value, had_errors) = execute_selection_set(&response, &selection, &schema, None);
+
+        // All fields present — should return the full selection
+        assert!(
+            !had_errors,
+            "Expected no errors when all fields are present"
+        );
+        assert_eq!(
+            value,
+            bjson!({
+                "__typename": "Entity",
+                "data": {
+                    "a": "value_a",
+                    "b": "value_b"
+                }
+            })
+        );
+    }
+
+    /// When a nullable required field is completely absent from the entity data (not present
+    /// at all, as opposed to present with a null value), `execute_selection_set` should fill
+    /// it in as null and proceed without errors.
+    #[test]
+    fn test_missing_nullable_required_field_proceeds_with_null() {
+        let schema = with_supergraph_boilerplate(
+            "type Query @join__type(graph: TEST) { me: String @join__field(graph: TEST) }
+            type Entity { code: String name: String }",
+        );
+        let schema = Schema::parse(&schema, &Default::default()).unwrap();
+
+        // `name` is completely absent from the response
+        let response = bjson!({
+            "__typename": "Entity",
+            "code": "ABC"
+        });
+
+        let requires = json!([
+            {
+                "kind": "InlineFragment",
+                "typeCondition": "Entity",
+                "selections": [
+                    {
+                        "kind": "Field",
+                        "name": "__typename",
+                    },
+                    {
+                        "kind": "Field",
+                        "name": "code",
+                    },
+                    {
+                        "kind": "Field",
+                        "name": "name",
+                    }
+                ],
+            },
+        ]);
+        let selection: Vec<Selection> = serde_json::from_value(requires).unwrap();
+
+        let (value, had_errors) = execute_selection_set(&response, &selection, &schema, None);
+
+        // Nullable field `name` is absent — should be filled as null without errors.
+        assert!(!had_errors, "Expected no errors for missing nullable field");
+        assert_eq!(
+            value,
+            bjson!({"__typename": "Entity", "code": "ABC", "name": null}),
+            "Missing nullable field should be filled as null in the representation"
         );
     }
 

--- a/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__typename_propagation2.snap
+++ b/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__typename_propagation2.snap
@@ -4,12 +4,16 @@ expression: "serde_json::to_value(&response).unwrap()"
 ---
 {
   "data": {
-    "book": {
-      "__typename": "Book",
-      "id": "1",
-      "author": {
-        "__typename": "Author"
+    "book": null
+  },
+  "extensions": {
+    "valueCompletion": [
+      {
+        "message": "Null value found for non-nullable type ID",
+        "path": [
+          "book"
+        ]
       }
-    }
+    ]
   }
 }

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_one_subgraph_cost_are_accepted@federated_ships_required.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_one_subgraph_cost_are_accepted@federated_ships_required.snap
@@ -3,9 +3,9 @@ source: apollo-router/tests/integration/demand_control.rs
 expression: parse_result_for_snapshot(response).await
 ---
 {
-  "apollo::demand_control::actual_cost": 9.0,
+  "apollo::demand_control::actual_cost": 6.0,
   "apollo::demand_control::actual_cost_by_subgraph": {
-    "vehicles": 9.0
+    "vehicles": 6.0
   },
   "apollo::demand_control::estimated_cost": 140.0,
   "apollo::demand_control::estimated_cost_by_subgraph": {
@@ -19,7 +19,7 @@ expression: parse_result_for_snapshot(response).await
   },
   "apollo::demand_control::strategy": "static_estimated",
   "apollo::experimental_mock_subgraphs::subgraph_call_count": {
-    "vehicles": 2
+    "vehicles": 1
   },
   "body": {
     "data": {


### PR DESCRIPTION
## Summary

- Fix a pre-existing bug where entities were still added to the `_entities` batch with malformed representations when a nested non-nullable field was missing **or returned as null** by the upstream subgraph.
- Change `execute_selection_set` to return `(Value, bool)` where the bool (`had_errors`) signals that a non-nullable field was missing and error-nulled along the way.
- Update `Variables::new` (in `fetch.rs`) to skip entities with `had_errors = true`, so malformed representations are no longer sent to subgraphs.
- Add four unit tests in `selection.rs` pinning down the new behavior (non-null parent, nullable parent, all-fields-present, nullable-miss negative case).
- Update two existing snapshots that incidentally exercised this bug: `typename_propagation2` (entity now correctly nullifies instead of partial-fetching with a malformed rep) and the demand-control `requests_exceeding_one_subgraph_cost_are_accepted` integration test (`vehicles` subgraph now called 1× instead of 2× since one entity fetch is correctly skipped).

## Details

Previously, `execute_selection_set` had no way to signal "a non-nullable field was missing inside a nested selection." When a `@requires` selection drilled into a nested object and one of its required leaves was absent, the function still returned a non-empty object — so `Variables::new` would happily add that entity to the `representations` list. The subgraph then received a malformed representation with a missing non-null field.

```rust
// before
fn execute_selection_set(..) -> Value

// after
fn execute_selection_set(..) -> (Value, bool)  // .1 = had_errors
```

`Variables::new` then uses `had_errors` to decide whether the entity is usable; unsatisfied entities are dropped from the batch.

Note on semantics: unlike the GraphQL spec response execution, `execute_selection_set` does **not** bubble error-nulls up to the nearest nullable parent. We keep the partial value for debugging/merging and let the caller decide what to do based on the `had_errors` flag.

This change is a prerequisite for the follow-up PR that emits `UNSATISFIED_FETCH_CONDITION` errors for these silently-skipped entities (ROUTER-1741, stacked on top).

## Test plan

- [x] `test_nested_non_null_missing_field_should_nullify_parent` — `Entity { data: NestedData! }`, `NestedData { a: String! b: String! }`, response missing `b` → `had_errors = true`, output `{ __typename, data: null }`
- [x] `test_nested_non_null_missing_field_nullable_parent_should_nullify` — same with nullable `data: NestedData` parent; still `had_errors = true`
- [x] `test_nested_fields_all_present` — happy path: no false positives
- [x] `test_missing_nullable_required_field_proceeds_with_null` — pins down that the signal is **only** raised for non-nullable misses; nullable missing fields are still filled with `null` and not flagged
- [x] `typename_propagation2` — snapshot updated; demonstrates the fix on a real-world scenario (null `__typename` in a `requires` selection)

<!-- start metadata -->

<!-- [ROUTER-1741] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This is a part of ROUTER-1741 and a follow-up PR will add a changeset.

[ROUTER-1741]: https://apollographql.atlassian.net/browse/ROUTER-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ