### PR TITLE
docs: update old link for graph artifacts

### DIFF
--- a/docs/source/routing/configuration/envvars.mdx
+++ b/docs/source/routing/configuration/envvars.mdx
@@ -87,7 +87,7 @@ An OCI reference to a graph artifact that contains the supergraph schema. The re
 
 When you set this option, the router uses the schema from the specified graph artifact instead of Apollo Uplink. The router still fetches entitlements and persisted queries from Uplink.
 
-For information on finding graph artifact references, see [Graph Artifacts](/graphos/platform/schema-management/delivery/graph-artifacts#find-oci-artifact-references).
+For information on finding graph artifact references, see [Graph Artifacts](/graphos/platform/schema-management/delivery/graph-artifacts/oci#find-oci-artifact-references).
 
 </td>
 </tr>


### PR DESCRIPTION
Updates old graph artifacts link.

Needs https://github.com/apollographql/docs-rewrite/pull/921/ merged first.