### PR TITLE
fix(composition): emit fallback `SubgraphLocation` when AST has no source

### DIFF
--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -8,6 +8,7 @@ use apollo_compiler::ast;
 use apollo_compiler::ast::OperationType;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexSet;
+use apollo_compiler::parser::LineColumn;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::ComponentName;
 use apollo_compiler::schema::Directive;
@@ -750,13 +751,24 @@ impl<S: HasMetadata> Subgraph<S> {
     }
 
     pub(crate) fn node_locations<T>(&self, node: &Node<T>) -> Locations {
-        self.schema()
+        let locations: Locations = self
+            .schema()
             .node_locations(node)
             .map(|range| SubgraphLocation {
                 subgraph: self.name.clone(),
                 range,
             })
-            .collect()
+            .collect();
+        if locations.is_empty() {
+            let default_range =
+                LineColumn { line: 0, column: 0 }..LineColumn { line: 0, column: 0 };
+            vec![SubgraphLocation {
+                subgraph: self.name.clone(),
+                range: default_range,
+            }]
+        } else {
+            locations
+        }
     }
 }
 


### PR DESCRIPTION
`Subgraph::node_locations` returned an empty `Vec` when a schema node lacked AST source location data (common after programmatic schema modifications during the upgrade step). This caused `report_mismatch` to omit subgraphs from the `locations` array, leading to incorrect `maybe_prepend_subgraph` prefix behavior.

With only one subgraph in locations, a `[subgraph]` prefix was added to the message; JS included all subgraphs (2+), so no prefix was added. The message bodies were identical but the prefix differed.

Now `node_locations` produces a fallback `SubgraphLocation` with a default range (`0:0..0:0`) when no source data exists, matching JS behavior. This resolves mismatches in `INCONSISTENT_ENTITY`, `INCONSISTENT_INTERFACE_VALUE_TYPE_FIELD`, and
`INCONSISTENT_OBJECT_VALUE_TYPE_FIELD` hints.
