### PR TITLE
feat: support HTTP/2 keep-alive (backport #9056)

### DIFF
--- a/apollo-router/src/configuration/shared/mod.rs
+++ b/apollo-router/src/configuration/shared/mod.rs
@@ -5,13 +5,6 @@ use serde::Deserialize;
 
 use crate::plugins::traffic_shaping::Http2Config;
 
-/// Default for idle keep-alive sockets in a connection pool for HttpClientService
-///
-/// NOTE: the default in hyper is 90s but historically has been set much lower (5s). I couldn't
-/// find a reason for such a low timeout for keep-alive sockets, so bumping it to 15s;
-/// taste/adjust, but leave a comment giving justification for any new threshold
-const DEFAULT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
-
 /// Default timeout for HTTP/2 keep-alive pings in HttpClientService
 ///
 /// NOTE: hyper_util's default keep-alive timeout is 20s, so we use the same value here
@@ -27,14 +20,6 @@ pub(crate) struct Client {
     /// Specify a DNS resolution strategy to use when resolving the coprocessor URL.
     pub(crate) dns_resolution_strategy: Option<DnsResolutionStrategy>,
 
-    #[serde(
-        deserialize_with = "humantime_serde::deserialize",
-        default = "default_pool_idle_timeout"
-    )]
-    #[schemars(with = "String", default = "default_pool_idle_timeout")]
-    /// Specify a timeout for idle sockets being kept-alive in the client's connection pool
-    pub(crate) pool_idle_timeout: Option<Duration>,
-
     /// Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If
     /// unset (the default), keep-alive pings are disabled.
     #[serde(deserialize_with = "humantime_serde::deserialize", default)]
@@ -48,12 +33,6 @@ pub(crate) struct Client {
     #[serde(deserialize_with = "humantime_serde::deserialize", default)]
     #[schemars(with = "Option<String>", default)]
     pub(crate) experimental_http2_keep_alive_timeout: Option<Duration>,
-}
-
-/// Returns the hardcoded default pool idle timeout for keep-alive sockets in a client's connection
-/// pool. Useful as a default for serde deserializers or other areas where this default is needed
-pub(crate) fn default_pool_idle_timeout() -> Option<Duration> {
-    Some(DEFAULT_POOL_IDLE_TIMEOUT)
 }
 
 #[derive(PartialEq, Default, Debug, Clone, Copy, Deserialize, JsonSchema)]
@@ -79,40 +58,6 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-
-    #[rstest]
-    #[case::humantime_seconds("pool_idle_timeout: 30s", Some(Duration::from_secs(30)))]
-    #[case::humantime_millis("pool_idle_timeout: 500ms", Some(Duration::from_millis(500)))]
-    #[case::humantime_minutes("pool_idle_timeout: 2m", Some(Duration::from_secs(120)))]
-    #[case::explicit_null("pool_idle_timeout: null", None)]
-    fn test_pool_idle_timeout_deserialization(
-        #[case] yaml: &str,
-        #[case] expected: Option<Duration>,
-    ) {
-        let client: Client = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(client.pool_idle_timeout, expected);
-    }
-
-    #[test]
-    fn test_pool_idle_timeout_default_when_omitted() {
-        let client: Client = serde_yaml::from_str("{}").unwrap();
-        assert_eq!(client.pool_idle_timeout, Some(DEFAULT_POOL_IDLE_TIMEOUT));
-    }
-
-    #[test]
-    fn test_pool_idle_timeout_default_value() {
-        assert_eq!(DEFAULT_POOL_IDLE_TIMEOUT, Duration::from_secs(15));
-        assert_eq!(default_pool_idle_timeout(), Some(Duration::from_secs(15)));
-    }
-
-    #[test]
-    fn test_client_default_has_pool_idle_timeout() {
-        let client = Client::default();
-        assert_eq!(client.pool_idle_timeout, None);
-
-        let client = Client::builder().build();
-        assert_eq!(client.pool_idle_timeout, None);
-    }
 
     #[test]
     fn test_client_deny_unknown_fields() {

--- a/apollo-router/src/configuration/shared/mod.rs
+++ b/apollo-router/src/configuration/shared/mod.rs
@@ -3,14 +3,62 @@ use serde::Deserialize;
 
 use crate::plugins::traffic_shaping::Http2Config;
 
+<<<<<<< HEAD
 /// HTTP client configuration for coprocessors.
+=======
+/// Default for idle keep-alive sockets in a connection pool for HttpClientService
+///
+/// NOTE: the default in hyper is 90s but historically has been set much lower (5s). I couldn't
+/// find a reason for such a low timeout for keep-alive sockets, so bumping it to 15s;
+/// taste/adjust, but leave a comment giving justification for any new threshold
+const DEFAULT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Default timeout for HTTP/2 keep-alive pings in HttpClientService
+///
+/// NOTE: hyper_util's default keep-alive timeout is 20s, so we use the same value here
+pub(crate) const DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// HTTP client configuration
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
 #[derive(PartialEq, Debug, Clone, Default, Deserialize, JsonSchema, buildstructor::Builder)]
 #[serde(deny_unknown_fields, default)]
 pub(crate) struct Client {
     /// Use HTTP/2 to communicate with the coprocessor.
     pub(crate) experimental_http2: Option<Http2Config>,
+
     /// Specify a DNS resolution strategy to use when resolving the coprocessor URL.
     pub(crate) dns_resolution_strategy: Option<DnsResolutionStrategy>,
+<<<<<<< HEAD
+=======
+
+    #[serde(
+        deserialize_with = "humantime_serde::deserialize",
+        default = "default_pool_idle_timeout"
+    )]
+    #[schemars(with = "String", default = "default_pool_idle_timeout")]
+    /// Specify a timeout for idle sockets being kept-alive in the client's connection pool
+    pub(crate) pool_idle_timeout: Option<Duration>,
+
+    /// Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If
+    /// unset (the default), keep-alive pings are disabled.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    pub(crate) experimental_http2_keep_alive_interval: Option<Duration>,
+
+    /// Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and
+    /// `experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.
+    // NB: can't make this non-optional due to the builder, but this gets
+    // `unwrap_or(DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT)`'ed at the callsite.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    pub(crate) experimental_http2_keep_alive_timeout: Option<Duration>,
+}
+
+/// Returns the hardcoded default pool idle timeout for keep-alive sockets in a client's connection
+/// pool. Useful as a default for serde deserializers or other areas where this default is needed
+pub(crate) fn default_pool_idle_timeout() -> Option<Duration> {
+    Some(DEFAULT_POOL_IDLE_TIMEOUT)
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
 }
 
 #[derive(PartialEq, Default, Debug, Clone, Copy, Deserialize, JsonSchema)]
@@ -28,3 +76,93 @@ pub(crate) enum DnsResolutionStrategy {
     /// Default: Query for `A` (IPv4) records first; if that fails, query for `AAAA` (IPv6) records
     Ipv4ThenIpv6,
 }
+<<<<<<< HEAD
+=======
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::humantime_seconds("pool_idle_timeout: 30s", Some(Duration::from_secs(30)))]
+    #[case::humantime_millis("pool_idle_timeout: 500ms", Some(Duration::from_millis(500)))]
+    #[case::humantime_minutes("pool_idle_timeout: 2m", Some(Duration::from_secs(120)))]
+    #[case::explicit_null("pool_idle_timeout: null", None)]
+    fn test_pool_idle_timeout_deserialization(
+        #[case] yaml: &str,
+        #[case] expected: Option<Duration>,
+    ) {
+        let client: Client = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(client.pool_idle_timeout, expected);
+    }
+
+    #[test]
+    fn test_pool_idle_timeout_default_when_omitted() {
+        let client: Client = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(client.pool_idle_timeout, Some(DEFAULT_POOL_IDLE_TIMEOUT));
+    }
+
+    #[test]
+    fn test_pool_idle_timeout_default_value() {
+        assert_eq!(DEFAULT_POOL_IDLE_TIMEOUT, Duration::from_secs(15));
+        assert_eq!(default_pool_idle_timeout(), Some(Duration::from_secs(15)));
+    }
+
+    #[test]
+    fn test_client_default_has_pool_idle_timeout() {
+        let client = Client::default();
+        assert_eq!(client.pool_idle_timeout, None);
+
+        let client = Client::builder().build();
+        assert_eq!(client.pool_idle_timeout, None);
+    }
+
+    #[test]
+    fn test_client_deny_unknown_fields() {
+        let result: Result<Client, _> = serde_yaml::from_str("bogus_field: true");
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    #[case::humantime_seconds(
+        "experimental_http2_keep_alive_interval: 30s",
+        Some(Duration::from_secs(30))
+    )]
+    #[case::humantime_millis(
+        "experimental_http2_keep_alive_interval: 500ms",
+        Some(Duration::from_millis(500))
+    )]
+    #[case::explicit_null("experimental_http2_keep_alive_interval: null", None)]
+    #[case::omitted("{}", None)]
+    fn test_keep_alive_interval_deserialization(
+        #[case] yaml: &str,
+        #[case] expected: Option<Duration>,
+    ) {
+        let client: Client = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(client.experimental_http2_keep_alive_interval, expected);
+    }
+
+    #[rstest]
+    #[case::humantime_seconds(
+        "experimental_http2_keep_alive_timeout: 10s",
+        Some(Duration::from_secs(10))
+    )]
+    #[case::humantime_millis(
+        "experimental_http2_keep_alive_timeout: 500ms",
+        Some(Duration::from_millis(500))
+    )]
+    #[case::explicit_null("experimental_http2_keep_alive_timeout: null", None)]
+    #[case::omitted("{}", None)]
+    fn test_keep_alive_timeout_deserialization(
+        #[case] yaml: &str,
+        #[case] expected: Option<Duration>,
+    ) {
+        let client: Client = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(client.experimental_http2_keep_alive_timeout, expected);
+    }
+}
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))

--- a/apollo-router/src/configuration/shared/mod.rs
+++ b/apollo-router/src/configuration/shared/mod.rs
@@ -1,11 +1,10 @@
+use std::time::Duration;
+
 use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::plugins::traffic_shaping::Http2Config;
 
-<<<<<<< HEAD
-/// HTTP client configuration for coprocessors.
-=======
 /// Default for idle keep-alive sockets in a connection pool for HttpClientService
 ///
 /// NOTE: the default in hyper is 90s but historically has been set much lower (5s). I couldn't
@@ -19,7 +18,6 @@ const DEFAULT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
 pub(crate) const DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// HTTP client configuration
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
 #[derive(PartialEq, Debug, Clone, Default, Deserialize, JsonSchema, buildstructor::Builder)]
 #[serde(deny_unknown_fields, default)]
 pub(crate) struct Client {
@@ -28,8 +26,6 @@ pub(crate) struct Client {
 
     /// Specify a DNS resolution strategy to use when resolving the coprocessor URL.
     pub(crate) dns_resolution_strategy: Option<DnsResolutionStrategy>,
-<<<<<<< HEAD
-=======
 
     #[serde(
         deserialize_with = "humantime_serde::deserialize",
@@ -58,7 +54,6 @@ pub(crate) struct Client {
 /// pool. Useful as a default for serde deserializers or other areas where this default is needed
 pub(crate) fn default_pool_idle_timeout() -> Option<Duration> {
     Some(DEFAULT_POOL_IDLE_TIMEOUT)
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
 }
 
 #[derive(PartialEq, Default, Debug, Clone, Copy, Deserialize, JsonSchema)]
@@ -76,8 +71,6 @@ pub(crate) enum DnsResolutionStrategy {
     /// Default: Query for `A` (IPv4) records first; if that fails, query for `AAAA` (IPv6) records
     Ipv4ThenIpv6,
 }
-<<<<<<< HEAD
-=======
 
 #[cfg(test)]
 mod tests {
@@ -165,4 +158,3 @@ mod tests {
         assert_eq!(client.experimental_http2_keep_alive_timeout, expected);
     }
 }
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -895,6 +895,33 @@ expression: "&schema"
             }
           ],
           "description": "Use HTTP/2 to communicate with the coprocessor."
+<<<<<<< HEAD
+=======
+        },
+        "experimental_http2_keep_alive_interval": {
+          "default": null,
+          "description": "Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If\nunset (the default), keep-alive pings are disabled.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "experimental_http2_keep_alive_timeout": {
+          "default": null,
+          "description": "Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and\n`experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pool_idle_timeout": {
+          "default": {
+            "nanos": 0,
+            "secs": 15
+          },
+          "description": "Specify a timeout for idle sockets being kept-alive in the client's connection pool",
+          "type": "string"
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
         }
       },
       "type": "object"
@@ -2463,6 +2490,22 @@ expression: "&schema"
             }
           ],
           "description": "Enable HTTP2 for connectors"
