### PR TITLE
fix: ensure defer + batch query error is sent as single json response instead of malformed multipart body (backport #9311)

### DIFF
--- a/.changesets/fix_rohan_b99_fix_defer_batch_error_malformed.md
+++ b/.changesets/fix_rohan_b99_fix_defer_batch_error_malformed.md
@@ -1,0 +1,5 @@
+### Ensure defer + batch query error is sent as single json response instead of malformed multipart body ([PR #9311](https://github.com/apollographql/router/pull/9311))
+
+Batched queries that use defer are not supported by the router, we now return a single response with errors to indicate this.
+
+By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9311

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -465,7 +465,7 @@ where
             Some(response) => {
                 if !response.has_next.unwrap_or(false)
                     && !response.subscribed.unwrap_or(false)
-                    && (accepts_json || accepts_wildcard)
+                    && (response.has_next.is_none() || accepts_json || accepts_wildcard)
                 {
                     let errors = response.errors.clone();
 

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -471,7 +471,7 @@ async fn it_will_process_a_non_batched_defered_query() {
 
 #[tokio::test]
 async fn it_will_not_process_a_batched_deferred_query() {
-    let expected_response = "[\r\n--graphql\r\ncontent-type: application/json\r\n\r\n{\"errors\":[{\"message\":\"Deferred responses and subscriptions aren't supported in batches\",\"extensions\":{\"code\":\"BATCHING_DEFER_UNSUPPORTED\"}}]}\r\n--graphql--\r\n,\r\n--graphql\r\ncontent-type: application/json\r\n\r\n{\"errors\":[{\"message\":\"Deferred responses and subscriptions aren't supported in batches\",\"extensions\":{\"code\":\"BATCHING_DEFER_UNSUPPORTED\"}}]}\r\n--graphql--\r\n]";
+    let expected_response = r#"[{"errors":[{"message":"Deferred responses and subscriptions aren't supported in batches","extensions":{"code":"BATCHING_DEFER_UNSUPPORTED"}}]},{"errors":[{"message":"Deferred responses and subscriptions aren't supported in batches","extensions":{"code":"BATCHING_DEFER_UNSUPPORTED"}}]}]"#;
 
     async fn with_config() -> router::Response {
         let query = "


### PR DESCRIPTION
At the moment, the response sent when receiving a batch query that uses defer is malformed with a broken json/multipart format. This PR changes it to be a single JSON response as its unsupported




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1690]: https://apollographql.atlassian.net/browse/ROUTER-1690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #9311 done by [Mergify](https://mergify.com).