### PR TITLE
fix(QP-execution): emit errors for skipped entity fetches

### DIFF
--- a/.changesets/fix_duckki_rh_1335.md
+++ b/.changesets/fix_duckki_rh_1335.md
@@ -1,0 +1,5 @@
+### Report errors when entity fetches are skipped due to missing non-nullable required fields ([PR #9191](https://github.com/apollographql/router/pull/9191))
+
+When a non-nullable field required by `@key`/`@requires` is missing from the entity representation, the router used to silently skip the downstream entity fetch — the response carried null fields with no errors and clients had no way to tell why. The router now detects these unsatisfied conditions per entity and generates `UNSATISFIED_FETCH_CONDITION` errors at the affected paths. Entity batching is handled correctly: entities with satisfied requirements are still fetched, and only the failed entities produce errors.
+
+By [@duckki](https://github.com/duckki) in https://github.com/apollographql/router/pull/9191

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use futures::StreamExt;
 use futures::future::join_all;
 use futures::prelude::*;
+use parking_lot::Mutex;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::BroadcastStream;
@@ -14,6 +15,7 @@ use super::DeferredNode;
 use super::PlanNode;
 use super::QueryPlan;
 use super::log;
+use super::selection::type_condition_matches;
 use super::subscription::SubscriptionHandle;
 use crate::Context;
 use crate::axum_factory::CanceledRequest;
@@ -46,8 +48,11 @@ use crate::services::fetch::ErrorMapping;
 use crate::services::fetch::SubscriptionRequest;
 use crate::services::fetch_service::FetchServiceFactory;
 use crate::services::new_service::ServiceFactory;
+use crate::spec::Fragments;
 use crate::spec::Query;
 use crate::spec::Schema;
+use crate::spec::Selection;
+use crate::spec::TYPENAME;
 
 impl QueryPlan {
     #[allow(clippy::too_many_arguments)]
@@ -73,8 +78,9 @@ impl QueryPlan {
 
         log::trace_query_plan(&self.root);
         let deferred_fetches = HashMap::new();
+        let skipped_entity_paths: Mutex<Vec<Path>> = Mutex::new(Vec::new());
 
-        let (value, errors) = self
+        let (value, mut errors) = self
             .root
             .execute_recursively(
                 &ExecutionParameters {
@@ -88,6 +94,7 @@ impl QueryPlan {
                     subscription_handle: &subscription_handle,
                     subscription_config,
                     subgraph_schemas,
+                    skipped_entity_paths: &skipped_entity_paths,
                 },
                 &root,
                 &initial_value.unwrap_or_default(),
@@ -99,6 +106,23 @@ impl QueryPlan {
                 "apollo.router.operations.defer",
                 "Number of requests that request deferred data",
                 1
+            );
+        }
+
+        // End-of-execution pass: walk the user's operation against the final
+        // merged data and emit `UNSATISFIED_FETCH_CONDITION` for each missing
+        // leaf that sits under a recorded skipped entity path.
+        let skipped_paths = std::mem::take(&mut *skipped_entity_paths.lock());
+        if !skipped_paths.is_empty() {
+            collect_unsatisfied_fetch_errors(
+                &self.query.operation.selection_set,
+                &self.query.fragments,
+                schema.as_ref(),
+                &supergraph_request.body().variables,
+                &value,
+                &Path::empty(),
+                &skipped_paths,
+                &mut errors,
             );
         }
 
@@ -126,6 +150,11 @@ pub(crate) struct ExecutionParameters<'a> {
     pub(crate) root_node: &'a PlanNode,
     pub(crate) subscription_handle: &'a Option<SubscriptionHandle>,
     pub(crate) subscription_config: &'a Option<SubscriptionConfig>,
+    /// Entity-level paths whose `_entities` fetch was skipped because a
+    /// required input was unsatisfied. Accumulated across the entire
+    /// execution; consumed at end-of-execution to generate
+    /// `UNSATISFIED_FETCH_CONDITION` errors against the final merged data.
+    pub(crate) skipped_entity_paths: &'a Mutex<Vec<Path>>,
 }
 
 impl PlanNode {
@@ -228,7 +257,9 @@ impl PlanNode {
                                 .build(),
                         ];
                     } else {
-                        match Variables::new(
+                        // Note: subscriptions currently pass empty requires (&[]), so
+                        // _unsatisfied_paths will always be empty.
+                        let (opt_variables, _unsatisfied_paths) = Variables::new(
                             &[],
                             &subscription_node.variable_usages,
                             parent_value,
@@ -237,7 +268,12 @@ impl PlanNode {
                             parameters.schema,
                             &subscription_node.input_rewrites,
                             &None,
-                        ) {
+                        );
+                        debug_assert!(
+                            _unsatisfied_paths.is_empty(),
+                            "subscriptions pass empty `requires` — unsatisfied_paths should always be empty",
+                        );
+                        match opt_variables {
                             Some(variables) => {
                                 let service = parameters.service_factory.create();
                                 let request = fetch::Request::Subscription(
@@ -283,7 +319,7 @@ impl PlanNode {
                         value = Value::Object(Object::default());
                         errors = Vec::new();
                     } else {
-                        match Variables::new(
+                        let (opt_variables, unsatisfied_paths) = Variables::new(
                             &fetch_node.requires,
                             &fetch_node.variable_usages,
                             parent_value,
@@ -292,7 +328,18 @@ impl PlanNode {
                             parameters.schema.as_ref(),
                             &fetch_node.input_rewrites,
                             &fetch_node.context_rewrites,
-                        ) {
+                        );
+
+                        // Record skipped entity paths; error generation is deferred to
+                        // end-of-execution where the final merged data is available.
+                        if !unsatisfied_paths.is_empty() {
+                            parameters
+                                .skipped_entity_paths
+                                .lock()
+                                .extend(unsatisfied_paths);
+                        }
+
+                        match opt_variables {
                             Some(variables) => {
                                 let paths = variables.inverted_paths.clone();
                                 let service = parameters.service_factory.create();
@@ -403,6 +450,7 @@ impl PlanNode {
                                         subscription_handle: parameters.subscription_handle,
                                         subscription_config: parameters.subscription_config,
                                         subgraph_schemas: parameters.subgraph_schemas,
+                                        skipped_entity_paths: parameters.skipped_entity_paths,
                                     },
                                     current_dir,
                                     &value,
@@ -575,9 +623,10 @@ impl DeferredNode {
             }
 
             let deferred_fetches = HashMap::new();
+            let deferred_skipped_paths: Mutex<Vec<Path>> = Mutex::new(Vec::new());
 
             if let Some(node) = deferred_inner {
-                let (mut v, err) = node
+                let (mut v, mut err) = node
                     .execute_recursively(
                         &ExecutionParameters {
                             context: &ctx,
@@ -590,6 +639,7 @@ impl DeferredNode {
                             subscription_handle: &subscription_handle,
                             subscription_config: &subscription_config,
                             subgraph_schemas: &subgraph_schemas,
+                            skipped_entity_paths: &deferred_skipped_paths,
                         },
                         &Path::default(),
                         &value,
@@ -609,6 +659,21 @@ impl DeferredNode {
                         primary_receiver.recv().await.unwrap_or_default();
                     v.type_aware_deep_merge(primary_value, &sc);
                     errors.extend(primary_errors)
+                }
+
+                // End-of-chunk pass for this deferred response.
+                let skipped_paths = std::mem::take(&mut *deferred_skipped_paths.lock());
+                if !skipped_paths.is_empty() {
+                    collect_unsatisfied_fetch_errors(
+                        &query.operation.selection_set,
+                        &query.fragments,
+                        &sc,
+                        &orig.body().variables,
+                        &v,
+                        &Path::empty(),
+                        &skipped_paths,
+                        &mut err,
+                    );
                 }
 
                 if let Err(e) = tx
@@ -656,4 +721,194 @@ impl DeferredNode {
             };
         }
     }
+}
+
+/// End-of-execution walker: traverse the user's selection set against the final
+/// merged response data and emit `UNSATISFIED_FETCH_CONDITION` for each missing
+/// field whose path sits under an entry in `skipped_paths`.
+///
+/// `skipped_paths` is the accumulator filled by `PlanNode::Fetch` execution:
+/// one path per entity whose `_entities` fetch was skipped because a required
+/// input was unsatisfied (paths are entity-root, not per-leaf).
+///
+/// A path is considered "under a skipped path" if some prefix equals an entry
+/// in `skipped_paths`. A field is considered "missing" if either it's absent
+/// from the value object or it's present-but-null. Missing fields that aren't
+/// under any skipped path are left alone — they're either explained by an
+/// existing subgraph error, or fall outside this PR's scope.
+#[allow(clippy::too_many_arguments)]
+fn collect_unsatisfied_fetch_errors(
+    selection_set: &[Selection],
+    fragments: &Fragments,
+    schema: &Schema,
+    variables: &Object,
+    value: &Value,
+    current_path: &Path,
+    skipped_paths: &[Path],
+    output: &mut Vec<Error>,
+) {
+    let current_type = value
+        .as_object()
+        .and_then(|o| o.get(TYPENAME))
+        .and_then(|v| v.as_str());
+
+    for selection in selection_set {
+        match selection {
+            Selection::Field {
+                name,
+                alias,
+                selection_set: sub,
+                include_skip,
+                ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                if name.as_str() == TYPENAME {
+                    continue;
+                }
+                let response_key = alias.as_ref().unwrap_or(name).as_str();
+                let field_value = value.as_object().and_then(|o| o.get(response_key));
+
+                // Treat absent OR null as "missing".
+                let missing = match field_value {
+                    None => true,
+                    Some(v) => v.is_null(),
+                };
+
+                let mut field_path = current_path.clone();
+                field_path.push(PathElement::Key(response_key.to_string(), None));
+
+                if missing {
+                    if is_under_skipped_path(&field_path, skipped_paths) {
+                        output.push(
+                            Error::builder()
+                                .message("Could not fetch field")
+                                .path(field_path)
+                                .extension_code("UNSATISFIED_FETCH_CONDITION")
+                                .build(),
+                        );
+                    }
+                    continue;
+                }
+
+                // Composite: recurse into the field's value if it has a sub-selection.
+                if let Some(sub_sel) = sub
+                    && let Some(field_value) = field_value
+                {
+                    descend_into_value(
+                        sub_sel,
+                        fragments,
+                        schema,
+                        variables,
+                        field_value,
+                        &field_path,
+                        skipped_paths,
+                        output,
+                    );
+                }
+            }
+            Selection::InlineFragment {
+                type_condition,
+                selection_set: sub,
+                include_skip,
+                known_type,
+                ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                let effective_type = known_type.as_deref().or(current_type);
+                if type_condition_matches(schema, effective_type, type_condition) {
+                    collect_unsatisfied_fetch_errors(
+                        sub,
+                        fragments,
+                        schema,
+                        variables,
+                        value,
+                        current_path,
+                        skipped_paths,
+                        output,
+                    );
+                }
+            }
+            Selection::FragmentSpread {
+                name,
+                known_type,
+                include_skip,
+                ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                let Some(fragment) = fragments.get(name) else {
+                    continue;
+                };
+                let effective_type = known_type.as_deref().or(current_type);
+                if type_condition_matches(schema, effective_type, &fragment.type_condition) {
+                    collect_unsatisfied_fetch_errors(
+                        &fragment.selection_set,
+                        fragments,
+                        schema,
+                        variables,
+                        value,
+                        current_path,
+                        skipped_paths,
+                        output,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Recurse into a field's value; if it's an array, iterate per-index with
+/// `PathElement::Index` segments. Otherwise descend into the value as an object.
+#[allow(clippy::too_many_arguments)]
+fn descend_into_value(
+    selection_set: &[Selection],
+    fragments: &Fragments,
+    schema: &Schema,
+    variables: &Object,
+    value: &Value,
+    current_path: &Path,
+    skipped_paths: &[Path],
+    output: &mut Vec<Error>,
+) {
+    if let Some(arr) = value.as_array() {
+        for (i, item) in arr.iter().enumerate() {
+            let mut item_path = current_path.clone();
+            item_path.push(PathElement::Index(i));
+            descend_into_value(
+                selection_set,
+                fragments,
+                schema,
+                variables,
+                item,
+                &item_path,
+                skipped_paths,
+                output,
+            );
+        }
+    } else {
+        collect_unsatisfied_fetch_errors(
+            selection_set,
+            fragments,
+            schema,
+            variables,
+            value,
+            current_path,
+            skipped_paths,
+            output,
+        );
+    }
+}
+
+/// True iff `path` has some prefix in `skipped`. Equality counts (a skipped
+/// entity path is "under itself"), so leaves of the skipped entity directly
+/// match.
+fn is_under_skipped_path(path: &Path, skipped: &[Path]) -> bool {
+    skipped
+        .iter()
+        .any(|sp| sp.len() <= path.len() && sp.iter().zip(path.iter()).all(|(a, b)| a == b))
 }

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use apollo_compiler::Name;
+use apollo_compiler::executable;
 use futures::StreamExt;
 use futures::future::join_all;
 use futures::prelude::*;
@@ -49,6 +51,7 @@ use crate::services::fetch::SubscriptionRequest;
 use crate::services::fetch_service::FetchServiceFactory;
 use crate::services::new_service::ServiceFactory;
 use crate::spec::Fragments;
+use crate::spec::IncludeSkip;
 use crate::spec::Query;
 use crate::spec::Schema;
 use crate::spec::Selection;
@@ -78,7 +81,7 @@ impl QueryPlan {
 
         log::trace_query_plan(&self.root);
         let deferred_fetches = HashMap::new();
-        let skipped_entity_paths: Mutex<Vec<Path>> = Mutex::new(Vec::new());
+        let skipped_entity_paths: Mutex<Vec<(Path, Arc<ResponseKeyTree>)>> = Mutex::new(Vec::new());
 
         let (value, mut errors) = self
             .root
@@ -109,22 +112,14 @@ impl QueryPlan {
             );
         }
 
-        // End-of-execution pass: walk the user's operation against the final
-        // merged data and emit `UNSATISFIED_FETCH_CONDITION` for each missing
-        // leaf that sits under a recorded skipped entity path.
-        let skipped_paths = std::mem::take(&mut *skipped_entity_paths.lock());
-        if !skipped_paths.is_empty() {
-            collect_unsatisfied_fetch_errors(
-                &self.query.operation.selection_set,
-                &self.query.fragments,
-                schema.as_ref(),
-                &supergraph_request.body().variables,
-                &value,
-                &Path::empty(),
-                &skipped_paths,
-                &mut errors,
-            );
-        }
+        emit_unsatisfied_fetch_errors(
+            std::mem::take(&mut *skipped_entity_paths.lock()),
+            &self.query,
+            schema.as_ref(),
+            &supergraph_request.body().variables,
+            &value,
+            &mut errors,
+        );
 
         Response::builder().data(value).errors(errors).build()
     }
@@ -150,11 +145,13 @@ pub(crate) struct ExecutionParameters<'a> {
     pub(crate) root_node: &'a PlanNode,
     pub(crate) subscription_handle: &'a Option<SubscriptionHandle>,
     pub(crate) subscription_config: &'a Option<SubscriptionConfig>,
-    /// Entity-level paths whose `_entities` fetch was skipped because a
-    /// required input was unsatisfied. Accumulated across the entire
-    /// execution; consumed at end-of-execution to generate
-    /// `UNSATISFIED_FETCH_CONDITION` errors against the final merged data.
-    pub(crate) skipped_entity_paths: &'a Mutex<Vec<Path>>,
+    /// Entries describing entities whose `_entities` fetch was skipped because
+    /// a required input was unsatisfied. Each entry pairs the entity-root path
+    /// with a tree of response keys the skipped fetch would have produced for
+    /// that entity (filtered by `__typename`). Accumulated across execution;
+    /// consumed at end-of-execution to generate `UNSATISFIED_FETCH_CONDITION`
+    /// errors against the final merged data.
+    pub(crate) skipped_entity_paths: &'a Mutex<Vec<(Path, Arc<ResponseKeyTree>)>>,
 }
 
 impl PlanNode {
@@ -330,13 +327,15 @@ impl PlanNode {
                             &fetch_node.context_rewrites,
                         );
 
-                        // Record skipped entity paths; error generation is deferred to
-                        // end-of-execution where the final merged data is available.
                         if !unsatisfied_paths.is_empty() {
-                            parameters
-                                .skipped_entity_paths
-                                .lock()
-                                .extend(unsatisfied_paths);
+                            record_skipped_entities(
+                                unsatisfied_paths,
+                                fetch_node,
+                                parent_value,
+                                parameters.schema.as_ref(),
+                                &parameters.supergraph_request.body().variables,
+                                parameters.skipped_entity_paths,
+                            );
                         }
 
                         match opt_variables {
@@ -623,7 +622,8 @@ impl DeferredNode {
             }
 
             let deferred_fetches = HashMap::new();
-            let deferred_skipped_paths: Mutex<Vec<Path>> = Mutex::new(Vec::new());
+            let deferred_skipped_paths: Mutex<Vec<(Path, Arc<ResponseKeyTree>)>> =
+                Mutex::new(Vec::new());
 
             if let Some(node) = deferred_inner {
                 let (mut v, mut err) = node
@@ -661,20 +661,14 @@ impl DeferredNode {
                     errors.extend(primary_errors)
                 }
 
-                // End-of-chunk pass for this deferred response.
-                let skipped_paths = std::mem::take(&mut *deferred_skipped_paths.lock());
-                if !skipped_paths.is_empty() {
-                    collect_unsatisfied_fetch_errors(
-                        &query.operation.selection_set,
-                        &query.fragments,
-                        &sc,
-                        &orig.body().variables,
-                        &v,
-                        &Path::empty(),
-                        &skipped_paths,
-                        &mut err,
-                    );
-                }
+                emit_unsatisfied_fetch_errors(
+                    std::mem::take(&mut *deferred_skipped_paths.lock()),
+                    &query,
+                    &sc,
+                    &orig.body().variables,
+                    &v,
+                    &mut err,
+                );
 
                 if let Err(e) = tx
                     .send(
@@ -723,19 +717,352 @@ impl DeferredNode {
     }
 }
 
-/// End-of-execution walker: traverse the user's selection set against the final
-/// merged response data and emit `UNSATISFIED_FETCH_CONDITION` for each missing
-/// field whose path sits under an entry in `skipped_paths`.
+// ──────────────────────────────────────────────────────────────────────────
+// Skipped-entity error generation
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Tree of response keys produced by a subgraph fetch for one entity, filtered
+/// to fragments matching the entity's `__typename` and not excluded by
+/// `@skip`/`@include`. The walker uses this at end-of-execution to tell
+/// "missing because this fetch was skipped" apart from "missing for some
+/// other reason" (e.g. a coprocessor stripped the field from a different
+/// fetch). An empty `children` map with `is_list_stop: false` is a scalar/enum
+/// leaf; `is_list_stop: true` marks a list-typed field — anything under the
+/// list is considered covered (we have no per-index info inside the tree).
+#[derive(Default, Debug)]
+pub(crate) struct ResponseKeyTree {
+    is_list_stop: bool,
+    children: HashMap<Name, ResponseKeyTree>,
+}
+
+impl ResponseKeyTree {
+    fn is_empty(&self) -> bool {
+        self.children.is_empty() && !self.is_list_stop
+    }
+}
+
+/// For each entity in `unsatisfied_paths`, build the `ResponseKeyTree` of
+/// response keys the skipped fetch would have produced for that entity
+/// (filtered by the entity's `__typename`) and append it to `accumulator`.
 ///
-/// `skipped_paths` is the accumulator filled by `PlanNode::Fetch` execution:
-/// one path per entity whose `_entities` fetch was skipped because a required
-/// input was unsatisfied (paths are entity-root, not per-leaf).
+/// Trees are deduped per `__typename` so a batched `_entities` skip of N
+/// entities of the same type costs one tree build and N `Arc::clone`s.
+fn record_skipped_entities(
+    unsatisfied_paths: Vec<Path>,
+    fetch_node: &FetchNode,
+    parent_value: &Value,
+    schema: &Schema,
+    variables: &Object,
+    accumulator: &Mutex<Vec<(Path, Arc<ResponseKeyTree>)>>,
+) {
+    let mut accumulator = accumulator.lock();
+    let mut tree_cache: HashMap<Option<String>, Option<Arc<ResponseKeyTree>>> = HashMap::new();
+    for entity_path in unsatisfied_paths {
+        let entity_data = get_value_at_path(parent_value, &entity_path);
+        let entity_type_key = typename_of(entity_data).map(str::to_owned);
+        let tree = tree_cache
+            .entry(entity_type_key.clone())
+            .or_insert_with(|| {
+                entity_response_key_tree(fetch_node, entity_type_key.as_deref(), schema, variables)
+                    .map(Arc::new)
+            });
+        if let Some(tree) = tree {
+            accumulator.push((entity_path, tree.clone()));
+        }
+    }
+}
+
+/// Build a tree of response keys for a subgraph `_entities` fetch, filtered
+/// to fragments matching `entity_type` and not excluded by `@skip`/`@include`.
+/// Returns `None` when the operation isn't an `_entities` fetch or the tree
+/// would be empty.
+fn entity_response_key_tree(
+    fetch_node: &FetchNode,
+    entity_type: Option<&str>,
+    schema: &Schema,
+    variables: &Object,
+) -> Option<ResponseKeyTree> {
+    let parsed = fetch_node.operation.as_parsed().ok()?;
+    let operation = parsed
+        .operations
+        .anonymous
+        .as_ref()
+        .or_else(|| parsed.operations.named.values().next())?;
+
+    let mut tree = ResponseKeyTree::default();
+    for sel in &operation.selection_set.selections {
+        if let executable::Selection::Field(f) = sel
+            && f.name.as_str() == "_entities"
+        {
+            collect_response_key_tree(
+                &f.selection_set,
+                parsed,
+                entity_type,
+                schema,
+                variables,
+                &mut tree,
+            );
+        }
+    }
+    if tree.is_empty() { None } else { Some(tree) }
+}
+
+/// Recursively populate `tree` from a subgraph selection set. Descends through
+/// inline fragments and named fragment spreads, filtering by `entity_type`
+/// against each fragment's type condition. Skips `__typename`. Stops at
+/// list-typed fields (marks `is_list_stop`) since the tree has no array
+/// indices.
+fn collect_response_key_tree(
+    selection_set: &executable::SelectionSet,
+    document: &executable::ExecutableDocument,
+    entity_type: Option<&str>,
+    schema: &Schema,
+    variables: &Object,
+    tree: &mut ResponseKeyTree,
+) {
+    for sel in &selection_set.selections {
+        match sel {
+            executable::Selection::Field(f) => {
+                if IncludeSkip::parse(&f.directives).should_skip(variables) {
+                    continue;
+                }
+                let key = f.response_key();
+                if key.as_str() == TYPENAME {
+                    continue;
+                }
+                let entry = tree.children.entry(key.clone()).or_default();
+                if f.ty().is_list() {
+                    entry.is_list_stop = true;
+                } else if !f.selection_set.selections.is_empty() {
+                    collect_response_key_tree(
+                        &f.selection_set,
+                        document,
+                        None,
+                        schema,
+                        variables,
+                        entry,
+                    );
+                }
+            }
+            executable::Selection::InlineFragment(frag) => {
+                if IncludeSkip::parse(&frag.directives).should_skip(variables) {
+                    continue;
+                }
+                let matches = frag
+                    .type_condition
+                    .as_ref()
+                    .is_none_or(|cond| type_condition_matches(schema, entity_type, cond.as_str()));
+                if matches {
+                    collect_response_key_tree(
+                        &frag.selection_set,
+                        document,
+                        entity_type,
+                        schema,
+                        variables,
+                        tree,
+                    );
+                }
+            }
+            executable::Selection::FragmentSpread(spread) => {
+                if IncludeSkip::parse(&spread.directives).should_skip(variables) {
+                    continue;
+                }
+                if let Some(fragment) = document.fragments.get(&spread.fragment_name)
+                    && type_condition_matches(
+                        schema,
+                        entity_type,
+                        fragment.type_condition().as_str(),
+                    )
+                {
+                    collect_response_key_tree(
+                        &fragment.selection_set,
+                        document,
+                        entity_type,
+                        schema,
+                        variables,
+                        tree,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Walk a JSON value to the location named by `path`, returning `&Value::Null`
+/// for any missing segment so callers can chain without `Option`.
+fn get_value_at_path<'a>(value: &'a Value, path: &Path) -> &'a Value {
+    path.iter()
+        .fold(value, |current, segment| match (segment, current) {
+            (PathElement::Key(k, _), Value::Object(obj)) => {
+                obj.get(k.as_str()).unwrap_or(&Value::Null)
+            }
+            (PathElement::Index(i), Value::Array(arr)) => arr.get(*i).unwrap_or(&Value::Null),
+            _ => &Value::Null,
+        })
+}
+
+fn typename_of(value: &Value) -> Option<&str> {
+    match value {
+        Value::Object(obj) => obj.get(TYPENAME).and_then(|v| v.as_str()),
+        _ => None,
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Skip tree
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Unified tree mirroring response navigation, with skipped-fetch coverage
+/// folded in. Built once at end-of-execution from all `(entity_path, tree)`
+/// entries; consulted by the walker via a `SkipState` cursor that advances
+/// in lockstep with the response-data walk. Coverage check is O(1) per leaf.
 ///
-/// A path is considered "under a skipped path" if some prefix equals an entry
-/// in `skipped_paths`. A field is considered "missing" if either it's absent
-/// from the value object or it's present-but-null. Missing fields that aren't
-/// under any skipped path are left alone — they're either explained by an
-/// existing subgraph error, or fall outside this PR's scope.
+/// Two kinds of navigation: by response key (composite descent) and by array
+/// index (list element descent). A node carries:
+/// - `covered`: a leaf-level skipped fetch ends here.
+/// - `covers_all_below`: a list-stop leaf in a `ResponseKeyTree` was grafted
+///   here, so anything reachable from this node is covered.
+#[derive(Default, Debug)]
+struct SkipTreeNode {
+    covered: bool,
+    covers_all_below: bool,
+    by_key: HashMap<String, SkipTreeNode>,
+    by_index: HashMap<usize, SkipTreeNode>,
+}
+
+impl SkipTreeNode {
+    fn build(skipped: &[(Path, Arc<ResponseKeyTree>)]) -> Self {
+        let mut root = SkipTreeNode::default();
+        for (entity_path, tree) in skipped {
+            // Navigate to the entity_path, creating intermediate nodes.
+            let mut cursor = &mut root;
+            for segment in entity_path.iter() {
+                match segment {
+                    PathElement::Key(k, _) => {
+                        cursor = cursor.by_key.entry(k.clone()).or_default();
+                    }
+                    PathElement::Index(i) => {
+                        cursor = cursor.by_index.entry(*i).or_default();
+                    }
+                    // Flatten/Fragment shouldn't appear in entity paths recorded by
+                    // `Variables::new`; if they do, skip gracefully.
+                    _ => return root,
+                }
+            }
+            graft_response_key_tree(cursor, tree);
+        }
+        root
+    }
+}
+
+/// Copy a `ResponseKeyTree`'s structure into a `SkipTreeNode`,
+/// preserving list-stop semantics as `covers_all_below`.
+fn graft_response_key_tree(target: &mut SkipTreeNode, tree: &ResponseKeyTree) {
+    if tree.is_list_stop {
+        target.covers_all_below = true;
+        return;
+    }
+    if tree.children.is_empty() {
+        target.covered = true;
+        return;
+    }
+    for (key, child) in &tree.children {
+        let target_child = target.by_key.entry(key.as_str().to_owned()).or_default();
+        graft_response_key_tree(target_child, child);
+    }
+}
+
+/// Cursor into a `SkipTreeNode`, advanced in lockstep with the response-data
+/// walk. `AllBelow` is a sticky synthetic state propagated from list-stop
+/// grafts.
+#[derive(Copy, Clone)]
+enum SkipState<'a> {
+    None,
+    AllBelow,
+    At(&'a SkipTreeNode),
+}
+
+impl<'a> SkipState<'a> {
+    fn root(tree: &'a SkipTreeNode) -> Self {
+        Self::At(tree)
+    }
+
+    fn descend_key(self, key: &str) -> Self {
+        match self {
+            Self::AllBelow => Self::AllBelow,
+            Self::At(t) if t.covers_all_below => Self::AllBelow,
+            Self::At(t) => match t.by_key.get(key) {
+                Some(child) => Self::At(child),
+                None => Self::None,
+            },
+            Self::None => Self::None,
+        }
+    }
+
+    fn descend_index(self, i: usize) -> Self {
+        match self {
+            Self::AllBelow => Self::AllBelow,
+            Self::At(t) if t.covers_all_below => Self::AllBelow,
+            Self::At(t) => match t.by_index.get(&i) {
+                Some(child) => Self::At(child),
+                // No per-index branch → pass through the same composite node:
+                // a tree built from "friends { name }" (no list-stop) has the
+                // walker at the `friends` node when entering the array, and
+                // the inner-element walk should continue from that same node
+                // (which has `name` as a child).
+                None => Self::At(t),
+            },
+            Self::None => Self::None,
+        }
+    }
+
+    fn is_covered(&self) -> bool {
+        match self {
+            Self::AllBelow => true,
+            Self::At(t) => t.covered || t.covers_all_below,
+            Self::None => false,
+        }
+    }
+}
+
+/// End-of-execution entry point: fold the per-entity `(Path, ResponseKeyTree)`
+/// entries into a single `SkipTreeNode`, then walk the user's operation
+/// against `value` and append `UNSATISFIED_FETCH_CONDITION` errors to
+/// `errors`. No-op when `skipped` is empty so callers can invoke
+/// unconditionally.
+///
+/// Both the primary response (in `QueryPlan::execute`) and each `@defer`
+/// chunk (in `DeferredNode::execute`) call this with their own accumulator.
+fn emit_unsatisfied_fetch_errors(
+    skipped: Vec<(Path, Arc<ResponseKeyTree>)>,
+    query: &Query,
+    schema: &Schema,
+    variables: &Object,
+    value: &Value,
+    errors: &mut Vec<Error>,
+) {
+    if skipped.is_empty() {
+        return;
+    }
+    let master = SkipTreeNode::build(&skipped);
+    collect_unsatisfied_fetch_errors(
+        &query.operation.selection_set,
+        &query.fragments,
+        schema,
+        variables,
+        value,
+        &Path::empty(),
+        SkipState::root(&master),
+        errors,
+    );
+}
+
+/// End-of-execution walker: traverse the user's selection set against the
+/// final merged response data and emit `UNSATISFIED_FETCH_CONDITION` for each
+/// missing field whose `SkipState` cursor reports coverage.
+///
+/// Walking the master skip tree in lockstep with the response walk turns the
+/// per-leaf coverage check into O(1) — one HashMap lookup per descend step.
 #[allow(clippy::too_many_arguments)]
 fn collect_unsatisfied_fetch_errors(
     selection_set: &[Selection],
@@ -744,7 +1071,7 @@ fn collect_unsatisfied_fetch_errors(
     variables: &Object,
     value: &Value,
     current_path: &Path,
-    skipped_paths: &[Path],
+    skip: SkipState<'_>,
     output: &mut Vec<Error>,
 ) {
     let current_type = value
@@ -770,17 +1097,17 @@ fn collect_unsatisfied_fetch_errors(
                 let response_key = alias.as_ref().unwrap_or(name).as_str();
                 let field_value = value.as_object().and_then(|o| o.get(response_key));
 
-                // Treat absent OR null as "missing".
                 let missing = match field_value {
                     None => true,
                     Some(v) => v.is_null(),
                 };
 
-                let mut field_path = current_path.clone();
-                field_path.push(PathElement::Key(response_key.to_string(), None));
+                let field_skip = skip.descend_key(response_key);
 
                 if missing {
-                    if is_under_skipped_path(&field_path, skipped_paths) {
+                    if field_skip.is_covered() {
+                        let mut field_path = current_path.clone();
+                        field_path.push(PathElement::Key(response_key.to_string(), None));
                         output.push(
                             Error::builder()
                                 .message("Could not fetch field")
@@ -792,10 +1119,11 @@ fn collect_unsatisfied_fetch_errors(
                     continue;
                 }
 
-                // Composite: recurse into the field's value if it has a sub-selection.
                 if let Some(sub_sel) = sub
                     && let Some(field_value) = field_value
                 {
+                    let mut field_path = current_path.clone();
+                    field_path.push(PathElement::Key(response_key.to_string(), None));
                     descend_into_value(
                         sub_sel,
                         fragments,
@@ -803,7 +1131,7 @@ fn collect_unsatisfied_fetch_errors(
                         variables,
                         field_value,
                         &field_path,
-                        skipped_paths,
+                        field_skip,
                         output,
                     );
                 }
@@ -827,7 +1155,7 @@ fn collect_unsatisfied_fetch_errors(
                         variables,
                         value,
                         current_path,
-                        skipped_paths,
+                        skip,
                         output,
                     );
                 }
@@ -853,7 +1181,7 @@ fn collect_unsatisfied_fetch_errors(
                         variables,
                         value,
                         current_path,
-                        skipped_paths,
+                        skip,
                         output,
                     );
                 }
@@ -862,8 +1190,6 @@ fn collect_unsatisfied_fetch_errors(
     }
 }
 
-/// Recurse into a field's value; if it's an array, iterate per-index with
-/// `PathElement::Index` segments. Otherwise descend into the value as an object.
 #[allow(clippy::too_many_arguments)]
 fn descend_into_value(
     selection_set: &[Selection],
@@ -872,7 +1198,7 @@ fn descend_into_value(
     variables: &Object,
     value: &Value,
     current_path: &Path,
-    skipped_paths: &[Path],
+    skip: SkipState<'_>,
     output: &mut Vec<Error>,
 ) {
     if let Some(arr) = value.as_array() {
@@ -886,7 +1212,7 @@ fn descend_into_value(
                 variables,
                 item,
                 &item_path,
-                skipped_paths,
+                skip.descend_index(i),
                 output,
             );
         }
@@ -898,17 +1224,8 @@ fn descend_into_value(
             variables,
             value,
             current_path,
-            skipped_paths,
+            skip,
             output,
         );
     }
-}
-
-/// True iff `path` has some prefix in `skipped`. Equality counts (a skipped
-/// entity path is "under itself"), so leaves of the skipped entity directly
-/// match.
-fn is_under_skipped_path(path: &Path, skipped: &[Path]) -> bool {
-    skipped
-        .iter()
-        .any(|sp| sp.len() <= path.len() && sp.iter().zip(path.iter()).all(|(a, b)| a == b))
 }

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -2,11 +2,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use apollo_compiler::Name;
+use apollo_compiler::collections::IndexMap;
 use apollo_compiler::executable;
 use futures::StreamExt;
 use futures::future::join_all;
 use futures::prelude::*;
-use parking_lot::Mutex;
+use tokio::sync::Mutex;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::BroadcastStream;
@@ -17,7 +18,6 @@ use super::DeferredNode;
 use super::PlanNode;
 use super::QueryPlan;
 use super::log;
-use super::selection::type_condition_matches;
 use super::subscription::SubscriptionHandle;
 use crate::Context;
 use crate::axum_factory::CanceledRequest;
@@ -81,7 +81,7 @@ impl QueryPlan {
 
         log::trace_query_plan(&self.root);
         let deferred_fetches = HashMap::new();
-        let skipped_entity_paths: Mutex<Vec<(Path, Arc<ResponseKeyTree>)>> = Mutex::new(Vec::new());
+        let skipped_entity_paths = Default::default();
 
         let (value, mut errors) = self
             .root
@@ -112,8 +112,9 @@ impl QueryPlan {
             );
         }
 
+        let skipped_entity_paths = skipped_entity_paths.lock().await;
         emit_unsatisfied_fetch_errors(
-            std::mem::take(&mut *skipped_entity_paths.lock()),
+            &skipped_entity_paths,
             &self.query,
             schema.as_ref(),
             &supergraph_request.body().variables,
@@ -145,12 +146,6 @@ pub(crate) struct ExecutionParameters<'a> {
     pub(crate) root_node: &'a PlanNode,
     pub(crate) subscription_handle: &'a Option<SubscriptionHandle>,
     pub(crate) subscription_config: &'a Option<SubscriptionConfig>,
-    /// Entries describing entities whose `_entities` fetch was skipped because
-    /// a required input was unsatisfied. Each entry pairs the entity-root path
-    /// with a tree of response keys the skipped fetch would have produced for
-    /// that entity (filtered by `__typename`). Accumulated across execution;
-    /// consumed at end-of-execution to generate `UNSATISFIED_FETCH_CONDITION`
-    /// errors against the final merged data.
     pub(crate) skipped_entity_paths: &'a Mutex<Vec<(Path, Arc<ResponseKeyTree>)>>,
 }
 
@@ -335,7 +330,8 @@ impl PlanNode {
                                 parameters.schema.as_ref(),
                                 &parameters.supergraph_request.body().variables,
                                 parameters.skipped_entity_paths,
-                            );
+                            )
+                            .await;
                         }
 
                         match opt_variables {
@@ -661,8 +657,9 @@ impl DeferredNode {
                     errors.extend(primary_errors)
                 }
 
+                let deferred_skipped_paths = deferred_skipped_paths.lock().await;
                 emit_unsatisfied_fetch_errors(
-                    std::mem::take(&mut *deferred_skipped_paths.lock()),
+                    &deferred_skipped_paths,
                     &query,
                     &sc,
                     &orig.body().variables,
@@ -721,23 +718,22 @@ impl DeferredNode {
 // Skipped-entity error generation
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Tree of response keys produced by a subgraph fetch for one entity, filtered
-/// to fragments matching the entity's `__typename` and not excluded by
-/// `@skip`/`@include`. The walker uses this at end-of-execution to tell
-/// "missing because this fetch was skipped" apart from "missing for some
-/// other reason" (e.g. a coprocessor stripped the field from a different
-/// fetch). An empty `children` map with `is_list_stop: false` is a scalar/enum
-/// leaf; `is_list_stop: true` marks a list-typed field — anything under the
-/// list is considered covered (we have no per-index info inside the tree).
+/// Tree of response keys produced by a subgraph fetch for one entity,
+/// over-approximated: we descend through every selection (including lists and
+/// undecidable type conditions) so that every possible leaf the skipped fetch
+/// could have produced shows up in `children`. Leaves are never fetched twice
+/// by another subgraph, so any missing leaf in the final response is a true
+/// positive `UNSATISFIED_FETCH_CONDITION`. Intermediate composite fields may
+/// be filled by another subgraph — those are not by themselves errors, only
+/// their genuinely-missing leaves are.
 #[derive(Default, Debug)]
 pub(crate) struct ResponseKeyTree {
-    is_list_stop: bool,
     children: HashMap<Name, ResponseKeyTree>,
 }
 
 impl ResponseKeyTree {
     fn is_empty(&self) -> bool {
-        self.children.is_empty() && !self.is_list_stop
+        self.children.is_empty()
     }
 }
 
@@ -747,7 +743,7 @@ impl ResponseKeyTree {
 ///
 /// Trees are deduped per `__typename` so a batched `_entities` skip of N
 /// entities of the same type costs one tree build and N `Arc::clone`s.
-fn record_skipped_entities(
+async fn record_skipped_entities(
     unsatisfied_paths: Vec<Path>,
     fetch_node: &FetchNode,
     parent_value: &Value,
@@ -755,40 +751,54 @@ fn record_skipped_entities(
     variables: &Object,
     accumulator: &Mutex<Vec<(Path, Arc<ResponseKeyTree>)>>,
 ) {
-    let mut accumulator = accumulator.lock();
-    let mut tree_cache: HashMap<Option<String>, Option<Arc<ResponseKeyTree>>> = HashMap::new();
+    let Ok(parsed) = fetch_node.operation.as_parsed() else {
+        // shouldn't happen -> skip recording
+        return;
+    };
+    let operation = parsed.operations.get(fetch_node.operation_name.as_deref());
+    let Ok(operation) = operation else {
+        // shouldn't happen -> skip recording
+        return;
+    };
+
+    let mut accumulator = accumulator.lock().await;
+    let mut tree_cache: HashMap<String, Arc<ResponseKeyTree>> = HashMap::new();
     for entity_path in unsatisfied_paths {
         let entity_data = get_value_at_path(parent_value, &entity_path);
-        let entity_type_key = typename_of(entity_data).map(str::to_owned);
-        let tree = tree_cache
-            .entry(entity_type_key.clone())
-            .or_insert_with(|| {
-                entity_response_key_tree(fetch_node, entity_type_key.as_deref(), schema, variables)
-                    .map(Arc::new)
-            });
-        if let Some(tree) = tree {
+        let entity_type = typename_of(entity_data).map(str::to_owned);
+        let Some(entity_type) = entity_type else {
+            // No `__typename` on the entity data - Drop this path silently rather than guessing.
+            continue;
+        };
+        let tree = tree_cache.entry(entity_type.clone()).or_insert_with(|| {
+            let tree = entity_response_key_tree(
+                operation,
+                &parsed.fragments,
+                &entity_type,
+                schema,
+                variables,
+            );
+            Arc::new(tree)
+        });
+        if !tree.is_empty() {
             accumulator.push((entity_path, tree.clone()));
         }
     }
 }
 
-/// Build a tree of response keys for a subgraph `_entities` fetch, filtered
-/// to fragments matching `entity_type` and not excluded by `@skip`/`@include`.
-/// Returns `None` when the operation isn't an `_entities` fetch or the tree
-/// would be empty.
+/// Build the over-approximated tree of response keys for a subgraph
+/// `_entities` fetch, anchored at `entity_type` (the runtime `__typename`).
+/// Iterates the operation's top-level `_entities` selection and accumulates
+/// keys via `collect_response_key_tree`. Returns an empty tree when the
+/// operation has no `_entities` field, or every fragment at that level
+/// definitely does not match the entity type.
 fn entity_response_key_tree(
-    fetch_node: &FetchNode,
-    entity_type: Option<&str>,
+    operation: &apollo_compiler::Node<executable::Operation>,
+    fragments: &IndexMap<Name, apollo_compiler::Node<executable::Fragment>>,
+    entity_type: &str,
     schema: &Schema,
     variables: &Object,
-) -> Option<ResponseKeyTree> {
-    let parsed = fetch_node.operation.as_parsed().ok()?;
-    let operation = parsed
-        .operations
-        .anonymous
-        .as_ref()
-        .or_else(|| parsed.operations.named.values().next())?;
-
+) -> ResponseKeyTree {
     let mut tree = ResponseKeyTree::default();
     for sel in &operation.selection_set.selections {
         if let executable::Selection::Field(f) = sel
@@ -796,30 +806,115 @@ fn entity_response_key_tree(
         {
             collect_response_key_tree(
                 &f.selection_set,
-                parsed,
-                entity_type,
-                schema,
+                Some(entity_type),
+                fragments,
                 variables,
+                schema,
                 &mut tree,
             );
         }
     }
-    if tree.is_empty() { None } else { Some(tree) }
+    tree
 }
 
-/// Recursively populate `tree` from a subgraph selection set. Descends through
-/// inline fragments and named fragment spreads, filtering by `entity_type`
-/// against each fragment's type condition. Skips `__typename`. Stops at
-/// list-typed fields (marks `is_list_stop`) since the tree has no array
-/// indices.
+/// Static three-valued resolution of a fragment type condition against the current type. Returns
+/// following values:
+/// - `Some(true)` when the condition definitely matches the runtime type
+/// - `Some(false)` when it definitely does not
+/// - `None` when static analysis cannot decide (the current type is abstract, or we have no
+///   current type because we descended into a field and lost type info).
+fn static_type_condition_match(
+    schema: &Schema,
+    current_type: &str,
+    type_condition: &str,
+) -> Option<bool> {
+    if current_type == type_condition {
+        return Some(true);
+    }
+    let current = schema.supergraph_schema().types.get(current_type)?;
+    let cond = schema.supergraph_schema().types.get(type_condition)?;
+
+    use apollo_compiler::schema::ExtendedType::*;
+    match current {
+        Object(o) => match cond {
+            Object(c) => Some(o.name == c.name),
+            Interface(i) => Some(o.implements_interfaces.contains(&i.name)),
+            Union(u) => Some(u.members.contains(&o.name)),
+            _ => Some(false),
+        },
+        // Abstract current type: undecidable without runtime info.
+        Interface(_) | Union(_) => None,
+        _ => Some(false),
+    }
+}
+
+/// Pick the more concrete of `current` and `condition` as the new current type.
+fn walker_refine_type<'a>(schema: &Schema, current: &'a str, condition: &'a str) -> &'a str {
+    use apollo_compiler::schema::ExtendedType::*;
+    if matches!(
+        schema.supergraph_schema().types.get(current),
+        Some(Object(_))
+    ) {
+        return current;
+    }
+    if matches!(
+        schema.supergraph_schema().types.get(condition),
+        Some(Object(_))
+    ) {
+        return condition;
+    }
+    current
+}
+
+/// Pick the more concrete of two types as the current type. Prefers a concrete object type over an
+/// abstract interface/union or an unknown type.
+fn refine_runtime_type<'a>(
+    schema: &Schema,
+    runtime: Option<&'a str>,
+    condition: &'a str,
+) -> Option<&'a str> {
+    use apollo_compiler::schema::ExtendedType::*;
+    if matches!(
+        runtime.and_then(|t| schema.supergraph_schema().types.get(t)),
+        Some(Object(_))
+    ) {
+        return runtime;
+    }
+    if matches!(
+        schema.supergraph_schema().types.get(condition),
+        Some(Object(_))
+    ) {
+        return Some(condition);
+    }
+    runtime
+}
+
+/// Recursively populate `tree` from a subgraph selection set, over-approximating
+/// the keys the skipped fetch would have produced.
+///
+/// "Over-approximate" means:
+/// - Descend through every composite field's sub-selection (including list-typed
+///   fields), so leaves nested arbitrarily deep land in `tree`.
+/// - Descend through inline fragments and named fragment spreads even when
+///   their type condition is statically undecidable (the current type is
+///   abstract, or we descended into a field and lost runtime type info).
+///   Definite no-match (`Some(false)`) is the only short-circuit.
+///
+/// We may collect leaves that wouldn't actually have been produced at runtime
+/// (e.g. a fragment on a sibling concrete object that didn't end up matching
+/// the runtime type), but that is fine: a leaf is only emitted as an error
+/// when it's also missing from the final merged response. Since leaves are
+/// never fetched twice across subgraphs, a missing leaf from this set is a
+/// true positive — `UNSATISFIED_FETCH_CONDITION` for the skipped fetch.
 fn collect_response_key_tree(
     selection_set: &executable::SelectionSet,
-    document: &executable::ExecutableDocument,
-    entity_type: Option<&str>,
-    schema: &Schema,
+    runtime_type: Option<&str>,
+    fragments: &IndexMap<Name, apollo_compiler::Node<executable::Fragment>>,
     variables: &Object,
+    schema: &Schema,
     tree: &mut ResponseKeyTree,
 ) {
+    let current_type = runtime_type.unwrap_or(selection_set.ty.as_str());
     for sel in &selection_set.selections {
         match sel {
             executable::Selection::Field(f) => {
@@ -831,15 +926,13 @@ fn collect_response_key_tree(
                     continue;
                 }
                 let entry = tree.children.entry(key.clone()).or_default();
-                if f.ty().is_list() {
-                    entry.is_list_stop = true;
-                } else if !f.selection_set.selections.is_empty() {
+                if !f.selection_set.selections.is_empty() {
                     collect_response_key_tree(
                         &f.selection_set,
-                        document,
                         None,
-                        schema,
+                        fragments,
                         variables,
+                        schema,
                         entry,
                     );
                 }
@@ -848,41 +941,46 @@ fn collect_response_key_tree(
                 if IncludeSkip::parse(&frag.directives).should_skip(variables) {
                     continue;
                 }
-                let matches = frag
-                    .type_condition
-                    .as_ref()
-                    .is_none_or(|cond| type_condition_matches(schema, entity_type, cond.as_str()));
-                if matches {
-                    collect_response_key_tree(
-                        &frag.selection_set,
-                        document,
-                        entity_type,
-                        schema,
-                        variables,
-                        tree,
-                    );
+                let matches = match frag.type_condition.as_ref() {
+                    None => Some(true),
+                    Some(cond) => static_type_condition_match(schema, current_type, cond.as_str()),
+                };
+                if matches == Some(false) {
+                    continue;
                 }
+                let refined = match frag.type_condition.as_ref() {
+                    Some(cond) => refine_runtime_type(schema, runtime_type, cond.as_str()),
+                    None => runtime_type,
+                };
+                collect_response_key_tree(
+                    &frag.selection_set,
+                    refined,
+                    fragments,
+                    variables,
+                    schema,
+                    tree,
+                );
             }
             executable::Selection::FragmentSpread(spread) => {
                 if IncludeSkip::parse(&spread.directives).should_skip(variables) {
                     continue;
                 }
-                if let Some(fragment) = document.fragments.get(&spread.fragment_name)
-                    && type_condition_matches(
-                        schema,
-                        entity_type,
-                        fragment.type_condition().as_str(),
-                    )
-                {
-                    collect_response_key_tree(
-                        &fragment.selection_set,
-                        document,
-                        entity_type,
-                        schema,
-                        variables,
-                        tree,
-                    );
+                let Some(fragment) = fragments.get(&spread.fragment_name) else {
+                    continue;
+                };
+                let cond = fragment.type_condition().as_str();
+                if static_type_condition_match(schema, current_type, cond) == Some(false) {
+                    continue;
                 }
+                let refined = refine_runtime_type(schema, runtime_type, cond);
+                collect_response_key_tree(
+                    &fragment.selection_set,
+                    refined,
+                    fragments,
+                    variables,
+                    schema,
+                    tree,
+                );
             }
         }
     }
@@ -918,14 +1016,10 @@ fn typename_of(value: &Value) -> Option<&str> {
 /// in lockstep with the response-data walk. Coverage check is O(1) per leaf.
 ///
 /// Two kinds of navigation: by response key (composite descent) and by array
-/// index (list element descent). A node carries:
-/// - `covered`: a leaf-level skipped fetch ends here.
-/// - `covers_all_below`: a list-stop leaf in a `ResponseKeyTree` was grafted
-///   here, so anything reachable from this node is covered.
+/// index (list element descent). A node with no `by_key`/`by_index` entries
+/// is a leaf-level skip target — the skipped fetch ended here.
 #[derive(Default, Debug)]
 struct SkipTreeNode {
-    covered: bool,
-    covers_all_below: bool,
     by_key: HashMap<String, SkipTreeNode>,
     by_index: HashMap<usize, SkipTreeNode>,
 }
@@ -955,30 +1049,20 @@ impl SkipTreeNode {
     }
 }
 
-/// Copy a `ResponseKeyTree`'s structure into a `SkipTreeNode`,
-/// preserving list-stop semantics as `covers_all_below`.
+/// Copy a `ResponseKeyTree`'s structure into a `SkipTreeNode`. A leaf in the
+/// source tree (no children) maps to a leaf in the target (no `by_key`/
+/// `by_index` entries).
 fn graft_response_key_tree(target: &mut SkipTreeNode, tree: &ResponseKeyTree) {
-    if tree.is_list_stop {
-        target.covers_all_below = true;
-        return;
-    }
-    if tree.children.is_empty() {
-        target.covered = true;
-        return;
-    }
     for (key, child) in &tree.children {
         let target_child = target.by_key.entry(key.as_str().to_owned()).or_default();
         graft_response_key_tree(target_child, child);
     }
 }
 
-/// Cursor into a `SkipTreeNode`, advanced in lockstep with the response-data
-/// walk. `AllBelow` is a sticky synthetic state propagated from list-stop
-/// grafts.
+/// Cursor into a `SkipTreeNode`, advanced in lockstep with the response-data walk.
 #[derive(Copy, Clone)]
 enum SkipState<'a> {
     None,
-    AllBelow,
     At(&'a SkipTreeNode),
 }
 
@@ -989,8 +1073,6 @@ impl<'a> SkipState<'a> {
 
     fn descend_key(self, key: &str) -> Self {
         match self {
-            Self::AllBelow => Self::AllBelow,
-            Self::At(t) if t.covers_all_below => Self::AllBelow,
             Self::At(t) => match t.by_key.get(key) {
                 Some(child) => Self::At(child),
                 None => Self::None,
@@ -999,42 +1081,40 @@ impl<'a> SkipState<'a> {
         }
     }
 
+    /// Walk one step into a list element.
+    /// - No per-index entries → pass through (`by_key` applies uniformly to
+    ///   every element).
+    /// - `by_index` has this index → descend into its per-entity subtree.
+    /// - `by_index` has entries but not this one → the index is not covered.
     fn descend_index(self, i: usize) -> Self {
         match self {
-            Self::AllBelow => Self::AllBelow,
-            Self::At(t) if t.covers_all_below => Self::AllBelow,
-            Self::At(t) => match t.by_index.get(&i) {
-                Some(child) => Self::At(child),
-                // No per-index branch → pass through the same composite node:
-                // a tree built from "friends { name }" (no list-stop) has the
-                // walker at the `friends` node when entering the array, and
-                // the inner-element walk should continue from that same node
-                // (which has `name` as a child).
-                None => Self::At(t),
-            },
+            Self::At(t) => {
+                if t.by_index.is_empty() {
+                    Self::At(t)
+                } else if let Some(child) = t.by_index.get(&i) {
+                    Self::At(child)
+                } else {
+                    Self::None
+                }
+            }
             Self::None => Self::None,
         }
     }
 
-    fn is_covered(&self) -> bool {
-        match self {
-            Self::AllBelow => true,
-            Self::At(t) => t.covered || t.covers_all_below,
-            Self::None => false,
-        }
+    /// True iff this state corresponds to any node in the master tree (leaf
+    /// or intermediate). The walker emits at a missing/null position whenever
+    /// the position is in the skip tree at all.
+    fn is_present(&self) -> bool {
+        !matches!(self, Self::None)
     }
 }
 
-/// End-of-execution entry point: fold the per-entity `(Path, ResponseKeyTree)`
-/// entries into a single `SkipTreeNode`, then walk the user's operation
-/// against `value` and append `UNSATISFIED_FETCH_CONDITION` errors to
-/// `errors`. No-op when `skipped` is empty so callers can invoke
-/// unconditionally.
-///
-/// Both the primary response (in `QueryPlan::execute`) and each `@defer`
-/// chunk (in `DeferredNode::execute`) call this with their own accumulator.
+/// End-of-execution entry point: fold the per-entity `(Path, ResponseKeyTree)` entries into a
+/// single `SkipTreeNode`, then walk the user's operation against `value` and append
+/// `UNSATISFIED_FETCH_CONDITION` errors to `errors`. No-op when `skipped` is empty so callers can
+/// invoke unconditionally.
 fn emit_unsatisfied_fetch_errors(
-    skipped: Vec<(Path, Arc<ResponseKeyTree>)>,
+    skipped: &[(Path, Arc<ResponseKeyTree>)],
     query: &Query,
     schema: &Schema,
     variables: &Object,
@@ -1044,9 +1124,10 @@ fn emit_unsatisfied_fetch_errors(
     if skipped.is_empty() {
         return;
     }
-    let master = SkipTreeNode::build(&skipped);
+    let master = SkipTreeNode::build(skipped);
     collect_unsatisfied_fetch_errors(
         &query.operation.selection_set,
+        query.operation.kind().default_type_name(),
         &query.fragments,
         schema,
         variables,
@@ -1055,6 +1136,105 @@ fn emit_unsatisfied_fetch_errors(
         SkipState::root(&master),
         errors,
     );
+}
+
+/// True iff the user's selection set at this composite contains a non-null
+/// field that the skipped fetch was going to provide and that is missing from
+/// the response data. When this is true, `format_response` will null-bubble
+/// from that leaf up to this composite, so the walker coalesces per-leaf
+/// emissions into a single error at the composite path.
+///
+/// Recurses through inline fragments and fragment spreads, honoring
+/// `@skip`/`@include` and applying `static_type_condition_match` strictly:
+/// only definite matches are descended into.
+fn composite_has_nonnull_miss(
+    selection_set: &[Selection],
+    current_type: &str,
+    fragments: &Fragments,
+    schema: &Schema,
+    variables: &Object,
+    value: &Value,
+    skip: SkipState<'_>,
+) -> bool {
+    for selection in selection_set {
+        match selection {
+            Selection::Field {
+                name,
+                alias,
+                field_type,
+                include_skip,
+                ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                if name.as_str() == TYPENAME {
+                    continue;
+                }
+                if !field_type.is_non_null() {
+                    continue;
+                }
+                let response_key = alias.as_ref().unwrap_or(name).as_str();
+                let field_value = value.as_object().and_then(|o| o.get(response_key));
+                let missing = match field_value {
+                    None => true,
+                    Some(v) => v.is_null(),
+                };
+                if !missing {
+                    continue;
+                }
+                if skip.descend_key(response_key).is_present() {
+                    return true;
+                }
+            }
+            Selection::InlineFragment {
+                type_condition,
+                selection_set: sub,
+                include_skip,
+                ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                if static_type_condition_match(schema, current_type, type_condition) == Some(true) {
+                    let refined = walker_refine_type(schema, current_type, type_condition.as_str());
+                    if composite_has_nonnull_miss(
+                        sub, refined, fragments, schema, variables, value, skip,
+                    ) {
+                        return true;
+                    }
+                }
+            }
+            Selection::FragmentSpread {
+                name, include_skip, ..
+            } => {
+                if include_skip.should_skip(variables) {
+                    continue;
+                }
+                let Some(fragment) = fragments.get(name) else {
+                    continue;
+                };
+                if static_type_condition_match(schema, current_type, &fragment.type_condition)
+                    == Some(true)
+                {
+                    let refined =
+                        walker_refine_type(schema, current_type, &fragment.type_condition);
+                    if composite_has_nonnull_miss(
+                        &fragment.selection_set,
+                        refined,
+                        fragments,
+                        schema,
+                        variables,
+                        value,
+                        skip,
+                    ) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
 }
 
 /// End-of-execution walker: traverse the user's selection set against the
@@ -1066,6 +1246,7 @@ fn emit_unsatisfied_fetch_errors(
 #[allow(clippy::too_many_arguments)]
 fn collect_unsatisfied_fetch_errors(
     selection_set: &[Selection],
+    parent_type: &str,
     fragments: &Fragments,
     schema: &Schema,
     variables: &Object,
@@ -1077,7 +1258,30 @@ fn collect_unsatisfied_fetch_errors(
     let current_type = value
         .as_object()
         .and_then(|o| o.get(TYPENAME))
-        .and_then(|v| v.as_str());
+        .and_then(|v| v.as_str())
+        .unwrap_or(parent_type);
+
+    // Pre-scan: if a non-null missing field below this composite is covered
+    // by the skip tree, format_response will null-bubble to here. Emit one
+    // error at this composite instead of descending and emitting per-leaf.
+    if composite_has_nonnull_miss(
+        selection_set,
+        current_type,
+        fragments,
+        schema,
+        variables,
+        value,
+        skip,
+    ) {
+        output.push(
+            Error::builder()
+                .message("Could not fetch field")
+                .path(current_path.clone())
+                .extension_code("UNSATISFIED_FETCH_CONDITION")
+                .build(),
+        );
+        return;
+    }
 
     for selection in selection_set {
         match selection {
@@ -1086,6 +1290,7 @@ fn collect_unsatisfied_fetch_errors(
                 alias,
                 selection_set: sub,
                 include_skip,
+                field_type,
                 ..
             } => {
                 if include_skip.should_skip(variables) {
@@ -1105,7 +1310,8 @@ fn collect_unsatisfied_fetch_errors(
                 let field_skip = skip.descend_key(response_key);
 
                 if missing {
-                    if field_skip.is_covered() {
+                    // Field is null/missing AND in the skip tree → emit here.
+                    if field_skip.is_present() {
                         let mut field_path = current_path.clone();
                         field_path.push(PathElement::Key(response_key.to_string(), None));
                         output.push(
@@ -1126,6 +1332,7 @@ fn collect_unsatisfied_fetch_errors(
                     field_path.push(PathElement::Key(response_key.to_string(), None));
                     descend_into_value(
                         sub_sel,
+                        field_type.inner_named_type().as_str(),
                         fragments,
                         schema,
                         variables,
@@ -1140,16 +1347,16 @@ fn collect_unsatisfied_fetch_errors(
                 type_condition,
                 selection_set: sub,
                 include_skip,
-                known_type,
                 ..
             } => {
                 if include_skip.should_skip(variables) {
                     continue;
                 }
-                let effective_type = known_type.as_deref().or(current_type);
-                if type_condition_matches(schema, effective_type, type_condition) {
+                if static_type_condition_match(schema, current_type, type_condition) == Some(true) {
+                    let refined = walker_refine_type(schema, current_type, type_condition.as_str());
                     collect_unsatisfied_fetch_errors(
                         sub,
+                        refined,
                         fragments,
                         schema,
                         variables,
@@ -1161,10 +1368,7 @@ fn collect_unsatisfied_fetch_errors(
                 }
             }
             Selection::FragmentSpread {
-                name,
-                known_type,
-                include_skip,
-                ..
+                name, include_skip, ..
             } => {
                 if include_skip.should_skip(variables) {
                     continue;
@@ -1172,10 +1376,14 @@ fn collect_unsatisfied_fetch_errors(
                 let Some(fragment) = fragments.get(name) else {
                     continue;
                 };
-                let effective_type = known_type.as_deref().or(current_type);
-                if type_condition_matches(schema, effective_type, &fragment.type_condition) {
+                if static_type_condition_match(schema, current_type, &fragment.type_condition)
+                    == Some(true)
+                {
+                    let refined =
+                        walker_refine_type(schema, current_type, &fragment.type_condition);
                     collect_unsatisfied_fetch_errors(
                         &fragment.selection_set,
+                        refined,
                         fragments,
                         schema,
                         variables,
@@ -1190,9 +1398,13 @@ fn collect_unsatisfied_fetch_errors(
     }
 }
 
+/// Step into a response value carrying a composite selection set: iterate
+/// array elements one at a time (advancing the skip-tree index cursor), or
+/// dispatch the non-array case to `collect_unsatisfied_fetch_errors`.
 #[allow(clippy::too_many_arguments)]
 fn descend_into_value(
     selection_set: &[Selection],
+    parent_type: &str,
     fragments: &Fragments,
     schema: &Schema,
     variables: &Object,
@@ -1207,6 +1419,7 @@ fn descend_into_value(
             item_path.push(PathElement::Index(i));
             descend_into_value(
                 selection_set,
+                parent_type,
                 fragments,
                 schema,
                 variables,
@@ -1219,6 +1432,7 @@ fn descend_into_value(
     } else {
         collect_unsatisfied_fetch_errors(
             selection_set,
+            parent_type,
             fragments,
             schema,
             variables,

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -209,6 +209,9 @@ impl Variables {
                     context.execute_on_path(path);
                 }
 
+                // Remember whether the source value at this path was already
+                // null before we tried to build the entity representation.
+                let source_was_null = value.is_null();
                 let mut value = execute_selection_set(value, requires, schema, None);
                 let value_ok = value.as_object().map(|o| !o.is_empty()).unwrap_or(false);
                 if value_ok {
@@ -223,11 +226,10 @@ impl Variables {
                             debug_assert!(inverted_paths.len() == values.len());
                         }
                     }
-                } else {
+                } else if !source_was_null {
                     // `execute_selection_set` returned an unusable representation
-                    // (Null or empty object) — the entity is effectively skipped.
-                    // Record the path so end-of-execution can emit an
-                    // UNSATISFIED_FETCH_CONDITION error against the final data.
+                    // (Null or empty object) and the source value was non-null,
+                    // so the entity is skipped — record the path.
                     unsatisfied_paths.push(path.clone());
                 }
             });

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -169,6 +169,14 @@ pub(crate) struct Variables {
 }
 
 impl Variables {
+    /// Build variables for a subgraph fetch from the current response data.
+    ///
+    /// Returns a pair of `(Option<Variables>, Vec<Path>)`:
+    /// - The first element is `Some(variables)` when entity representations were successfully
+    ///   built, or `None` when there are no entities to fetch (either no matching data or all
+    ///   entities were skipped).
+    /// - The second element is a list of paths for entities whose required fields were
+    ///   unsatisfied (and thus skipped). The caller should generate errors for these paths.
     #[instrument(skip_all, level = "debug", name = "make_variables")]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -180,7 +188,7 @@ impl Variables {
         schema: &Schema,
         input_rewrites: &Option<Vec<rewrites::DataRewrite>>,
         context_rewrites: &Option<Vec<rewrites::DataRewrite>>,
-    ) -> Option<Variables> {
+    ) -> (Option<Variables>, Vec<Path>) {
         let body = request.body();
         let mut subgraph_context = SubgraphContext::new(data, schema, context_rewrites);
         if !requires.is_empty() {
@@ -192,6 +200,7 @@ impl Variables {
                     .map(|(variable_key, value)| (variable_key.clone(), value.clone()))
             }));
 
+            let mut unsatisfied_paths: Vec<Path> = Vec::new();
             let mut inverted_paths: Vec<Vec<Path>> = Vec::new();
             let mut values: IndexSet<Value> = IndexSet::default();
             data.select_values_and_paths(schema, current_dir, |path, value| {
@@ -201,7 +210,8 @@ impl Variables {
                 }
 
                 let mut value = execute_selection_set(value, requires, schema, None);
-                if value.as_object().map(|o| !o.is_empty()).unwrap_or(false) {
+                let value_ok = value.as_object().map(|o| !o.is_empty()).unwrap_or(false);
+                if value_ok {
                     rewrites::apply_rewrites(schema, &mut value, input_rewrites);
                     match values.get_index_of(&value) {
                         Some(index) => {
@@ -213,11 +223,17 @@ impl Variables {
                             debug_assert!(inverted_paths.len() == values.len());
                         }
                     }
+                } else {
+                    // `execute_selection_set` returned an unusable representation
+                    // (Null or empty object) — the entity is effectively skipped.
+                    // Record the path so end-of-execution can emit an
+                    // UNSATISFIED_FETCH_CONDITION error against the final data.
+                    unsatisfied_paths.push(path.clone());
                 }
             });
 
             if values.is_empty() {
-                return None;
+                return (None, unsatisfied_paths);
             }
 
             let representations = Value::Array(Vec::from_iter(values));
@@ -227,11 +243,14 @@ impl Variables {
             };
 
             variables.insert("representations", representations);
-            Some(Variables {
-                variables,
-                inverted_paths,
-                contextual_arguments,
-            })
+            (
+                Some(Variables {
+                    variables,
+                    inverted_paths,
+                    contextual_arguments,
+                }),
+                unsatisfied_paths,
+            )
         } else {
             // with nested operations (Query or Mutation has an operation returning a Query or Mutation),
             // when the first fetch fails, the query plan will still execute up until the second fetch,
@@ -244,21 +263,24 @@ impl Variables {
                     .map(|value| value.is_null())
                     .unwrap_or(true)
             {
-                return None;
+                return (None, Vec::new());
             }
 
-            Some(Variables {
-                variables: variable_usages
-                    .iter()
-                    .filter_map(|key| {
-                        body.variables
-                            .get_key_value(key.as_ref())
-                            .map(|(variable_key, value)| (variable_key.clone(), value.clone()))
-                    })
-                    .collect::<Object>(),
-                inverted_paths: Vec::new(),
-                contextual_arguments: None,
-            })
+            (
+                Some(Variables {
+                    variables: variable_usages
+                        .iter()
+                        .filter_map(|key| {
+                            body.variables
+                                .get_key_value(key.as_ref())
+                                .map(|(variable_key, value)| (variable_key.clone(), value.clone()))
+                        })
+                        .collect::<Object>(),
+                    inverted_paths: Vec::new(),
+                    contextual_arguments: None,
+                }),
+                Vec::new(),
+            )
         }
     }
 }

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -152,7 +152,7 @@ pub(crate) fn execute_selection_set<'a>(
 /// <https://spec.graphql.org/October2021/#DoesFragmentTypeApply()>
 /// <https://spec.graphql.org/October2021/#CompleteValue()>
 /// <https://spec.graphql.org/October2021/#ResolveAbstractType()>
-fn type_condition_matches(
+pub(crate) fn type_condition_matches(
     schema: &Schema,
     current_type: Option<&str>,
     type_condition: &str,

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -152,7 +152,7 @@ pub(crate) fn execute_selection_set<'a>(
 /// <https://spec.graphql.org/October2021/#DoesFragmentTypeApply()>
 /// <https://spec.graphql.org/October2021/#CompleteValue()>
 /// <https://spec.graphql.org/October2021/#ResolveAbstractType()>
-pub(crate) fn type_condition_matches(
+fn type_condition_matches(
     schema: &Schema,
     current_type: Option<&str>,
     type_condition: &str,

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -1892,3 +1892,1579 @@ fn broken_plan_does_not_panic() {
         r#"[1:3] Cannot query field "invalid" on type "Query"."#
     );
 }
+
+// When a non-nullable field in a @requires selection is missing from the upstream subgraph
+// response (e.g. stripped by a coprocessor), the entire downstream entity fetch shouldn't be
+// silently skipped with no error. We ensure that errors are propagated to the client response
+// explaining why the entity fields were nullified.
+#[tokio::test]
+async fn missing_nonnull_field_in_requires_returns_error() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+  {
+    entity: Entity @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+  {
+    id: ID!
+    name: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    computed: String @join__field(graph: SUB2, requires: "code")
+    nickname: String @join__field(graph: SUB2, requires: "name")
+  }"#;
+
+    let query = "query {
+        entity {
+          id
+          computed
+          nickname
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        // Router queries sub1 for entity fields including code and name (needed for @requires)
+                        serde_json::json! {{"query": "{entity{__typename id name code}}"}},
+                        // Sub1 returns WITHOUT code (simulating coprocessor stripping the field from the request,
+                        // so the subgraph never received it and doesn't return it)
+                        serde_json::json! {{"data": {
+                            "entity": {
+                              "__typename": "Entity",
+                              "id": "1",
+                              "name": "Alice"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let data = &value["data"]["entity"];
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Both fields are null because the entity was nullified (non-nullable @requires field missing).
+    // Per GraphQL spec, null bubbles up from the missing non-nullable field to the entity.
+    assert_eq!(data["computed"], serde_json::Value::Null);
+    assert_eq!(data["nickname"], serde_json::Value::Null);
+
+    // The response now includes errors for each unfetched field.
+    // Previously (bug), errors was empty — the fetch was silently skipped.
+    assert_eq!(errors.len(), 2, "should have one error per unfetched field");
+
+    let error_paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
+    assert!(
+        error_paths.contains(&&serde_json::json!(["entity", "computed"])),
+        "should have error for entity.computed, got: {:?}",
+        error_paths
+    );
+    assert!(
+        error_paths.contains(&&serde_json::json!(["entity", "nickname"])),
+        "should have error for entity.nickname, got: {:?}",
+        error_paths
+    );
+
+    // Error messages are abstract — they don't expose internal @requires details.
+    for err in errors {
+        assert_eq!(
+            err["extensions"]["code"].as_str(),
+            Some("UNSATISFIED_FETCH_CONDITION"),
+        );
+    }
+}
+
+// Variant of `missing_nonnull_field_in_requires_returns_error` where `computed` is a non-nullable
+// field. When the skipped fetch's field is non-nullable, `apply_selection_set` propagates null up
+// to the parent (entity), per the GraphQL spec. The UNSATISFIED_FETCH_CONDITION error is still
+// emitted at the leaf that caused the skip.
+#[tokio::test]
+async fn missing_nonnull_field_in_requires_returns_error_nonnull_leaf() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+  {
+    entity: Entity @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+  {
+    id: ID!
+    name: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    computed: String! @join__field(graph: SUB2, requires: "code")
+    nickname: String @join__field(graph: SUB2, requires: "name")
+  }"#;
+
+    let query = "query {
+        entity {
+          id
+          computed
+          nickname
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id name code}}"}},
+                        // sub1 returns WITHOUT code — sub2 (which requires code) is skipped.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                              "__typename": "Entity",
+                              "id": "1",
+                              "name": "Alice"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    // `computed: String!` is non-nullable — the missing value bubbles up and nullifies
+    // `data.entity` per GraphQL null-propagation rules.
+    assert_eq!(value["data"]["entity"], serde_json::Value::Null);
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Exactly two UNSATISFIED_FETCH_CONDITION errors — one per field sub2 would have supplied.
+    // No separate null-propagation error is emitted when `computed: String!` bubbles up.
+    assert_eq!(
+        errors.len(),
+        2,
+        "expected only UNSATISFIED_FETCH_CONDITION errors, got: {:?}",
+        errors
+    );
+    let paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "computed"])),
+        "should have error for entity.computed, got: {:?}",
+        paths
+    );
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "nickname"])),
+        "should have error for entity.nickname, got: {:?}",
+        paths
+    );
+    for err in errors {
+        assert_eq!(
+            err["extensions"]["code"].as_str(),
+            Some("UNSATISFIED_FETCH_CONDITION"),
+        );
+    }
+}
+
+// Variant of `missing_nonnull_field_in_requires_returns_error` where the root `Query.entity`
+// field is non-nullable. With `computed: String!` also non-nullable, the missing value at the
+// leaf bubbles up: `computed` → `entity` (becomes null) → `data` (becomes null, since
+// `Query.entity` is non-null). This tests how null-propagation behaves when there's no
+// nullable ancestor to stop at.
+#[tokio::test]
+async fn missing_nonnull_field_in_requires_returns_error_nonnull_entity() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+  {
+    entity: Entity! @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+  {
+    id: ID!
+    name: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    computed: String! @join__field(graph: SUB2, requires: "code")
+    nickname: String @join__field(graph: SUB2, requires: "name")
+  }"#;
+
+    let query = "query {
+        entity {
+          id
+          computed
+          nickname
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id name code}}"}},
+                        // sub1 returns WITHOUT code — sub2 (which requires code) is skipped.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                              "__typename": "Entity",
+                              "id": "1",
+                              "name": "Alice"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    // `computed: String!` missing → nullifies `entity` → `Query.entity: Entity!` is non-null →
+    // the null bubbles up to `data` itself.
+    assert_eq!(value["data"], serde_json::Value::Null);
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Still exactly the two UNSATISFIED_FETCH_CONDITION errors — one per field sub2 would have
+    // supplied. No extra error is emitted for the null-propagation to `data`.
+    assert_eq!(
+        errors.len(),
+        2,
+        "expected only UNSATISFIED_FETCH_CONDITION errors, got: {:?}",
+        errors
+    );
+    let paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "computed"])),
+        "should have error for entity.computed, got: {:?}",
+        paths
+    );
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "nickname"])),
+        "should have error for entity.nickname, got: {:?}",
+        paths
+    );
+    for err in errors {
+        assert_eq!(
+            err["extensions"]["code"].as_str(),
+            Some("UNSATISFIED_FETCH_CONDITION"),
+        );
+    }
+}
+
+// Confirms an asymmetry in `spec/query.rs` response formatting:
+// * When a non-nullable field is MISSING (absent) from a subgraph response,
+//   `apply_selection_set` nullifies it and pushes a message to `parameters.errors` —
+//   which lands only in the `valueCompletion` extension, NOT in `response.errors`.
+//   So, even with `enable_result_coercion_errors: true`, no user-visible error is surfaced.
+// * When a subgraph returns an explicit NULL for a non-nullable field,
+//   `format_non_nullable_value` pushes to BOTH `parameters.errors` AND
+//   `parameters.coercion_errors` — the latter is appended to `response.errors` when
+//   `enable_result_coercion_errors: true`, yielding a `RESPONSE_VALIDATION_FAILED` error.
+//
+// This is why @requires-driven skips (which look like "missing" from the formatter's
+// perspective — the field was never fetched) silently dropped without this PR's
+// UNSATISFIED_FETCH_CONDITION errors.
+#[tokio::test]
+async fn response_formatting_missing_vs_null_nonnull_field_asymmetry() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+  scalar link__Import
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+  }
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query @join__type(graph: SUB1) {
+    entity: Entity @join__field(graph: SUB1)
+  }
+
+  type Entity @join__type(graph: SUB1, key: "id") {
+    id: ID!
+    name: String! @join__field(graph: SUB1)
+  }"#;
+
+    let query = "query { entity { id name } }";
+
+    // Helper: build a service whose single subgraph returns the given `entity` payload.
+    async fn run_with_entity(
+        schema: &str,
+        query: &str,
+        entity: serde_json::Value,
+    ) -> serde_json::Value {
+        let subgraphs = MockedSubgraphs(
+            [(
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{id name}}"}},
+                        serde_json::json! {{"data": {"entity": entity}}},
+                    )
+                    .build(),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let service = TestHarness::builder()
+            // Enable coercion errors so any errors generated by `format_non_nullable_value`
+            // show up in `response.errors`.
+            .configuration_json(serde_json::json!({
+                "include_subgraph_errors": { "all": true },
+                "supergraph": { "enable_result_coercion_errors": true },
+            }))
+            .unwrap()
+            .schema(schema)
+            .extra_plugin(subgraphs)
+            .build_supergraph()
+            .await
+            .unwrap();
+        let request = supergraph::Request::fake_builder()
+            .context(Context::new())
+            .query(query)
+            .build()
+            .unwrap();
+        let mut stream = service.oneshot(request).await.unwrap();
+        serde_json::to_value(stream.next_response().await.unwrap()).unwrap()
+    }
+
+    // Case A: `name` is MISSING (absent) from the subgraph response.
+    let missing = run_with_entity(schema, query, serde_json::json!({ "id": "1" })).await;
+    assert_eq!(
+        missing["data"]["entity"],
+        serde_json::Value::Null,
+        "non-null `name` missing → `entity` nullified"
+    );
+    assert!(
+        missing["errors"].is_null() || missing["errors"].as_array().unwrap().is_empty(),
+        "missing non-null field should NOT generate a user-visible error; got {:?}",
+        missing["errors"]
+    );
+
+    // Case B: `name` is explicitly NULL in the subgraph response.
+    let null = run_with_entity(
+        schema,
+        query,
+        serde_json::json!({ "id": "1", "name": null }),
+    )
+    .await;
+    assert_eq!(
+        null["data"]["entity"],
+        serde_json::Value::Null,
+        "null non-null `name` → `entity` nullified"
+    );
+    let errors = null["errors"]
+        .as_array()
+        .expect("null case should surface a coercion error");
+    assert_eq!(
+        errors.len(),
+        1,
+        "null non-null field should generate exactly one coercion error; got {:?}",
+        errors
+    );
+    assert_eq!(
+        errors[0]["extensions"]["code"].as_str(),
+        Some("RESPONSE_VALIDATION_FAILED"),
+    );
+    assert_eq!(errors[0]["path"], serde_json::json!(["entity", "name"]));
+}
+
+// Regression test: when a list of entities is fetched and only some entities have missing
+// non-nullable @requires fields, the router should still fetch the successful entities
+// and generate errors only for the failed ones.
+#[tokio::test]
+async fn batched_entity_partial_requires_failure() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+  {
+    entities: [Entity] @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+  {
+    id: ID!
+    code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    computed: String @join__field(graph: SUB2, requires: "code")
+  }"#;
+
+    let query = "query {
+        entities {
+          id
+          computed
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entities{__typename id code}}"}},
+                        // Entity 0 and 2 have code, entity 1 and 3 do NOT (missing required field)
+                        serde_json::json! {{"data": {
+                            "entities": [
+                              {"__typename": "Entity", "id": "1", "code": "ABC"},
+                              {"__typename": "Entity", "id": "2"},
+                              {"__typename": "Entity", "id": "3", "code": "XYZ"},
+                              {"__typename": "Entity", "id": "4"}
+                            ]
+                        } }},
+                    )
+                    .build(),
+            ),
+            (
+                "sub2",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{
+                            "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on Entity{computed}}}",
+                            "variables": {
+                                "representations": [
+                                    {"__typename": "Entity", "id": "1", "code": "ABC"},
+                                    {"__typename": "Entity", "id": "3", "code": "XYZ"}
+                                ]
+                            }
+                        }},
+                        serde_json::json! {{"data": {
+                            "_entities": [
+                                {"computed": "computed-1"},
+                                {"computed": "computed-3"}
+                            ]
+                        } }},
+                    )
+                    .build(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let entities = value["data"]["entities"]
+        .as_array()
+        .expect("entities should be an array");
+
+    // Entities 0 and 2 succeeded — they have computed values
+    assert_eq!(entities[0]["computed"], serde_json::json!("computed-1"));
+    assert_eq!(entities[2]["computed"], serde_json::json!("computed-3"));
+
+    // Entities 1 and 3 failed — computed is null because code was missing
+    assert_eq!(entities[1]["computed"], serde_json::Value::Null);
+    assert_eq!(entities[3]["computed"], serde_json::Value::Null);
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Should have errors for the 2 failed entities
+    assert_eq!(errors.len(), 2, "should have one error per failed entity");
+
+    let error_paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
+    assert!(
+        error_paths.contains(&&serde_json::json!(["entities", 1, "computed"])),
+        "should have error for entities[1].computed, got: {:?}",
+        error_paths
+    );
+    assert!(
+        error_paths.contains(&&serde_json::json!(["entities", 3, "computed"])),
+        "should have error for entities[3].computed, got: {:?}",
+        error_paths
+    );
+
+    for err in errors {
+        assert_eq!(
+            err["extensions"]["code"].as_str(),
+            Some("UNSATISFIED_FETCH_CONDITION"),
+        );
+    }
+}
+
+// Regression test: when two @requires fetches execute in parallel at the same
+// entity path, skipping one must not produce errors for the sibling fetch's
+// fields. Before the fix, `errors_for_skipped_fetch` reported every input-query
+// field absent from `parent_value` — which swept in fields the other parallel
+// fetch was about to provide.
+#[tokio::test]
+async fn parallel_sibling_skipped_fetch_does_not_over_report() {
+    run_parallel_sibling_skipped_fetch(false).await;
+}
+
+// Same scenario, but with `generate_query_fragments: true`. The skipped fetch's
+// operation may contain named fragment spreads; verifying the fix still intersects
+// correctly against the fetch's response shape when fragments are present.
+#[tokio::test]
+async fn parallel_sibling_skipped_fetch_does_not_over_report_generate_fragments() {
+    run_parallel_sibling_skipped_fetch(true).await;
+}
+
+async fn run_parallel_sibling_skipped_fetch(generate_query_fragments: bool) {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/sub1")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/sub2")
+    SUB3 @join__graph(name: "sub3", url: "http://localhost:4002/sub3")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+    @join__type(graph: SUB3)
+  {
+    entity: Entity @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+    @join__type(graph: SUB3, key: "id", extension: true)
+  {
+    id: ID!
+    code1: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+    code2: String! @join__field(graph: SUB1) @join__field(graph: SUB3, external: true)
+    a: String @join__field(graph: SUB1)
+    b: String @join__field(graph: SUB2, requires: "code1")
+    c: String @join__field(graph: SUB3, requires: "code2")
+  }"#;
+
+    let query = "query {
+        entity {
+          a
+          b
+          c
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id a code1 code2}}"}},
+                        // code1 is missing — sub2 (which requires code1) will be skipped.
+                        // code2 is present — sub3 (which requires code2) will succeed.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                                "__typename": "Entity",
+                                "id": "1",
+                                "a": "a-value",
+                                "code2": "c2"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+            (
+                "sub3",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{
+                            "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on Entity{c}}}",
+                            "variables": {
+                                "representations": [
+                                    {"__typename": "Entity", "id": "1", "code2": "c2"}
+                                ]
+                            }
+                        }},
+                        serde_json::json! {{"data": {
+                            "_entities": [
+                                {"c": "c-value"}
+                            ]
+                        } }},
+                    )
+                    .build(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+            "supergraph": {
+                "generate_query_fragments": generate_query_fragments,
+            }
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let entity = &value["data"]["entity"];
+    // sub1 and sub3 succeeded — `a` and `c` should be populated, `b` is null.
+    assert_eq!(entity["a"], serde_json::json!("a-value"));
+    assert_eq!(entity["c"], serde_json::json!("c-value"));
+    assert_eq!(entity["b"], serde_json::Value::Null);
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Only `entity.b` should be reported — NOT `entity.c`, even though `c`
+    // was absent from parent_value at the time sub2 was skipped.
+    assert_eq!(
+        errors.len(),
+        1,
+        "should only report the skipped sibling's field, got: {:?}",
+        errors
+    );
+    assert_eq!(errors[0]["path"], serde_json::json!(["entity", "b"]));
+    assert_eq!(
+        errors[0]["extensions"]["code"].as_str(),
+        Some("UNSATISFIED_FETCH_CONDITION"),
+    );
+}
+
+// Regression test: a chained @requires failure. Fetch A misses a field that
+// fetch B requires; fetch B would have produced an input that fetch C
+// requires, but that input isn't in the user's operation. When B is skipped,
+// C is also skipped — but errors should only be emitted for fields the user
+// asked for. The planner-internal intermediate field should NOT appear in
+// error paths.
+//
+// Scenario:
+//   query { entity { final other } }
+//   sub1: _entities -> { id, code }           (code missing)
+//   sub2: _entities { aux other } requires "code"   (skipped, would have supplied `aux` and `other`)
+//   sub3: _entities { final } requires "aux"        (skipped transitively — `aux` never fetched)
+//
+// Expected errors:
+//   [entity, other] — sub2's skip, user-visible field
+//   [entity, final] — sub3's skip, user-visible field
+// NOT [entity, aux] — planner-internal, not in the user's operation.
+#[tokio::test]
+async fn chained_requires_skipped_fetch_hides_internal_fields() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/sub1")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/sub2")
+    SUB3 @join__graph(name: "sub3", url: "http://localhost:4002/sub3")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+    @join__type(graph: SUB3)
+  {
+    entity: Entity @join__field(graph: SUB1)
+  }
+
+  type Entity
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+    @join__type(graph: SUB3, key: "id", extension: true)
+  {
+    id: ID!
+    code: String!
+      @join__field(graph: SUB1)
+      @join__field(graph: SUB2, external: true)
+    aux: String!
+      @join__field(graph: SUB2, requires: "code")
+      @join__field(graph: SUB3, external: true)
+    other: String @join__field(graph: SUB2, requires: "code")
+    final: String @join__field(graph: SUB3, requires: "aux")
+  }"#;
+
+    let query = "query {
+        entity {
+          final
+          other
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id code}}"}},
+                        // code missing — sub2 (which requires code) is skipped; sub3 follows.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                                "__typename": "Entity",
+                                "id": "1"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            // sub2 and sub3 should never be called.
+            ("sub2", MockSubgraph::builder().build()),
+            ("sub3", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Exactly two errors — one per user-visible field that went unfetched.
+    // `aux` is planner-internal (not in the user's operation) and must NOT
+    // appear in any error path.
+    let paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
+    assert_eq!(
+        errors.len(),
+        2,
+        "expected exactly 2 UNSATISFIED_FETCH_CONDITION errors, got: {:?}",
+        errors
+    );
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "other"])),
+        "should have error for entity.other, got: {:?}",
+        paths
+    );
+    assert!(
+        paths.contains(&&serde_json::json!(["entity", "final"])),
+        "should have error for entity.final, got: {:?}",
+        paths
+    );
+    for err in errors {
+        assert_eq!(
+            err["extensions"]["code"].as_str(),
+            Some("UNSATISFIED_FETCH_CONDITION"),
+        );
+        // `aux` is planner-internal — it must NOT leak into user-visible errors.
+        assert_ne!(
+            err["path"],
+            serde_json::json!(["entity", "aux"]),
+            "planner-internal `aux` leaked into errors: {:?}",
+            err
+        );
+    }
+}
+
+// Regression test: when two subgraph fetches share a composite field via
+// @shareable, and one is skipped by a missing @requires input, the sibling
+// fetch still provides its subfields. Error reporting should cover the fields
+// that only the skipped fetch would have supplied, not the shared parent.
+//
+// Scenario:
+//   query { me { profile { firstName address } } }
+//   subA: me -> User { id, fullName }   (fullName missing from response)
+//   subB: User.profile @requires(fullName) -> { firstName }   (skipped)
+//   subC: User.profile -> { address }                         (succeeds)
+#[tokio::test]
+async fn skipped_fetch_with_overlapping_shareable_composite_field() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUBA @join__graph(name: "suba", url: "http://localhost:4001/suba")
+    SUBB @join__graph(name: "subb", url: "http://localhost:4002/subb")
+    SUBC @join__graph(name: "subc", url: "http://localhost:4003/subc")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+    @join__type(graph: SUBC)
+  {
+    me: User @join__field(graph: SUBA)
+  }
+
+  type User
+    @join__type(graph: SUBA, key: "id")
+    @join__type(graph: SUBB, key: "id", extension: true)
+    @join__type(graph: SUBC, key: "id", extension: true)
+  {
+    id: ID!
+    fullName: String! @join__field(graph: SUBA) @join__field(graph: SUBB, external: true)
+    profile: Profile
+      @join__field(graph: SUBB, requires: "fullName")
+      @join__field(graph: SUBC)
+  }
+
+  type Profile
+    @join__type(graph: SUBB)
+    @join__type(graph: SUBC)
+  {
+    firstName: String @join__field(graph: SUBB)
+    address: String @join__field(graph: SUBC)
+  }"#;
+
+    let query = "query {
+        me {
+          profile {
+            firstName
+            address
+          }
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "suba",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{me{__typename id fullName}}"}},
+                        // fullName missing — subB (which requires fullName) will be skipped.
+                        serde_json::json! {{"data": {
+                            "me": {
+                                "__typename": "User",
+                                "id": "1"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            // subB is skipped — it should never be called.
+            ("subb", MockSubgraph::builder().build()),
+            (
+                "subc",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{
+                            "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{profile{address}}}}",
+                            "variables": {
+                                "representations": [
+                                    {"__typename": "User", "id": "1"}
+                                ]
+                            }
+                        }},
+                        serde_json::json! {{"data": {
+                            "_entities": [
+                                {"profile": {"address": "123 Main St"}}
+                            ]
+                        } }},
+                    )
+                    .build(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    // subC succeeded — address should be present; firstName was not fetched.
+    let profile = &value["data"]["me"]["profile"];
+    assert_eq!(profile["address"], serde_json::json!("123 Main St"));
+    assert_eq!(profile["firstName"], serde_json::Value::Null);
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Only firstName (uniquely provided by the skipped subB) should be reported.
+    // `profile` itself should NOT be flagged — subC successfully provided it.
+    assert_eq!(
+        errors.len(),
+        1,
+        "should only report the field uniquely provided by the skipped fetch, got: {:?}",
+        errors
+    );
+    assert_eq!(
+        errors[0]["path"],
+        serde_json::json!(["me", "profile", "firstName"])
+    );
+    assert_eq!(
+        errors[0]["extensions"]["code"].as_str(),
+        Some("UNSATISFIED_FETCH_CONDITION"),
+    );
+}
+
+// When the skipped fetch would have populated a list-typed field with per-item
+// sub-selections, the error must stop at the list field itself. The
+// response-key tree has no array indices, so we can't enumerate per-item
+// leaves like `[..., addresses, 0, street]`.
+//
+// Scenario:
+//   query { me { addresses { street city } } }
+//   subA: me -> User { id, fullName }   (fullName missing from response)
+//   subB: User.addresses @requires(fullName) -> [Address { street, city }] (skipped)
+#[tokio::test]
+async fn skipped_fetch_with_list_field_reports_at_list_level() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUBA @join__graph(name: "suba", url: "http://localhost:4001/suba")
+    SUBB @join__graph(name: "subb", url: "http://localhost:4002/subb")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    me: User @join__field(graph: SUBA)
+  }
+
+  type User
+    @join__type(graph: SUBA, key: "id")
+    @join__type(graph: SUBB, key: "id", extension: true)
+  {
+    id: ID!
+    fullName: String! @join__field(graph: SUBA) @join__field(graph: SUBB, external: true)
+    addresses: [Address]
+      @join__field(graph: SUBB, requires: "fullName")
+  }
+
+  type Address
+    @join__type(graph: SUBB)
+  {
+    street: String @join__field(graph: SUBB)
+    city: String @join__field(graph: SUBB)
+  }"#;
+
+    let query = "query {
+        me {
+          addresses {
+            street
+            city
+          }
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "suba",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{me{__typename id fullName}}"}},
+                        // fullName missing — subB (which requires fullName) will be skipped.
+                        serde_json::json! {{"data": {
+                            "me": {
+                                "__typename": "User",
+                                "id": "1"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            // subB is skipped — it should never be called.
+            ("subb", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // Exactly one error, at the list field itself — not descending with fake
+    // indices or enumerating per-item leaves under `addresses`.
+    assert_eq!(
+        errors.len(),
+        1,
+        "should emit one error at the list field, got: {:?}",
+        errors
+    );
+    assert_eq!(errors[0]["path"], serde_json::json!(["me", "addresses"]));
+    assert_eq!(
+        errors[0]["extensions"]["code"].as_str(),
+        Some("UNSATISFIED_FETCH_CONDITION"),
+    );
+}
+
+// When a shareable list-typed field is partially fetched — one subgraph
+// populates the array while another's fetch is skipped for @requires — we
+// still emit an error at the list field. The tree has no array indices, so we
+// can't enumerate per-item leaves for the skipped subgraph's contributions,
+// and the list-level emission must not be suppressed just because another
+// fetch already wrote a value at that path.
+//
+// Scenario:
+//   query { person { friends { name hobby job } } }
+//   subA: person -> Person { id, friends: [Friend{name, hobby}] }   (fullName missing)
+//   subB: Person.friends @requires(fullName) -> [Friend{job}]       (skipped)
+#[tokio::test]
+async fn skipped_fetch_with_shareable_list_field_reports_error_and_value() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUBA @join__graph(name: "suba", url: "http://localhost:4001/suba")
+    SUBB @join__graph(name: "subb", url: "http://localhost:4002/subb")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    person: Person @join__field(graph: SUBA)
+  }
+
+  type Person
+    @join__type(graph: SUBA, key: "id")
+    @join__type(graph: SUBB, key: "id", extension: true)
+  {
+    id: ID!
+    fullName: String! @join__field(graph: SUBA) @join__field(graph: SUBB, external: true)
+    friends: [Friend]
+      @join__field(graph: SUBA)
+      @join__field(graph: SUBB, requires: "fullName")
+  }
+
+  type Friend
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    name: String @join__field(graph: SUBA) @join__field(graph: SUBB)
+    hobby: String @join__field(graph: SUBA)
+    job: String @join__field(graph: SUBB)
+  }"#;
+
+    let query = "query {
+        person {
+          friends {
+            name
+            hobby
+            job
+          }
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "suba",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{person{__typename id friends{name hobby} fullName}}"}},
+                        // fullName missing — subB (which requires fullName) is skipped.
+                        serde_json::json! {{"data": {
+                            "person": {
+                                "__typename": "Person",
+                                "id": "1",
+                                "friends": [
+                                    { "name": "Alice", "hobby": "chess" }
+                                ]
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            // subB is skipped — it should never be called.
+            ("subb", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+
+    // One UNSATISFIED_FETCH_CONDITION error at the per-element leaf —
+    // walking final data lets us pinpoint the missing field inside subA's
+    // populated array (`job` on element 0).
+    let unsatisfied: Vec<_> = errors
+        .iter()
+        .filter(|e| e["extensions"]["code"].as_str() == Some("UNSATISFIED_FETCH_CONDITION"))
+        .collect();
+    assert_eq!(
+        unsatisfied.len(),
+        1,
+        "should emit exactly one UNSATISFIED_FETCH_CONDITION, got: {:?}",
+        errors
+    );
+    assert_eq!(
+        unsatisfied[0]["path"],
+        serde_json::json!(["person", "friends", 0, "job"])
+    );
+
+    // The response still carries the array populated by subA.
+    let friends = &value["data"]["person"]["friends"];
+    assert!(
+        friends.is_array(),
+        "friends should be populated by subA, got: {:?}",
+        value["data"]
+    );
+    assert_eq!(friends[0]["name"].as_str(), Some("Alice"));
+    assert_eq!(friends[0]["hobby"].as_str(), Some("chess"));
+}

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -2158,31 +2158,23 @@ async fn missing_nonnull_field_in_requires_returns_error_nonnull_leaf() {
         .as_array()
         .expect("errors should be present");
 
-    // Exactly two UNSATISFIED_FETCH_CONDITION errors — one per field sub2 would have supplied.
-    // No separate null-propagation error is emitted when `computed: String!` bubbles up.
+    // ONE UNSATISFIED_FETCH_CONDITION error at the nullable boundary (`entity`),
+    // not per-leaf. The walker detects a non-null user-asked-for field
+    // (`computed: String!`) is missing and covered by the skip tree, and
+    // coalesces emission to `[entity]` — the path where `format_response`
+    // will land the null. The nullable sibling `nickname` is *not* emitted
+    // because the entity itself will be null in the final response.
     assert_eq!(
         errors.len(),
-        2,
-        "expected only UNSATISFIED_FETCH_CONDITION errors, got: {:?}",
+        1,
+        "expected one UNSATISFIED_FETCH_CONDITION at the entity boundary, got: {:?}",
         errors
     );
-    let paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
-    assert!(
-        paths.contains(&&serde_json::json!(["entity", "computed"])),
-        "should have error for entity.computed, got: {:?}",
-        paths
+    assert_eq!(errors[0]["path"], serde_json::json!(["entity"]));
+    assert_eq!(
+        errors[0]["extensions"]["code"].as_str(),
+        Some("UNSATISFIED_FETCH_CONDITION"),
     );
-    assert!(
-        paths.contains(&&serde_json::json!(["entity", "nickname"])),
-        "should have error for entity.nickname, got: {:?}",
-        paths
-    );
-    for err in errors {
-        assert_eq!(
-            err["extensions"]["code"].as_str(),
-            Some("UNSATISFIED_FETCH_CONDITION"),
-        );
-    }
 }
 
 // Variant of `missing_nonnull_field_in_requires_returns_error` where the root `Query.entity`
@@ -2304,31 +2296,22 @@ async fn missing_nonnull_field_in_requires_returns_error_nonnull_entity() {
         .as_array()
         .expect("errors should be present");
 
-    // Still exactly the two UNSATISFIED_FETCH_CONDITION errors — one per field sub2 would have
-    // supplied. No extra error is emitted for the null-propagation to `data`.
+    // ONE UNSATISFIED_FETCH_CONDITION error at `[entity]`. The walker stops
+    // bubbling at the entity level (even though `Query.entity: Entity!` is
+    // non-null and would propagate further); `format_response` carries the
+    // null up to `data` from there. We don't emit a second error for the
+    // root-level null — the entity-level error is the user-visible signal.
     assert_eq!(
         errors.len(),
-        2,
-        "expected only UNSATISFIED_FETCH_CONDITION errors, got: {:?}",
+        1,
+        "expected one UNSATISFIED_FETCH_CONDITION at the entity boundary, got: {:?}",
         errors
     );
-    let paths: Vec<&serde_json::Value> = errors.iter().map(|e| &e["path"]).collect();
-    assert!(
-        paths.contains(&&serde_json::json!(["entity", "computed"])),
-        "should have error for entity.computed, got: {:?}",
-        paths
+    assert_eq!(errors[0]["path"], serde_json::json!(["entity"]));
+    assert_eq!(
+        errors[0]["extensions"]["code"].as_str(),
+        Some("UNSATISFIED_FETCH_CONDITION"),
     );
-    assert!(
-        paths.contains(&&serde_json::json!(["entity", "nickname"])),
-        "should have error for entity.nickname, got: {:?}",
-        paths
-    );
-    for err in errors {
-        assert_eq!(
-            err["extensions"]["code"].as_str(),
-            Some("UNSATISFIED_FETCH_CONDITION"),
-        );
-    }
 }
 
 // Confirms an asymmetry in `spec/query.rs` response formatting:
@@ -3467,4 +3450,821 @@ async fn skipped_fetch_with_shareable_list_field_reports_error_and_value() {
     );
     assert_eq!(friends[0]["name"].as_str(), Some("Alice"));
     assert_eq!(friends[0]["hobby"].as_str(), Some("chess"));
+}
+
+// When a shareable list-typed field has one subgraph fetch skipped for
+// `@requires` while another subgraph populates the array, only the keys
+// the skipped fetch was going to produce should be flagged — not unrelated
+// nullable fields owned by the populating subgraph.
+//
+// In this scenario, subA owns the optional `email` field on `Friend`. subA
+// legitimately returns `email: null` for friend 0 (nullable, no error).
+// subB owns `job` and is skipped. The correct behavior is to emit exactly
+// one error at `[person, friends, 0, job]` — subB's field — and leave
+// `email` alone.
+//
+// This was a regression target: the earlier `is_list_stop`/`covers_all_below`
+// design would mark the whole `[person, friends]` subtree as covered, which
+// flagged both `job` and `email`. The current builder descends through lists
+// and records only keys the skipped subgraph's operation actually selects,
+// so siblings filled by the populating subgraph are untouched.
+#[tokio::test]
+async fn shareable_list_skipped_fetch_does_not_flag_unrelated_nullable_field() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUBA @join__graph(name: "suba", url: "http://localhost:4001/suba")
+    SUBB @join__graph(name: "subb", url: "http://localhost:4002/subb")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    person: Person @join__field(graph: SUBA)
+  }
+
+  type Person
+    @join__type(graph: SUBA, key: "id")
+    @join__type(graph: SUBB, key: "id", extension: true)
+  {
+    id: ID!
+    fullName: String! @join__field(graph: SUBA) @join__field(graph: SUBB, external: true)
+    friends: [Friend]
+      @join__field(graph: SUBA)
+      @join__field(graph: SUBB, requires: "fullName")
+  }
+
+  type Friend
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    name:  String @join__field(graph: SUBA) @join__field(graph: SUBB)
+    hobby: String @join__field(graph: SUBA)
+    email: String @join__field(graph: SUBA)   # subA-only, nullable
+    job:   String @join__field(graph: SUBB)   # subB-only — subB is skipped
+  }"#;
+
+    let query = "query {
+        person {
+          friends {
+            name
+            hobby
+            email
+            job
+          }
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "suba",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{person{__typename id friends{name hobby email} fullName}}"}},
+                        // fullName missing → subB skipped. `email` legitimately null.
+                        serde_json::json! {{"data": {
+                            "person": {
+                                "__typename": "Person",
+                                "id": "1",
+                                "friends": [
+                                    { "name": "Alice", "hobby": "chess", "email": null }
+                                ]
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("subb", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+    let unsatisfied: Vec<_> = errors
+        .iter()
+        .filter(|e| e["extensions"]["code"].as_str() == Some("UNSATISFIED_FETCH_CONDITION"))
+        .collect();
+    let paths: Vec<_> = unsatisfied.iter().map(|e| &e["path"]).collect();
+
+    // Correct behavior: exactly one error at subB's field. `email` is subA's
+    // (and legitimately null), so it must NOT appear.
+    assert_eq!(
+        unsatisfied.len(),
+        1,
+        "should emit exactly one UNSATISFIED_FETCH_CONDITION at subB's field, got: {:?}",
+        paths
+    );
+    assert_eq!(
+        unsatisfied[0]["path"],
+        serde_json::json!(["person", "friends", 0, "job"])
+    );
+    assert!(
+        !paths.contains(&&serde_json::json!(["person", "friends", 0, "email"])),
+        "email is subA's nullable field, not subB's — must not be flagged. paths: {:?}",
+        paths
+    );
+}
+
+// Regression: a parent fetch may legitimately return `null` at an entity slot
+// (e.g. a nullable list element, or an upstream fetch that null-propagated and
+// already emitted its own error). The dependent `@requires` fetch, when it
+// walks `select_values_and_paths` over the parent value, will see that null,
+// `execute_selection_set` will return null, and there is no representation
+// to send. That's not a skipped `@requires` — there's nothing to fetch in the
+// first place. We must NOT synthesize an `UNSATISFIED_FETCH_CONDITION` for
+// the null path.
+//
+// Scenario:
+//   query { friends { job } }
+//   subA: friends -> [Friend{name}, null]
+//   subB: Friend.job @requires(name)
+// Expected: no UNSATISFIED_FETCH_CONDITION error for the null element; the
+// successful friend resolves through subB normally.
+#[tokio::test]
+async fn null_source_value_does_not_emit_unsatisfied_fetch_error() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUBA @join__graph(name: "suba", url: "http://localhost:4001/suba")
+    SUBB @join__graph(name: "subb", url: "http://localhost:4002/subb")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    friends: [Friend] @join__field(graph: SUBA)
+  }
+
+  type Friend
+    @join__type(graph: SUBA, key: "id")
+    @join__type(graph: SUBB, key: "id", extension: true)
+  {
+    id: ID!
+    name: String! @join__field(graph: SUBA) @join__field(graph: SUBB, external: true)
+    job: String @join__field(graph: SUBB, requires: "name")
+  }"#;
+
+    let query = "query { friends { job } }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "suba",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{friends{__typename id name}}"}},
+                        // One real friend (subB can resolve), one null element
+                        // (no entity to fetch — must not produce an error).
+                        serde_json::json! {{"data": {
+                            "friends": [
+                                {"__typename": "Friend", "id": "1", "name": "Alice"},
+                                null
+                            ]
+                        } }},
+                    )
+                    .build(),
+            ),
+            (
+                "subb",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{
+                            "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on Friend{job}}}",
+                            "variables": {
+                                "representations": [
+                                    {"__typename": "Friend", "id": "1", "name": "Alice"}
+                                ]
+                            }
+                        }},
+                        serde_json::json! {{"data": {
+                            "_entities": [
+                                {"job": "engineer"}
+                            ]
+                        } }},
+                    )
+                    .build(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    // friends[1] is null; friends[0].job came back from subB.
+    assert_eq!(
+        value["data"]["friends"][0]["job"],
+        serde_json::json!("engineer")
+    );
+    assert!(value["data"]["friends"][1].is_null());
+
+    // No UNSATISFIED_FETCH_CONDITION may appear: the null entity slot was
+    // already null before subB was considered, so there's no skipped fetch.
+    let empty = Vec::new();
+    let errors = value["errors"].as_array().unwrap_or(&empty);
+    let unsatisfied: Vec<_> = errors
+        .iter()
+        .filter(|e| e["extensions"]["code"].as_str() == Some("UNSATISFIED_FETCH_CONDITION"))
+        .collect();
+    assert!(
+        unsatisfied.is_empty(),
+        "null source entity must not synthesize UNSATISFIED_FETCH_CONDITION, got: {:?}",
+        unsatisfied
+    );
+}
+
+// Regression: a skipped subgraph fetch may include an inline fragment under
+// a composite field whose runtime type we cannot determine statically (the
+// containing field returns an abstract type). The builder over-approximates
+// by descending through the fragment anyway and recording its leaves, so
+// the skip tree has entries for `info.id` and `info.url`. When `info` is
+// itself missing from the merged response (no other subgraph filled it),
+// the walker emits a single truncated error at `info` rather than guessing
+// per-leaf, because the missing-field rule fires the moment any skip-tree
+// node is present at a missing key.
+//
+// Scenario:
+//   query { entity { info { id ... on Photo { url } } } }
+//   subA: entity -> Entity { id }                (base missing, subB skipped)
+//   subB: Entity { info { id ... on Photo { url } } } @requires(base)
+//
+// Expected: one error at [entity, info], not at [entity, info, id] or
+// [entity, info, url].
+#[tokio::test]
+async fn skipped_fetch_with_unresolvable_fragment_truncates_at_composite() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUBA @join__graph(name: "suba", url: "http://localhost:4001/suba")
+    SUBB @join__graph(name: "subb", url: "http://localhost:4002/subb")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    entity: Entity @join__field(graph: SUBA)
+  }
+
+  type Entity
+    @join__type(graph: SUBA, key: "id")
+    @join__type(graph: SUBB, key: "id", extension: true)
+  {
+    id: ID!
+    base: String! @join__field(graph: SUBA) @join__field(graph: SUBB, external: true)
+    info: Item @join__field(graph: SUBB, requires: "base")
+  }
+
+  interface Item
+    @join__type(graph: SUBB)
+  {
+    id: ID!
+  }
+
+  type Photo implements Item
+    @join__type(graph: SUBB)
+    @join__implements(graph: SUBB, interface: "Item")
+  {
+    id: ID!
+    url: String!
+  }
+
+  type Doc implements Item
+    @join__type(graph: SUBB)
+    @join__implements(graph: SUBB, interface: "Item")
+  {
+    id: ID!
+    content: String!
+  }"#;
+
+    let query = "query {
+        entity {
+          info {
+            id
+            ... on Photo { url }
+          }
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "suba",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id base}}"}},
+                        // base missing → subB skipped.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                                "__typename": "Entity",
+                                "id": "1"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("subb", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let errors = value["errors"]
+        .as_array()
+        .expect("errors should be present");
+    let unsatisfied: Vec<_> = errors
+        .iter()
+        .filter(|e| e["extensions"]["code"].as_str() == Some("UNSATISFIED_FETCH_CONDITION"))
+        .collect();
+    let paths: Vec<_> = unsatisfied.iter().map(|e| &e["path"]).collect();
+
+    assert_eq!(
+        unsatisfied.len(),
+        1,
+        "should emit exactly one truncated error at the composite, got: {:?}",
+        paths
+    );
+    assert_eq!(
+        unsatisfied[0]["path"],
+        serde_json::json!(["entity", "info"])
+    );
+}
+
+// Documents the walker's intentional under-approximation: when a fragment's
+// type condition cannot be resolved statically against the current type
+// (e.g. the composite has no `__typename` in the merged response and the
+// field's static type is an interface), the walker does NOT descend into
+// the fragment. Any leaf the skipped fetch was going to provide under that
+// fragment is silently missed — a deliberate false negative, traded for
+// avoiding false positives at sibling concrete branches we can't disprove.
+//
+// Setup: SUBA non-shareably owns `entity.info` and returns the object
+// without a `__typename` (subgraphs are not obligated to include it for
+// non-entity composites). SUBB has a `@requires`-driven extension that
+// would have filled `info.url`, but is skipped because `base` is missing.
+// The walker sees `info` present, descends, looks at the `... on Photo`
+// fragment, can't statically prove the runtime type, and skips it. The
+// skipped `info.url` leaf goes unreported.
+#[tokio::test]
+async fn unresolvable_fragment_at_walker_under_approximates_skipped_leaf() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUBA @join__graph(name: "suba", url: "http://localhost:4001/suba")
+    SUBB @join__graph(name: "subb", url: "http://localhost:4002/subb")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    entity: Entity @join__field(graph: SUBA)
+  }
+
+  type Entity
+    @join__type(graph: SUBA, key: "id")
+    @join__type(graph: SUBB, key: "id", extension: true)
+  {
+    id: ID!
+    base: String! @join__field(graph: SUBA) @join__field(graph: SUBB, external: true)
+    info: Item
+      @join__field(graph: SUBA)
+      @join__field(graph: SUBB, requires: "base")
+  }
+
+  interface Item
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    id: ID!
+  }
+
+  type Photo implements Item
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+    @join__implements(graph: SUBA, interface: "Item")
+    @join__implements(graph: SUBB, interface: "Item")
+  {
+    id: ID!
+    url: String @join__field(graph: SUBA) @join__field(graph: SUBB)
+  }"#;
+
+    let query = "query {
+        entity {
+          info {
+            id
+            ... on Photo { url }
+          }
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "suba",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id info{__typename id ...on Photo{url}}}}"}},
+                        // info is present (so the walker descends into it),
+                        // but the response intentionally omits __typename on
+                        // info. This makes the walker fall back to the field's
+                        // static type `Item`, which is abstract, so the
+                        // `... on Photo` fragment is statically undecidable.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                                "__typename": "Entity",
+                                "id": "1",
+                                "info": {
+                                    "id": "p1"
+                                }
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            // subB is skipped because `base` is missing from subA's response.
+            ("subb", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let empty = Vec::new();
+    let errors = value["errors"].as_array().unwrap_or(&empty);
+    let unsatisfied: Vec<_> = errors
+        .iter()
+        .filter(|e| e["extensions"]["code"].as_str() == Some("UNSATISFIED_FETCH_CONDITION"))
+        .collect();
+    let paths: Vec<_> = unsatisfied.iter().map(|e| &e["path"]).collect();
+
+    // No UNSATISFIED_FETCH_CONDITION should be emitted: walker hit a
+    // statically-undecidable fragment at `info` and under-approximated
+    // rather than risk a false positive against a concrete branch it
+    // couldn't disprove. The skipped `info.url` leaf is silently missed.
+    assert!(
+        unsatisfied.is_empty(),
+        "walker should under-approximate at undecidable fragment, got: {:?}",
+        paths
+    );
+}
+
+// Exercises `SkipState::descend_index` when the master skip tree has
+// `by_index` entries for SOME indices in a list but not the one currently
+// being walked. The cursor must return `Self::None` (rather than passing
+// through to the container node) so that non-skipped sibling elements
+// don't accidentally pick up leaf coverage that was registered against the
+// container as a whole.
+//
+// Scenario:
+//   query { people { id extra } }
+//   subA: people -> [User{id:"1"}, User{id:"2", name:"B"}]
+//   subB: User.extra @requires(name)
+//
+// people[0] omits `name` (non-null required input), so the representation
+// for subB can't be built and the entity fetch is recorded as skipped at
+// `[people, 0]`. The resulting skip tree has
+// `people_node.by_index = {0: extra-subtree}` and `people_node.by_key = {}`
+// — the per-index branch covers people[0]'s missing `extra`, while
+// people[1] is non-skipped and walks past the `by_index` lookup miss into
+// `Self::None`.
+//
+// Expected: exactly one error at `[people, 0, extra]`; people[1] reports
+// nothing even though the walker visits its field selections.
+#[tokio::test]
+async fn list_with_partial_index_skip_does_not_taint_sibling_elements() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    SUBA @join__graph(name: "suba", url: "http://localhost:4001/suba")
+    SUBB @join__graph(name: "subb", url: "http://localhost:4002/subb")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: SUBA)
+    @join__type(graph: SUBB)
+  {
+    people: [User] @join__field(graph: SUBA)
+  }
+
+  type User
+    @join__type(graph: SUBA, key: "id")
+    @join__type(graph: SUBB, key: "id", extension: true)
+  {
+    id: ID!
+    name: String! @join__field(graph: SUBA) @join__field(graph: SUBB, external: true)
+    extra: String @join__field(graph: SUBB, requires: "name")
+  }"#;
+
+    let query = "query { people { id extra } }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "suba",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{people{__typename id name}}"}},
+                        // people[0] omits `name` entirely → subB representation
+                        // can't be built and the entity is recorded as skipped
+                        // at `[people, 0]`. people[1] has `name` set, so subB
+                        // runs for it.
+                        serde_json::json! {{"data": {
+                            "people": [
+                                {"__typename": "User", "id": "1"},
+                                {"__typename": "User", "id": "2", "name": "B"}
+                            ]
+                        } }},
+                    )
+                    .build(),
+            ),
+            // subB is only invoked for people[1]. The test cares about the
+            // index-exhaustiveness check, not subB's response shape, so we
+            // leave the mock returning the default empty data.
+            ("subb", MockSubgraph::default()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    let value = serde_json::to_value(&response).unwrap();
+
+    let empty = Vec::new();
+    let errors = value["errors"].as_array().unwrap_or(&empty);
+    let unsatisfied: Vec<_> = errors
+        .iter()
+        .filter(|e| e["extensions"]["code"].as_str() == Some("UNSATISFIED_FETCH_CONDITION"))
+        .collect();
+    let paths: Vec<_> = unsatisfied.iter().map(|e| &e["path"]).collect();
+
+    // Exactly one error at people[0].extra. people[1].extra is also null in
+    // the merged response, but the walker hits the new `by_index` branch
+    // (entries exist but `1` isn't one) and yields `Self::None`, so no
+    // emission fires for the sibling element.
+    assert_eq!(
+        unsatisfied.len(),
+        1,
+        "should emit exactly one UNSATISFIED_FETCH_CONDITION at people[0].extra, got: {:?}",
+        paths
+    );
+    assert_eq!(
+        unsatisfied[0]["path"],
+        serde_json::json!(["people", 0, "extra"])
+    );
+    assert!(
+        !paths.iter().any(|p| {
+            p.as_array()
+                .and_then(|a| a.first())
+                .is_some_and(|first| first == "people")
+                && p.as_array().and_then(|a| a.get(1)).is_some_and(|i| i == 1)
+        }),
+        "no error should reference people[1], got: {:?}",
+        paths
+    );
 }

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__nullability_bubbling.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__nullability_bubbling.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/services/supergraph/tests.rs
-assertion_line: 435
 expression: response
 ---
 {

--- a/apollo-router/src/spec/field_type.rs
+++ b/apollo-router/src/spec/field_type.rs
@@ -307,6 +307,12 @@ impl FieldType {
     pub(crate) fn is_non_null(&self) -> bool {
         self.0.is_non_null()
     }
+
+    /// The name of the underlying named type, unwrapping any list/non-null
+    /// modifiers. For example, both `Foo!` and `[Foo]!` return `"Foo"`.
+    pub(crate) fn inner_named_type(&self) -> &schema::NamedType {
+        self.0.inner_named_type()
+    }
 }
 
 impl From<&'_ schema::Type> for FieldType {


### PR DESCRIPTION
## Summary

Reports `UNSATISFIED_FETCH_CONDITION` errors when an `_entities` fetch is skipped because a non-nullable `@key`/`@requires` input is missing on the parent entity. Previously, the Router silently dropped the entity — the response showed `null`s for the downstream fields with no indication of why.

## Details

The error set for each skipped entity fetch is computed precisely via a three-step tree walk in `errors_for_skipped_entity` (`execution.rs`):

1. **Build** a `ResponseKeyTree` from the subgraph fetch's selection set — exactly what the fetch would have produced for this entity. Honors inline fragments, named fragment spreads, `@skip`/`@include`, and `__typename` filtering.
2. **Intersect** with the user's operation at `current_dir` — strips planner-internal fields (extra `__typename`s, key fields, `@requires`-driven inputs the user didn't ask for) so errors don't leak planning details.
3. **Emit** at each leaf path that isn't already populated in the merged entity data — a sibling fetch may have supplied a field this fetch would have, in which case there's nothing to report.

Other notable pieces:

- `Variables::new` (`fetch.rs`) now returns `(Option<Variables>, Vec<Path>)`, where `.1` is the list of paths whose required fields were unsatisfied (and thus skipped). The caller threads these paths through to the executor.
- **Lists are best-effort.** `ResponseKeyTree` has no array indices, so it can't address per-element paths like `[friends, 0, job]`. Step 1 stops at list-typed fields (`is_list_stop`) and Step 3 emits at the list field unconditionally — a parallel fetch may have populated the array, but can't have filled in the per-item fields this subgraph would have supplied.
- **Error code `UNSATISFIED_FETCH_CONDITION` is deliberately abstract.** It does not leak `@requires` or any other planning details into the user-visible response.

### Why the response formatter didn't already surface this

`apply_selection_set` in `spec/query.rs` *does* generate errors for explicit null values on non-null fields (via `format_non_nullable_value` — they land in `response.errors` as `RESPONSE_VALIDATION_FAILED` when result coercion errors are enabled), but does *not* surface user-visible errors for fields that are simply *absent* from subgraph responses — those go only to the `valueCompletion` extension. A `@requires`-skipped fetch looks exactly like "missing" from the formatter's perspective, which is why the bug was silent pre-PR. The `response_formatting_missing_vs_null_nonnull_field_asymmetry` test pins this down for future readers.

## Test plan

- [x] Base case: `missing_nonnull_field_in_requires_returns_error` — silent skip → explicit errors
- [x] Null-propagation variants:
  - `missing_nonnull_field_in_requires_returns_error_nonnull_leaf` — `String!` leaf nullifies `data.entity`
  - `missing_nonnull_field_in_requires_returns_error_nonnull_entity` — `Entity!` nullifies `data` itself
- [x] Partial batch: `batched_entity_partial_requires_failure` — only the failed entities produce errors; the satisfied ones are still fetched
- [x] Over-report trap: `parallel_sibling_skipped_fetch_does_not_over_report` (+ `_generate_fragments` variant) — don't flag sibling fetch's fields when sibling is concurrently running
- [x] Internal-field leak: `chained_requires_skipped_fetch_hides_internal_fields` — transitively-skipped fetch doesn't leak planner-internal `@requires` fields
- [x] Leaf-level precision: `skipped_fetch_with_overlapping_shareable_composite_field` — report at the leaf, not the composite, when another fetch partially populated the composite
- [x] List stop:
  - `skipped_fetch_with_list_field_reports_at_list_level` — report at the list path
  - `skipped_fetch_with_shareable_list_field_reports_error_and_value` — report at the list path even when another fetch populated the array
- [x] Formatter asymmetry control: `response_formatting_missing_vs_null_nonnull_field_asymmetry` — documents why the formatter didn't already surface this
- [x] Snapshot update: `typename_propagation2` — adds the `errors: [UNSATISFIED_FETCH_CONDITION]` array on top of the `valueCompletion` extension introduced by the precursor PR
- [x] Snapshot update: `requests_exceeding_one_subgraph_cost_are_accepted@federated_ships_required` integration test reflects the new errors and one fewer subgraph call when a fetch is correctly skipped

<!-- start metadata -->

<!-- [ROUTER-1741] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [ ] Manual tests, as necessary


[ROUTER-1741]: https://apollographql.atlassian.net/browse/ROUTER-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