+        },
+        "experimental_http2_keep_alive_interval": {
+          "default": null,
+          "description": "Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If\nunset (the default), keep-alive pings are disabled.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "experimental_http2_keep_alive_timeout": {
+          "default": null,
+          "description": "Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and\n`experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "global_rate_limit": {
           "anyOf": [
@@ -10361,6 +10404,22 @@ expression: "&schema"
             }
           ],
           "description": "Enable HTTP2 for subgraphs"
+        },
+        "experimental_http2_keep_alive_interval": {
+          "default": null,
+          "description": "Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If\nunset (the default), keep-alive pings are disabled.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "experimental_http2_keep_alive_timeout": {
+          "default": null,
+          "description": "Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and\n`experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "global_rate_limit": {
           "anyOf": [

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -911,14 +911,6 @@ expression: "&schema"
             "string",
             "null"
           ]
-        },
-        "pool_idle_timeout": {
-          "default": {
-            "nanos": 0,
-            "secs": 15
-          },
-          "description": "Specify a timeout for idle sockets being kept-alive in the client's connection pool",
-          "type": "string"
         }
       },
       "type": "object"
@@ -2514,14 +2506,6 @@ expression: "&schema"
             }
           ],
           "description": "Enable global rate limiting"
-        },
-        "pool_idle_timeout": {
-          "default": {
-            "nanos": 0,
-            "secs": 15
-          },
-          "description": "Specify a timeout for idle sockets being kept-alive in the client's connection pool",
-          "type": "string"
         },
         "timeout": {
           "default": null,
@@ -10436,14 +10420,6 @@ expression: "&schema"
             }
           ],
           "description": "Enable global rate limiting"
-        },
-        "pool_idle_timeout": {
-          "default": {
-            "nanos": 0,
-            "secs": 15
-          },
-          "description": "Specify a timeout for idle sockets being kept-alive in the client's connection pool",
-          "type": "string"
         },
         "timeout": {
           "default": null,

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -872,7 +872,7 @@ expression: "&schema"
     },
     "Client": {
       "additionalProperties": false,
-      "description": "HTTP client configuration for coprocessors.",
+      "description": "HTTP client configuration",
       "properties": {
         "dns_resolution_strategy": {
           "anyOf": [
@@ -895,8 +895,6 @@ expression: "&schema"
             }
           ],
           "description": "Use HTTP/2 to communicate with the coprocessor."
-<<<<<<< HEAD
-=======
         },
         "experimental_http2_keep_alive_interval": {
           "default": null,
@@ -921,7 +919,6 @@ expression: "&schema"
           },
           "description": "Specify a timeout for idle sockets being kept-alive in the client's connection pool",
           "type": "string"
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
         }
       },
       "type": "object"
@@ -2517,6 +2514,14 @@ expression: "&schema"
             }
           ],
           "description": "Enable global rate limiting"
+        },
+        "pool_idle_timeout": {
+          "default": {
+            "nanos": 0,
+            "secs": 15
+          },
+          "description": "Specify a timeout for idle sockets being kept-alive in the client's connection pool",
+          "type": "string"
         },
         "timeout": {
           "default": null,
@@ -10431,6 +10436,14 @@ expression: "&schema"
             }
           ],
           "description": "Enable global rate limiting"
+        },
+        "pool_idle_timeout": {
+          "default": {
+            "nanos": 0,
+            "secs": 15
+          },
+          "description": "Specify a timeout for idle sockets being kept-alive in the client's connection pool",
+          "type": "string"
         },
         "timeout": {
           "default": null,

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -70,6 +70,26 @@ struct Shaping {
     experimental_http2: Option<Http2Config>,
     /// DNS resolution strategy for subgraphs
     dns_resolution_strategy: Option<DnsResolutionStrategy>,
+<<<<<<< HEAD
+=======
+    /// Specify a timeout for idle sockets being kept-alive in the client's connection pool
+    #[serde(
+        deserialize_with = "humantime_serde::deserialize",
+        default = "default_pool_idle_timeout"
+    )]
+    #[schemars(with = "String", default = "default_pool_idle_timeout")]
+    pool_idle_timeout: Option<Duration>,
+    /// Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If
+    /// unset (the default), keep-alive pings are disabled.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    experimental_http2_keep_alive_interval: Option<Duration>,
+    /// Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and
+    /// `experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    experimental_http2_keep_alive_timeout: Option<Duration>,
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
 }
 
 #[derive(PartialEq, Default, Debug, Clone, Deserialize, JsonSchema)]
@@ -107,6 +127,24 @@ impl Merge for Shaping {
                     .as_ref()
                     .or(fallback.dns_resolution_strategy.as_ref())
                     .cloned(),
+<<<<<<< HEAD
+=======
+                pool_idle_timeout: self
+                    .pool_idle_timeout
+                    .as_ref()
+                    .or(fallback.pool_idle_timeout.as_ref())
+                    .cloned(),
+                experimental_http2_keep_alive_interval: self
+                    .experimental_http2_keep_alive_interval
+                    .as_ref()
+                    .or(fallback.experimental_http2_keep_alive_interval.as_ref())
+                    .cloned(),
+                experimental_http2_keep_alive_timeout: self
+                    .experimental_http2_keep_alive_timeout
+                    .as_ref()
+                    .or(fallback.experimental_http2_keep_alive_timeout.as_ref())
+                    .cloned(),
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             },
         }
     }
@@ -155,6 +193,26 @@ struct ConnectorShaping {
     experimental_http2: Option<Http2Config>,
     /// DNS resolution strategy for connectors
     dns_resolution_strategy: Option<DnsResolutionStrategy>,
+<<<<<<< HEAD
+=======
+    /// Specify a timeout for idle sockets being kept-alive in the client's connection pool
+    #[serde(
+        deserialize_with = "humantime_serde::deserialize",
+        default = "default_pool_idle_timeout"
+    )]
+    #[schemars(with = "String", default = "default_pool_idle_timeout")]
+    pool_idle_timeout: Option<Duration>,
+    /// Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If
+    /// unset (the default), keep-alive pings are disabled.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    experimental_http2_keep_alive_interval: Option<Duration>,
+    /// Configure the timeout for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled and
+    /// `experimental_http2_keep_alive_interval` to be set. Defaults to 20 seconds.
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
+    experimental_http2_keep_alive_timeout: Option<Duration>,
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
 }
 
 impl Merge for ConnectorShaping {
@@ -179,6 +237,24 @@ impl Merge for ConnectorShaping {
                     .as_ref()
                     .or(fallback.dns_resolution_strategy.as_ref())
                     .cloned(),
+<<<<<<< HEAD
+=======
+                pool_idle_timeout: self
+                    .pool_idle_timeout
+                    .as_ref()
+                    .or(fallback.pool_idle_timeout.as_ref())
+                    .cloned(),
+                experimental_http2_keep_alive_interval: self
+                    .experimental_http2_keep_alive_interval
+                    .as_ref()
+                    .or(fallback.experimental_http2_keep_alive_interval.as_ref())
+                    .cloned(),
+                experimental_http2_keep_alive_timeout: self
+                    .experimental_http2_keep_alive_timeout
+                    .as_ref()
+                    .or(fallback.experimental_http2_keep_alive_timeout.as_ref())
+                    .cloned(),
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             },
         }
     }
@@ -548,6 +624,16 @@ impl TrafficShaping {
         .map(|config| crate::configuration::shared::Client {
             experimental_http2: config.shaping.experimental_http2,
             dns_resolution_strategy: config.shaping.dns_resolution_strategy,
+<<<<<<< HEAD
+=======
+            pool_idle_timeout: config.shaping.pool_idle_timeout,
+            experimental_http2_keep_alive_interval: config
+                .shaping
+                .experimental_http2_keep_alive_interval,
+            experimental_http2_keep_alive_timeout: config
+                .shaping
+                .experimental_http2_keep_alive_timeout,
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
         })
         .unwrap_or_default()
     }
@@ -561,6 +647,13 @@ impl TrafficShaping {
             .map(|config| crate::configuration::shared::Client {
                 experimental_http2: config.experimental_http2,
                 dns_resolution_strategy: config.dns_resolution_strategy,
+<<<<<<< HEAD
+=======
+                pool_idle_timeout: config.pool_idle_timeout,
+                experimental_http2_keep_alive_interval: config
+                    .experimental_http2_keep_alive_interval,
+                experimental_http2_keep_alive_timeout: config.experimental_http2_keep_alive_timeout,
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             })
             .unwrap_or_default()
     }
@@ -1006,6 +1099,11 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Enable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv6ThenIpv4),
+<<<<<<< HEAD
+=======
+                pool_idle_timeout: default_pool_idle_timeout(),
+                ..Default::default()
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             },
         );
         assert_eq!(
@@ -1013,6 +1111,11 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Disable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv4Only),
+<<<<<<< HEAD
+=======
+                pool_idle_timeout: default_pool_idle_timeout(),
+                ..Default::default()
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             },
         );
         assert_eq!(
@@ -1020,6 +1123,11 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Disable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv6Only),
+<<<<<<< HEAD
+=======
+                pool_idle_timeout: default_pool_idle_timeout(),
+                ..Default::default()
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             },
         );
     }
@@ -1260,4 +1368,296 @@ mod test {
         .expect("our body is valid json");
         assert_eq!("Your request has been timed out", j["errors"][0]["message"]);
     }
