### PR TITLE
fix(composition): preserve default value literals without expansion

### DIFF
--- a/apollo-federation/src/compat.rs
+++ b/apollo-federation/src/compat.rs
@@ -147,28 +147,48 @@ pub(crate) fn remove_non_semantic_directives(schema: &mut Schema) {
 // Just a boolean with a `?` operator
 type CoerceResult = Result<(), ()>;
 
-/// Recursively assign default values in input object values, mutating the value.
+#[derive(Clone, Copy)]
+enum DefaultValueBehavior {
+    /// Inject missing input object fields from their type-level defaults.
+    /// Correct for executable document coercion at runtime.
+    Expand,
+    /// Preserve the literal as written — only check validity.
+    /// Correct for schema-level default values in composition output.
+    Check,
+}
+
+/// Recursively coerce input object values, mutating the value.
 /// If the default value is invalid, returns `Err(())`.
 fn coerce_value(
     types: &IndexMap<Name, ExtendedType>,
     target: &mut Node<Value>,
     ty: &Type,
+    default_value_behavior: DefaultValueBehavior,
 ) -> CoerceResult {
     match (target.make_mut(), types.get(ty.inner_named_type())) {
         (Value::Object(object), Some(ExtendedType::InputObject(definition))) if ty.is_named() => {
             for (field_name, field_definition) in definition.fields.iter() {
                 match object.iter_mut().find(|(key, _value)| key == field_name) {
                     Some((_name, value)) => {
-                        coerce_value(types, value, &field_definition.ty)?;
+                        coerce_value(types, value, &field_definition.ty, default_value_behavior)?;
                     }
                     None => {
-                        if let Some(default_value) = &field_definition.default_value {
-                            let mut value = default_value.clone();
-                            // If the default value is an input object we may need to fill in
-                            // its defaulted fields recursively.
-                            coerce_value(types, &mut value, &field_definition.ty)?;
-                            object.push((field_name.clone(), value));
-                        } else if field_definition.is_required() {
+                        if matches!(default_value_behavior, DefaultValueBehavior::Expand) {
+                            if let Some(default_value) = &field_definition.default_value {
+                                let mut value = default_value.clone();
+                                coerce_value(
+                                    types,
+                                    &mut value,
+                                    &field_definition.ty,
+                                    DefaultValueBehavior::Expand,
+                                )?;
+                                object.push((field_name.clone(), value));
+                            } else if field_definition.is_required() {
+                                return Err(());
+                            }
+                        } else if field_definition.default_value.is_none()
+                            && field_definition.is_required()
+                        {
                             return Err(());
                         }
                     }
@@ -177,7 +197,7 @@ fn coerce_value(
         }
         (Value::List(list), Some(_)) if ty.is_list() => {
             for element in list {
-                coerce_value(types, element, ty.item_type())?;
+                coerce_value(types, element, ty.item_type(), default_value_behavior)?;
             }
         }
         // Coerce single values (except null) to a list.
@@ -190,7 +210,7 @@ fn coerce_value(
             | Value::Boolean(_),
             Some(_),
         ) if ty.is_list() => {
-            coerce_value(types, target, ty.item_type())?;
+            coerce_value(types, target, ty.item_type(), default_value_behavior)?;
             *target.make_mut() = Value::List(vec![target.clone()]);
         }
 
@@ -241,7 +261,7 @@ fn coerce_arguments_default_values(
             continue;
         };
 
-        if coerce_value(types, default_value, &arg.ty).is_err() {
+        if coerce_value(types, default_value, &arg.ty, DefaultValueBehavior::Check).is_err() {
             arg.default_value = None;
         }
     }
@@ -252,9 +272,6 @@ fn coerce_arguments_default_values(
 /// JS keeps `= {}` verbatim in the upgraded subgraph SDL regardless of required fields;
 /// the supergraph/API-schema path uses [`coerce_arguments_default_values`] directly, which
 /// still strips them there.
-///
-/// Valid `= {}` (input type whose required fields all have defaults) is still expanded as
-/// normal; only the stripping-on-failure is suppressed for empty-object values.
 fn coerce_arguments_default_values_keep_empty_object(
     types: &IndexMap<Name, ExtendedType>,
     arguments: &mut Vec<Node<InputValueDefinition>>,
@@ -266,7 +283,7 @@ fn coerce_arguments_default_values_keep_empty_object(
         };
         let is_empty_object =
             matches!(default_value.as_ref(), Value::Object(fields) if fields.is_empty());
-        if coerce_value(types, default_value, &arg.ty).is_err() {
+        if coerce_value(types, default_value, &arg.ty, DefaultValueBehavior::Check).is_err() {
             if is_empty_object {
                 // Restore `= {}` — coerce_value may have partially mutated the value before
                 // failing. Matches graphql-js parse-time behavior: keep `= {}` even when the
@@ -313,7 +330,14 @@ pub(crate) fn coerce_schema_default_values(schema: &mut Schema) {
                         continue;
                     };
 
-                    if coerce_value(&types, default_value, &field.ty).is_err() {
+                    if coerce_value(
+                        &types,
+                        default_value,
+                        &field.ty,
+                        DefaultValueBehavior::Check,
+                    )
+                    .is_err()
+                    {
                         field.default_value = None;
                     }
                 }
@@ -390,7 +414,14 @@ pub(crate) fn coerce_schema_values(schema: &mut Schema) {
                         continue;
                     };
                     let is_empty_object = matches!(default_value.as_ref(), Value::Object(fields) if fields.is_empty());
-                    if coerce_value(&types, default_value, &field.ty).is_err() {
+                    if coerce_value(
+                        &types,
+                        default_value,
+                        &field.ty,
+                        DefaultValueBehavior::Check,
+                    )
+                    .is_err()
+                    {
                         if is_empty_object {
                             *default_value.make_mut() = Value::Object(Default::default());
                         } else {
@@ -454,7 +485,12 @@ fn coerce_directive_application_values(
                 continue;
             };
             let arg = arg.make_mut();
-            _ = coerce_value(&schema.types, &mut arg.value, &definition.ty);
+            _ = coerce_value(
+                &schema.types,
+                &mut arg.value,
+                &definition.ty,
+                DefaultValueBehavior::Expand,
+            );
         }
     }
 }
@@ -474,7 +510,12 @@ fn coerce_directive_application_values_schema(
                 continue;
             };
             let arg = arg.make_mut();
-            _ = coerce_value(type_definitions, &mut arg.value, &definition.ty);
+            _ = coerce_value(
+                type_definitions,
+                &mut arg.value,
+                &definition.ty,
+                DefaultValueBehavior::Check,
+            );
         }
     }
 }
@@ -494,7 +535,12 @@ fn coerce_directive_application_values_ast(
                 continue;
             };
             let arg = arg.make_mut();
-            _ = coerce_value(type_definitions, &mut arg.value, &definition.ty);
+            _ = coerce_value(
+                type_definitions,
+                &mut arg.value,
+                &definition.ty,
+                DefaultValueBehavior::Check,
+            );
         }
     }
 }
@@ -513,7 +559,12 @@ fn coerce_selection_set_values(
                         continue;
                     };
                     let arg = arg.make_mut();
-                    _ = coerce_value(&schema.types, &mut arg.value, &definition.ty);
+                    _ = coerce_value(
+                        &schema.types,
+                        &mut arg.value,
+                        &definition.ty,
+                        DefaultValueBehavior::Expand,
+                    );
                 }
                 coerce_directive_application_values(schema, &mut field.directives);
                 coerce_selection_set_values(schema, &mut field.selection_set);
@@ -545,7 +596,12 @@ fn coerce_operation_values(schema: &Valid<Schema>, operation: &mut Node<executab
         // query planner behaviour.
         // In queries, I hope we can just reject queries with invalid default values instead of
         // silently doing the wrong thing :)
-        _ = coerce_value(&schema.types, default_value, &variable.ty);
+        _ = coerce_value(
+            &schema.types,
+            default_value,
+            &variable.ty,
+            DefaultValueBehavior::Expand,
+        );
     }
 
     coerce_selection_set_values(schema, &mut operation.selection_set);

--- a/apollo-federation/tests/api_schema.rs
+++ b/apollo-federation/tests/api_schema.rs
@@ -2322,7 +2322,7 @@ fn propagates_default_input_values() {
 
     insta::assert_snapshot!(api_schema, @r###"
     type Query {
-      field(input: Input = {one: 0, nested: {one: 2, two: 2, default: "default"}, two: 2, three: 3, object: {value: 2}, nestedWithDefault: {one: 1, two: 2, default: "default"}}): Int
+      field(input: Input = {one: 0, nested: {one: 2}}): Int
     }
 
     input Input {
@@ -2333,11 +2333,7 @@ fn propagates_default_input_values() {
         value: 2,
       }
       nested: Nested
-      nestedWithDefault: Nested! = {
-        one: 1,
-        two: 2,
-        default: "default",
-      }
+      nestedWithDefault: Nested! = {}
     }
 
     input InputObject {
@@ -2402,7 +2398,7 @@ fn matches_graphql_js_default_value_propagation() {
     insta::assert_snapshot!(api_schema, @r###"
     type Query {
       defaultShouldBeRemoved(arg: OneRequiredOneDefault): Int
-      defaultShouldHavePropagatedValues(arg: OneOptionalOneDefault = {defaulted: false}): Int
+      defaultShouldHavePropagatedValues(arg: OneOptionalOneDefault = {}): Int
     }
 
     input OneOptionalOneDefault {

--- a/apollo-federation/tests/composition/compose_misc.rs
+++ b/apollo-federation/tests/composition/compose_misc.rs
@@ -92,6 +92,79 @@ fn misc_drops_empty_object_default_when_only_some_subgraphs_declare_it() {
     );
 }
 
+/// Partial input object defaults must be preserved as written — composition should not expand
+/// them by injecting type-level field defaults for absent fields.
+#[test]
+fn misc_preserves_partial_input_object_defaults_without_expansion() {
+    let subgraph = ServiceDefinition {
+        name: "subgraph",
+        type_defs: r#"
+        type Query {
+          products(filter: SearchFilter = {paging: {limit: 10}, sorting: []}): [Product!]!
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+          name: String!
+        }
+
+        input SearchFilter {
+          paging: PagingInput = {limit: 10}
+          sorting: [SortInput!] = []
+          inStock: Boolean = true
+        }
+
+        input PagingInput {
+          limit: Int = 10
+        }
+
+        input SortInput {
+          field: String = "created_at"
+          direction: String = "DESC"
+        }
+        "#,
+    };
+
+    let supergraph = compose_as_fed2_subgraphs(&[subgraph]).expect("composition should succeed");
+    let query = supergraph
+        .schema()
+        .schema()
+        .get_object("Query")
+        .expect("Query type should exist in the supergraph");
+    assert_snapshot!(query);
+}
+
+/// Defaults inside list elements should also be preserved without expansion.
+#[test]
+fn misc_preserves_defaults_inside_list_elements() {
+    let subgraph = ServiceDefinition {
+        name: "subgraph",
+        type_defs: r#"
+        type Query {
+          products(sort: [SortInput!] = [{}]): [Product!]!
+        }
+
+        type Product @key(fields: "id") {
+          id: ID!
+          name: String!
+        }
+
+        input SortInput {
+          field: String = "created_at"
+          direction: String = "DESC"
+        }
+        "#,
+    };
+
+    let supergraph = compose_as_fed2_subgraphs(&[subgraph]).expect("composition should succeed");
+    let query = supergraph
+        .schema()
+        .schema()
+        .get_object("Query")
+        .expect("Query type should exist in the schema");
+    assert_snapshot!(query);
+}
+
 #[test]
 fn misc_works_with_normal_graphql_type_extension_when_definition_is_empty() {
     let subgraph_a = ServiceDefinition {

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_misc__misc_preserves_defaults_inside_list_elements.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_misc__misc_preserves_defaults_inside_list_elements.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-federation/tests/composition/compose_misc.rs
+expression: query
+---
+type Query @join__type(graph: SUBGRAPH) {
+  products(sort: [SortInput!] = [{}]): [Product!]!
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_misc__misc_preserves_partial_input_object_defaults_without_expansion.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_misc__misc_preserves_partial_input_object_defaults_without_expansion.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-federation/tests/composition/compose_misc.rs
+expression: query
+---
+type Query @join__type(graph: SUBGRAPH) {
+  products(filter: SearchFilter = {paging: {limit: 10}, sorting: []}): [Product!]!
+}


### PR DESCRIPTION
Stop `coerce_value()` from injecting type-level field defaults into partial input object literals during schema-level composition. Previously, a default like `{paging: {limit: 10}, sorting: []}` would be expanded to include absent fields (e.g. `inStock: true`), diverging from the subgraph's authored intent.

Introduce `DefaultValueBehavior` enum (`Expand` / `Check`) so the same `coerce_value()` function serves both contexts:
- `Check` (schema-level): validates the literal but preserves it as written — used by `coerce_schema_default_values`, `coerce_arguments_default_values_keep_empty_object`, and related schema/AST paths.
- `Expand` (executable-document): injects missing fields from type-level defaults — used by `coerce_operation_values`, `coerce_selection_set_values`, and directive application values on executable documents.
