### PR TITLE
chore(nextest): document ws_passthrough::* retention rationale

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,6 +10,34 @@
 #
 # Frankly, it may be best to just retry all tests in the apollo-router::integration_tests
 # module, as they have a high failure rate, in general.
+# Intentional retention rationale for `subscriptions::ws_passthrough::*`:
+# Stress test (2026-05-13, 10 local iterations on macOS) flaked in 4/10 iterations
+# across three distinct sites within this module. Each was rescued by
+# `retries = 2`. Even after Phase 6 Steps 1+2+3+5 landed (PR #9341 — server
+# readiness polls, callback formula-sleep removal, `Arc<Notify>` dedup race fix
+# for `*_dedup_close_early`), other tests in this file still surface real-time
+# races that the harness facilities in scope for this de-flake project cannot
+# reach:
+#
+#   * `test_subscription_ws_passthrough_on_schema_reload` (line ~799) — asserts
+#     `apollo_router_open_connections{state=terminating}` has drained to 0
+#     immediately after `assert_reloaded().await`, racing connection-shutdown
+#     bookkeeping against the metric snapshot. Observed left=2 right=1.
+#   * `test_subscription_ws_passthrough_dedup` (line ~893) — reads
+#     `apollo_router_operations_subscriptions_total{subscriptions_deduplicated="true"}`
+#     before the dedup counter increment has been observed; got 0 when 1 was
+#     expected.
+#   * `test_subscription_ws_passthrough_with_non_ascii_headers` (line ~1208) —
+#     checks an `AtomicBool` flipped by the WS server's close handler before
+#     the server has observed the close.
+#
+# All three are kernel-side timing races (atomic visibility / metrics scrape
+# vs. teardown task scheduling), not amenable to a `tokio::time::pause()` fix.
+# They belong to Phase 10's "real-time race" cohort (blog Arc 6f) and need
+# either explicit "drained" signaling on the router side or a metrics
+# poll-with-deadline harness extension. Glob kept (not enumerated) because the
+# failure mode is module-wide and any test in the file is a plausible next
+# victim. Remove this entry once the underlying signaling lands.
 retries = 2
 filter = '''
    ( binary_id(=apollo-router::integration_tests) & test(#integration::subscriptions::ws_passthrough::*) )


### PR DESCRIPTION
## Summary

- Final Phase-6 / Phase-10 close-out for the last wildcard on the
  `retries = 2` list in `.config/nextest.toml`. **Path (b)** of the
  decision tree: the stress test surfaced flakes, so the glob stays and
  this PR documents *why*.
- 10-iteration local stress run on `dev`@`2edff7e17` after Phase 6 Steps
  1+2+3+5 (PR #9341 already merged) and Phase 10 residue removal (PR
  #9404) confirmed the glob is still doing real work: the test suite
  passed 10/10 with retries, but 4/10 iterations required a retry,
  hitting three distinct race sites within the `ws_passthrough` module.
- Adds a TOML comment block above the filter naming the three observed
  failure sites, the underlying race class (kernel-side real-time
  races / atomic-visibility-vs-teardown-scheduling), why they're
  out-of-scope for the harness facilities in this de-flake project,
  and the explicit exit criterion for removing the entry.
- No filter or behavior change. `cargo nextest list -p apollo-router`
  still parses cleanly.

### Stress test results (2026-05-13, local, macOS, `cargo nextest run -p apollo-router --tests -E 'binary(integration_tests) & test(ws_passthrough)'`)

| Iter | Result | Flaky test | Site |
|------|--------|------------|------|
| 1 | flaky | `test_subscription_ws_passthrough_on_schema_reload` | line ~799 (`total_active + total_terminating == 1`, left=2 right=1) |
| 2 | clean | — | — |
| 3 | clean | — | — |
| 4 | flaky | `test_subscription_ws_passthrough_dedup` | line ~893 (deduplicated counter) |
| 5 | clean | — | — |
| 6 | clean | — | — |
| 7 | clean | — | — |
| 8 | flaky | `..._with_non_ascii_headers::config_1_SUBSCRIPTION_CONFIG_GRAPHQL_WS` | line ~1208 (`is_closed` `AtomicBool`) |
| 9 | flaky | `test_subscription_ws_passthrough_dedup` | line ~893 (left=0 right=1) |
| 10 | clean | — | — |

10/10 suite passes with retries; 4/10 iterations had TRY 1 failures
rescued by `retries = 2`. Three distinct race sites, all kernel-side
timing races between metrics scrape / atomic visibility and teardown
task scheduling.

### Context

- `flaky-test-phases/phase-6-subscriptions.md` — Phase 6 fixes, including
  Step 3 `Arc<Notify>` dedup race fix (which addressed
  `*_dedup_close_early` specifically, not the three sites observed here).
- `flaky-test-phases/phase-10-residue.md` Status section + Step 4 —
  previously called this "intentional retention" but did not document
  empirical evidence; this PR supplies the evidence.
- Refs PR #9341 (Phase 6 umbrella, merged) and #9404 (Phase 10 residue,
  merged).

## Test plan

- [x] `cargo nextest list -p apollo-router --tests 2>&1 | head -50`
      — confirms `.config/nextest.toml` still parses (no
      `expected expression` / `missing expression` errors). Comment was
      placed as TOML-level `#` lines above the `filter` heredoc; nextest's
      filter DSL does not accept inline `#` comments inside `'''…'''`,
      which was verified by an initial incorrect placement.
- [x] 10x local stress run captured above; see commit message for the
      full per-iteration failure detail.
- [ ] CI: confirm `cargo nextest list --message-format json` and the
      existing test workflows are unaffected (no-op semantically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)