+<<<<<<< HEAD
+=======
+
+    #[tokio::test]
+    async fn test_subgraph_pool_idle_timeout_override_and_fallback() {
+        let config = serde_yaml::from_str::<Config>(
+            r#"
+        all:
+          pool_idle_timeout: 10s
+        subgraphs:
+          fast:
+            pool_idle_timeout: 2s
+          explicit_null:
+            pool_idle_timeout: null
+        router:
+          timeout: 65s
+        "#,
+        )
+        .unwrap();
+
+        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("fast")
+                .pool_idle_timeout,
+            Some(Duration::from_secs(2)),
+            "subgraph-specific override should win"
+        );
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("explicit_null")
+                .pool_idle_timeout,
+            Some(Duration::from_secs(10)),
+            "explicit null falls back to all"
+        );
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("unknown")
+                .pool_idle_timeout,
+            Some(Duration::from_secs(10)),
+            "unknown subgraph falls back to all"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_connector_pool_idle_timeout_override_and_fallback() {
+        let config = serde_yaml::from_str::<Config>(
+            r#"
+        connector:
+          all:
+            pool_idle_timeout: 20s
+          sources:
+            my_source:
+              pool_idle_timeout: 3s
+            explicit_null:
+              pool_idle_timeout: null
+        router:
+          timeout: 65s
+        "#,
+        )
+        .unwrap();
+
+        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            shaping_config
+                .connector_client_config("my_source")
+                .pool_idle_timeout,
+            Some(Duration::from_secs(3)),
+            "source-specific override should win"
+        );
+
+        assert_eq!(
+            shaping_config
+                .connector_client_config("explicit_null")
+                .pool_idle_timeout,
+            Some(Duration::from_secs(20)),
+            "explicit null falls back to all"
+        );
+
+        assert_eq!(
+            shaping_config
+                .connector_client_config("unknown")
+                .pool_idle_timeout,
+            Some(Duration::from_secs(20)),
+            "unknown source falls back to all"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pool_idle_timeout_uses_default_when_not_configured() {
+        let config = serde_yaml::from_str::<Config>(
+            r#"
+        all:
+          experimental_http2: disable
+        router:
+          timeout: 65s
+        "#,
+        )
+        .unwrap();
+
+        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("any")
+                .pool_idle_timeout,
+            default_pool_idle_timeout(),
+            "when pool_idle_timeout is not in the config, it should use the default"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subgraph_keep_alive_override_and_fallback() {
+        let config = serde_yaml::from_str::<Config>(
+            r#"
+        all:
+          experimental_http2_keep_alive_interval: 30s
+          experimental_http2_keep_alive_timeout: 10s
+        subgraphs:
+          fast:
+            experimental_http2_keep_alive_interval: 5s
+          explicit_null:
+            experimental_http2_keep_alive_interval: null
+        "#,
+        )
+        .unwrap();
+
+        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("fast")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(5)),
+            "subgraph-specific override should win"
+        );
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("explicit_null")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(30)),
+            "explicit null falls back to all"
+        );
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("unknown")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(30)),
+            "unknown subgraph falls back to all"
+        );
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("unknown")
+                .experimental_http2_keep_alive_timeout,
+            Some(Duration::from_secs(10)),
+            "timeout is inherited from all"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_connector_keep_alive_override_and_fallback() {
+        let config = serde_yaml::from_str::<Config>(
+            r#"
+        connector:
+          all:
+            experimental_http2_keep_alive_interval: 30s
+            experimental_http2_keep_alive_timeout: 10s
+          sources:
+            my_source:
+              experimental_http2_keep_alive_interval: 5s
+            explicit_null:
+              experimental_http2_keep_alive_interval: null
+        "#,
+        )
+        .unwrap();
+
+        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            shaping_config
+                .connector_client_config("my_source")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(5)),
+            "source-specific override should win"
+        );
+
+        assert_eq!(
+            shaping_config
+                .connector_client_config("explicit_null")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(30)),
+            "explicit null falls back to all"
+        );
+
+        assert_eq!(
+            shaping_config
+                .connector_client_config("unknown")
+                .experimental_http2_keep_alive_interval,
+            Some(Duration::from_secs(30)),
+            "unknown source falls back to all"
+        );
+
+        assert_eq!(
+            shaping_config
+                .connector_client_config("unknown")
+                .experimental_http2_keep_alive_timeout,
+            Some(Duration::from_secs(10)),
+            "timeout is inherited from all"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_keep_alive_is_none_when_not_configured() {
+        let config = serde_yaml::from_str::<Config>("{}").unwrap();
+
+        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("any")
+                .experimental_http2_keep_alive_interval,
+            None,
+            "keep-alive interval should be None when not configured"
+        );
+        assert_eq!(
+            shaping_config
+                .subgraph_client_config("any")
+                .experimental_http2_keep_alive_timeout,
+            None,
+            "keep-alive timeout should be None when not configured"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn it_raises_different_errors_for_timeouts_and_rate_limits() {
+        // expected behavior: the first request sent will timeout, the second request will return
+        // immediately due to the ratelimit
+        let config: serde_json::Value = serde_yaml::from_str(
+            r#"
+        router:
+            global_rate_limit:
+                capacity: 1
+                interval: 100ms
+            timeout: 150ms
+        "#,
+        )
+        .unwrap();
+
+        let plugin = get_traffic_shaping_plugin(&config).await;
+        let svc = ServiceBuilder::new()
+            .service_fn(move |_req: router::Request| async {
+                sleep(Duration::from_millis(500)).await;
+                RouterResponse::fake_builder().build()
+            })
+            .boxed();
+
+        let mut router_service = plugin.router_service(svc);
+
+        let mut tasks = JoinSet::new();
+        for _ in 0..2 {
+            let request = RouterRequest::fake_builder().build().unwrap();
+            tasks.spawn(router_service.ready().await.unwrap().call(request));
+        }
+
+        let mut results = tasks.join_all().await.into_iter();
+
+        let response = results.next().unwrap().unwrap().response;
+        assert_eq!(StatusCode::SERVICE_UNAVAILABLE, response.status());
+
+        let response = results.next().unwrap().unwrap().response;
+        assert_eq!(StatusCode::GATEWAY_TIMEOUT, response.status());
+    }
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
 }

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -637,8 +637,6 @@ mod test {
     use serde_json_bytes::ByteString;
     use serde_json_bytes::Value;
     use serde_json_bytes::json;
-    use tokio::task::JoinSet;
-    use tokio::time::sleep;
     use tower::Service;
 
     use super::*;
@@ -1444,45 +1442,5 @@ mod test {
             None,
             "keep-alive timeout should be None when not configured"
         );
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn it_raises_different_errors_for_timeouts_and_rate_limits() {
-        // expected behavior: the first request sent will timeout, the second request will return
-        // immediately due to the ratelimit
-        let config: serde_json::Value = serde_yaml::from_str(
-            r#"
-        router:
-            global_rate_limit:
-                capacity: 1
-                interval: 100ms
-            timeout: 150ms
-        "#,
-        )
-        .unwrap();
-
-        let plugin = get_traffic_shaping_plugin(&config).await;
-        let svc = ServiceBuilder::new()
-            .service_fn(move |_req: router::Request| async {
-                sleep(Duration::from_millis(500)).await;
-                RouterResponse::fake_builder().build()
-            })
-            .boxed();
-
-        let mut router_service = plugin.router_service(svc);
-
-        let mut tasks = JoinSet::new();
-        for _ in 0..2 {
-            let request = RouterRequest::fake_builder().build().unwrap();
-            tasks.spawn(router_service.ready().await.unwrap().call(request));
-        }
-
-        let mut results = tasks.join_all().await.into_iter();
-
-        let response = results.next().unwrap().unwrap().response;
-        assert_eq!(StatusCode::SERVICE_UNAVAILABLE, response.status());
-
-        let response = results.next().unwrap().unwrap().response;
-        assert_eq!(StatusCode::GATEWAY_TIMEOUT, response.status());
     }
 }

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -31,7 +31,6 @@ use tower::timeout::error::Elapsed;
 
 use self::deduplication::QueryDeduplicationLayer;
 use crate::configuration::shared::DnsResolutionStrategy;
-use crate::configuration::shared::default_pool_idle_timeout;
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::PluginInit;
@@ -71,13 +70,6 @@ struct Shaping {
     experimental_http2: Option<Http2Config>,
     /// DNS resolution strategy for subgraphs
     dns_resolution_strategy: Option<DnsResolutionStrategy>,
-    /// Specify a timeout for idle sockets being kept-alive in the client's connection pool
-    #[serde(
-        deserialize_with = "humantime_serde::deserialize",
-        default = "default_pool_idle_timeout"
-    )]
-    #[schemars(with = "String", default = "default_pool_idle_timeout")]
-    pool_idle_timeout: Option<Duration>,
     /// Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If
     /// unset (the default), keep-alive pings are disabled.
     #[serde(deserialize_with = "humantime_serde::deserialize", default)]
@@ -124,11 +116,6 @@ impl Merge for Shaping {
                     .dns_resolution_strategy
                     .as_ref()
                     .or(fallback.dns_resolution_strategy.as_ref())
-                    .cloned(),
-                pool_idle_timeout: self
-                    .pool_idle_timeout
-                    .as_ref()
-                    .or(fallback.pool_idle_timeout.as_ref())
                     .cloned(),
                 experimental_http2_keep_alive_interval: self
                     .experimental_http2_keep_alive_interval
@@ -188,13 +175,6 @@ struct ConnectorShaping {
     experimental_http2: Option<Http2Config>,
     /// DNS resolution strategy for connectors
     dns_resolution_strategy: Option<DnsResolutionStrategy>,
-    /// Specify a timeout for idle sockets being kept-alive in the client's connection pool
-    #[serde(
-        deserialize_with = "humantime_serde::deserialize",
-        default = "default_pool_idle_timeout"
-    )]
-    #[schemars(with = "String", default = "default_pool_idle_timeout")]
-    pool_idle_timeout: Option<Duration>,
     /// Configure the interval for HTTP/2 keep-alive pings. Requires HTTP/2 to be enabled. If
     /// unset (the default), keep-alive pings are disabled.
     #[serde(deserialize_with = "humantime_serde::deserialize", default)]
@@ -228,11 +208,6 @@ impl Merge for ConnectorShaping {
                     .dns_resolution_strategy
                     .as_ref()
                     .or(fallback.dns_resolution_strategy.as_ref())
-                    .cloned(),
-                pool_idle_timeout: self
-                    .pool_idle_timeout
-                    .as_ref()
-                    .or(fallback.pool_idle_timeout.as_ref())
                     .cloned(),
                 experimental_http2_keep_alive_interval: self
                     .experimental_http2_keep_alive_interval
@@ -613,7 +588,6 @@ impl TrafficShaping {
         .map(|config| crate::configuration::shared::Client {
             experimental_http2: config.shaping.experimental_http2,
             dns_resolution_strategy: config.shaping.dns_resolution_strategy,
-            pool_idle_timeout: config.shaping.pool_idle_timeout,
             experimental_http2_keep_alive_interval: config
                 .shaping
                 .experimental_http2_keep_alive_interval,
@@ -633,7 +607,6 @@ impl TrafficShaping {
             .map(|config| crate::configuration::shared::Client {
                 experimental_http2: config.experimental_http2,
                 dns_resolution_strategy: config.dns_resolution_strategy,
-                pool_idle_timeout: config.pool_idle_timeout,
                 experimental_http2_keep_alive_interval: config
                     .experimental_http2_keep_alive_interval,
                 experimental_http2_keep_alive_timeout: config.experimental_http2_keep_alive_timeout,
@@ -1084,7 +1057,6 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Enable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv6ThenIpv4),
-                pool_idle_timeout: default_pool_idle_timeout(),
                 ..Default::default()
             },
         );
@@ -1093,7 +1065,6 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Disable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv4Only),
-                pool_idle_timeout: default_pool_idle_timeout(),
                 ..Default::default()
             },
         );
@@ -1102,7 +1073,6 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Disable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv6Only),
-                pool_idle_timeout: default_pool_idle_timeout(),
                 ..Default::default()
             },
         );
@@ -1343,124 +1313,6 @@ mod test {
         )
         .expect("our body is valid json");
         assert_eq!("Your request has been timed out", j["errors"][0]["message"]);
