### PR TITLE
chore(tests): drop stale doc-pointers + dead hard-coded redis namespace

### DIFF
--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1628,8 +1628,7 @@ impl IntegrationTest {
         // Previously 3 s. Raised to 10 s when the harness began injecting
         // a `connection_shutdown_timeout` default to prevent the 60 s
         // production default from hanging tests that hold HTTP/2 client
-        // connections open past the response (see `merge_overrides` and
-        // flaky-test-phases/blog-details.md Arc 2a for the full story).
+        // connections open past the response (see `merge_overrides`).
         let router = self.router.as_mut().expect("router must have been started");
         let now = Instant::now();
         while now.elapsed() < Duration::from_secs(10) {
@@ -1904,11 +1903,10 @@ fn merge_overrides(
     //
     // This race is latent in any test that makes an HTTP request and then
     // calls `graceful_shutdown()`. It first surfaced on 2026-04-16 against
-    // `test_http2_max_header_list_size_exceeded` (see commit f4d6aa0c6 and
-    // flaky-test-phases/blog-details.md Arc 2a for the full story). Rather
-    // than patch each vulnerable fixture individually, inject a 5 s default
-    // at the harness layer, paired with a widened `assert_shutdown` budget
-    // (see that helper for the matching constant).
+    // `test_http2_max_header_list_size_exceeded` (see commit f4d6aa0c6).
+    // Rather than patch each vulnerable fixture individually, inject a 5 s
+    // default at the harness layer, paired with a widened `assert_shutdown`
+    // budget (see that helper for the matching constant).
     //
     // The 5 s value is a trade-off:
     // - Must be long enough that intentionally-in-flight requests finish

--- a/apollo-router/tests/integration/telemetry/fixtures/response_cache.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/response_cache.router.yaml
@@ -31,7 +31,6 @@ response_cache:
       redis:
         urls:
           - redis://127.0.0.1:6379
-        namespace: test_response_cache_metrics
         pool_size: 2
     subgraphs:
       products:


### PR DESCRIPTION
## Summary

Three small uniformity-cleanup edits in `apollo-router/tests/`:

1. **`tests/common.rs:1632`** — drop pointer at `flaky-test-phases/blog-details.md Arc 2a` inside `assert_shutdown_with_deadline`'s 10-second deadline comment. The path resolves to a project-internal notebook outside the repo, so the cross-ref implies a referent that doesn't exist for any reader outside the originating project. The surrounding comment block (and the in-tree `merge_overrides` reference one line above) already conveys the relevant context.

2. **`tests/common.rs:1908`** — same fix for the matching reference inside `merge_overrides`'s `connection_shutdown_timeout` default-injection comment. The SHA `f4d6aa0c6` reference at the same site survives.

3. **`tests/integration/telemetry/fixtures/response_cache.router.yaml`** — drop dead hard-coded `namespace: test_response_cache_metrics`. The harness's `insert_redis_namespace` unconditionally overwrites `/response_cache/subgraph/all/redis/namespace` with a per-test UUID, so the fixture's value was already dead config. Brings the fixture in line with the convention used elsewhere.

Net change: comment-only + one YAML-line deletion, no behavioral change.

## Test plan

- [ ] CI green on the touched test binary (`apollo-router::integration_tests` + `apollo-router` unit tests).

<!-- jira: ROUTER-1737 -->