### PR TITLE
chore(nextest): drop subscriptions::callback retry-list entries (Phase 6 follow-up)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -16,8 +16,6 @@ filter = '''
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::connectors::authentication::test_aws_sig_v4_signing) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::coprocessor::test_coprocessor_response_handling) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_response::test_valid_extensions_service_for_subgraph_error) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::callback::test_subscription_callback_pure_error_payload) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::callback::test_subscription_callback) )
 '''
 
 [profile.ci]


### PR DESCRIPTION
## Summary

Final cleanup from the multi-week de-flake project: drop the two `integration::subscriptions::callback::*` retry-list entries from `.config/nextest.toml`. The underlying fix landed in #9341 (Phase 6 Step 2 — replaced a formula-based sleep with a deadline-bounded poll loop), but the retry-list entries themselves were never dropped at that time because the callback tests gate on the `graphos` feature and don't run in standard CI, so we couldn't observe stability through the usual `ci_checks` insights dashboard.

With enough post-merge stability behind us, this PR drops the entries. Retry-list goes from **6 → 4** on `dev`.

If they re-flake under `--features ci` runs, the corrective fix shape (deadline-bounded poll loop) is documented in [`flaky-test-phases/phase-6-subscriptions.md`](../blob/dev/flaky-test-phases/phase-6-subscriptions.md) and can be reapplied.

## Test plan

- [x] `cargo nextest list -p apollo-router` parses the updated config without errors
- [ ] CI green on this branch
- [ ] No re-flake observed in subsequent `--features ci` runs that exercise `subscriptions::callback::*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)