### PR TITLE
fix(traffic_shaping): use lazy pool eviction to avoid inter-request TCP closes (backport #9308)

### DIFF
--- a/.changesets/feat_caroline_rh1334_pool_idle_eviction_mode.md
+++ b/.changesets/feat_caroline_rh1334_pool_idle_eviction_mode.md
@@ -1,0 +1,7 @@
+### Fix connection pool to use lazy idle eviction ([PR #9308](https://github.com/apollographql/router/pull/9308))
+
+When `pool_idle_timeout` was introduced in v2.13.0, the router unconditionally enabled a background timer that proactively closed idle connections exceeding the timeout. In some network environments, the TCP close sent by this background task raced with a new connection attempt and caused significant latency spikes on the next request.
+
+The router now uses lazy eviction: connections are only closed at checkout time, when a request finds a pooled connection that has exceeded `pool_idle_timeout`. No TCP closes are sent between requests. This matches router behavior before v2.13.0.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9308

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -268,11 +268,13 @@ impl HttpClientService {
 
         let mut client_builder =
             hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new());
+        // NOTE: pool_timer is intentionally not set. pool_timer enables a background task that
+        // proactively closes idle connections when they exceed pool_idle_timeout. Without it,
+        // eviction is lazy: connections are checked and dropped at checkout time only. Lazy
+        // eviction avoids a TCP close window that can delay new connections in some network
+        // environments.
         client_builder
             .pool_idle_timeout(pool_idle_timeout)
-            // WARN: for `pool_idle_timeout` to work, it needs a pool timer; don't remove this
-            // unless you're also removing `pool_idle_timeout`
-            .pool_timer(TokioTimer::new())
             .http2_only(http2 == Http2Config::Http2Only);
         if let Some(interval) = http2_keep_alive_interval {
             client_builder
@@ -288,12 +290,10 @@ impl HttpClientService {
 
         #[cfg(unix)]
         let unix_client = {
+            // NOTE: pool_timer is intentionally not set; see comment on client_builder above.
             let unix_client_inner =
                 hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
                     .pool_idle_timeout(pool_idle_timeout)
-                    // WARN: for `pool_idle_timeout` to work, it needs a pool timer; don't remove this
-                    // unless you're also removing `pool_idle_timeout`
-                    .pool_timer(TokioTimer::new())
                     .http2_only(http2 == Http2Config::Http2Only)
                     .build(UnixConnector);
 

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -1491,15 +1491,18 @@ mod pool_idle_timeout {
 
     use super::*;
 
-    /// Server that counts how many TCP connections are accepted
+    /// Server that counts how many TCP connections are accepted and how many are currently open.
     async fn serve_counting(
         listener: TcpListener,
         connection_count: Arc<AtomicUsize>,
+        live_connection_count: Arc<AtomicUsize>,
     ) -> std::io::Result<()> {
         loop {
             let (stream, _) = listener.accept().await?;
             connection_count.fetch_add(1, Ordering::SeqCst);
+            live_connection_count.fetch_add(1, Ordering::SeqCst);
             let io = TokioIo::new(stream);
+            let live = live_connection_count.clone();
             tokio::spawn(async move {
                 let svc = hyper::service::service_fn(|_request: Request<Incoming>| async {
                     Ok::<_, Infallible>(
@@ -1513,6 +1516,7 @@ mod pool_idle_timeout {
                 let _ = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
                     .serve_connection_with_upgrades(io, svc)
                     .await;
+                live.fetch_sub(1, Ordering::SeqCst);
             });
         }
     }
@@ -1555,7 +1559,11 @@ mod pool_idle_timeout {
         let socket_addr = listener.local_addr().unwrap();
         let connection_count = Arc::new(AtomicUsize::new(0));
 
-        tokio::task::spawn(serve_counting(listener, connection_count.clone()));
+        tokio::task::spawn(serve_counting(
+            listener,
+            connection_count.clone(),
+            Arc::new(AtomicUsize::new(0)),
+        ));
 
         let mut service = HttpClientService::test_new(
             "test",
@@ -1586,6 +1594,56 @@ mod pool_idle_timeout {
             connection_count.load(Ordering::SeqCst),
             expected_connections,
             "expected {expected_connections} total TCP connections for timeout {timeout:?} with {sleep_between:?} sleep"
+        );
+    }
+
+    /// Regression test: the router does not proactively close idle connections between requests.
+    /// Before this fix, `pool_timer` was unconditionally set, enabling a background eviction task
+    /// that sent TCP closes between requests and caused latency spikes in some network environments.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_idle_connections_not_proactively_closed() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let socket_addr = listener.local_addr().unwrap();
+        let live_connection_count = Arc::new(AtomicUsize::new(0));
+
+        tokio::task::spawn(serve_counting(
+            listener,
+            Arc::new(AtomicUsize::new(0)),
+            live_connection_count.clone(),
+        ));
+
+        let client_config = crate::configuration::shared::Client {
+            pool_idle_timeout: Some(Duration::from_millis(50)),
+            ..Default::default()
+        };
+        let service = HttpClientService::test_new(
+            "test",
+            rustls::ClientConfig::builder()
+                .with_native_roots()
+                .expect("read native TLS root certificates")
+                .with_no_client_auth(),
+            client_config,
+        )
+        .expect("can create HttpClientService");
+
+        let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
+
+        let response = send_request(service.clone(), url.clone(), r#"{"query":"{ a }"}"#).await;
+        assert_eq!(response.http_response.status(), StatusCode::OK);
+        assert_eq!(
+            live_connection_count.load(Ordering::SeqCst),
+            1,
+            "connection is open after first request"
+        );
+
+        // Sleep well past the 50ms idle timeout. Without pool_timer, no background task fires,
+        // so the connection must still be open in the pool.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        assert_eq!(
+            live_connection_count.load(Ordering::SeqCst),
+            1,
+            "connection must not be proactively closed between requests"
         );
     }
 }

--- a/docs/source/routing/customization/coprocessor/index.mdx
+++ b/docs/source/routing/customization/coprocessor/index.mdx
@@ -265,6 +265,19 @@ coprocessor:
     experimental_http2: http2only
 ```
 
+#### Connection pool
+
+The router maintains a pool of connections to your coprocessor. Use `pool_idle_timeout` to set how long an idle connection stays in the pool before it's eligible for eviction. The default is 15 seconds. Set it to `null` to disable idle eviction entirely.
+
+Expired connections are evicted lazily: when the router fetches a connection from the pool to make a request, it discards any connection that has been idle longer than `pool_idle_timeout` and opens a fresh one.
+
+```yaml title="router.yaml"
+coprocessor:
+  url: http://service.example.com
+  client:
+    pool_idle_timeout: 30s  # default: 15s; set to null to disable
+```
+
 ## Coprocessor request format
 
 The router communicates with your coprocessor via HTTP POST requests (called **coprocessor requests**). The body of each coprocessor request is a JSON object with properties that describe either the current client request or the current router response.

--- a/docs/source/routing/performance/traffic-shaping.mdx
+++ b/docs/source/routing/performance/traffic-shaping.mdx
@@ -258,6 +258,20 @@ Keep-alive pings require HTTP/2 to be active. Setting `experimental_http2: disab
 
 </Note>
 
+### Connection pool
+
+The router maintains a pool of connections to each subgraph. Use `pool_idle_timeout` to set how long an idle connection stays in the pool before it's eligible for eviction. The default is 15 seconds. Set it to `null` to disable idle eviction entirely.
+
+Expired connections are evicted lazily: when the router fetches a connection from the pool to make a request, it discards any connection that has been idle longer than `pool_idle_timeout` and opens a fresh one.
+
+```yaml title="router.yaml"
+traffic_shaping:
+  all:
+    pool_idle_timeout: 30s  # default: 15s; set to null to disable
+```
+
+This option applies under `all`, per-subgraph under `subgraphs`, and per-source under `connector.sources`.
+
 ### Ordering
 
 Traffic shaping always executes these steps in the same order, to ensure a consistent behavior. Declaration order in the configuration will not affect the runtime order:


### PR DESCRIPTION
## Summary

Removes the unconditional `pool_timer` from the hyper client builder, switching the connection pool to lazy eviction.

**Background:** When `pool_idle_timeout` was made configurable in v2.13.0, the router unconditionally set `pool_timer` on the hyper client, enabling a background task that proactively closed idle connections when they exceeded the timeout. In some network environments, the TCP close sent by this background task raced with a new outgoing connection attempt and caused significant latency spikes on the next request.

**Fix:** Remove `pool_timer`. The pool now uses lazy eviction: connections are checked and dropped at checkout time only, when a request finds a pooled connection that has exceeded `pool_idle_timeout`. This matches router behavior before v2.13.0.

## Reviewer notes

- `pool_timer` is removed from both the HTTP and unix client builders. A comment on each explains why it's absent.
- The `test_idle_connections_not_proactively_closed` regression test verifies this behavior: after sleeping well past the idle timeout, the server-side `live_connection_count` must still be 1 (connection was not proactively closed).

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible
- [x] Documentation completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added and documented
- Tests added and passing
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

No metrics added (connection pool policy change). No integration tests added (unit test covers the behavioral regression directly).<hr>This is an automatic backport of pull request #9308 done by [Mergify](https://mergify.com).