### PR TITLE
fix(composition): align `@interfaceObject` subgraph name quoting with JS

### DIFF
--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -52,7 +52,9 @@ use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::validators::from_context::parse_context;
-use crate::utils::human_readable::human_readable_subgraph_names;
+use crate::utils::human_readable::HumanReadableListOptions;
+use crate::utils::human_readable::HumanReadableListPrefix;
+use crate::utils::human_readable::human_readable_list;
 use crate::utils::human_readable::human_readable_types;
 
 #[derive(Debug, Clone)]
@@ -235,7 +237,7 @@ impl Merger {
                     match source {
                         Some(_source_field) => {
                             // Direct field definition in this subgraph
-                            Some(self.names[*i].clone())
+                            Some(format!("\"{}\"", self.names[*i]))
                         }
                         None => {
                             // Check for interface object fields
@@ -248,7 +250,7 @@ impl Merger {
 
                             // Build description for interface object abstraction
                             Some(format!(
-                                "{} (through @interfaceObject {})",
+                                "\"{}\" (through @interfaceObject {})",
                                 self.names[*i],
                                 human_readable_types(
                                     itf_object_fields.iter().map(|f| f.type_name.clone())
@@ -264,7 +266,16 @@ impl Merger {
                 message: format!(
                     "Field \"{}\" is marked @external on all the subgraphs in which it is listed ({}).",
                     dest,
-                    human_readable_subgraph_names(defining_subgraphs.iter())
+                    human_readable_list(
+                        defining_subgraphs.iter().map(|s| s.as_str()),
+                        HumanReadableListOptions {
+                            prefix: Some(HumanReadableListPrefix {
+                                singular: "subgraph",
+                                plural: "subgraphs",
+                            }),
+                            ..Default::default()
+                        },
+                    )
                 ),
             };
 
@@ -701,7 +712,7 @@ impl Merger {
                     // field.
                     for field in itf_object_fields {
                         let subgraph_str = format!(
-                            "{} (through @interfaceObject field \"{}.{}\")",
+                            "\"{}\" (through @interfaceObject field \"{}.{}\")",
                             self.names[*idx], field.type_name, field.field_name
                         );
                         categorize_field(*idx, subgraph_str, &field.into());
@@ -711,7 +722,7 @@ impl Merger {
                     if !merge_context.is_used_overridden(*idx)
                         && !merge_context.is_unused_overridden(*idx)
                     {
-                        let subgraph = self.names[*idx].clone();
+                        let subgraph = format!("\"{}\"", self.names[*idx]);
                         categorize_field(*idx, subgraph, source);
                     }
                 }
@@ -719,7 +730,17 @@ impl Merger {
         }
 
         fn print_subgraphs<T: HasSubgraph>(arr: &[T]) -> String {
-            human_readable_subgraph_names(arr.iter().map(|s| s.subgraph()))
+            human_readable_list(
+                arr.iter().map(|s| s.subgraph().to_string()),
+                HumanReadableListOptions {
+                    prefix: Some(HumanReadableListPrefix {
+                        singular: "subgraph",
+                        plural: "subgraphs",
+                    }),
+                    output_length_limit: 500,
+                    ..Default::default()
+                },
+            )
         }
 
         if !non_shareable_sources.is_empty()
@@ -747,7 +768,7 @@ impl Merger {
 
             let extra_hint = if let Some(s) = subgraph_with_targetless_override {
                 format!(
-                    " (please note that \"{}.{}\" has an @override directive in \"{}\" that targets an unknown subgraph so this could be due to misspelling the @override(from:) argument)",
+                    " (please note that \"{}.{}\" has an @override directive in {} that targets an unknown subgraph so this could be due to misspelling the @override(from:) argument)",
                     dest.type_name(),
                     dest.field_name(),
                     s.subgraph,

--- a/apollo-federation/tests/composition/compose_directive_sharing.rs
+++ b/apollo-federation/tests/composition/compose_directive_sharing.rs
@@ -486,7 +486,7 @@ fn interface_object_field_requires_shareable() {
         &result,
         &[(
             "INVALID_FIELD_SHARING",
-            r#"Non-shareable field "Entity.sku" is resolved from multiple subgraphs: it is resolved from subgraphs "subgraphA", "subgraphB (through @interfaceObject field "Node.sku")" and "subgraphC" and defined as non-shareable in subgraph "subgraphB (through @interfaceObject field "Node.sku")""#,
+            r#"Non-shareable field "Entity.sku" is resolved from multiple subgraphs: it is resolved from subgraphs "subgraphA", "subgraphB" (through @interfaceObject field "Node.sku") and "subgraphC" and defined as non-shareable in subgraph "subgraphB" (through @interfaceObject field "Node.sku")"#,
         )],
     );
 }

--- a/apollo-federation/tests/composition/override_directive.rs
+++ b/apollo-federation/tests/composition/override_directive.rs
@@ -782,7 +782,7 @@ mod interface_object {
                 ),
                 (
                     "INVALID_FIELD_SHARING",
-                    r#"Non-shareable field "A.a" is resolved from multiple subgraphs: it is resolved from subgraphs "Subgraph1 (through @interfaceObject field "I.a")" and "Subgraph2" and defined as non-shareable in all of them"#,
+                    r#"Non-shareable field "A.a" is resolved from multiple subgraphs: it is resolved from subgraphs "Subgraph1" (through @interfaceObject field "I.a") and "Subgraph2" and defined as non-shareable in all of them"#,
                 ),
             ],
         );
@@ -839,7 +839,7 @@ mod interface_object {
                 ),
                 (
                     "INVALID_FIELD_SHARING",
-                    r#"Non-shareable field "A.a" is resolved from multiple subgraphs: it is resolved from subgraphs "Subgraph1 (through @interfaceObject field "I.a")" and "Subgraph2" and defined as non-shareable in all of them"#,
+                    r#"Non-shareable field "A.a" is resolved from multiple subgraphs: it is resolved from subgraphs "Subgraph1" (through @interfaceObject field "I.a") and "Subgraph2" and defined as non-shareable in all of them"#,
                 ),
             ],
         );


### PR DESCRIPTION
Pre-quote subgraph names in `validate_field_sharing` and `EXTERNAL_MISSING_ON_BASE` error paths so the `(through @interfaceObject ...)` suffix appears outside the quotes, matching the JS composition output.

Before: `"subgraphB (through @interfaceObject field "Node.sku")"`
After:  `"subgraphB" (through @interfaceObject field "Node.sku")`

JS references:
- `printSubgraphs` pre-quotes at merge.ts:1896 https://github.com/apollographql/federation/blob/main/composition-js/src/merging/merge.ts#L1896
- `printHumanReadableList` passes strings through without adding quotes https://github.com/apollographql/federation/blob/main/internals-js/src/utils.ts#L352
