### PR TITLE
fix: avoid panic in AggregateMeterProvider::create_registered_instrument by returning noop instrument (backport #9248)

### DIFF
--- a/.changesets/fix_rohan_b99_aggregate_meter_provider_create_registered_instrument_panic.md
+++ b/.changesets/fix_rohan_b99_aggregate_meter_provider_create_registered_instrument_panic.md
@@ -1,0 +1,5 @@
+### fix: avoid panic in AggregateMeterProvider::create_registered_instrument by returning noop instrument ([PR #9248](https://github.com/apollographql/router/pull/9248))
+
+Prevent spurious `cannot use meter provider after shutdown` error message during router shutdown.
+
+By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9248

--- a/apollo-router/src/metrics/aggregation.rs
+++ b/apollo-router/src/metrics/aggregation.rs
@@ -278,10 +278,14 @@ impl AggregateMeterProvider {
         Arc<T>: Into<InstrumentWrapper>,
     {
         let mut guard = self.inner.lock();
-        let inner = guard
-            .as_mut()
-            .expect("cannot use meter provider after shutdown");
-        inner.create_registered_instrument(create_fn)
+        if let Some(inner) = guard.as_mut() {
+            inner.create_registered_instrument(create_fn)
+        } else {
+            // After shutdown, create a noop instrument via a temporary default Inner
+            // (which uses noop providers). The instrument won't be registered anywhere
+            // since the provider is already shut down, but callers won't panic.
+            Arc::new((create_fn)(&mut Inner::default()))
+        }
     }
 
     #[cfg(test)]
@@ -1057,5 +1061,16 @@ mod test {
         )
         .with_interval(Duration::from_millis(10))
         .build()
+    }
+
+    #[test]
+    fn test_create_registered_instrument_after_shutdown() {
+        let meter_provider = AggregateMeterProvider::default();
+        meter_provider.shutdown().unwrap();
+
+        // Must not panic — returns a noop instrument instead
+        let counter = meter_provider
+            .create_registered_instrument(|inner| inner.meter("test").u64_counter("c").build());
+        counter.add(1, &[]);
     }
 }


### PR DESCRIPTION
Avoids an error message (`cannot use meter provider after shutdown`) being logged while the router is shutting down if create_registered_instrument is called




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1698]: https://apollographql.atlassian.net/browse/ROUTER-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #9248 done by [Mergify](https://mergify.com).