### PR TITLE
chore(ci): add retry-list drift detection

### DIFF
--- a/.github/workflows/retry-list-drift.yml
+++ b/.github/workflows/retry-list-drift.yml
@@ -43,12 +43,16 @@ jobs:
         # requires `libdw-dev` (provided by elfutils). Without it,
         # `cargo nextest list --tests` -- which runs `cargo test --no-run`
         # to compile the test binaries before listing -- fails on
-        # `ubuntu-latest` runners (libdw is not preinstalled). Other CI lanes
-        # build apollo-router under CircleCI's images, which already ship
-        # libdw, so this lane is the only one that needs an explicit install.
+        # `ubuntu-latest` runners (libdw is not preinstalled).
+        #
+        # `apollo-router`'s build script also invokes `protoc` (via
+        # `tonic-prost-build`) to codegen tonic stubs, so `protobuf-compiler`
+        # is required too. Other CI lanes build apollo-router under
+        # CircleCI's images, which already ship libdw and protoc, so this
+        # lane is the only one that needs an explicit install.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libdw-dev
+          sudo apt-get install -y libdw-dev protobuf-compiler
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2

--- a/.github/workflows/retry-list-drift.yml
+++ b/.github/workflows/retry-list-drift.yml
@@ -37,6 +37,19 @@ jobs:
         # Use the project's pinned toolchain from rust-toolchain.toml.
         run: rustup show active-toolchain || rustup toolchain install
 
+      - name: Install system dependencies
+        # `apollo-router` has a Linux-only dev-dependency on `rstack` (with the
+        # `dw` feature), which transitively pulls in `dw-sys`. Building it
+        # requires `libdw-dev` (provided by elfutils). Without it,
+        # `cargo nextest list --tests` -- which runs `cargo test --no-run`
+        # to compile the test binaries before listing -- fails on
+        # `ubuntu-latest` runners (libdw is not preinstalled). Other CI lanes
+        # build apollo-router under CircleCI's images, which already ship
+        # libdw, so this lane is the only one that needs an explicit install.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdw-dev
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/retry-list-drift.yml
+++ b/.github/workflows/retry-list-drift.yml
@@ -1,0 +1,58 @@
+name: retry-list drift detection
+
+# Audits `.config/nextest.toml`'s retry-list filter to ensure every
+# `test(=<name>)` entry still corresponds to a live test in the
+# apollo-router crate.  Phase 9 of the de-flake project found that
+# 14 of 30 retry-list entries had silently become "paper tigers" -
+# the underlying test had been renamed or removed but the filter
+# entry was left behind.  Catching that drift on PR keeps the list
+# honest.
+#
+# Only exact-match (`test(=...)`) entries are checked.  Glob entries
+# (`test(#...)`) are skipped by design - matching zero tests is not
+# necessarily drift for a glob.
+
+on:
+  pull_request:
+    paths:
+      - '.config/nextest.toml'
+      - 'scripts/check_retry_list_drift.sh'
+      - '.github/workflows/retry-list-drift.yml'
+
+# Cancel in-flight runs for the same PR on push.
+concurrency:
+  group: retry-list-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift_check:
+    name: check for dead retry-list entries
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        # Use the project's pinned toolchain from rust-toolchain.toml.
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Cache cargo build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target
+          key: retry-list-drift-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            retry-list-drift-${{ runner.os }}-
+
+      - name: Run drift check
+        run: ./scripts/check_retry_list_drift.sh

