### PR TITLE
chore: retire the retry-list block (243 → 0)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,19 +1,3 @@
-[[profile.default.overrides]]
-# These are known flaky tests according to the test flakiness report provided
-# in CircleCI insights, based on the `dev` branch:
-#
-# https://app.circleci.com/insights/github/apollographql/router/workflows/ci_checks/tests
-#
-# We will retry these tests up to 2 additional times. Retry counts are recorded.
-# Items on this list should be prioritized to get improved and removed from this
-# list at the time they are fixed.
-#
-# Frankly, it may be best to just retry all tests in the apollo-router::integration_tests
-# module, as they have a high failure rate, in general.
-retries = 2
-filter = '''
-'''
-
 [profile.ci]
 # Print out output for failing tests as soon as they fail, and also at the end
 # of the run (for easy scrollability).

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,9 +12,6 @@
 # module, as they have a high failure rate, in general.
 retries = 2
 filter = '''
-   ( binary_id(=apollo-router::integration_tests) & test(=integration::connectors::authentication::test_aws_sig_v4_signing) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::coprocessor::test_coprocessor_response_handling) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_response::test_valid_extensions_service_for_subgraph_error) )
 '''
 
 [profile.ci]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,8 +15,6 @@ filter = '''
    ( binary_id(=apollo-router::integration_tests) & test(=integration::connectors::authentication::test_aws_sig_v4_signing) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::coprocessor::test_coprocessor_response_handling) )
 or ( binary_id(=apollo-router::integration_tests) & test(=integration::subgraph_response::test_valid_extensions_service_for_subgraph_error) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::callback::test_subscription_callback_pure_error_payload) )
-or ( binary_id(=apollo-router::integration_tests) & test(=integration::subscriptions::callback::test_subscription_callback) )
 '''
 
 [profile.ci]

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -198,10 +198,6 @@ fn mint_test_license_jwt() -> String {
 /// bootstrap a missing baseline. If a future test needs Registry-source
 /// schema, the mock has to return a real `supergraphSdl` body (mirror
 /// the License JWT pattern above).
-///
-/// Lifted into the harness from a per-test helper that originally
-/// lived in `tests/integration/telemetry/metrics.rs::test_metrics_reloading`
-/// (`b3a0986e0`).
 async fn mock_license_uplink() -> wiremock::MockServer {
     let server = wiremock::MockServer::start().await;
 
@@ -2327,11 +2323,10 @@ fn merge_overrides(
     // "unable to shutdown router, this probably means a hang".
     //
     // This race is latent in any test that makes an HTTP request and then
-    // calls `graceful_shutdown()`. It first surfaced on 2026-04-16 against
-    // `test_http2_max_header_list_size_exceeded` (see commit f4d6aa0c6).
-    // Rather than patch each vulnerable fixture individually, inject a 5 s
-    // default at the harness layer, paired with a widened `assert_shutdown`
-    // budget (see that helper for the matching constant).
+    // calls `graceful_shutdown()`. Rather than patch each vulnerable fixture
+    // individually, inject a 5 s default at the harness layer, paired with a
+    // widened `assert_shutdown` budget (see that helper for the matching
+    // constant).
     //
     // The 5 s value is a trade-off:
     // - Must be long enough that intentionally-in-flight requests finish


### PR DESCRIPTION
## Stacked on #9418

This PR is the closeout for the de-flake project. After it merges, `.config/nextest.toml` has **no `[[profile.default.overrides]]` retry block at all** — the project's goal of literal 0 retry-list entries is achieved.

## Consolidates 3 drafts
- #9407 — drop 2 `subscriptions::callback::*` entries (Phase 6 follow-up; the underlying fix was PR #9341).
- #9408 — drop 3 Phase 7 P11 + SigV4 entries (post-CI-watch verification cleanup).
- #9409 — `apollo-router/tests/common.rs` doc-baseline comment cleanup (inherited from PR #9257).

Plus one new commit: deletes the entire `[[profile.default.overrides]] filter = '''…'''` block. The `[test-groups]` and `[profile.ci.*]` blocks remain.

## What this finishes
The 243 → 0 journey. Started weeks ago. The retry-list block goes away; future PRs that try to re-introduce a `retries = N` override block should be caught at code-review time (per project decision 2026-05-13, drift-detection CI was rejected as the wrong guardrail — see #9410 closure comment).

## Supersedes
- #9407
- #9408
- #9409

<!-- jira: ROUTER-1722 -->