### PR TITLE
fix(redis): close subscribe-after-publish race in required_to_start connect path

### DIFF
--- a/.changesets/fix_redis_required_to_start_subscribe_race.md
+++ b/.changesets/fix_redis_required_to_start_subscribe_race.md
@@ -1,0 +1,15 @@
+### Fix `required_to_start: true` startup hang on unreachable Redis
+
+When `supergraph.query_planning.cache.redis.required_to_start` (or the corresponding APQ / entity cache / response cache flag) is set to `true` and Redis is unreachable, the router's startup path could hang indefinitely instead of failing fast.
+
+**What was happening**
+
+`RedisCacheStorage::create_client_pool` called `client_pool.connect_pool()` (which spawns fred's connection tasks immediately) and then `client_pool.wait_for_connect().await`. `wait_for_connect` subscribes to fred's per-client `connect` broadcast channel at the moment it is `.await`ed — but the broadcast channel does not buffer events for late subscribers. If fred's bounded reconnect policy exhausted its 15 attempts before the subscription was registered, the terminal `broadcast_connect(Err(..))` was fired into the void, fred aborted the pool, and the subscriber waited forever for an event that would never come.
+
+This was a subscribe-after-publish race that surfaced as a 120 s timeout on the `connection_failure_blocks_startup` integration test on contended CI runners.
+
+**What changed**
+
+`create_client_pool` now mirrors fred's own `Pool::init` shape: when `required_to_start` is set, the per-client connect-notification receivers are collected *before* `connect_pool()` is called. We then await each receiver in turn. The broader connection lifecycle (separate per-client `ConnectHandle`s for the watcher task, reconnect policy, pool recreation) is unchanged.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9412

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -457,10 +457,58 @@ impl RedisCacheStorage {
             ACTIVE_CLIENT_COUNT.fetch_add(1, Ordering::Relaxed);
         }
 
+        // When `required_to_start` is set, subscribe to each client's `connect`
+        // notification *before* kicking off connection tasks. fred's
+        // `Pool::wait_for_connect` subscribes only at the moment it is `.await`ed,
+        // so there is a race: if `connect_pool` exhausts its reconnection policy
+        // before `wait_for_connect` reaches the `recv()` call, the terminal
+        // `broadcast_connect(Err(..))` is fired before any subscriber exists. The
+        // broadcast channel does not buffer past events for late subscribers, and
+        // fred never sends another connect event (the pool has aborted), so
+        // `wait_for_connect` hangs indefinitely. We saw this surface in CI as the
+        // `connection_failure_blocks_startup` integration test timing out at the
+        // nextest 120 s deadline.
+        //
+        // We mirror fred's own `Pool::init` shape (clients/pool.rs `init`) which
+        // collects subscribers first and then calls `connect`, but keep the
+        // separate per-client `ConnectHandle`s that the downstream watcher task
+        // (see below) needs to detect a pool abort. This is a subscribe-before-
+        // publish fix; the broader connection lifecycle is unchanged.
+        let connect_rxs: Vec<_> = if self.redis_client_config.required_to_start {
+            client_pool
+                .clients()
+                .iter()
+                .map(|c| c.inner().notifications.connect.load().subscribe())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         // NB: error is not recorded here as it will be observed by the task following `client.error_rx()`
         let client_handles = client_pool.connect_pool();
         if self.redis_client_config.required_to_start {
-            client_pool.wait_for_connect().await?;
+            // Drive each pre-subscribed receiver to its first event. If any
+            // client's connect attempts ultimately fail, surface that error so the
+            // router can refuse to start (the contract documented on
+            // `required_to_start`).
+            for mut rx in connect_rxs {
+                match rx.recv().await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => return Err(Box::new(e)),
+                    Err(RecvError::Lagged(_)) => {
+                        // A lag means the broadcast queue overflowed between the
+                        // subscribe and recv; this only happens under extreme load
+                        // and is not a connect failure, so wait for the next event.
+                        continue;
+                    }
+                    Err(RecvError::Closed) => {
+                        return Err(Box::new(RedisError::new(
+                            RedisErrorKind::Canceled,
+                            "redis connect notification channel closed before any connect attempt completed",
+                        )));
+                    }
+                }
+            }
             tracing::trace!("redis connections established");
         }
 


### PR DESCRIPTION
## Summary

`integration::redis::connection_failure_blocks_startup` timed out at 120 s on CI for two PRs today that only touched comments / docs:

- PR #9409 — https://circleci.com/gh/apollographql/router/369728
- PR #9411 — https://circleci.com/gh/apollographql/router/369751

Both runs showed the same shape: nextest's slow-timeout escalated (`SLOW [>30s]` → `[>60s]` → `[>90s]` → `TERMINATING [>120s]` → `TIMEOUT`), and the only test-scoped log lines (just before kill) were two `ConnectionRefused` errors plus `redis client aborted; marking for recreation`. The test is comment-stable on both branches, so the failures had to be the same flake surfacing on `dev`-baseline runs.

## Race class

Subscribe-after-publish on a `tokio::sync::broadcast` channel — a variant of T18 (cross-component observability race) but within fred's pool API rather than between router and test.

`RedisCacheStorage::create_client_pool` did:

```rust
let client_handles = client_pool.connect_pool();  // fred spawns connect tasks immediately
if required_to_start {
    client_pool.wait_for_connect().await?;        // subscribes lazily at .await
}
```

fred's `wait_for_connect` calls `notifications.connect.load().subscribe().recv().await`. The `subscribe()` happens at the moment of `.await`, so under load on the 4 vCPU CircleCI runner with the rest of the integration suite running, the bounded reconnect policy (15 attempts, 1ms → 2000ms exponential, factor 5) could exhaust before the subscription was registered. The terminal `broadcast_connect(Err(ConnectionRefused))` fired into the void; tokio's broadcast does not buffer past events for new subscribers; fred aborted the pool and never broadcast again; `recv()` waited indefinitely. Test hit nextest's 120 s deadline.

This matches fred's own `Pool::init` source comments (clients/pool.rs line 265+): `init` deliberately subscribes *before* calling `connect()` to avoid exactly this race.

## Fix

`apollo-router/src/cache/redis.rs` (lines ~455-505): when `required_to_start` is set, collect each client's connect-notification receiver *before* calling `connect_pool()`, then await each receiver in turn. The pool-level `wait_for_connect()` call is gone. The per-client `ConnectHandle`s passed to the watcher task (which detects pool abort) are unchanged.

## Stress results

Local nextest 10/10 pass on the targeted test:

```
cargo nextest run -p apollo-router --tests \
  -E 'test(=integration::redis::connection_failure_blocks_startup)' \
  --retries 0 --no-fail-fast --profile ci
```

Also verified the broader surface:

- `integration::redis::*` — 19/19 pass
- `cache::redis::test::test_against_redis::*` — 39/39 pass

## Constraints

- DRAFT.
- No `.config/nextest.toml` retry-list additions (the project's hard rule for this phase).
- No `flaky-test-phases/` touches (gitignored).
- Branched off `origin/dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)