--- a/scripts/check_retry_list_drift.sh
+++ b/scripts/check_retry_list_drift.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# check_retry_list_drift.sh
+#
+# Detects "drift" in the retry-list filter inside `.config/nextest.toml`:
+# entries that reference test names which no longer exist (renamed, deleted,
+# or feature-gated away). These dead entries accumulate silently because
+# nextest's filter language doesn't error on names that match nothing.
+#
+# Why: Phase 9 of the de-flake project (#9338) found 14 of 30 retry-list
+# entries were dead. The list looked imposing but every other entry was a
+# paper tiger. Periodically auditing prevents the next "243 -> 0" cleanup
+# cycle from starting with a head start of dead entries.
+#
+# What it does:
+#   1. Parses `.config/nextest.toml` for the `retries = 2` block and extracts
+#      every `test(=<name>)` entry from its `filter = '''...'''` value.
+#   2. Runs `cargo nextest list -p apollo-router --message-format json`
+#      with the same feature flags used in CI.
+#   3. Confirms each exact-match entry corresponds to at least one live
+#      test.  Exits non-zero with a list of dead entries if any miss.
+#
+# What it does NOT do:
+#   * Glob entries (`test(#...)`) are skipped. Globs match zero or more
+#     tests by design; "matches zero" isn't necessarily drift, and verifying
+#     would require re-implementing nextest's glob semantics.
+#   * Does not validate `binary_id(...)` predicates - we only check that
+#     the test name itself is reachable somewhere in the workspace.
+#
+# Usage:
+#   scripts/check_retry_list_drift.sh
+#
+# Exits 0 on success, 1 if drift is detected, 2 on parser / tool errors.
+
+set -euo pipefail
+
+NEXTEST_CONFIG="${NEXTEST_CONFIG:-.config/nextest.toml}"
+CARGO_PACKAGE="${CARGO_PACKAGE:-apollo-router}"
+# Match CI feature flags.  These are the same features CI passes to
+# `cargo xtask test` (see `.circleci/config.yml`: `--features ci,snapshot`)
+# so that the set of "live tests" the audit sees matches the set CI sees.
+CARGO_FEATURES="${CARGO_FEATURES:-ci,snapshot}"
+
+if [[ ! -f "${NEXTEST_CONFIG}" ]]; then
+  echo "error: ${NEXTEST_CONFIG} not found" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Extract the retry-list filter block.
+#
+# The retry list lives in the first `[[profile.default.overrides]]` block
+# that contains `retries = 2`.  We extract the contents of its
+# `filter = '''...'''` triple-quoted string.
+# ---------------------------------------------------------------------------
+retry_filter="$(awk '
+  /^\[\[profile\.default\.overrides\]\]/ { in_block = 1; saw_retries = 0; next }
+  in_block && /^\[/                      { in_block = 0; in_filter = 0 }
+  in_block && /^retries[[:space:]]*=/    { saw_retries = 1 }
+  in_block && saw_retries && /filter[[:space:]]*=[[:space:]]*'\'\'\''/ {
+    in_filter = 1
+    next
+  }
+  in_filter && /'\'\'\''/                { in_filter = 0; exit }
+  in_filter                              { print }
+' "${NEXTEST_CONFIG}")"
+
+if [[ -z "${retry_filter}" ]]; then
+  echo "info: no retry-list filter found in ${NEXTEST_CONFIG} - nothing to check" >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Extract `test(=<name>)` entries.  Skip `test(#<glob>)` deliberately.
+# ---------------------------------------------------------------------------
+mapfile -t exact_entries < <(
+  printf '%s\n' "${retry_filter}" \
+    | grep -oE 'test\(=[^)]+\)' \
+    | sed -E 's/^test\(=//; s/\)$//' \
+    | sort -u
+)
+
+glob_count="$(printf '%s\n' "${retry_filter}" | grep -cE 'test\(#[^)]+\)' || true)"
+
+echo "Retry-list audit: ${#exact_entries[@]} exact-match entries, ${glob_count} glob entries (skipped)."
+
+if [[ "${#exact_entries[@]}" -eq 0 ]]; then
+  echo "No exact-match entries to check."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 3. List all tests in the package via nextest's JSON output.
+# ---------------------------------------------------------------------------
+echo "Listing tests in package '${CARGO_PACKAGE}' with features '${CARGO_FEATURES}'..."
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+list_output="${tmpdir}/nextest-list.json"
+
+if ! cargo nextest list \
+      -p "${CARGO_PACKAGE}" \
+      --features "${CARGO_FEATURES}" \
+      --message-format json \
+      --tests \
+      > "${list_output}" 2> "${tmpdir}/nextest-list.err"; then
+  echo "error: 'cargo nextest list' failed" >&2
+  cat "${tmpdir}/nextest-list.err" >&2
+  exit 2
+fi
+
+# Flatten the JSON list into a stream of "test-name" lines.  The JSON shape
+# is {"rust-suites": {"<suite>": {"testcases": {"<name>": {...}}}}}.
+all_tests="${tmpdir}/all-tests.txt"
+if command -v jq > /dev/null 2>&1; then
+  jq -r '."rust-suites"[].testcases | keys[]' "${list_output}" \
+    | sort -u > "${all_tests}"
+else
+  # Fallback: nextest also supports `--message-format human` listing.
+  cargo nextest list \
+        -p "${CARGO_PACKAGE}" \
+        --features "${CARGO_FEATURES}" \
+        --tests 2> /dev/null \
+    | awk '/^    / { print $1 }' \
+    | sort -u > "${all_tests}"
+fi
+
+total_tests="$(wc -l < "${all_tests}" | tr -d ' ')"
+echo "Found ${total_tests} tests."
+
+# ---------------------------------------------------------------------------
+# 4. Verify each exact-match entry resolves to at least one live test.
+# ---------------------------------------------------------------------------
+dead_entries=()
+for entry in "${exact_entries[@]}"; do
+  if ! grep -Fxq "${entry}" "${all_tests}"; then
+    dead_entries+=("${entry}")
+  fi
+done
+
+if [[ "${#dead_entries[@]}" -eq 0 ]]; then
+  echo "OK: all ${#exact_entries[@]} exact-match retry-list entries resolve to live tests."
+  exit 0
+fi
+
+echo ""
+echo "DRIFT DETECTED: ${#dead_entries[@]} retry-list entries reference tests that do not exist:" >&2
+for entry in "${dead_entries[@]}"; do
+  echo "  - test(=${entry})" >&2
+done
+echo "" >&2
+echo "These tests have likely been renamed, removed, or feature-gated since the" >&2
+echo "entry was added.  Remove them from the 'filter' value in:" >&2
+echo "  ${NEXTEST_CONFIG}" >&2
+echo "" >&2
+echo "If a test is feature-gated, ensure CARGO_FEATURES in this script includes" >&2
+echo "the gating feature, then re-run." >&2
+exit 1


### PR DESCRIPTION
## Summary

Adds an automated audit that catches "paper tiger" entries in
`.config/nextest.toml`'s retry-list filter -- entries that reference
test names which no longer exist.

Phase 9 of the de-flake project (#9338, continued in #9404) found
that **14 of 30 retry-list entries were dead** -- their underlying
tests had been renamed or removed, but the filter entries were never
cleaned up. The list looked imposing but every other entry was a
paper tiger. Without an automated check, the next cleanup cycle
will start with a similar head start of dead entries.

This adds:

1. **`scripts/check_retry_list_drift.sh`** -- a small bash script
   that parses the `retries = 2` block's `filter = '''...'''` value,
   extracts every `test(=<name>)` entry, runs `cargo nextest list
   -p apollo-router --features ci,snapshot --message-format json
   --tests` (the same feature set CI uses), and fails if any entry
   doesn't correspond to a live test.
2. **`.github/workflows/retry-list-drift.yml`** -- a GitHub Actions
   workflow that runs the script on every PR that touches
   `.config/nextest.toml` (or the audit itself).

## What is checked

- Only `test(=<name>)` exact-match entries are validated.
- `test(#<name>)` glob entries are skipped by design: a glob can
  legally match zero tests, so "matches zero" isn't necessarily
  drift -- only exact-match drift is unambiguous.

## CI system choice

The repo uses CircleCI for the main test pipeline. I implemented
this as a GitHub Actions workflow instead because Actions has
native `paths:` filtering on `pull_request` triggers, which keeps
the audit free for any PR that doesn't touch nextest config. The
same path-conditional behaviour on CircleCI would require migrating
to dynamic config via the `path-filtering` orb -- a much larger
change than this audit itself warrants. The repo already uses
`.github/workflows/main.yml` for a similar PR-meta check
(NEXT_CHANGELOG reminder), so this fits the existing pattern.

Happy to port to CircleCI if reviewers prefer -- flagged as draft
to surface this decision.

## Test plan

Tested locally on this branch:

- [x] Ran `scripts/check_retry_list_drift.sh` against current `dev`'s
      `.config/nextest.toml`. Result: `OK: all 3 exact-match retry-list
      entries resolve to live tests.` (exit 0). The retry list on dev
      currently has 1 glob entry (skipped) + 3 exact-match entries
      after #9404's sweep.
- [x] Injected a fake entry `test(=nonexistent_test_xyz)` into the
      filter, re-ran the script:
      ```
      DRIFT DETECTED: 1 retry-list entries reference tests that do not exist:
        - test(=nonexistent_test_xyz)
      ```
      Exit 1. Then reverted -- no spurious changes in this PR.
- [ ] CI green on this PR (verifies workflow YAML is well-formed and
      the runner can install nextest + complete the audit within the
      25-minute timeout).
- [ ] Optional follow-up: as a smoke test of the workflow trigger
      itself, the reviewer could push a commit that re-injects the
      fake entry into `.config/nextest.toml` on a throwaway branch and
      verify CI catches it.

## Notes for reviewers

- Marked **draft** intentionally per the original ticket's
  "stretch / optional" framing. Promote to ready once the CI-system
  choice (GHA vs CircleCI) is agreed.
- The script's `CARGO_FEATURES` default (`ci,snapshot`) mirrors the
  features passed to `cargo xtask test` in `.circleci/config.yml`.
  If a future retry-list entry requires a different feature gate to
  be visible, that feature needs to be added to both places.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>