### PR TITLE
fix(traffic_shaping): use lazy pool eviction to avoid inter-request TCP closes (backport #9308)

### DIFF
--- a/.changesets/feat_caroline_rh1334_pool_idle_eviction_mode.md
+++ b/.changesets/feat_caroline_rh1334_pool_idle_eviction_mode.md
@@ -1,0 +1,7 @@
+### Fix connection pool to use lazy idle eviction ([PR #9308](https://github.com/apollographql/router/pull/9308))
+
+When `pool_idle_timeout` was introduced in v2.13.0, the router unconditionally enabled a background timer that proactively closed idle connections exceeding the timeout. In some network environments, the TCP close sent by this background task raced with a new connection attempt and caused significant latency spikes on the next request.
+
+The router now uses lazy eviction: connections are only closed at checkout time, when a request finds a pooled connection that has exceeded `pool_idle_timeout`. No TCP closes are sent between requests. This matches router behavior before v2.13.0.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9308

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -101,6 +101,110 @@ pub(crate) struct HttpClientService {
 }
 
 impl HttpClientService {
+<<<<<<< HEAD
+=======
+    /// Test-wrapper for HttpClientService::new()
+    ///
+    /// NOTE: this separation is primarily to keep us from exposing `new()`
+    /// when we don't need to
+    #[cfg_attr(test, allow(unreachable_pub))]
+    pub(crate) fn test_new(
+        service: impl Into<String>,
+        tls_config: ClientConfig,
+        client_config: crate::configuration::shared::Client,
+    ) -> Result<Self, BoxError> {
+        Self::new(service, tls_config, client_config)
+    }
+
+    /// Create a new HttpClientService using:
+    ///
+    /// - the service's name (eg, connector name, hardcoded "coprocessor", or the subgraph's name) for
+    ///   use in errors and potentially signing requests
+    /// - the tls config to be used in setting tls; though, this is actually rustls's and hyper
+    ///   figuring out which parts of a broader config to use for tls
+    /// - the client's config, which is _our_ set of options from the router config for use in
+    ///   enabling/disabling features like http/2
+    fn new(
+        service: impl Into<String>,
+        tls_config: ClientConfig,
+        client_config: crate::configuration::shared::Client,
+    ) -> Result<Self, BoxError> {
+        let mut http_connector =
+            new_async_http_connector(client_config.dns_resolution_strategy.unwrap_or_default())?;
+        http_connector.set_nodelay(true);
+        http_connector.set_keepalive(Some(std::time::Duration::from_secs(60)));
+        http_connector.enforce_http(false);
+
+        let builder = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http();
+
+        let pool_idle_timeout = client_config.pool_idle_timeout;
+        let http2_keep_alive_interval = client_config.experimental_http2_keep_alive_interval;
+        let http2_keep_alive_timeout = client_config
+            .experimental_http2_keep_alive_timeout
+            .unwrap_or(DEFAULT_HTTP2_KEEP_ALIVE_TIMEOUT);
+
+        let http2 = client_config.experimental_http2.unwrap_or_default();
+        let connector = match http2 {
+            Http2Config::Enable => builder
+                .enable_http1()
+                .enable_http2()
+                .wrap_connector(http_connector),
+            Http2Config::Disable => builder.enable_http1().wrap_connector(http_connector),
+            Http2Config::Http2Only => builder.enable_http2().wrap_connector(http_connector),
+        };
+
+        let mut client_builder =
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new());
+        // NOTE: pool_timer is intentionally not set. pool_timer enables a background task that
+        // proactively closes idle connections when they exceed pool_idle_timeout. Without it,
+        // eviction is lazy: connections are checked and dropped at checkout time only. Lazy
+        // eviction avoids a TCP close window that can delay new connections in some network
+        // environments.
+        client_builder
+            .pool_idle_timeout(pool_idle_timeout)
+            .http2_only(http2 == Http2Config::Http2Only);
+        if let Some(interval) = http2_keep_alive_interval {
+            client_builder
+                // WARN: http2 keep-alive requires a timer; don't remove this
+                .timer(TokioTimer::new())
+                .http2_keep_alive_interval(Some(interval))
+                .http2_keep_alive_timeout(http2_keep_alive_timeout)
+                // Send pings even when the connection is idle in the pool, so stale
+                // connections are detected before a request is made on them
+                .http2_keep_alive_while_idle(true);
+        }
+        let http_client = client_builder.build(connector);
+
+        #[cfg(unix)]
+        let unix_client = {
+            // NOTE: pool_timer is intentionally not set; see comment on client_builder above.
+            let unix_client_inner =
+                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                    .pool_idle_timeout(pool_idle_timeout)
+                    .http2_only(http2 == Http2Config::Http2Only)
+                    .build(UnixConnector);
+
+            ServiceBuilder::new()
+                .layer(DecompressionLayer::new())
+                .layer(WireBodySizeLayer)
+                .service(unix_client_inner)
+        };
+
+        Ok(Self {
+            http_client: ServiceBuilder::new()
+                .layer(DecompressionLayer::new())
+                .layer(WireBodySizeLayer)
+                .service(http_client),
+            #[cfg(unix)]
+            unix_client,
+            service: Arc::new(service.into()),
+        })
+    }
+
+    /// Creates a client for talking to subgraphs
+>>>>>>> d13285eb (fix(traffic_shaping): use lazy pool eviction to avoid inter-request TCP closes (#9308))
     pub(crate) fn from_config_for_subgraph(
         service: impl Into<String>,
         configuration: &Configuration,

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -1087,8 +1087,40 @@ async fn test_alpn_falls_back_to_http1_when_server_only_supports_http1() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let socket_addr = listener.local_addr().unwrap();
 
+<<<<<<< HEAD
     let negotiated_protocol = NegotiatedProtocolTracker::new();
     let negotiated_clone = negotiated_protocol.clone();
+=======
+    /// Server that counts how many TCP connections are accepted and how many are currently open.
+    async fn serve_counting(
+        listener: TcpListener,
+        connection_count: Arc<AtomicUsize>,
+        live_connection_count: Arc<AtomicUsize>,
+    ) -> std::io::Result<()> {
+        loop {
+            let (stream, _) = listener.accept().await?;
+            connection_count.fetch_add(1, Ordering::SeqCst);
+            live_connection_count.fetch_add(1, Ordering::SeqCst);
+            let io = TokioIo::new(stream);
+            let live = live_connection_count.clone();
+            tokio::spawn(async move {
+                let svc = hyper::service::service_fn(|_request: Request<Incoming>| async {
+                    Ok::<_, Infallible>(
+                        http::Response::builder()
+                            .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                            .status(StatusCode::OK)
+                            .body::<Body>(r#"{"data":null}"#.into())
+                            .unwrap(),
+                    )
+                });
+                let _ = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+                    .serve_connection_with_upgrades(io, svc)
+                    .await;
+                live.fetch_sub(1, Ordering::SeqCst);
+            });
+        }
+    }
+>>>>>>> d13285eb (fix(traffic_shaping): use lazy pool eviction to avoid inter-request TCP closes (#9308))
 
     tokio::task::spawn(tls_server(
         listener,
@@ -1109,6 +1141,7 @@ async fn test_alpn_falls_back_to_http1_when_server_only_supports_http1() {
         },
     );
 
+<<<<<<< HEAD
     let subgraph_service = HttpClientService::from_config_for_subgraph(
         "test",
         &config,
@@ -1119,6 +1152,13 @@ async fn test_alpn_falls_back_to_http1_when_server_only_supports_http1() {
             .build(),
     )
     .unwrap();
+=======
+        tokio::task::spawn(serve_counting(
+            listener,
+            connection_count.clone(),
+            Arc::new(AtomicUsize::new(0)),
+        ));
+>>>>>>> d13285eb (fix(traffic_shaping): use lazy pool eviction to avoid inter-request TCP closes (#9308))
 
     let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
     let response = subgraph_service
@@ -1141,11 +1181,75 @@ async fn test_alpn_falls_back_to_http1_when_server_only_supports_http1() {
 
     assert_eq!(response.http_response.status(), StatusCode::OK);
 
+<<<<<<< HEAD
     let body_bytes = router::body::into_bytes(response.http_response.into_parts().1)
         .await
         .unwrap();
     let body = std::str::from_utf8(&body_bytes).unwrap();
     assert_eq!(body, r#"{"data": null}"#);
+=======
+        tokio::time::sleep(sleep_between).await;
+
+        tower::ServiceExt::ready(&mut service).await.unwrap();
+        let response = send_request(service, url, r#"{"query":"{ b }"}"#).await;
+        assert_eq!(response.http_response.status(), StatusCode::OK);
+        assert_eq!(
+            connection_count.load(Ordering::SeqCst),
+            expected_connections,
+            "expected {expected_connections} total TCP connections for timeout {timeout:?} with {sleep_between:?} sleep"
+        );
+    }
+
+    /// Regression test: the router does not proactively close idle connections between requests.
+    /// Before this fix, `pool_timer` was unconditionally set, enabling a background eviction task
+    /// that sent TCP closes between requests and caused latency spikes in some network environments.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_idle_connections_not_proactively_closed() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let socket_addr = listener.local_addr().unwrap();
+        let live_connection_count = Arc::new(AtomicUsize::new(0));
+
+        tokio::task::spawn(serve_counting(
+            listener,
+            Arc::new(AtomicUsize::new(0)),
+            live_connection_count.clone(),
+        ));
+
+        let client_config = crate::configuration::shared::Client {
+            pool_idle_timeout: Some(Duration::from_millis(50)),
+            ..Default::default()
+        };
+        let service = HttpClientService::test_new(
+            "test",
+            rustls::ClientConfig::builder()
+                .with_native_roots()
+                .expect("read native TLS root certificates")
+                .with_no_client_auth(),
+            client_config,
+        )
+        .expect("can create HttpClientService");
+
+        let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
+
+        let response = send_request(service.clone(), url.clone(), r#"{"query":"{ a }"}"#).await;
+        assert_eq!(response.http_response.status(), StatusCode::OK);
+        assert_eq!(
+            live_connection_count.load(Ordering::SeqCst),
+            1,
+            "connection is open after first request"
+        );
+
+        // Sleep well past the 50ms idle timeout. Without pool_timer, no background task fires,
+        // so the connection must still be open in the pool.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        assert_eq!(
+            live_connection_count.load(Ordering::SeqCst),
+            1,
+            "connection must not be proactively closed between requests"
+        );
+    }
+>>>>>>> d13285eb (fix(traffic_shaping): use lazy pool eviction to avoid inter-request TCP closes (#9308))
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/docs/source/routing/customization/coprocessor/index.mdx
+++ b/docs/source/routing/customization/coprocessor/index.mdx
@@ -201,6 +201,19 @@ coprocessor:
     experimental_http2: http2only
 ```
 
+#### Connection pool
+
+The router maintains a pool of connections to your coprocessor. Use `pool_idle_timeout` to set how long an idle connection stays in the pool before it's eligible for eviction. The default is 15 seconds. Set it to `null` to disable idle eviction entirely.
+
+Expired connections are evicted lazily: when the router fetches a connection from the pool to make a request, it discards any connection that has been idle longer than `pool_idle_timeout` and opens a fresh one.
+
+```yaml title="router.yaml"
+coprocessor:
+  url: http://service.example.com
+  client:
+    pool_idle_timeout: 30s  # default: 15s; set to null to disable
+```
+
 ## Coprocessor request format
 
 The router communicates with your coprocessor via HTTP POST requests (called **coprocessor requests**). The body of each coprocessor request is a JSON object with properties that describe either the current client request or the current router response.

--- a/docs/source/routing/performance/traffic-shaping.mdx
+++ b/docs/source/routing/performance/traffic-shaping.mdx
@@ -211,6 +211,44 @@ traffic_shaping:
 
 <HttpConnection type="subgraph" />
 
+<<<<<<< HEAD
+=======
+#### HTTP/2 keep-alive
+
+Router can send periodic HTTP/2 PING frames on idle subgraph connections to detect and close stale connections before they cause request failures. This is particularly useful when connections can become silently broken (for example, due to network timeouts or load balancer idle timeouts).
+
+Use `experimental_http2_keep_alive_interval` to enable keep-alive pings. When you set this, the router sends a PING frame after a connection has been idle for the specified duration. If your subgraph does not respond within `experimental_http2_keep_alive_timeout` (default: 20 seconds), the connection is closed.
+
+Both options apply under `all`, per-subgraph under `subgraphs`, and per-source under `connector.sources`.
+
+```yaml title="router.yaml"
+traffic_shaping:
+  all:
+    experimental_http2_keep_alive_interval: 30s # Send a PING every 30s on idle connections
+    experimental_http2_keep_alive_timeout: 10s  # Close the connection if no PONG within 10s
+```
+
+<Note>
+
+Keep-alive pings require HTTP/2 to be active. Setting `experimental_http2: disable` will prevent pings from being sent regardless of these settings.
+
+</Note>
+
+### Connection pool
+
+The router maintains a pool of connections to each subgraph. Use `pool_idle_timeout` to set how long an idle connection stays in the pool before it's eligible for eviction. The default is 15 seconds. Set it to `null` to disable idle eviction entirely.
+
+Expired connections are evicted lazily: when the router fetches a connection from the pool to make a request, it discards any connection that has been idle longer than `pool_idle_timeout` and opens a fresh one.
+
+```yaml title="router.yaml"
+traffic_shaping:
+  all:
+    pool_idle_timeout: 30s  # default: 15s; set to null to disable
+```
+
+This option applies under `all`, per-subgraph under `subgraphs`, and per-source under `connector.sources`.
+
+>>>>>>> d13285eb (fix(traffic_shaping): use lazy pool eviction to avoid inter-request TCP closes (#9308))
 ### Ordering
 
 Traffic shaping always executes these steps in the same order, to ensure a consistent behavior. Declaration order in the configuration will not affect the runtime order:


### PR DESCRIPTION
## Summary

Removes the unconditional `pool_timer` from the hyper client builder, switching the connection pool to lazy eviction.

**Background:** When `pool_idle_timeout` was made configurable in v2.13.0, the router unconditionally set `pool_timer` on the hyper client, enabling a background task that proactively closed idle connections when they exceeded the timeout. In some network environments, the TCP close sent by this background task raced with a new outgoing connection attempt and caused significant latency spikes on the next request.

**Fix:** Remove `pool_timer`. The pool now uses lazy eviction: connections are checked and dropped at checkout time only, when a request finds a pooled connection that has exceeded `pool_idle_timeout`. This matches router behavior before v2.13.0.

## Reviewer notes

- `pool_timer` is removed from both the HTTP and unix client builders. A comment on each explains why it's absent.
- The `test_idle_connections_not_proactively_closed` regression test verifies this behavior: after sleeping well past the idle timeout, the server-side `live_connection_count` must still be 1 (connection was not proactively closed).

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible
- [x] Documentation completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added and documented
- Tests added and passing
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

No metrics added (connection pool policy change). No integration tests added (unit test covers the behavioral regression directly).<hr>This is an automatic backport of pull request #9308 done by [Mergify](https://mergify.com).