### PR TITLE
test(connectors): fix order-dependent flake in test_interface_object

### DIFF
--- a/.changesets/maint_aaron_flake_test_interface_object.md
+++ b/.changesets/maint_aaron_flake_test_interface_object.md
@@ -1,0 +1,5 @@
+### Fix arm-Linux flake in `plugins::connectors::tests::test_interface_object`
+
+Use `Plan::Sequence` + `Plan::Parallel` from `req_asserts` instead of positional matching for the five entity-resolution fetches that the connectors plugin issues in parallel. The previous positional assertion happened to pass on most runs because the fetches typically arrived in a stable order, but arm-Linux CI scheduling exposed a legitimate ordering race where `/itfs/2` arrived before `/itfs/1`, producing `"[Request 3]: Expected path /itfs/1, got /itfs/2"`. Only the test asserts changed; production behavior is unaffected.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -1776,28 +1776,32 @@ async fn test_interface_object() {
     }
     "###);
 
-    req_asserts::matches(
-        &mock_server.received_requests().await.unwrap(),
-        vec![
-          Matcher::new().method("GET").path("/itfs"),
-          Matcher::new().method("GET").path("/itfs/1/e"),
-          Matcher::new().method("GET").path("/itfs/2/e"),
-          Matcher::new().method("GET").path("/itfs/1"),
-          Matcher::new().method("GET").path("/itfs/2"),
-          Matcher::new()
-            .method("POST")
-            .path("/graphql")
-            .body(serde_json::json!({
-              "query": r#"query($representations: [_Any!]!) { _entities(representations: $representations) { ... on Itf { __typename ... on T1 { a } ... on T2 { b } } } }"#,
-              "variables": {
-                "representations": [
-                  { "__typename": "Itf", "id": 1 },
-                  { "__typename": "Itf", "id": 2 }
-                ]
-              }
-            })),
-        ],
-    );
+    // The five entity-resolution fetches (per-id field fetches and the
+    // _entities POST) run in parallel after the root /itfs fetch, so their
+    // arrival order at the mock server is non-deterministic. Use
+    // Plan::Sequence + Plan::Parallel to assert without depending on order.
+    let plan = Plan::Sequence(vec![
+        Plan::Fetch(Matcher::new().method("GET").path("/itfs")),
+        Plan::Parallel(vec![
+            Matcher::new().method("GET").path("/itfs/1/e"),
+            Matcher::new().method("GET").path("/itfs/2/e"),
+            Matcher::new().method("GET").path("/itfs/1"),
+            Matcher::new().method("GET").path("/itfs/2"),
+            Matcher::new()
+                .method("POST")
+                .path("/graphql")
+                .body(serde_json::json!({
+                  "query": r#"query($representations: [_Any!]!) { _entities(representations: $representations) { ... on Itf { __typename ... on T1 { a } ... on T2 { b } } } }"#,
+                  "variables": {
+                    "representations": [
+                      { "__typename": "Itf", "id": 1 },
+                      { "__typename": "Itf", "id": 2 }
+                    ]
+                  }
+                })),
+        ]),
+    ]);
+    plan.assert_matches(&mock_server.received_requests().await.unwrap());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Fixes an arm-Linux flake in `plugins::connectors::tests::test_interface_object` surfaced on CircleCI build [370038](https://circleci.com/gh/apollographql/router/370038) (`test-arm_linux_test` lane).
- The test asserted five parallel entity-resolution fetches positionally with `req_asserts::matches`, but those fetches run concurrently and arrival order at the wiremock server is non-deterministic. Most runs landed in the asserted order; arm-Linux CI scheduling exposed the legitimate race.
- Switched to the established `Plan::Sequence(vec![Plan::Fetch, Plan::Parallel])` pattern already used elsewhere in the same file (e.g. `mod.rs:361`). The root `/itfs` fetch stays sequential; the five downstream fetches (`/itfs/{n}`, `/itfs/{n}/e`, and the `_entities` POST) match in any order.
- Only the test assertion changed; production behavior is unaffected.

## Failure evidence (from CircleCI 370038)

```
thread 'plugins::connectors::tests::test_interface_object' (9694) panicked at
  apollo-router/src/plugins/connectors/tests/req_asserts.rs:134:37:
called `Result::unwrap()` on an `Err` value:
  "[Request 3]: Expected path /itfs/1, got /itfs/2"
```

Position 3 expected `/itfs/1`; got `/itfs/2`. Both are parallel entity fetches.

## Race class

T-paper-tiger / arc 6n escapee — the test was on the original retry list, removed by PR #9404 (Phase 10 residue) as "stable based on local stress," and is now resurfacing on arm Linux which has different scheduling characteristics than the amd Linux where prior stress runs happened. The fix is to remove the order assumption rather than to chase the schedule.

## Test plan

- [x] `cargo nextest run -p apollo-router -E 'test(=plugins::connectors::tests::test_interface_object)'` -- single run passes.
- [x] Stress: 30/30 iterations passing locally with `--retries 0 --no-fail-fast`.
- [x] Full `plugins::connectors::tests::*` module: 73/73 passing (no regression in sibling tests).
- [ ] CI green on arm Linux.

## Constraints respected

- No changes to `.config/nextest.toml` retry list.
- Independent of PRs #9418 / #9419.
- Branched from `origin/dev`, not from `flake-fix/test-stability-bundle`.