### PR TITLE
fix(file_uploads): apply `http_max_request_bytes` limit only to the operations field, not file streams (backport #9226)

### DIFF
--- a/.changesets/fix_caroline_router_1695.md
+++ b/.changesets/fix_caroline_router_1695.md
@@ -1,0 +1,7 @@
+### fix(file_uploads): apply `http_max_request_bytes` only to the operations field, not file streams ([PR #9226](https://github.com/apollographql/router/pull/9226))
+
+Previously, `limits.http_max_request_bytes` (default 2 MB) was applied to the entire multipart body of file upload requests, causing large file uploads to be rejected even when `preview_file_uploads.protocols.multipart.limits.max_file_size` was configured to allow them.
+
+The limit now applies only to the GraphQL operations field (the query and variables). File data is bounded separately by `max_file_size`, enforced by the multer parser.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9226

--- a/apollo-router/src/plugins/file_uploads/mod.rs
+++ b/apollo-router/src/plugins/file_uploads/mod.rs
@@ -26,6 +26,7 @@ use crate::json_ext;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::PluginInit;
 use crate::plugin::PluginPrivate;
+use crate::plugins::limits::BodyLimitControl;
 use crate::services::execution;
 use crate::services::router;
 use crate::services::router::body::RouterBody;
@@ -196,7 +197,32 @@ async fn router_layer(
         request_parts.headers.insert(CONTENT_TYPE, content_type);
         request_parts.headers.remove(CONTENT_LENGTH);
 
-        let request_body = router::body::from_result_stream(operations_stream);
+        // Buffer the operations field so http_max_request_bytes applies to it specifically.
+        // The underlying Limited<Body> enforces the limit while we read here. Once buffered,
+        // disable the global limit so file streams aren't constrained by it; per-file size
+        // limits (max_file_size) still apply via the multer parser.
+        //
+        // Buffering is not wasteful: the downstream supergraph service reads the entire
+        // operations body into memory anyway for JSON parsing, and the operations field is
+        // bounded by http_max_request_bytes (default 2 MB), so peak memory usage is unchanged.
+        //
+        // If the operations field exceeds http_max_request_bytes, this never returns an Err:
+        // Limited<Body> stalls (returns Poll::Pending forever) and the RequestBodyLimitLayer's
+        // abort semaphore fires a 413 that cancels this future before .bytes() can resolve.
+        // The only errors that reach map_err here are genuine multer errors (bad encoding, etc.).
+        let operations_bytes = operations_stream
+            .bytes()
+            .await
+            .map_err(FileUploadError::InvalidMultipartRequest)?;
+        if let Some(control) = request_parts.extensions.get::<BodyLimitControl>() {
+            // update_limit asserts new > current, so skip if already at usize::MAX
+            // (only possible if http_max_request_bytes was explicitly set to usize::MAX).
+            if control.limit() < usize::MAX {
+                control.update_limit(usize::MAX);
+            }
+        }
+
+        let request_body = router::body::from_bytes(operations_bytes);
         return Ok(router::Request::from((
             http::Request::from_parts(request_parts, request_body),
             req.context,

--- a/apollo-router/src/plugins/limits/mod.rs
+++ b/apollo-router/src/plugins/limits/mod.rs
@@ -6,6 +6,7 @@ use std::error::Error;
 use async_trait::async_trait;
 use bytesize::ByteSize;
 use http::StatusCode;
+pub(crate) use layer::BodyLimitControl;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;

--- a/apollo-router/tests/fixtures/file_upload/body_limit.router.yaml
+++ b/apollo-router/tests/fixtures/file_upload/body_limit.router.yaml
@@ -1,0 +1,19 @@
+# Config for testing that http_max_request_bytes applies to the operations field
+# but not to file streams in multipart uploads.
+csrf:
+  required_headers:
+    - x-my-header
+    - apollo-require-preflight
+preview_file_uploads:
+  enabled: true
+  protocols:
+    multipart:
+      enabled: true
+      mode: stream
+      limits:
+        max_file_size: 5mb
+        max_files: 5
+limits:
+  http_max_request_bytes: 50000
+include_subgraph_errors:
+  all: true

--- a/apollo-router/tests/integration/file_upload.rs
+++ b/apollo-router/tests/integration/file_upload.rs
@@ -10,6 +10,7 @@ use tower::BoxError;
 const FILE_CONFIG: &str = include_str!("../fixtures/file_upload/default.router.yaml");
 const FILE_CONFIG_LARGE_LIMITS: &str = include_str!("../fixtures/file_upload/large.router.yaml");
 const FILE_CONFIG_WITH_RHAI: &str = include_str!("../fixtures/file_upload/rhai.router.yaml");
+const FILE_CONFIG_BODY_LIMIT: &str = include_str!("../fixtures/file_upload/body_limit.router.yaml");
 
 /// Create a valid handler for the [helper::FileUploadTestServer].
 macro_rules! make_handler {
@@ -1041,6 +1042,80 @@ async fn it_fails_incompatible_query_order() -> Result<(), BoxError> {
               ]
             }
             "###);
+        })
+        .await
+}
+
+/// Verifies that a file larger than http_max_request_bytes can still be uploaded when the file
+/// itself is within max_file_size. The body limit should apply only to the operations field.
+#[tokio::test(flavor = "multi_thread")]
+async fn it_uploads_file_larger_than_http_max_request_bytes() -> Result<(), BoxError> {
+    // body_limit.router.yaml sets http_max_request_bytes = 50000 (~50 KB) and max_file_size = 5 MB.
+    // This file is 200 KB — well above the global body limit but within the per-file limit.
+    // Without the fix this test fails because Limited<Body> fires while streaming file data.
+    const ONE_KB: usize = 1024;
+    const FILE_SIZE: usize = 200 * ONE_KB;
+    static FILE_DATA: [u8; ONE_KB] = [0xBB; ONE_KB];
+
+    let file = tokio_stream::iter(
+        (0..FILE_SIZE / ONE_KB).map(|_| Ok(bytes::Bytes::from_static(&FILE_DATA))),
+    );
+
+    let request = helper::create_request(vec!["large.bin"], vec![file]);
+
+    helper::FileUploadTestServer::builder()
+        .config(FILE_CONFIG_BODY_LIMIT)
+        .handler(make_handler!(helper::verify_stream).with_state((FILE_SIZE, 0xBB)))
+        .request(request)
+        .subgraph_mapping("uploads", "/")
+        .build()
+        .run_test(|response| {
+            insta::assert_json_snapshot!(response, @r###"
+            {
+              "data": {
+                "file0": {
+                  "filename": "large.bin",
+                  "body": "successfully verified all bytes as '0xBB'"
+                }
+              }
+            }
+            "###);
+        })
+        .await
+}
+
+/// Verifies that an operations field larger than http_max_request_bytes is still rejected.
+#[tokio::test(flavor = "multi_thread")]
+async fn it_rejects_operations_field_larger_than_http_max_request_bytes() -> Result<(), BoxError> {
+    use reqwest::multipart::Form;
+    use reqwest::multipart::Part;
+
+    // body_limit.router.yaml sets http_max_request_bytes = 50000 (~50 KB).
+    // Build an operations field that is larger than 50 KB.
+    let large_query = format!(
+        r#"{{"query":"mutation ($file: Upload) {{ file: singleUpload(file: $file) {{ filename body }} }}","variables":{{"file":null,"padding":"{}"}}}}"#,
+        "x".repeat(60_000),
+    );
+
+    let request = Form::new()
+        .part("operations", Part::text(large_query))
+        .part(
+            "map",
+            Part::text(serde_json::json!({ "0": ["variables.file"] }).to_string()),
+        )
+        .part("0", Part::text("tiny").file_name("tiny.txt"));
+
+    helper::FileUploadTestServer::builder()
+        .config(FILE_CONFIG_BODY_LIMIT)
+        .handler(make_handler!(helper::echo_single_file))
+        .request(request)
+        .subgraph_mapping("uploads", "/")
+        .build()
+        .run_test(|response| {
+            assert!(
+                !response.errors.is_empty(),
+                "expected an error for oversized operations field but got: {response:?}"
+            );
         })
         .await
 }

--- a/docs/source/routing/operations/file-upload.mdx
+++ b/docs/source/routing/operations/file-upload.mdx
@@ -127,6 +127,9 @@ The router includes default limits for file uploads to prevent denial-of-service
 You can configure both the maximum file size and number of files to accept.
 If a request exceeds a limit, the router rejects the request.
 
+The `limits.http_max_request_bytes` setting applies to the GraphQL operations field (the query and variables) of the multipart request, not to the uploaded file data itself.
+Limit file data using `protocols.multipart.limits.max_file_size`.
+
 #### Configuration reference
 
 The following are attributes of the root [`preview_file_uploads`](#configure-file-upload-support-in-the-router) configuration.

--- a/docs/source/routing/security/request-limits.mdx
+++ b/docs/source/routing/security/request-limits.mdx
@@ -274,6 +274,9 @@ to protect against unbounded memory consumption.
 This limit is checked before JSON parsing.
 Both the GraphQL document and associated variables count toward it.
 
+For [multipart file upload](/graphos/routing/operations/file-upload) requests, this limit applies only to the GraphQL operations field (the query and variables), not to the uploaded file data.
+Limit file data separately with `preview_file_uploads.protocols.multipart.limits.max_file_size`.
+
 The default value is `2000000` bytes, 2 MB.
 
 Before increasing this limit significantly consider testing performance


### PR DESCRIPTION


## Summary

Fixes a bug where `limits.http_max_request_bytes` (default 2 MB) was applied to the **entire** multipart body of file upload requests, causing large file uploads to be rejected even when `preview_file_uploads.protocols.multipart.limits.max_file_size` was configured to allow them.

### What changed

In `router_layer` (the file uploads plugin checkpoint), the operations field (the GraphQL query/variables) is now fully buffered while the global body limit is active. Once buffered, [`BodyLimitControl::update_limit(usize::MAX)`](https://github.com/apollographql/router/blob/dev/apollo-router/src/plugins/limits/layer.rs) is called to disable the limit for the rest of the multipart stream, so file data flows through without hitting the global cap.

- `http_max_request_bytes` continues to bound the **operations field** (query + variables)
- File data is bounded by `max_file_size` (enforced by the multer parser, unchanged)
- Buffering the operations field is not wasteful: it is already bounded by `http_max_request_bytes`, and the downstream supergraph service would buffer it entirely for JSON parsing anyway

`BodyLimitControl` is re-exported from `plugins::limits` so it's accessible from the file uploads plugin.

---

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible
- [x] Documentation completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added and documented
- Tests added and passing
    - [x] Integration tests (`it_uploads_file_larger_than_http_max_request_bytes`, `it_rejects_operations_field_larger_than_http_max_request_bytes`)

[ROUTER-1695]: https://apollographql.atlassian.net/browse/ROUTER-1695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #9226 done by [Mergify](https://mergify.com).