### PR TITLE
test(apollo_otel_traces): canonicalize span ordering before snapshot capture

### DIFF
--- a/apollo-router/tests/apollo_otel_traces.rs
+++ b/apollo-router/tests/apollo_otel_traces.rs
@@ -330,8 +330,9 @@ async fn get_batch_router_service(
 /// `assert_report!` collapse the keys to `[start_time]` etc. in the
 /// rendered yaml.
 fn sort_spans_for_snapshot(report: &mut ExportTraceServiceRequest) {
-    use opentelemetry_proto::tonic::trace::v1::Span;
     use std::collections::HashMap;
+
+    use opentelemetry_proto::tonic::trace::v1::Span;
 
     for resource_spans in &mut report.resource_spans {
         for scope_spans in &mut resource_spans.scope_spans {
@@ -356,9 +357,7 @@ fn sort_spans_for_snapshot(report: &mut ExportTraceServiceRequest) {
             let mut children_of: HashMap<Vec<u8>, Vec<usize>> = HashMap::new();
             let mut roots: Vec<usize> = Vec::new();
             for (idx, span) in original.iter().enumerate() {
-                if span.parent_span_id.is_empty()
-                    || !id_to_idx.contains_key(&span.parent_span_id)
-                {
+                if span.parent_span_id.is_empty() || !id_to_idx.contains_key(&span.parent_span_id) {
                     roots.push(idx);
                 } else {
                     children_of
@@ -403,8 +402,7 @@ fn sort_spans_for_snapshot(report: &mut ExportTraceServiceRequest) {
             // Option so we can `.take()` it exactly once even if the input
             // contains duplicate span_ids (which would be a bug, but the
             // sort shouldn't silently drop spans on its behalf).
-            let mut slots: Vec<Option<Span>> =
-                original.into_iter().map(Some).collect();
+            let mut slots: Vec<Option<Span>> = original.into_iter().map(Some).collect();
             scope_spans.spans = ordered
                 .into_iter()
                 .filter_map(|idx| slots[idx].take())

--- a/apollo-router/tests/apollo_otel_traces.rs
+++ b/apollo-router/tests/apollo_otel_traces.rs
@@ -305,13 +305,127 @@ async fn get_batch_router_service(
     )
 }
 
+/// Canonicalise span ordering inside an `ExportTraceServiceRequest` so insta
+/// snapshots are stable across runs.
+///
+/// **Why this exists.** The OTLP HTTP exporter ships spans in the order the
+/// tracing-opentelemetry layer hands them to the batch span processor, which
+/// is the order their associated tokio task drops the `EnteredSpan` guard.
+/// Under `flavor = "multi_thread"` two sibling spans (e.g. `parse_query`
+/// scheduled on the compute-job pool and the supergraph-side `compute_job` /
+/// `compute_job.execution` spans on a different worker) can finish in either
+/// relative order, which permutes the `spans` vec the test asserts on. The
+/// snapshot content is byte-for-byte identical otherwise — only the array
+/// ordering changes — so the cure is to canonicalise the order before
+/// asserting. See blog-details.md / T10 (non-deterministic ordering).
+///
+/// **Shape chosen.** A hierarchical DFS rooted at each span whose
+/// `parent_span_id` is empty (or whose parent is not present in this batch).
+/// At every node, children are sorted by
+/// `(start_time_unix_nano, end_time_unix_nano, name, span_id)`. This keeps
+/// parents adjacent to their children (so the rendered snapshot still reads
+/// as a trace tree) while making sibling ordering deterministic across
+/// runs. Span timestamps are not yet redacted at this point, so the sort
+/// key carries real temporal information; the insta redactions later in
+/// `assert_report!` collapse the keys to `[start_time]` etc. in the
+/// rendered yaml.
+fn sort_spans_for_snapshot(report: &mut ExportTraceServiceRequest) {
+    use opentelemetry_proto::tonic::trace::v1::Span;
+    use std::collections::HashMap;
+
+    for resource_spans in &mut report.resource_spans {
+        for scope_spans in &mut resource_spans.scope_spans {
+            // Take the spans out so we can re-insert them in canonical order.
+            let original: Vec<Span> = std::mem::take(&mut scope_spans.spans);
+            if original.is_empty() {
+                continue;
+            }
+
+            // Stable index from span_id -> position in `original`, so the
+            // DFS can collect indices instead of cloning Spans.
+            let id_to_idx: HashMap<Vec<u8>, usize> = original
+                .iter()
+                .enumerate()
+                .map(|(i, s)| (s.span_id.clone(), i))
+                .collect();
+
+            // parent_span_id -> Vec<idx of child in `original`>. Roots key
+            // off an empty parent_span_id or a parent_span_id that doesn't
+            // resolve inside this batch (defensive — shouldn't happen for
+            // these tests, but keeps a stray span from being dropped).
+            let mut children_of: HashMap<Vec<u8>, Vec<usize>> = HashMap::new();
+            let mut roots: Vec<usize> = Vec::new();
+            for (idx, span) in original.iter().enumerate() {
+                if span.parent_span_id.is_empty()
+                    || !id_to_idx.contains_key(&span.parent_span_id)
+                {
+                    roots.push(idx);
+                } else {
+                    children_of
+                        .entry(span.parent_span_id.clone())
+                        .or_default()
+                        .push(idx);
+                }
+            }
+
+            // Sort a slice of indices into `original` by the canonical key.
+            let sort_key = |idx: &usize| -> (u64, u64, String, Vec<u8>) {
+                let s = &original[*idx];
+                (
+                    s.start_time_unix_nano,
+                    s.end_time_unix_nano,
+                    s.name.clone(),
+                    s.span_id.clone(),
+                )
+            };
+            roots.sort_by_key(sort_key);
+            for v in children_of.values_mut() {
+                v.sort_by_key(sort_key);
+            }
+
+            // DFS: visit each root, then its children in sorted order, etc.
+            // Iterative to avoid blowing the stack on pathological trees.
+            let mut ordered: Vec<usize> = Vec::with_capacity(original.len());
+            let mut stack: Vec<usize> = roots.into_iter().rev().collect();
+            while let Some(idx) = stack.pop() {
+                ordered.push(idx);
+                let span_id = &original[idx].span_id;
+                if let Some(kids) = children_of.get(span_id) {
+                    // Push in reverse so they come off the stack in sorted
+                    // order.
+                    for child in kids.iter().rev() {
+                        stack.push(*child);
+                    }
+                }
+            }
+
+            // Reconstruct the spans vec in DFS order. Wrap each span in
+            // Option so we can `.take()` it exactly once even if the input
+            // contains duplicate span_ids (which would be a bug, but the
+            // sort shouldn't silently drop spans on its behalf).
+            let mut slots: Vec<Option<Span>> =
+                original.into_iter().map(Some).collect();
+            scope_spans.spans = ordered
+                .into_iter()
+                .filter_map(|idx| slots[idx].take())
+                .collect();
+        }
+    }
+}
+
 macro_rules! assert_report {
         ($report: expr)=> {
             assert_report!($report, false)
         };
         ($report: expr, $batch: literal)=> {
+            // Take ownership locally so we can canonicalise span ordering
+            // without forcing every call site to declare `let mut report`.
+            // Without the sort, the OTLP exporter's spans vec is permuted
+            // by tokio-task drop order — see `sort_spans_for_snapshot`.
+            let mut report = $report;
+            sort_spans_for_snapshot(&mut report);
             insta::with_settings!({sort_maps => true}, {
-                    insta::assert_yaml_snapshot!($report, {
+                    insta::assert_yaml_snapshot!(report, {
                         ".**.attributes" => insta::sorted_redaction(),
                         ".**.attributes[]" => insta::dynamic_redaction(|mut value, _| {
                             let mut redacted_attributes = vec![


### PR DESCRIPTION
## Summary

Fixes a latent flake in `apollo-router/tests/apollo_otel_traces.rs` where the OTLP-batch `ExportTraceServiceRequest.spans` vec is populated in `EnteredSpan`-drop order across the tokio multi-thread runtime. Sibling spans (`parse_query`, `compute_job`, `compute_job.execution`) can finish in either relative order, permuting the saved insta snapshot without changing any span content. CircleCI build 369788 on #9413 (Phase 11) is the most recent hit; the race has been latent since the multi-thread runtime was introduced.

## Fix

Introduce `sort_spans_for_snapshot` and call it from `assert_report!` before `assert_yaml_snapshot!`.

- **Sort shape:** hierarchical DFS. Per `scope_spans`, group by `parent_span_id`. Roots (empty parent or parent absent from this batch) are sorted first; then iterative DFS visits each subtree with children sorted by `(start_time_unix_nano, end_time_unix_nano, name, span_id)`. Parents stay adjacent to their children so the rendered snapshot still reads as a trace tree.
- **Macro:** takes ownership locally (`let mut report = $report;`) so all 14 existing `assert_report!(report)` / `assert_report!(report, true)` call sites compile unchanged.
- **Snapshots regenerated:** 0. The 24 saved `apollo_otel_traces__*.snap` files already happen to be in the canonical DFS order this helper produces, so the change is purely defensive against the permutation that bit CI.

## Stress results

- 30 / 30 PASS on single `apollo_otel_traces::connector` (`--retries 0 --no-fail-fast`)
- 10 / 10 PASS on full `apollo_otel_traces` binary (12 tests/run, **120 / 120**)

## Follow-up

`apollo-router/tests/apollo_reports.rs` uses the same `ExportTraceServiceRequest` shape and the same `assert_yaml_snapshot!` pattern. It almost certainly carries the same latent flake. **Not addressed here** to keep this PR minimal — will file as a separate change.

## Test plan

- [x] `cargo check -p apollo-router --tests --features ci,snapshot`
- [x] `cargo nextest run -p apollo-router --tests -E 'binary(apollo_otel_traces)' --features ci,snapshot`
- [x] 30x single-test stress on `connector`
- [x] 10x full-binary stress

Unblocks #9413.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>