-    }
-
-    #[tokio::test]
-    async fn test_subgraph_pool_idle_timeout_override_and_fallback() {
-        let config = serde_yaml::from_str::<Config>(
-            r#"
-        all:
-          pool_idle_timeout: 10s
-        subgraphs:
-          fast:
-            pool_idle_timeout: 2s
-          explicit_null:
-            pool_idle_timeout: null
-        router:
-          timeout: 65s
-        "#,
-        )
-        .unwrap();
-
-        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
-            .await
-            .unwrap();
-
-        assert_eq!(
-            shaping_config
-                .subgraph_client_config("fast")
-                .pool_idle_timeout,
-            Some(Duration::from_secs(2)),
-            "subgraph-specific override should win"
-        );
-
-        assert_eq!(
-            shaping_config
-                .subgraph_client_config("explicit_null")
-                .pool_idle_timeout,
-            Some(Duration::from_secs(10)),
-            "explicit null falls back to all"
-        );
-
-        assert_eq!(
-            shaping_config
-                .subgraph_client_config("unknown")
-                .pool_idle_timeout,
-            Some(Duration::from_secs(10)),
-            "unknown subgraph falls back to all"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_connector_pool_idle_timeout_override_and_fallback() {
-        let config = serde_yaml::from_str::<Config>(
-            r#"
-        connector:
-          all:
-            pool_idle_timeout: 20s
-          sources:
-            my_source:
-              pool_idle_timeout: 3s
-            explicit_null:
-              pool_idle_timeout: null
-        router:
-          timeout: 65s
-        "#,
-        )
-        .unwrap();
-
-        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
-            .await
-            .unwrap();
-
-        assert_eq!(
-            shaping_config
-                .connector_client_config("my_source")
-                .pool_idle_timeout,
-            Some(Duration::from_secs(3)),
-            "source-specific override should win"
-        );
-
-        assert_eq!(
-            shaping_config
-                .connector_client_config("explicit_null")
-                .pool_idle_timeout,
-            Some(Duration::from_secs(20)),
-            "explicit null falls back to all"
-        );
-
-        assert_eq!(
-            shaping_config
-                .connector_client_config("unknown")
-                .pool_idle_timeout,
-            Some(Duration::from_secs(20)),
-            "unknown source falls back to all"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_pool_idle_timeout_uses_default_when_not_configured() {
-        let config = serde_yaml::from_str::<Config>(
-            r#"
-        all:
-          experimental_http2: disable
-        router:
-          timeout: 65s
-        "#,
-        )
-        .unwrap();
-
-        let shaping_config = TrafficShaping::new(PluginInit::fake_builder().config(config).build())
-            .await
-            .unwrap();
-
-        assert_eq!(
-            shaping_config
-                .subgraph_client_config("any")
-                .pool_idle_timeout,
-            default_pool_idle_timeout(),
-            "when pool_idle_timeout is not in the config, it should use the default"
-        );
     }
 
     #[tokio::test]

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -31,6 +31,7 @@ use tower::timeout::error::Elapsed;
 
 use self::deduplication::QueryDeduplicationLayer;
 use crate::configuration::shared::DnsResolutionStrategy;
+use crate::configuration::shared::default_pool_idle_timeout;
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::PluginInit;
@@ -70,8 +71,6 @@ struct Shaping {
     experimental_http2: Option<Http2Config>,
     /// DNS resolution strategy for subgraphs
     dns_resolution_strategy: Option<DnsResolutionStrategy>,
-<<<<<<< HEAD
-=======
     /// Specify a timeout for idle sockets being kept-alive in the client's connection pool
     #[serde(
         deserialize_with = "humantime_serde::deserialize",
@@ -89,7 +88,6 @@ struct Shaping {
     #[serde(deserialize_with = "humantime_serde::deserialize", default)]
     #[schemars(with = "Option<String>", default)]
     experimental_http2_keep_alive_timeout: Option<Duration>,
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
 }
 
 #[derive(PartialEq, Default, Debug, Clone, Deserialize, JsonSchema)]
@@ -127,8 +125,6 @@ impl Merge for Shaping {
                     .as_ref()
                     .or(fallback.dns_resolution_strategy.as_ref())
                     .cloned(),
-<<<<<<< HEAD
-=======
                 pool_idle_timeout: self
                     .pool_idle_timeout
                     .as_ref()
@@ -144,7 +140,6 @@ impl Merge for Shaping {
                     .as_ref()
                     .or(fallback.experimental_http2_keep_alive_timeout.as_ref())
                     .cloned(),
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             },
         }
     }
@@ -193,8 +188,6 @@ struct ConnectorShaping {
     experimental_http2: Option<Http2Config>,
     /// DNS resolution strategy for connectors
     dns_resolution_strategy: Option<DnsResolutionStrategy>,
-<<<<<<< HEAD
-=======
     /// Specify a timeout for idle sockets being kept-alive in the client's connection pool
     #[serde(
         deserialize_with = "humantime_serde::deserialize",
@@ -212,7 +205,6 @@ struct ConnectorShaping {
     #[serde(deserialize_with = "humantime_serde::deserialize", default)]
     #[schemars(with = "Option<String>", default)]
     experimental_http2_keep_alive_timeout: Option<Duration>,
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
 }
 
 impl Merge for ConnectorShaping {
@@ -237,8 +229,6 @@ impl Merge for ConnectorShaping {
                     .as_ref()
                     .or(fallback.dns_resolution_strategy.as_ref())
                     .cloned(),
-<<<<<<< HEAD
-=======
                 pool_idle_timeout: self
                     .pool_idle_timeout
                     .as_ref()
@@ -254,7 +244,6 @@ impl Merge for ConnectorShaping {
                     .as_ref()
                     .or(fallback.experimental_http2_keep_alive_timeout.as_ref())
                     .cloned(),
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             },
         }
     }
@@ -624,8 +613,6 @@ impl TrafficShaping {
         .map(|config| crate::configuration::shared::Client {
             experimental_http2: config.shaping.experimental_http2,
             dns_resolution_strategy: config.shaping.dns_resolution_strategy,
-<<<<<<< HEAD
-=======
             pool_idle_timeout: config.shaping.pool_idle_timeout,
             experimental_http2_keep_alive_interval: config
                 .shaping
@@ -633,7 +620,6 @@ impl TrafficShaping {
             experimental_http2_keep_alive_timeout: config
                 .shaping
                 .experimental_http2_keep_alive_timeout,
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
         })
         .unwrap_or_default()
     }
@@ -647,13 +633,10 @@ impl TrafficShaping {
             .map(|config| crate::configuration::shared::Client {
                 experimental_http2: config.experimental_http2,
                 dns_resolution_strategy: config.dns_resolution_strategy,
-<<<<<<< HEAD
-=======
                 pool_idle_timeout: config.pool_idle_timeout,
                 experimental_http2_keep_alive_interval: config
                     .experimental_http2_keep_alive_interval,
                 experimental_http2_keep_alive_timeout: config.experimental_http2_keep_alive_timeout,
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             })
             .unwrap_or_default()
     }
@@ -681,6 +664,8 @@ mod test {
     use serde_json_bytes::ByteString;
     use serde_json_bytes::Value;
     use serde_json_bytes::json;
+    use tokio::task::JoinSet;
+    use tokio::time::sleep;
     use tower::Service;
 
     use super::*;
@@ -1099,11 +1084,8 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Enable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv6ThenIpv4),
-<<<<<<< HEAD
-=======
                 pool_idle_timeout: default_pool_idle_timeout(),
                 ..Default::default()
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             },
         );
         assert_eq!(
@@ -1111,11 +1093,8 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Disable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv4Only),
-<<<<<<< HEAD
-=======
                 pool_idle_timeout: default_pool_idle_timeout(),
                 ..Default::default()
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             },
         );
         assert_eq!(
@@ -1123,11 +1102,8 @@ mod test {
             crate::configuration::shared::Client {
                 experimental_http2: Some(Http2Config::Disable),
                 dns_resolution_strategy: Some(DnsResolutionStrategy::Ipv6Only),
-<<<<<<< HEAD
-=======
                 pool_idle_timeout: default_pool_idle_timeout(),
                 ..Default::default()
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
             },
         );
     }
@@ -1368,8 +1344,6 @@ mod test {
         .expect("our body is valid json");
         assert_eq!("Your request has been timed out", j["errors"][0]["message"]);
     }
-<<<<<<< HEAD
-=======
 
     #[tokio::test]
     async fn test_subgraph_pool_idle_timeout_override_and_fallback() {
@@ -1659,5 +1633,4 @@ mod test {
         let response = results.next().unwrap().unwrap().response;
         assert_eq!(StatusCode::GATEWAY_TIMEOUT, response.status());
     }
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
 }

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -34,6 +34,7 @@ use super::HttpResponse;
 use crate::Configuration;
 use crate::axum_factory::compression::Compressor;
 use crate::configuration::TlsClientAuth;
+use crate::configuration::shared::DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT;
 use crate::error::FetchError;
 use crate::plugins::authentication::subgraph::SigningParamsConfig;
 use crate::plugins::telemetry::HttpClientAttributes;
@@ -101,6 +102,110 @@ pub(crate) struct HttpClientService {
 }
 
 impl HttpClientService {
+<<<<<<< HEAD
+=======
+    /// Test-wrapper for HttpClientService::new()
+    ///
+    /// NOTE: this separation is primarily to keep us from exposing `new()`
+    /// when we don't need to
+    #[cfg_attr(test, allow(unreachable_pub))]
+    pub(crate) fn test_new(
+        service: impl Into<String>,
+        tls_config: ClientConfig,
+        client_config: crate::configuration::shared::Client,
+    ) -> Result<Self, BoxError> {
+        Self::new(service, tls_config, client_config)
+    }
+
+    /// Create a new HttpClientService using:
+    ///
+    /// - the service's name (eg, connector name, hardcoded "coprocessor", or the subgraph's name) for
+    ///   use in errors and potentially signing requests
+    /// - the tls config to be used in setting tls; though, this is actually rustls's and hyper
+    ///   figuring out which parts of a broader config to use for tls
+    /// - the client's config, which is _our_ set of options from the router config for use in
+    ///   enabling/disabling features like http/2
+    fn new(
+        service: impl Into<String>,
+        tls_config: ClientConfig,
+        client_config: crate::configuration::shared::Client,
+    ) -> Result<Self, BoxError> {
+        let mut http_connector =
+            new_async_http_connector(client_config.dns_resolution_strategy.unwrap_or_default())?;
+        http_connector.set_nodelay(true);
+        http_connector.set_keepalive(Some(std::time::Duration::from_secs(60)));
+        http_connector.enforce_http(false);
+
+        let builder = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http();
+
+        let pool_idle_timeout = client_config.pool_idle_timeout;
+        let http2_keep_alive_interval = client_config.experimental_http2_keep_alive_interval;
+        let http2_keep_alive_timeout = client_config
+            .experimental_http2_keep_alive_timeout
+            .unwrap_or(DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT);
+
+        let http2 = client_config.experimental_http2.unwrap_or_default();
+        let connector = match http2 {
+            Http2Config::Enable => builder
+                .enable_http1()
+                .enable_http2()
+                .wrap_connector(http_connector),
+            Http2Config::Disable => builder.enable_http1().wrap_connector(http_connector),
+            Http2Config::Http2Only => builder.enable_http2().wrap_connector(http_connector),
+        };
+
+        let mut client_builder =
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new());
+        client_builder
+            .pool_idle_timeout(pool_idle_timeout)
+            // WARN: for `pool_idle_timeout` to work, it needs a pool timer; don't remove this
+            // unless you're also removing `pool_idle_timeout`
+            .pool_timer(TokioTimer::new())
+            .http2_only(http2 == Http2Config::Http2Only);
+        if let Some(interval) = http2_keep_alive_interval {
+            client_builder
+                // WARN: http2 keep-alive requires a timer; don't remove this
+                .timer(TokioTimer::new())
+                .http2_keep_alive_interval(Some(interval))
+                .http2_keep_alive_timeout(http2_keep_alive_timeout)
+                // Send pings even when the connection is idle in the pool, so stale
+                // connections are detected before a request is made on them
+                .http2_keep_alive_while_idle(true);
+        }
+        let http_client = client_builder.build(connector);
+
+        #[cfg(unix)]
+        let unix_client = {
+            let unix_client_inner =
+                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                    .pool_idle_timeout(pool_idle_timeout)
+                    // WARN: for `pool_idle_timeout` to work, it needs a pool timer; don't remove this
+                    // unless you're also removing `pool_idle_timeout`
+                    .pool_timer(TokioTimer::new())
+                    .http2_only(http2 == Http2Config::Http2Only)
+                    .build(UnixConnector);
+
+            ServiceBuilder::new()
+                .layer(DecompressionLayer::new())
+                .layer(WireBodySizeLayer)
+                .service(unix_client_inner)
+        };
+
+        Ok(Self {
+            http_client: ServiceBuilder::new()
+                .layer(DecompressionLayer::new())
+                .layer(WireBodySizeLayer)
+                .service(http_client),
+            #[cfg(unix)]
+            unix_client,
+            service: Arc::new(service.into()),
+        })
+    }
+
+    /// Creates a client for talking to subgraphs
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
     pub(crate) fn from_config_for_subgraph(
         service: impl Into<String>,
         configuration: &Configuration,

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -2,6 +2,7 @@ use std::error::Error as _;
 use std::fmt::Display;
 use std::sync::Arc;
 use std::task::Poll;
+use std::time::Duration;
 
 use ::serde::Deserialize;
 use futures::future::BoxFuture;
@@ -60,6 +61,8 @@ type UnixHTTPClient = Decompression<hyper_util::client::legacy::Client<UnixConne
 type MixedClient = Either<HTTPClient, UnixHTTPClient>;
 #[cfg(not(unix))]
 type MixedClient = HTTPClient;
+
+const POOL_IDLE_TIMEOUT_DURATION: Option<Duration> = Some(Duration::from_secs(5));
 
 // interior mutability is not a concern here, the value is never modified
 #[allow(clippy::declare_interior_mutable_const)]
@@ -137,7 +140,6 @@ impl HttpClientService {
             .with_tls_config(tls_config)
             .https_or_http();
 
-        let pool_idle_timeout = client_config.pool_idle_timeout;
         let http2_keep_alive_interval = client_config.experimental_http2_keep_alive_interval;
         let http2_keep_alive_timeout = client_config
             .experimental_http2_keep_alive_timeout
@@ -156,10 +158,7 @@ impl HttpClientService {
         let mut client_builder =
             hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new());
         client_builder
-            .pool_idle_timeout(pool_idle_timeout)
-            // WARN: for `pool_idle_timeout` to work, it needs a pool timer; don't remove this
-            // unless you're also removing `pool_idle_timeout`
-            .pool_timer(TokioTimer::new())
+            .pool_idle_timeout(POOL_IDLE_TIMEOUT_DURATION)
             .http2_only(http2 == Http2Config::Http2Only);
         if let Some(interval) = http2_keep_alive_interval {
             client_builder
@@ -184,10 +183,7 @@ impl HttpClientService {
                     hyper_util::client::legacy::Client::builder(
                         hyper_util::rt::TokioExecutor::new(),
                     )
-                    .pool_idle_timeout(pool_idle_timeout)
-                    // WARN: for `pool_idle_timeout` to work, it needs a pool timer; don't remove this
-                    // unless you're also removing `pool_idle_timeout`
-                    .pool_timer(TokioTimer::new())
+                    .pool_idle_timeout(POOL_IDLE_TIMEOUT_DURATION)
                     .http2_only(http2 == Http2Config::Http2Only)
                     .build(UnixConnector),
                 ),

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -103,72 +103,6 @@ pub(crate) struct HttpClientService {
 }
 
 impl HttpClientService {
-    pub(crate) fn new(
-        service: impl Into<String>,
-        tls_config: ClientConfig,
-        client_config: crate::configuration::shared::Client,
-    ) -> Result<Self, BoxError> {
-        let mut http_connector =
-            new_async_http_connector(client_config.dns_resolution_strategy.unwrap_or_default())?;
-        http_connector.set_nodelay(true);
-        http_connector.set_keepalive(Some(std::time::Duration::from_secs(60)));
-        http_connector.enforce_http(false);
-
-        let builder = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_tls_config(tls_config)
-            .https_or_http();
-
-        let http2_keep_alive_interval = client_config.experimental_http2_keep_alive_interval;
-        let http2_keep_alive_timeout = client_config
-            .experimental_http2_keep_alive_timeout
-            .unwrap_or(DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT);
-
-        let http2 = client_config.experimental_http2.unwrap_or_default();
-        let connector = match http2 {
-            Http2Config::Enable => builder
-                .enable_http1()
-                .enable_http2()
-                .wrap_connector(http_connector),
-            Http2Config::Disable => builder.enable_http1().wrap_connector(http_connector),
-            Http2Config::Http2Only => builder.enable_http2().wrap_connector(http_connector),
-        };
-
-        let mut client_builder =
-            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new());
-        client_builder
-            .pool_idle_timeout(POOL_IDLE_TIMEOUT_DURATION)
-            .http2_only(http2 == Http2Config::Http2Only);
-        if let Some(interval) = http2_keep_alive_interval {
-            client_builder
-                // WARN: http2 keep-alive requires a timer; don't remove this
-                .timer(TokioTimer::new())
-                .http2_keep_alive_interval(Some(interval))
-                .http2_keep_alive_timeout(http2_keep_alive_timeout)
-                // Send pings even when the connection is idle in the pool, so stale
-                // connections are detected before a request is made on them
-                .http2_keep_alive_while_idle(true);
-        }
-        let http_client = client_builder.build(connector);
-
-        Ok(Self {
-            http_client: ServiceBuilder::new()
-                .layer(DecompressionLayer::new())
-                .service(http_client),
-            #[cfg(unix)]
-            unix_client: ServiceBuilder::new()
-                .layer(DecompressionLayer::new())
-                .service(
-                    hyper_util::client::legacy::Client::builder(
-                        hyper_util::rt::TokioExecutor::new(),
-                    )
-                    .pool_idle_timeout(POOL_IDLE_TIMEOUT_DURATION)
-                    .http2_only(http2 == Http2Config::Http2Only)
-                    .build(UnixConnector),
-                ),
-            service: Arc::new(service.into()),
-        })
-    }
-
     /// Creates a client for talking to subgraphs
     pub(crate) fn from_config_for_subgraph(
         service: impl Into<String>,
@@ -244,6 +178,68 @@ impl HttpClientService {
             generate_tls_client_config(tls_cert_store, client_cert_config.map(|arc| arc.as_ref()))?;
 
         HttpClientService::new(name, tls_client_config, client_config)
+    }
+
+    pub(crate) fn new(
+        service: impl Into<String>,
+        tls_config: ClientConfig,
+        client_config: crate::configuration::shared::Client,
+    ) -> Result<Self, BoxError> {
+        let mut http_connector =
+            new_async_http_connector(client_config.dns_resolution_strategy.unwrap_or_default())?;
+        http_connector.set_nodelay(true);
+        http_connector.set_keepalive(Some(std::time::Duration::from_secs(60)));
+        http_connector.enforce_http(false);
+
+        let builder = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http1();
+
+        let http2_keep_alive_interval = client_config.experimental_http2_keep_alive_interval;
+        let http2_keep_alive_timeout = client_config
+            .experimental_http2_keep_alive_timeout
+            .unwrap_or(DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT);
+
+        let http2 = client_config.experimental_http2.unwrap_or_default();
+        let connector = if http2 != Http2Config::Disable {
+            builder.enable_http2().wrap_connector(http_connector)
+        } else {
+            builder.wrap_connector(http_connector)
+        };
+
+        let mut client_builder =
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new());
+        client_builder
+            .pool_idle_timeout(POOL_IDLE_TIMEOUT_DURATION)
+            .http2_only(http2 == Http2Config::Http2Only);
+        if let Some(interval) = http2_keep_alive_interval {
+            client_builder
+                // WARN: http2 keep-alive requires a timer; don't remove this
+                .timer(TokioTimer::new())
+                .http2_keep_alive_interval(Some(interval))
+                .http2_keep_alive_timeout(http2_keep_alive_timeout)
+                // Send pings even when the connection is idle in the pool, so stale
+                // connections are detected before a request is made on them
+                .http2_keep_alive_while_idle(true);
+        }
+        let http_client = client_builder.build(connector);
+
+        Ok(Self {
+            http_client: ServiceBuilder::new()
+                .layer(DecompressionLayer::new())
+                .service(http_client),
+            #[cfg(unix)]
+            unix_client: ServiceBuilder::new()
+                .layer(DecompressionLayer::new())
+                .service(
+                    hyper_util::client::legacy::Client::builder(
+                        hyper_util::rt::TokioExecutor::new(),
+                    )
+                    .build(UnixConnector),
+                ),
+            service: Arc::new(service.into()),
+        })
     }
 
     /// Creates a client using only a `Client` config, with an empty TLS root store.

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -62,11 +62,10 @@ type MixedClient = Either<HTTPClient, UnixHTTPClient>;
 #[cfg(not(unix))]
 type MixedClient = HTTPClient;
 
-const POOL_IDLE_TIMEOUT_DURATION: Option<Duration> = Some(Duration::from_secs(5));
-
 // interior mutability is not a concern here, the value is never modified
 #[allow(clippy::declare_interior_mutable_const)]
 static ACCEPTED_ENCODINGS: HeaderValue = HeaderValue::from_static("gzip, br, deflate");
+const POOL_IDLE_TIMEOUT_DURATION: Option<Duration> = Some(Duration::from_secs(5));
 
 #[derive(PartialEq, Debug, Clone, Deserialize, JsonSchema, Copy)]
 #[serde(rename_all = "lowercase")]
@@ -104,28 +103,7 @@ pub(crate) struct HttpClientService {
 }
 
 impl HttpClientService {
-    /// Test-wrapper for HttpClientService::new()
-    ///
-    /// NOTE: this separation is primarily to keep us from exposing `new()`
-    /// when we don't need to
-    #[cfg_attr(test, allow(unreachable_pub))]
-    pub(crate) fn test_new(
-        service: impl Into<String>,
-        tls_config: ClientConfig,
-        client_config: crate::configuration::shared::Client,
-    ) -> Result<Self, BoxError> {
-        Self::new(service, tls_config, client_config)
-    }
-
-    /// Create a new HttpClientService using:
-    ///
-    /// - the service's name (eg, connector name, hardcoded "coprocessor", or the subgraph's name) for
-    ///   use in errors and potentially signing requests
-    /// - the tls config to be used in setting tls; though, this is actually rustls's and hyper
-    ///   figuring out which parts of a broader config to use for tls
-    /// - the client's config, which is _our_ set of options from the router config for use in
-    ///   enabling/disabling features like http/2
-    fn new(
+    pub(crate) fn new(
         service: impl Into<String>,
         tls_config: ClientConfig,
         client_config: crate::configuration::shared::Client,

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -2,7 +2,6 @@ use std::error::Error as _;
 use std::fmt::Display;
 use std::sync::Arc;
 use std::task::Poll;
-use std::time::Duration;
 
 use ::serde::Deserialize;
 use futures::future::BoxFuture;
@@ -14,6 +13,7 @@ use http::header::CONTENT_ENCODING;
 use http_body_util::BodyExt;
 use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioTimer;
 #[cfg(unix)]
 use hyperlocal::UnixConnector;
 use opentelemetry::global;
@@ -64,7 +64,6 @@ type MixedClient = HTTPClient;
 // interior mutability is not a concern here, the value is never modified
 #[allow(clippy::declare_interior_mutable_const)]
 static ACCEPTED_ENCODINGS: HeaderValue = HeaderValue::from_static("gzip, br, deflate");
-const POOL_IDLE_TIMEOUT_DURATION: Option<Duration> = Some(Duration::from_secs(5));
 
 #[derive(PartialEq, Debug, Clone, Deserialize, JsonSchema, Copy)]
 #[serde(rename_all = "lowercase")]
@@ -102,8 +101,6 @@ pub(crate) struct HttpClientService {
 }
 
 impl HttpClientService {
-<<<<<<< HEAD
-=======
     /// Test-wrapper for HttpClientService::new()
     ///
     /// NOTE: this separation is primarily to keep us from exposing `new()`
@@ -176,36 +173,29 @@ impl HttpClientService {
         }
         let http_client = client_builder.build(connector);
 
-        #[cfg(unix)]
-        let unix_client = {
-            let unix_client_inner =
-                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+        Ok(Self {
+            http_client: ServiceBuilder::new()
+                .layer(DecompressionLayer::new())
+                .service(http_client),
+            #[cfg(unix)]
+            unix_client: ServiceBuilder::new()
+                .layer(DecompressionLayer::new())
+                .service(
+                    hyper_util::client::legacy::Client::builder(
+                        hyper_util::rt::TokioExecutor::new(),
+                    )
                     .pool_idle_timeout(pool_idle_timeout)
                     // WARN: for `pool_idle_timeout` to work, it needs a pool timer; don't remove this
                     // unless you're also removing `pool_idle_timeout`
                     .pool_timer(TokioTimer::new())
                     .http2_only(http2 == Http2Config::Http2Only)
-                    .build(UnixConnector);
-
-            ServiceBuilder::new()
-                .layer(DecompressionLayer::new())
-                .layer(WireBodySizeLayer)
-                .service(unix_client_inner)
-        };
-
-        Ok(Self {
-            http_client: ServiceBuilder::new()
-                .layer(DecompressionLayer::new())
-                .layer(WireBodySizeLayer)
-                .service(http_client),
-            #[cfg(unix)]
-            unix_client,
+                    .build(UnixConnector),
+                ),
             service: Arc::new(service.into()),
         })
     }
 
     /// Creates a client for talking to subgraphs
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
     pub(crate) fn from_config_for_subgraph(
         service: impl Into<String>,
         configuration: &Configuration,
@@ -282,49 +272,13 @@ impl HttpClientService {
         HttpClientService::new(name, tls_client_config, client_config)
     }
 
-    pub(crate) fn new(
-        service: impl Into<String>,
-        tls_config: ClientConfig,
+    /// Creates a client using only a `Client` config, with an empty TLS root store.
+    #[cfg(test)]
+    pub(crate) fn from_client_config(
         client_config: crate::configuration::shared::Client,
     ) -> Result<Self, BoxError> {
-        let mut http_connector =
-            new_async_http_connector(client_config.dns_resolution_strategy.unwrap_or_default())?;
-        http_connector.set_nodelay(true);
-        http_connector.set_keepalive(Some(std::time::Duration::from_secs(60)));
-        http_connector.enforce_http(false);
-
-        let builder = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_tls_config(tls_config)
-            .https_or_http()
-            .enable_http1();
-
-        let http2 = client_config.experimental_http2.unwrap_or_default();
-        let connector = if http2 != Http2Config::Disable {
-            builder.enable_http2().wrap_connector(http_connector)
-        } else {
-            builder.wrap_connector(http_connector)
-        };
-
-        let http_client =
-            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                .pool_idle_timeout(POOL_IDLE_TIMEOUT_DURATION)
-                .http2_only(http2 == Http2Config::Http2Only)
-                .build(connector);
-        Ok(Self {
-            http_client: ServiceBuilder::new()
-                .layer(DecompressionLayer::new())
-                .service(http_client),
-            #[cfg(unix)]
-            unix_client: ServiceBuilder::new()
-                .layer(DecompressionLayer::new())
-                .service(
-                    hyper_util::client::legacy::Client::builder(
-                        hyper_util::rt::TokioExecutor::new(),
-                    )
-                    .build(UnixConnector),
-                ),
-            service: Arc::new(service.into()),
-        })
+        let tls_client_config = generate_tls_client_config(RootCertStore::empty(), None)?;
+        Self::new("test", tls_client_config, client_config)
     }
 
     pub(crate) fn native_roots_store() -> RootCertStore {

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -734,7 +734,7 @@ async fn test_subgraph_h2c() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let socket_addr = listener.local_addr().unwrap();
     tokio::task::spawn(emulate_h2c_server(listener));
-    let subgraph_service = HttpClientService::test_new(
+    let subgraph_service = HttpClientService::new(
         "test",
         rustls::ClientConfig::builder()
             .with_native_roots()
@@ -1014,7 +1014,7 @@ async fn test_compressed_request_response_body() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let socket_addr = listener.local_addr().unwrap();
     tokio::task::spawn(emulate_subgraph_compressed_response(listener));
-    let subgraph_service = HttpClientService::test_new(
+    let subgraph_service = HttpClientService::new(
         "test",
         rustls::ClientConfig::builder()
             .with_native_roots()

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -610,7 +610,6 @@ async fn tls_client_auth() {
     )
     .unwrap();
 
-<<<<<<< HEAD
     let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
     let response = subgraph_service
         .oneshot(HttpRequest {
@@ -628,248 +627,148 @@ async fn tls_client_auth() {
     assert_eq!(
         std::str::from_utf8(
             &router::body::into_bytes(response.http_response.into_parts().1)
-=======
-#[cfg(unix)]
-#[derive(Debug, Clone)]
-enum ExpectedVersion {
-    Http2,
-    Http11,
-    Any,
+                .await
+                .unwrap()
+        )
+        .unwrap(),
+        r#"{"data": null}"#
+    );
 }
 
-#[cfg(unix)]
-impl ExpectedVersion {
-    fn check(&self, tracker: &HttpVersionTracker) {
-        let got = tracker.get();
-        match self {
-            ExpectedVersion::Http2 => assert!(
-                got == Some(Version::HTTP_2),
-                "expected HTTP/2, got: {got:?}"
-            ),
-            ExpectedVersion::Http11 => assert!(
-                got == Some(Version::HTTP_11),
-                "expected HTTP/1.1, got: {got:?}"
-            ),
-            ExpectedVersion::Any => assert!(got.is_some(), "expected a version to be captured"),
-        }
-    }
+#[tokio::test(flavor = "multi_thread")]
+async fn tls_client_auth_connector() {
+    let server_certificate_pem = include_str!("./testdata/server.crt");
+    let ca_pem = include_str!("./testdata/CA/ca.crt");
+    let server_key_pem = include_str!("./testdata/server.key");
+
+    let mut server_certificates = load_certs(server_certificate_pem).unwrap();
+    let ca_certificate = load_certs(ca_pem).unwrap().remove(0);
+    server_certificates.push(ca_certificate.clone());
+    let key = load_key(server_key_pem).unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let socket_addr = listener.local_addr().unwrap();
+    tokio::task::spawn(tls_server_with_client_auth(
+        listener,
+        server_certificates,
+        key,
+        ca_certificate,
+        r#"{"my_field": "abc"}"#,
+    ));
+
+    let client_certificate_pem = include_str!("./testdata/client.crt");
+    let client_key_pem = include_str!("./testdata/client.key");
+
+    let client_certificates = load_certs(client_certificate_pem).unwrap();
+    let client_key = load_key(client_key_pem).unwrap();
+
+    // we cannot parse a configuration from text, because certificates are generally
+    // added by file expansion and we don't have access to that here, and inserting
+    // the PEM data directly generates parsing issues due to end of line characters
+    let mut config = Configuration::default();
+    config.tls.connector.sources.insert(
+        "test".to_string(),
+        TlsClient {
+            certificate_authorities: Some(ca_pem.into()),
+            client_authentication: Some(Arc::new(TlsClientAuth {
+                certificate_chain: client_certificates,
+                key: client_key,
+            })),
+        },
+    );
+    let subgraph_service = HttpClientService::from_config_for_connector(
+        "test",
+        &config,
+        &rustls::RootCertStore::empty(),
+        crate::configuration::shared::Client::default(),
+    )
+    .unwrap();
+
+    let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
+    let response = subgraph_service
+        .oneshot(HttpRequest {
+            http_request: http::Request::builder()
+                .uri(url)
+                .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                .body(router::body::from_bytes(r#"{}"#))
+                .unwrap(),
+            context: Context::new(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        std::str::from_utf8(
+            &router::body::into_bytes(response.http_response.into_parts().1)
+                .await
+                .unwrap()
+        )
+        .unwrap(),
+        r#"{"my_field": "abc"}"#
+    );
 }
 
-mod tls {
-    // Note: The TLS tests rely on checked-in certificates valid until Oct 7 2033.
-    // If tests fail after that date, regenerate in the testdata directory:
-    //   openssl x509 -req -in server_self_signed.csr -signkey server.key \
-    //     -out server_self_signed.crt -extfile server.ext -days 3650
-    use super::*;
-
-    #[rstest]
-    #[case::subgraph(ServiceKind::Subgraph)]
-    #[case::connector(ServiceKind::Connector)]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn tls_self_signed(#[case] kind: ServiceKind) {
-        let certificate_pem = include_str!("./testdata/server_self_signed.crt");
-        let key_pem = include_str!("./testdata/server.key");
-
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let socket_addr = listener.local_addr().unwrap();
-        let negotiated_protocol = NegotiatedProtocolTracker::new();
-
-        tokio::task::spawn(tls_server(
-            listener,
-            load_certs(certificate_pem).unwrap(),
-            load_key(key_pem).unwrap(),
-            r#"{"data": null}"#,
-            negotiated_protocol.clone(),
-            vec![alpn::H2.to_vec(), alpn::HTTP_1_1.to_vec()],
-        ));
-
-        let mut config = Configuration::default();
-        insert_tls_config(
-            &mut config,
-            kind,
-            TlsClient {
-                certificate_authorities: Some(certificate_pem.into()),
-                client_authentication: None,
-            },
-        );
-        let service = make_service(kind, &config, Default::default());
-
-        let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
-        let response = send_request(service, url, r#"{"query":"{ test }"}"#).await;
-        assert_response_body(response, r#"{"data": null}"#).await;
+// starts a local server emulating a subgraph returning status code 401
+async fn emulate_h2c_server(listener: TcpListener) {
+    async fn handle(_request: http::Request<Body>) -> Result<http::Response<Body>, Infallible> {
+        println!("h2C server got req: {_request:?}");
+        Ok(http::Response::builder()
+            .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+            .status(StatusCode::OK)
+            .body(
+                serde_json::to_string(&Response {
+                    data: Some(Value::default()),
+                    ..Response::default()
+                })
+                .expect("always valid")
+                .into(),
+            )
+            .unwrap())
     }
 
-    #[rstest]
-    #[case::subgraph(ServiceKind::Subgraph)]
-    #[case::connector(ServiceKind::Connector)]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn tls_custom_root(#[case] kind: ServiceKind) {
-        let certificate_pem = include_str!("./testdata/server.crt");
-        let ca_pem = include_str!("./testdata/CA/ca.crt");
-        let key_pem = include_str!("./testdata/server.key");
-
-        let mut certificates = load_certs(certificate_pem).unwrap();
-        certificates.extend(load_certs(ca_pem).unwrap());
-
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let socket_addr = listener.local_addr().unwrap();
-        let negotiated_protocol = NegotiatedProtocolTracker::new();
-
-        tokio::task::spawn(tls_server(
-            listener,
-            certificates,
-            load_key(key_pem).unwrap(),
-            r#"{"data": null}"#,
-            negotiated_protocol.clone(),
-            vec![alpn::H2.to_vec(), alpn::HTTP_1_1.to_vec()],
-        ));
-
-        let mut config = Configuration::default();
-        insert_tls_config(
-            &mut config,
-            kind,
-            TlsClient {
-                certificate_authorities: Some(ca_pem.into()),
-                client_authentication: None,
-            },
-        );
-        let service = make_service(kind, &config, Default::default());
-
-        let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
-        let response = send_request(service, url, r#"{"query":"{ test }"}"#).await;
-        assert_response_body(response, r#"{"data": null}"#).await;
-    }
-
-    #[rstest]
-    #[case::subgraph(ServiceKind::Subgraph)]
-    #[case::connector(ServiceKind::Connector)]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn tls_client_auth(#[case] kind: ServiceKind) {
-        let server_certificate_pem = include_str!("./testdata/server.crt");
-        let ca_pem = include_str!("./testdata/CA/ca.crt");
-        let server_key_pem = include_str!("./testdata/server.key");
-
-        let mut server_certificates = load_certs(server_certificate_pem).unwrap();
-        let ca_certificate = load_certs(ca_pem).unwrap().remove(0);
-        server_certificates.push(ca_certificate.clone());
-
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let socket_addr = listener.local_addr().unwrap();
-
-        tokio::task::spawn(tls_server_with_client_auth(
-            listener,
-            server_certificates,
-            load_key(server_key_pem).unwrap(),
-            ca_certificate,
-            r#"{"data": null}"#,
-        ));
-
-        let client_certificate_pem = include_str!("./testdata/client.crt");
-        let client_key_pem = include_str!("./testdata/client.key");
-
-        let mut config = Configuration::default();
-        insert_tls_config(
-            &mut config,
-            kind,
-            TlsClient {
-                certificate_authorities: Some(ca_pem.into()),
-                client_authentication: Some(Arc::new(TlsClientAuth {
-                    certificate_chain: load_certs(client_certificate_pem).unwrap(),
-                    key: load_key(client_key_pem).unwrap(),
-                })),
-            },
-        );
-        let service = make_service(kind, &config, Default::default());
-
-        let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
-        let response = send_request(service, url, r#"{"query":"{ test }"}"#).await;
-        assert_response_body(response, r#"{"data": null}"#).await;
-    }
+    // XXX(@goto-bus-stop): ideally this server would *only* support HTTP 2 and not HTTP 1
+    serve(listener, handle).await.unwrap();
 }
 
-mod h2c_cleartext {
-    use super::*;
-    use crate::configuration::shared::Client;
-
-    // Starts a local server that responds with a default GraphQL response over plain HTTP.
-    async fn emulate_h2c_server(listener: TcpListener) {
-        async fn handle(request: http::Request<Body>) -> Result<http::Response<Body>, Infallible> {
-            let response_builder =
-                http::Response::builder().header(CONTENT_TYPE, APPLICATION_JSON.essence_str());
-
-            let response = match request.version() {
-                Version::HTTP_2 => {
-                    let response_body = serde_json::to_string(&Response {
-                        data: Some(Value::default()),
-                        ..Response::default()
-                    });
-                    response_builder
-                        .status(StatusCode::OK)
-                        .body(response_body.unwrap().into())
-                }
-                Version::HTTP_11 => response_builder
-                    .status(StatusCode::HTTP_VERSION_NOT_SUPPORTED)
-                    .body(Body::empty()),
-                version => panic!("unexpected version {version:?}"),
-            };
-
-            Ok(response.unwrap())
-        }
-
-        serve(listener, handle).await.unwrap();
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_subgraph_h2c_works_with_http2only() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let socket_addr = listener.local_addr().unwrap();
-        tokio::task::spawn(emulate_h2c_server(listener));
-
-        let client_config = Client::builder()
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subgraph_h2c() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let socket_addr = listener.local_addr().unwrap();
+    tokio::task::spawn(emulate_h2c_server(listener));
+    let subgraph_service = HttpClientService::test_new(
+        "test",
+        rustls::ClientConfig::builder()
+            .with_native_roots()
+            .expect("read native TLS root certificates")
+            .with_no_client_auth(),
+        crate::configuration::shared::Client::builder()
             .experimental_http2(Http2Config::Http2Only)
-            .build();
-        let subgraph_service =
-            HttpClientService::from_client_config(client_config).expect("can create a HttpService");
+            .build(),
+    )
+    .expect("can create a HttpService");
 
-        let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
-        let response = send_request(
-            subgraph_service,
-            url,
-            r#"{"query":"{ me { name username } }"#,
+    let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
+    let response = subgraph_service
+        .oneshot(HttpRequest {
+            http_request: http::Request::builder()
+                .uri(url)
+                .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                .body(router::body::from_bytes(
+                    r#"{"query":"{ me { name username } }"#,
+                ))
+                .unwrap(),
+            context: Context::new(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        std::str::from_utf8(
+            &router::body::into_bytes(response.http_response.into_parts().1)
+                .await
+                .unwrap()
         )
-        .await;
-
-        assert_response_body(response, r#"{"data":null}"#).await;
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_subgraph_h2c_not_used_with_enable() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let socket_addr = listener.local_addr().unwrap();
-        tokio::task::spawn(emulate_h2c_server(listener));
-
-        let client_config = Client::builder()
-            .experimental_http2(Http2Config::Enable)
-            .build();
-        let subgraph_service =
-            HttpClientService::from_client_config(client_config).expect("can create a HttpService");
-
-        let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
-        let response = send_request(
-            subgraph_service,
-            url,
-            r#"{"query":"{ me { name username } }"#,
-        )
-        .await;
-
-        // h2c only works with `Http2Config::Http2Only` - hyper only supports HTTP/2 with TLS or
-        // with 'prior knowledge'
-        // https://github.com/hyperium/hyper/issues/2411
-        assert_eq!(
-            response.http_response.status(),
-            StatusCode::HTTP_VERSION_NOT_SUPPORTED
-        );
-    }
+        .unwrap(),
+        r#"{"data":null}"#
+    );
 }
 
 mod h2c_keep_alive {
@@ -888,8 +787,8 @@ mod h2c_keep_alive {
     use super::*;
     use crate::configuration::shared::Client;
 
-    /// Wraps a TcpStream and emits a `()` on the `ping_tx` channel each time the server reads an H2
-    /// PING frame sent by the client.
+    /// Wraps a TcpStream and emits a `()` on the `ping_tx` channel each time the server reads an
+    /// H2 PING frame sent by the client.
     struct SpyStream {
         inner: TcpStream,
         ping_tx: Sender<()>,
@@ -1069,157 +968,6 @@ mod h2c_keep_alive {
     }
 }
 
-mod compressed_req_res {
-    use super::*;
-
-    async fn emulate_subgraph_compressed_response(listener: TcpListener) {
-        async fn handle(request: http::Request<Body>) -> Result<http::Response<Body>, Infallible> {
-            let body = router::body::into_bytes(request.into_body())
->>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
-                .await
-                .unwrap()
-        )
-        .unwrap(),
-        r#"{"data": null}"#
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn tls_client_auth_connector() {
-    let server_certificate_pem = include_str!("./testdata/server.crt");
-    let ca_pem = include_str!("./testdata/CA/ca.crt");
-    let server_key_pem = include_str!("./testdata/server.key");
-
-    let mut server_certificates = load_certs(server_certificate_pem).unwrap();
-    let ca_certificate = load_certs(ca_pem).unwrap().remove(0);
-    server_certificates.push(ca_certificate.clone());
-    let key = load_key(server_key_pem).unwrap();
-
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let socket_addr = listener.local_addr().unwrap();
-    tokio::task::spawn(tls_server_with_client_auth(
-        listener,
-        server_certificates,
-        key,
-        ca_certificate,
-        r#"{"my_field": "abc"}"#,
-    ));
-
-    let client_certificate_pem = include_str!("./testdata/client.crt");
-    let client_key_pem = include_str!("./testdata/client.key");
-
-    let client_certificates = load_certs(client_certificate_pem).unwrap();
-    let client_key = load_key(client_key_pem).unwrap();
-
-    // we cannot parse a configuration from text, because certificates are generally
-    // added by file expansion and we don't have access to that here, and inserting
-    // the PEM data directly generates parsing issues due to end of line characters
-    let mut config = Configuration::default();
-    config.tls.connector.sources.insert(
-        "test".to_string(),
-        TlsClient {
-            certificate_authorities: Some(ca_pem.into()),
-            client_authentication: Some(Arc::new(TlsClientAuth {
-                certificate_chain: client_certificates,
-                key: client_key,
-            })),
-        },
-    );
-    let subgraph_service = HttpClientService::from_config_for_connector(
-        "test",
-        &config,
-        &rustls::RootCertStore::empty(),
-        crate::configuration::shared::Client::default(),
-    )
-    .unwrap();
-
-    let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
-    let response = subgraph_service
-        .oneshot(HttpRequest {
-            http_request: http::Request::builder()
-                .uri(url)
-                .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
-                .body(router::body::from_bytes(r#"{}"#))
-                .unwrap(),
-            context: Context::new(),
-        })
-        .await
-        .unwrap();
-    assert_eq!(
-        std::str::from_utf8(
-            &router::body::into_bytes(response.http_response.into_parts().1)
-                .await
-                .unwrap()
-        )
-        .unwrap(),
-        r#"{"my_field": "abc"}"#
-    );
-}
-
-// starts a local server emulating a subgraph returning status code 401
-async fn emulate_h2c_server(listener: TcpListener) {
-    async fn handle(_request: http::Request<Body>) -> Result<http::Response<Body>, Infallible> {
-        println!("h2C server got req: {_request:?}");
-        Ok(http::Response::builder()
-            .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
-            .status(StatusCode::OK)
-            .body(
-                serde_json::to_string(&Response {
-                    data: Some(Value::default()),
-                    ..Response::default()
-                })
-                .expect("always valid")
-                .into(),
-            )
-            .unwrap())
-    }
-
-    // XXX(@goto-bus-stop): ideally this server would *only* support HTTP 2 and not HTTP 1
-    serve(listener, handle).await.unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_subgraph_h2c() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let socket_addr = listener.local_addr().unwrap();
-    tokio::task::spawn(emulate_h2c_server(listener));
-    let subgraph_service = HttpClientService::new(
-        "test",
-        rustls::ClientConfig::builder()
-            .with_native_roots()
-            .expect("read native TLS root certificates")
-            .with_no_client_auth(),
-        crate::configuration::shared::Client::builder()
-            .experimental_http2(Http2Config::Http2Only)
-            .build(),
-    )
-    .expect("can create a HttpService");
-
-    let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
-    let response = subgraph_service
-        .oneshot(HttpRequest {
-            http_request: http::Request::builder()
-                .uri(url)
-                .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
-                .body(router::body::from_bytes(
-                    r#"{"query":"{ me { name username } }"#,
-                ))
-                .unwrap(),
-            context: Context::new(),
-        })
-        .await
-        .unwrap();
-    assert_eq!(
-        std::str::from_utf8(
-            &router::body::into_bytes(response.http_response.into_parts().1)
-                .await
-                .unwrap()
-        )
-        .unwrap(),
-        r#"{"data":null}"#
-    );
-}
-
 // starts a local server emulating a subgraph returning compressed response
 async fn emulate_subgraph_compressed_response(listener: TcpListener) {
     async fn handle(request: http::Request<Body>) -> Result<http::Response<Body>, Infallible> {
@@ -1266,7 +1014,7 @@ async fn test_compressed_request_response_body() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let socket_addr = listener.local_addr().unwrap();
     tokio::task::spawn(emulate_subgraph_compressed_response(listener));
-    let subgraph_service = HttpClientService::new(
+    let subgraph_service = HttpClientService::test_new(
         "test",
         rustls::ClientConfig::builder()
             .with_native_roots()

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -610,6 +610,7 @@ async fn tls_client_auth() {
     )
     .unwrap();
 
+<<<<<<< HEAD
     let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
     let response = subgraph_service
         .oneshot(HttpRequest {
@@ -627,6 +628,454 @@ async fn tls_client_auth() {
     assert_eq!(
         std::str::from_utf8(
             &router::body::into_bytes(response.http_response.into_parts().1)
+=======
+#[cfg(unix)]
+#[derive(Debug, Clone)]
+enum ExpectedVersion {
+    Http2,
+    Http11,
+    Any,
+}
+
+#[cfg(unix)]
+impl ExpectedVersion {
+    fn check(&self, tracker: &HttpVersionTracker) {
+        let got = tracker.get();
+        match self {
+            ExpectedVersion::Http2 => assert!(
+                got == Some(Version::HTTP_2),
+                "expected HTTP/2, got: {got:?}"
+            ),
+            ExpectedVersion::Http11 => assert!(
+                got == Some(Version::HTTP_11),
+                "expected HTTP/1.1, got: {got:?}"
+            ),
+            ExpectedVersion::Any => assert!(got.is_some(), "expected a version to be captured"),
+        }
+    }
+}
+
+mod tls {
+    // Note: The TLS tests rely on checked-in certificates valid until Oct 7 2033.
+    // If tests fail after that date, regenerate in the testdata directory:
+    //   openssl x509 -req -in server_self_signed.csr -signkey server.key \
+    //     -out server_self_signed.crt -extfile server.ext -days 3650
+    use super::*;
+
+    #[rstest]
+    #[case::subgraph(ServiceKind::Subgraph)]
+    #[case::connector(ServiceKind::Connector)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tls_self_signed(#[case] kind: ServiceKind) {
+        let certificate_pem = include_str!("./testdata/server_self_signed.crt");
+        let key_pem = include_str!("./testdata/server.key");
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let socket_addr = listener.local_addr().unwrap();
+        let negotiated_protocol = NegotiatedProtocolTracker::new();
+
+        tokio::task::spawn(tls_server(
+            listener,
+            load_certs(certificate_pem).unwrap(),
+            load_key(key_pem).unwrap(),
+            r#"{"data": null}"#,
+            negotiated_protocol.clone(),
+            vec![alpn::H2.to_vec(), alpn::HTTP_1_1.to_vec()],
+        ));
+
+        let mut config = Configuration::default();
+        insert_tls_config(
+            &mut config,
+            kind,
+            TlsClient {
+                certificate_authorities: Some(certificate_pem.into()),
+                client_authentication: None,
+            },
+        );
+        let service = make_service(kind, &config, Default::default());
+
+        let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
+        let response = send_request(service, url, r#"{"query":"{ test }"}"#).await;
+        assert_response_body(response, r#"{"data": null}"#).await;
+    }
+
+    #[rstest]
+    #[case::subgraph(ServiceKind::Subgraph)]
+    #[case::connector(ServiceKind::Connector)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tls_custom_root(#[case] kind: ServiceKind) {
+        let certificate_pem = include_str!("./testdata/server.crt");
+        let ca_pem = include_str!("./testdata/CA/ca.crt");
+        let key_pem = include_str!("./testdata/server.key");
+
+        let mut certificates = load_certs(certificate_pem).unwrap();
+        certificates.extend(load_certs(ca_pem).unwrap());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let socket_addr = listener.local_addr().unwrap();
+        let negotiated_protocol = NegotiatedProtocolTracker::new();
+
+        tokio::task::spawn(tls_server(
+            listener,
+            certificates,
+            load_key(key_pem).unwrap(),
+            r#"{"data": null}"#,
+            negotiated_protocol.clone(),
+            vec![alpn::H2.to_vec(), alpn::HTTP_1_1.to_vec()],
+        ));
+
+        let mut config = Configuration::default();
+        insert_tls_config(
+            &mut config,
+            kind,
+            TlsClient {
+                certificate_authorities: Some(ca_pem.into()),
+                client_authentication: None,
+            },
+        );
+        let service = make_service(kind, &config, Default::default());
+
+        let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
+        let response = send_request(service, url, r#"{"query":"{ test }"}"#).await;
+        assert_response_body(response, r#"{"data": null}"#).await;
+    }
+
+    #[rstest]
+    #[case::subgraph(ServiceKind::Subgraph)]
+    #[case::connector(ServiceKind::Connector)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tls_client_auth(#[case] kind: ServiceKind) {
+        let server_certificate_pem = include_str!("./testdata/server.crt");
+        let ca_pem = include_str!("./testdata/CA/ca.crt");
+        let server_key_pem = include_str!("./testdata/server.key");
+
+        let mut server_certificates = load_certs(server_certificate_pem).unwrap();
+        let ca_certificate = load_certs(ca_pem).unwrap().remove(0);
+        server_certificates.push(ca_certificate.clone());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let socket_addr = listener.local_addr().unwrap();
+
+        tokio::task::spawn(tls_server_with_client_auth(
+            listener,
+            server_certificates,
+            load_key(server_key_pem).unwrap(),
+            ca_certificate,
+            r#"{"data": null}"#,
+        ));
+
+        let client_certificate_pem = include_str!("./testdata/client.crt");
+        let client_key_pem = include_str!("./testdata/client.key");
+
+        let mut config = Configuration::default();
+        insert_tls_config(
+            &mut config,
+            kind,
+            TlsClient {
+                certificate_authorities: Some(ca_pem.into()),
+                client_authentication: Some(Arc::new(TlsClientAuth {
+                    certificate_chain: load_certs(client_certificate_pem).unwrap(),
+                    key: load_key(client_key_pem).unwrap(),
+                })),
+            },
+        );
+        let service = make_service(kind, &config, Default::default());
+
+        let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
+        let response = send_request(service, url, r#"{"query":"{ test }"}"#).await;
+        assert_response_body(response, r#"{"data": null}"#).await;
+    }
+}
+
+mod h2c_cleartext {
+    use super::*;
+    use crate::configuration::shared::Client;
+
+    // Starts a local server that responds with a default GraphQL response over plain HTTP.
+    async fn emulate_h2c_server(listener: TcpListener) {
+        async fn handle(request: http::Request<Body>) -> Result<http::Response<Body>, Infallible> {
+            let response_builder =
+                http::Response::builder().header(CONTENT_TYPE, APPLICATION_JSON.essence_str());
+
+            let response = match request.version() {
+                Version::HTTP_2 => {
+                    let response_body = serde_json::to_string(&Response {
+                        data: Some(Value::default()),
+                        ..Response::default()
+                    });
+                    response_builder
+                        .status(StatusCode::OK)
+                        .body(response_body.unwrap().into())
+                }
+                Version::HTTP_11 => response_builder
+                    .status(StatusCode::HTTP_VERSION_NOT_SUPPORTED)
+                    .body(Body::empty()),
+                version => panic!("unexpected version {version:?}"),
+            };
+
+            Ok(response.unwrap())
+        }
+
+        serve(listener, handle).await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_subgraph_h2c_works_with_http2only() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let socket_addr = listener.local_addr().unwrap();
+        tokio::task::spawn(emulate_h2c_server(listener));
+
+        let client_config = Client::builder()
+            .experimental_http2(Http2Config::Http2Only)
+            .build();
+        let subgraph_service =
+            HttpClientService::from_client_config(client_config).expect("can create a HttpService");
+
+        let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
+        let response = send_request(
+            subgraph_service,
+            url,
+            r#"{"query":"{ me { name username } }"#,
+        )
+        .await;
+
+        assert_response_body(response, r#"{"data":null}"#).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_subgraph_h2c_not_used_with_enable() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let socket_addr = listener.local_addr().unwrap();
+        tokio::task::spawn(emulate_h2c_server(listener));
+
+        let client_config = Client::builder()
+            .experimental_http2(Http2Config::Enable)
+            .build();
+        let subgraph_service =
+            HttpClientService::from_client_config(client_config).expect("can create a HttpService");
+
+        let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
+        let response = send_request(
+            subgraph_service,
+            url,
+            r#"{"query":"{ me { name username } }"#,
+        )
+        .await;
+
+        // h2c only works with `Http2Config::Http2Only` - hyper only supports HTTP/2 with TLS or
+        // with 'prior knowledge'
+        // https://github.com/hyperium/hyper/issues/2411
+        assert_eq!(
+            response.http_response.status(),
+            StatusCode::HTTP_VERSION_NOT_SUPPORTED
+        );
+    }
+}
+
+mod h2c_keep_alive {
+    use std::pin::Pin;
+    use std::task::Context;
+    use std::task::Poll;
+    use std::time::Duration;
+
+    use tokio::io::AsyncRead;
+    use tokio::io::AsyncWrite;
+    use tokio::io::ReadBuf;
+    use tokio::net::TcpStream;
+    use tokio::sync::mpsc::Sender;
+    use tokio::task::JoinHandle;
+
+    use super::*;
+    use crate::configuration::shared::Client;
+
+    /// Wraps a TcpStream and emits a `()` on the `ping_tx` channel each time the server reads an H2
+    /// PING frame sent by the client.
+    struct SpyStream {
+        inner: TcpStream,
+        ping_tx: Sender<()>,
+    }
+
+    impl SpyStream {
+        fn new(stream: TcpStream, ping_tx: Sender<()>) -> Self {
+            Self {
+                inner: stream,
+                ping_tx,
+            }
+        }
+    }
+
+    impl AsyncRead for SpyStream {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            let before = buf.filled().len();
+
+            let result = Pin::new(&mut self.inner).poll_read(cx, buf);
+            if matches!(result, Poll::Ready(Ok(()))) {
+                let new_bytes = buf.filled()[before..].to_vec();
+                if is_ping_frame(&new_bytes) {
+                    self.ping_tx.try_send(()).unwrap();
+                }
+            }
+
+            result
+        }
+    }
+
+    impl AsyncWrite for SpyStream {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Pin::new(&mut self.inner).poll_write(cx, buf)
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.inner).poll_flush(cx)
+        }
+
+        fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.inner).poll_shutdown(cx)
+        }
+    }
+
+    /// Check whether a raw byte slice is an H2 PING frame (not an ACK) per RFC 7540.
+    ///
+    /// This assumes the PING frame arrives as its own chunk — it inspects fixed offsets 3 and 4
+    /// for the frame type and flags rather than doing full frame parsing. In practice this works
+    /// because hyper sends keep-alive PINGs as standalone writes.
+    ///
+    /// References: [frame header] (§4.1), [PING frame] (§6.7)
+    ///
+    /// [frame header]: https://datatracker.ietf.org/doc/html/rfc7540#section-4.1
+    /// [PING frame]: https://datatracker.ietf.org/doc/html/rfc7540#section-6.7
+    fn is_ping_frame(data: &[u8]) -> bool {
+        const FRAME_HEADER_SIZE: usize = 9;
+        const PING_FRAME_TYPE: u8 = 0x06;
+        const ACK_FLAG: u8 = 0x01;
+
+        if data.len() < FRAME_HEADER_SIZE {
+            return false;
+        }
+
+        let frame_type = data[3];
+        let flags = data[4];
+
+        frame_type == PING_FRAME_TYPE && flags & ACK_FLAG == 0
+    }
+
+    /// Start a spy H2 server that counts H2 PING frames sent by the client. Returns a
+    /// [`JoinHandle`] that resolves to the total ping count once the server connection closes.
+    fn start_spy_server_and_ping_counter(listener: TcpListener) -> JoinHandle<usize> {
+        let (ping_tx, mut ping_rx) = tokio::sync::mpsc::channel(100);
+
+        let _spy_server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let spy_stream = SpyStream::new(stream, ping_tx);
+
+            let svc = hyper::service::service_fn(|_request: Request<Incoming>| async {
+                let response_body = serde_json::to_string(&Response {
+                    data: Some(Value::default()),
+                    ..Response::default()
+                })
+                .unwrap();
+                Ok::<_, Infallible>(
+                    http::Response::builder()
+                        .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                        .status(StatusCode::OK)
+                        .body(Body::from(response_body))
+                        .unwrap(),
+                )
+            });
+
+            // serve_connection drives the h2 connection, including automatic PING ACKs
+            let _ = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+                .serve_connection(TokioIo::new(spy_stream), svc)
+                .await;
+        });
+
+        tokio::spawn(async move {
+            let mut ping_count = 0;
+            while let Some(()) = ping_rx.recv().await {
+                ping_count += 1;
+            }
+            ping_count
+        })
+    }
+
+    /// Start a spy server, make one request with the given client config, wait for keep-alive
+    /// intervals to fire, then return the number of H2 PING frames the server observed.
+    async fn run_server_and_count_keep_alive_pings(
+        client_config: Client,
+    ) -> Result<usize, BoxError> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let socket_addr = listener.local_addr()?;
+
+        let ping_counter = start_spy_server_and_ping_counter(listener);
+        let service = HttpClientService::from_client_config(client_config)?;
+
+        let url = Uri::from_str(&format!("http://{socket_addr}"))?;
+        let request = HttpRequest {
+            http_request: Request::builder()
+                .uri(url)
+                .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                .body(router::body::from_bytes(r#"{"query":"{ me }"}"#))?,
+            context: crate::Context::new(),
+        };
+
+        // Clone so the service (and its connection pool) stays alive after the request
+        service.clone().oneshot(request).await?;
+
+        // Wait for several keep-alive intervals while the connection sits idle in the pool
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        drop(service);
+
+        Ok(ping_counter.await?)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_keep_alive_pings_are_sent() {
+        let client_config = Client::builder()
+            .experimental_http2(Http2Config::Http2Only)
+            .experimental_http2_keep_alive_interval(Duration::from_millis(50))
+            .build();
+
+        let ping_count = run_server_and_count_keep_alive_pings(client_config)
+            .await
+            .unwrap();
+        assert!(
+            ping_count > 0,
+            "expected at least one H2 PING frame from the client, got {ping_count}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_no_pings_without_keep_alive() {
+        let client_config = Client::builder()
+            .experimental_http2(Http2Config::Http2Only)
+            // no keep-alive interval configured
+            .build();
+
+        let ping_count = run_server_and_count_keep_alive_pings(client_config)
+            .await
+            .unwrap();
+        assert_eq!(
+            ping_count, 0,
+            "expected no H2 PING frames when keep-alive is not configured"
+        );
+    }
+}
+
+mod compressed_req_res {
+    use super::*;
+
+    async fn emulate_subgraph_compressed_response(listener: TcpListener) {
+        async fn handle(request: http::Request<Body>) -> Result<http::Response<Body>, Infallible> {
+            let body = router::body::into_bytes(request.into_body())
+>>>>>>> 1f06b0f7 (feat: support HTTP/2 keep-alive (#9056))
                 .await
                 .unwrap()
         )

--- a/apollo-router/src/test_harness/http_snapshot.rs
+++ b/apollo-router/src/test_harness/http_snapshot.rs
@@ -503,7 +503,7 @@ impl SnapshotServer {
             }
         };
 
-        let http_service = HttpClientService::new(
+        let http_service = HttpClientService::test_new(
             "test",
             rustls::ClientConfig::builder()
                 .with_native_roots()

--- a/apollo-router/src/test_harness/http_snapshot.rs
+++ b/apollo-router/src/test_harness/http_snapshot.rs
@@ -503,7 +503,7 @@ impl SnapshotServer {
             }
         };
 
-        let http_service = HttpClientService::test_new(
+        let http_service = HttpClientService::new(
             "test",
             rustls::ClientConfig::builder()
                 .with_native_roots()

--- a/docs/shared/config/traffic_shaping.mdx
+++ b/docs/shared/config/traffic_shaping.mdx
@@ -7,6 +7,8 @@ traffic_shaping:
     deduplicate_query: false
     dns_resolution_strategy: ipv4_only
     experimental_http2: enable
+    experimental_http2_keep_alive_interval: null
+    experimental_http2_keep_alive_timeout: null
     global_rate_limit:
       capacity: 1
       interval: 30s
@@ -16,6 +18,8 @@ traffic_shaping:
       compression: gzip
       dns_resolution_strategy: ipv4_only
       experimental_http2: enable
+      experimental_http2_keep_alive_interval: null
+      experimental_http2_keep_alive_timeout: null
       global_rate_limit:
         capacity: 1
         interval: 30s

--- a/docs/shared/router-config-properties-table.mdx
+++ b/docs/shared/router-config-properties-table.mdx
@@ -1490,6 +1490,8 @@ traffic_shaping:
     deduplicate_query: false
     dns_resolution_strategy: ipv4_only
     experimental_http2: enable
+    experimental_http2_keep_alive_interval: null
+    experimental_http2_keep_alive_timeout: null
     global_rate_limit:
       capacity: 1
       interval: 30s
@@ -1499,6 +1501,8 @@ traffic_shaping:
       compression: gzip
       dns_resolution_strategy: ipv4_only
       experimental_http2: enable
+      experimental_http2_keep_alive_interval: null
+      experimental_http2_keep_alive_timeout: null
       global_rate_limit:
         capacity: 1
         interval: 30s

--- a/docs/source/routing/performance/traffic-shaping.mdx
+++ b/docs/source/routing/performance/traffic-shaping.mdx
@@ -211,6 +211,27 @@ traffic_shaping:
 
 <HttpConnection type="subgraph" />
 
+#### HTTP/2 keep-alive
+
+Router can send periodic HTTP/2 PING frames on idle subgraph connections to detect and close stale connections before they cause request failures. This is particularly useful when connections can become silently broken (for example, due to network timeouts or load balancer idle timeouts).
+
+Use `experimental_http2_keep_alive_interval` to enable keep-alive pings. When you set this, the router sends a PING frame after a connection has been idle for the specified duration. If your subgraph does not respond within `experimental_http2_keep_alive_timeout` (default: 20 seconds), the connection is closed.
+
+Both options apply under `all`, per-subgraph under `subgraphs`, and per-source under `connector.sources`.
+
+```yaml title="router.yaml"
+traffic_shaping:
+  all:
+    experimental_http2_keep_alive_interval: 30s # Send a PING every 30s on idle connections
+    experimental_http2_keep_alive_timeout: 10s  # Close the connection if no PONG within 10s
+```
+
+<Note>
+
+Keep-alive pings require HTTP/2 to be active. Setting `experimental_http2: disable` will prevent pings from being sent regardless of these settings.
+
+</Note>
+
 ### Ordering
 
 Traffic shaping always executes these steps in the same order, to ensure a consistent behavior. Declaration order in the configuration will not affect the runtime order:


### PR DESCRIPTION
This PR adds a configurable HTTP/2 keep-alive for subgraph and connector connections. Enabling keep-alive causes the router to detect and close dead connections proactively, freeing their connection pool permits.

It adds two new traffic_shaping configuration options for controlling HTTP/2 keep-alive pings on subgraph and connector connections:
* `experimental_http2_keep_alive_interval`: how often to send a PING frame on an idle connection (disabled by default)
* `experimental_http2_keep_alive_timeout`: how long to wait for a PONG before treating the connection as dead (default: 20s, matching hyper's default)

Both options are available under all, per-subgraph, and per-connector-source, with the same merge/fallback behavior as other traffic shaping settings.

#### Implementation notes:
* Keep-alive pings require `http2_keep_alive_while_idle(true)` and a timer to be set on the hyper client builder — without these, pings are never sent on idle connections. Both are configured automatically when the interval is set.
* The behavior is verified with a spy stream test that counts raw H2 PING frames (type 0x06, no ACK flag) received by the server.




---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1659]: https://apollographql.atlassian.net/browse/ROUTER-1659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ<hr>This is an automatic backport of pull request #9056 done by [Mergify](https://mergify.com).