### PR TITLE
Adding deprecation warning for connectors.subgraphs

### DIFF
--- a/.changesets/maint_zach_router_1757_deprecate_connectors_subgraphs.md
+++ b/.changesets/maint_zach_router_1757_deprecate_connectors_subgraphs.md
@@ -1,0 +1,5 @@
+### Deprecate `connectors.subgraphs` configuration field
+
+The `connectors.subgraphs` configuration field is now deprecated in favor of `connectors.sources`. When `connectors.subgraphs` is set, the router will emit a deprecation warning at startup directing operators to rename the key. The field will be removed in a future 3.x release.
+
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/<TBD>

--- a/.changesets/maint_zach_router_1757_deprecate_connectors_subgraphs.md
+++ b/.changesets/maint_zach_router_1757_deprecate_connectors_subgraphs.md
@@ -2,4 +2,4 @@
 
 The `connectors.subgraphs` configuration field is now deprecated in favor of `connectors.sources`. When `connectors.subgraphs` is set, the router will emit a deprecation warning at startup directing operators to rename the key. The field will be removed in a future 3.x release.
 
-By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/<TBD>
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/9415

--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -59,6 +59,15 @@ impl Plugin for Connectors {
             );
         }
 
+        #[allow(deprecated)]
+        if !init.config.subgraphs.is_empty() {
+            tracing::warn!(
+                "The `connectors.subgraphs` configuration field is deprecated and will be \
+                 removed in a future release. Rename it to `connectors.sources`. See \
+                 https://www.apollographql.com/docs/graphos/routing/configuration/yaml#connectors"
+            );
+        }
+
         let max_requests = init
             .config
             .max_requests_per_operation_per_source


### PR DESCRIPTION
The `connectors.subgraphs` configuration field is now deprecated in favor of `connectors.sources`. When `connectors.subgraphs` is set, the router will emit a deprecation warning at startup directing operators to rename the key. The field will be removed in a future 3.x release.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
