### PR TITLE
chore(nextest): drop Phase 7 P11 + SigV4 retry-list entries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,9 +13,6 @@
 retries = 2
 filter = '''
    ( binary_id(=apollo-router::integration_tests) & test(#integration::subscriptions::ws_passthrough::*) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::connectors::authentication::test_aws_sig_v4_signing) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::coprocessor::test_coprocessor_response_handling) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_response::test_valid_extensions_service_for_subgraph_error) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::callback::test_subscription_callback_pure_error_payload) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::callback::test_subscription_callback) )
 '''


### PR DESCRIPTION
## Summary

Removes the three retry-list entries that #9337 intentionally retained for a post-merge CI-watch verification window:

- `integration::connectors::authentication::test_aws_sig_v4_signing` (SigV4)
- `integration::coprocessor::test_coprocessor_response_handling` (P11)
- `integration::subgraph_response::test_valid_extensions_service_for_subgraph_error` (P11)

This is the cleanup step described in `flaky-test-phases/phase-10-residue.md` Step 4: "After #9337 merges + 3-day CI watch: file a one-line PR removing the 3 retained Phase 7 entries (SigV4 + 2x P11) if CI confirms 50/50."

The retry-list filter goes from 6 entries to 3. The OR-chain syntax is preserved: first remaining entry has no leading `or`, every subsequent entry does.

## Context

- Phase 7 (#9337): https://github.com/apollographql/router/pull/9337
- Phase plan: `flaky-test-phases/phase-10-residue.md` Step 4
- Multi-week de-flake project drove the retry list from 243 to 6 entries on `dev`; this PR takes it to 3.

## Test plan

- [x] `cargo nextest list -p apollo-router` parses the updated config without errors
- [ ] CI green on this PR confirms the deletions don't reintroduce flake

Draft PR - not promoting to ready-for-review yet.