### PR TITLE
chore(docs): promote C8/C9/C10 to Established + dev-baseline comment cleanup

### DIFF
--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -198,10 +198,6 @@ fn mint_test_license_jwt() -> String {
 /// bootstrap a missing baseline. If a future test needs Registry-source
 /// schema, the mock has to return a real `supergraphSdl` body (mirror
 /// the License JWT pattern above).
-///
-/// Lifted into the harness from a per-test helper that originally
-/// lived in `tests/integration/telemetry/metrics.rs::test_metrics_reloading`
-/// (`b3a0986e0`).
 async fn mock_license_uplink() -> wiremock::MockServer {
     let server = wiremock::MockServer::start().await;
 
@@ -2300,11 +2296,10 @@ fn merge_overrides(
     // "unable to shutdown router, this probably means a hang".
     //
     // This race is latent in any test that makes an HTTP request and then
-    // calls `graceful_shutdown()`. It first surfaced on 2026-04-16 against
-    // `test_http2_max_header_list_size_exceeded` (see commit f4d6aa0c6).
-    // Rather than patch each vulnerable fixture individually, inject a 5 s
-    // default at the harness layer, paired with a widened `assert_shutdown`
-    // budget (see that helper for the matching constant).
+    // calls `graceful_shutdown()`. Rather than patch each vulnerable fixture
+    // individually, inject a 5 s default at the harness layer, paired with a
+    // widened `assert_shutdown` budget (see that helper for the matching
+    // constant).
     //
     // The 5 s value is a trade-off:
     // - Must be long enough that intentionally-in-flight requests finish


### PR DESCRIPTION
## Summary

Docs/contracts cleanup PR in the final phase of the multi-week de-flake project.

**Note on scope:** This PR was originally also supposed to promote three harness contracts (C8, C9, C10) in `flaky-test-phases/HARNESS-CONTRACT.md` from `PROPOSED` to `Established`. That directory is **gitignored** in this repo, so any edits there would not appear in the PR diff. The intended promotions are recorded in the commit message for traceability:

- **C8** (Uplink sandboxing): Established. #9333 (merged 2026-05-12 as `f3dc47009` on dev).
- **C9** (Orbiter sandboxing): Established. #9333 (merged 2026-05-12 as `f3dc47009` on dev).
- **C10** (Subgraph URL sandboxing): Established. #9339 (merged 2026-05-13 as `e00f50b00` on dev).

If/when `flaky-test-phases/` becomes a tracked directory, those promotions can land in a follow-up.

## What this PR actually changes

`apollo-router/tests/common.rs` — two doc-comment trims, no code behavior changes:

1. Above `mock_license_uplink`, drop the `Lifted into the harness from a per-test helper that originally lived in tests/integration/telemetry/metrics.rs::test_metrics_reloading (b3a0986e0)` trailer. The provenance points to #9257; the helper has been the harness baseline long enough that the historical pointer is no longer informative.
2. In `merge_overrides`'s `connection_shutdown_timeout` injection block, drop the `It first surfaced on 2026-04-16 against test_http2_max_header_list_size_exceeded (see commit f4d6aa0c6)` line. The surrounding paragraphs still describe what the override does and why the 5 s budget was chosen.

Related: #9333, #9339, #9257.

## Test plan

- [x] `cargo check -p apollo-router` passes
- [x] `cargo nextest list -p apollo-router` parses the config and enumerates tests cleanly
- [ ] CI green on the doc-only change

DRAFT — see scope note above re: `flaky-test-phases/` gitignore.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>