### PR TITLE
Removing deprecated context: true|false

### DIFF
--- a/.changesets/breaking_zach_router_1756_remove_coprocessor_context_boolean.md
+++ b/.changesets/breaking_zach_router_1756_remove_coprocessor_context_boolean.md
@@ -9,4 +9,4 @@ The boolean form of the `context` field on each coprocessor stage (`context: tru
 
 To preserve existing behavior, an automatic configuration migration rewrites `context: true` to `context: deprecated` and drops `context: false` on router startup. See [https://go.apollo.dev/o/coprocessor-context](https://go.apollo.dev/o/coprocessor-context) for details.
 
-By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/0
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/9453

--- a/.changesets/breaking_zach_router_1756_remove_coprocessor_context_boolean.md
+++ b/.changesets/breaking_zach_router_1756_remove_coprocessor_context_boolean.md
@@ -1,0 +1,12 @@
+### Remove deprecated boolean form of `coprocessor.<stage>.context`
+
+The boolean form of the `context` field on each coprocessor stage (`context: true` / `context: false`) was deprecated and has now been removed across all 10 coprocessor stage configurations (`router.{request,response}`, `supergraph.{request,response}`, `execution.{request,response}`, `subgraph.all.{request,response}`, `connector.all.{request,response}`). Use the structured form instead:
+
+- `context: all` — send every context entry with the current key names
+- `context: deprecated` — send every context entry using the pre-2.x deprecated key names
+- `context: selective: [key1, key2, ...]` — only send the listed context keys
+- omit the field — do not send context (the default)
+
+To preserve existing behavior, an automatic configuration migration rewrites `context: true` to `context: deprecated` and drops `context: false` on router startup. See [https://go.apollo.dev/o/coprocessor-context](https://go.apollo.dev/o/coprocessor-context) for details.
+
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/0

--- a/.changesets/breaking_zach_router_1756_remove_coprocessor_context_boolean.md
+++ b/.changesets/breaking_zach_router_1756_remove_coprocessor_context_boolean.md
@@ -5,8 +5,8 @@ The boolean form of the `context` field on each coprocessor stage (`context: tru
 - `context: all` — send every context entry with the current key names
 - `context: deprecated` — send every context entry using the pre-2.x deprecated key names
 - `context: selective: [key1, key2, ...]` — only send the listed context keys
-- omit the field — do not send context (the default)
+- `context: none` — do not send context (the default; equivalent to omitting the field)
 
-To preserve existing behavior, an automatic configuration migration rewrites `context: true` to `context: deprecated` and drops `context: false` on router startup. See [https://go.apollo.dev/o/coprocessor-context](https://go.apollo.dev/o/coprocessor-context) for details.
+To preserve existing behavior, an automatic configuration migration rewrites `context: true` to `context: deprecated` and `context: false` to `context: none` on router startup. See [https://go.apollo.dev/o/coprocessor-context](https://go.apollo.dev/o/coprocessor-context) for details.
 
 By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/9453

--- a/apollo-router/src/configuration/migrations/3000-coprocessor_context_boolean.yaml
+++ b/apollo-router/src/configuration/migrations/3000-coprocessor_context_boolean.yaml
@@ -1,9 +1,9 @@
 description: |
   `coprocessor.<stage>.context: true` / `context: false` has been removed. The structured form
-  (`context: all` / `context: deprecated` / `context: selective: [...]`) is the replacement.
-  `true` is migrated to `deprecated` (which preserves the prior behavior of sending context keys
-  using their pre-2.x deprecated names) and `false` is removed (context is no longer sent, which
-  is the default). See https://go.apollo.dev/o/coprocessor-context
+  (`context: none` / `context: all` / `context: deprecated` / `context: selective: [...]`) is the
+  replacement. `true` is migrated to `deprecated` (which preserves the prior behavior of sending
+  context keys using their pre-2.x deprecated names) and `false` is migrated to `none` (context
+  is no longer sent, which is the default). See https://go.apollo.dev/o/coprocessor-context
 actions:
   - type: change
     path: coprocessor.router.request.context
@@ -12,7 +12,7 @@ actions:
   - type: change
     path: coprocessor.router.request.context
     from: false
-    to: null
+    to: none
   - type: change
     path: coprocessor.router.response.context
     from: true
@@ -20,7 +20,7 @@ actions:
   - type: change
     path: coprocessor.router.response.context
     from: false
-    to: null
+    to: none
   - type: change
     path: coprocessor.supergraph.request.context
     from: true
@@ -28,7 +28,7 @@ actions:
   - type: change
     path: coprocessor.supergraph.request.context
     from: false
-    to: null
+    to: none
   - type: change
     path: coprocessor.supergraph.response.context
     from: true
@@ -36,7 +36,7 @@ actions:
   - type: change
     path: coprocessor.supergraph.response.context
     from: false
-    to: null
+    to: none
   - type: change
     path: coprocessor.execution.request.context
     from: true
@@ -44,7 +44,7 @@ actions:
   - type: change
     path: coprocessor.execution.request.context
     from: false
-    to: null
+    to: none
   - type: change
     path: coprocessor.execution.response.context
     from: true
@@ -52,7 +52,7 @@ actions:
   - type: change
     path: coprocessor.execution.response.context
     from: false
-    to: null
+    to: none
   - type: change
     path: coprocessor.subgraph.all.request.context
     from: true
@@ -60,7 +60,7 @@ actions:
   - type: change
     path: coprocessor.subgraph.all.request.context
     from: false
-    to: null
+    to: none
   - type: change
     path: coprocessor.subgraph.all.response.context
     from: true
@@ -68,7 +68,7 @@ actions:
   - type: change
     path: coprocessor.subgraph.all.response.context
     from: false
-    to: null
+    to: none
   - type: change
     path: coprocessor.connector.all.request.context
     from: true
@@ -76,7 +76,7 @@ actions:
   - type: change
     path: coprocessor.connector.all.request.context
     from: false
-    to: null
+    to: none
   - type: change
     path: coprocessor.connector.all.response.context
     from: true
@@ -84,4 +84,4 @@ actions:
   - type: change
     path: coprocessor.connector.all.response.context
     from: false
-    to: null
+    to: none

--- a/apollo-router/src/configuration/migrations/3000-coprocessor_context_boolean.yaml
+++ b/apollo-router/src/configuration/migrations/3000-coprocessor_context_boolean.yaml
@@ -1,0 +1,87 @@
+description: |
+  `coprocessor.<stage>.context: true` / `context: false` has been removed. The structured form
+  (`context: all` / `context: deprecated` / `context: selective: [...]`) is the replacement.
+  `true` is migrated to `deprecated` (which preserves the prior behavior of sending context keys
+  using their pre-2.x deprecated names) and `false` is removed (context is no longer sent, which
+  is the default). See https://go.apollo.dev/o/coprocessor-context
+actions:
+  - type: change
+    path: coprocessor.router.request.context
+    from: true
+    to: deprecated
+  - type: change
+    path: coprocessor.router.request.context
+    from: false
+    to: null
+  - type: change
+    path: coprocessor.router.response.context
+    from: true
+    to: deprecated
+  - type: change
+    path: coprocessor.router.response.context
+    from: false
+    to: null
+  - type: change
+    path: coprocessor.supergraph.request.context
+    from: true
+    to: deprecated
+  - type: change
+    path: coprocessor.supergraph.request.context
+    from: false
+    to: null
+  - type: change
+    path: coprocessor.supergraph.response.context
+    from: true
+    to: deprecated
+  - type: change
+    path: coprocessor.supergraph.response.context
+    from: false
+    to: null
+  - type: change
+    path: coprocessor.execution.request.context
+    from: true
+    to: deprecated
+  - type: change
+    path: coprocessor.execution.request.context
+    from: false
+    to: null
+  - type: change
+    path: coprocessor.execution.response.context
+    from: true
+    to: deprecated
+  - type: change
+    path: coprocessor.execution.response.context
+    from: false
+    to: null
+  - type: change
+    path: coprocessor.subgraph.all.request.context
+    from: true
+    to: deprecated
+  - type: change
+    path: coprocessor.subgraph.all.request.context
+    from: false
+    to: null
+  - type: change
+    path: coprocessor.subgraph.all.response.context
+    from: true
+    to: deprecated
+  - type: change
+    path: coprocessor.subgraph.all.response.context
+    from: false
+    to: null
+  - type: change
+    path: coprocessor.connector.all.request.context
+    from: true
+    to: deprecated
+  - type: change
+    path: coprocessor.connector.all.request.context
+    from: false
+    to: null
+  - type: change
+    path: coprocessor.connector.all.response.context
+    from: true
+    to: deprecated
+  - type: change
+    path: coprocessor.connector.all.response.context
+    from: false
+    to: null

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2277,12 +2277,9 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ContextConf"
-            },
-            {
-              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -2336,12 +2333,9 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ContextConf"
-            },
-            {
-              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -2951,6 +2945,11 @@ expression: "&schema"
     "ContextConf": {
       "description": "Configures the context",
       "oneOf": [
+        {
+          "const": "none",
+          "description": "Do not send context to the coprocessor (the default)",
+          "type": "string"
+        },
         {
           "const": "all",
           "description": "Send all context keys to coprocessor",
@@ -3897,12 +3896,9 @@ expression: "&schema"
           "type": "boolean"
         },
         "context": {
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ContextConf"
-            },
-            {
-              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -3951,12 +3947,9 @@ expression: "&schema"
           "description": "Send the body (can be true/false or selective with data/errors/extensions)"
         },
         "context": {
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ContextConf"
-            },
-            {
-              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -8556,12 +8549,9 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ContextConf"
-            },
-            {
-              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -8615,12 +8605,9 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ContextConf"
-            },
-            {
-              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -10295,12 +10282,9 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ContextConf"
-            },
-            {
-              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -10362,12 +10346,9 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ContextConf"
-            },
-            {
-              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -11583,12 +11564,9 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ContextConf"
-            },
-            {
-              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -11640,12 +11618,9 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "anyOf": [
+          "allOf": [
             {
               "$ref": "#/definitions/ContextConf"
-            },
-            {
-              "type": "null"
             }
           ],
           "description": "Send the context"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/tests.rs
-assertion_line: 28
 expression: "&schema"
 ---
 {
@@ -2278,9 +2277,12 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/ContextConf"
+            },
+            {
+              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -2334,9 +2336,12 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/ContextConf"
+            },
+            {
+              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -2944,16 +2949,36 @@ expression: "&schema"
       "type": "object"
     },
     "ContextConf": {
-      "anyOf": [
+      "description": "Configures the context",
+      "oneOf": [
         {
-          "description": "Deprecated configuration using a boolean",
-          "type": "boolean"
+          "const": "all",
+          "description": "Send all context keys to coprocessor",
+          "type": "string"
         },
         {
-          "$ref": "#/definitions/NewContextConf"
+          "const": "deprecated",
+          "description": "Send all context keys using deprecated names (from router 1.x) to coprocessor",
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Only send the list of context keys to coprocessor",
+          "properties": {
+            "selective": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "uniqueItems": true
+            }
+          },
+          "required": [
+            "selective"
+          ],
+          "type": "object"
         }
-      ],
-      "description": "Configures the context"
+      ]
     },
     "CooperativeCancellation": {
       "additionalProperties": false,
@@ -3872,9 +3897,12 @@ expression: "&schema"
           "type": "boolean"
         },
         "context": {
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/ContextConf"
+            },
+            {
+              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -3923,9 +3951,12 @@ expression: "&schema"
           "description": "Send the body (can be true/false or selective with data/errors/extensions)"
         },
         "context": {
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/ContextConf"
+            },
+            {
+              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -7279,38 +7310,6 @@ expression: "&schema"
       "description": "Config for the test plugin",
       "type": "object"
     },
-    "NewContextConf": {
-      "description": "Configures the context",
-      "oneOf": [
-        {
-          "const": "all",
-          "description": "Send all context keys to coprocessor",
-          "type": "string"
-        },
-        {
-          "const": "deprecated",
-          "description": "Send all context keys using deprecated names (from router 1.x) to coprocessor",
-          "type": "string"
-        },
-        {
-          "additionalProperties": false,
-          "description": "Only send the list of context keys to coprocessor",
-          "properties": {
-            "selective": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array",
-              "uniqueItems": true
-            }
-          },
-          "required": [
-            "selective"
-          ],
-          "type": "object"
-        }
-      ]
-    },
     "OTLPConfig": {
       "additionalProperties": false,
       "properties": {
@@ -8557,9 +8556,12 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/ContextConf"
+            },
+            {
+              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -8613,9 +8615,12 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/ContextConf"
+            },
+            {
+              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -10290,9 +10295,12 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/ContextConf"
+            },
+            {
+              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -10354,9 +10362,12 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/ContextConf"
+            },
+            {
+              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -11572,9 +11583,12 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/ContextConf"
+            },
+            {
+              "type": "null"
             }
           ],
           "description": "Send the context"
@@ -11626,9 +11640,12 @@ expression: "&schema"
           "description": "Condition to trigger this stage"
         },
         "context": {
-          "allOf": [
+          "anyOf": [
             {
               "$ref": "#/definitions/ContextConf"
+            },
+            {
+              "type": "null"
             }
           ],
           "description": "Send the context"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@coprocessor_context_boolean.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@coprocessor_context_boolean.router.yaml.snap
@@ -1,0 +1,23 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+coprocessor:
+  url: "http://example.com"
+  router:
+    request:
+      context: deprecated
+    response:
+      context: ~
+  supergraph:
+    request:
+      context: deprecated
+  subgraph:
+    all:
+      request:
+        context: ~
+  connector:
+    all:
+      request:
+        context: deprecated

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@coprocessor_context_boolean.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@coprocessor_context_boolean.router.yaml.snap
@@ -9,14 +9,14 @@ coprocessor:
     request:
       context: deprecated
     response:
-      context: ~
+      context: none
   supergraph:
     request:
       context: deprecated
   subgraph:
     all:
       request:
-        context: ~
+        context: none
   connector:
     all:
       request:

--- a/apollo-router/src/configuration/testdata/metrics/coprocessor.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/coprocessor.router.yaml
@@ -5,13 +5,13 @@ coprocessor:
     request:
       headers: true
       body: true
-      context: true
+      context: all
       method: true
       path: true
       sdl: true
     response:
       sdl: true
-      context: true
+      context: all
       body: true
       headers: true
       status_code: true
@@ -19,12 +19,12 @@ coprocessor:
     request:
       headers: true
       body: true
-      context: true
+      context: all
       method: true
       sdl: true
     response:
       sdl: true
-      context: true
+      context: all
       body: true
       headers: true
       status_code: true
@@ -33,20 +33,20 @@ coprocessor:
       request:
         headers: true
         body: true
-        context: true
+        context: all
         method: true
       response:
         status_code: true
         headers: true
         body: true
-        context: true
+        context: all
         service_name: true
   connector:
     all:
       request:
         headers: true
         body: true
-        context: true
+        context: all
         method: true
         uri: true
         service_name: true

--- a/apollo-router/src/configuration/testdata/migrations/coprocessor_context_boolean.router.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/coprocessor_context_boolean.router.yaml
@@ -1,0 +1,18 @@
+coprocessor:
+  url: http://example.com
+  router:
+    request:
+      context: true
+    response:
+      context: false
+  supergraph:
+    request:
+      context: true
+  subgraph:
+    all:
+      request:
+        context: false
+  connector:
+    all:
+      request:
+        context: true

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -168,9 +168,13 @@ fn apply_migration(config: &Value, migration: &Migration) -> Result<Value, Confi
                 }
             }
             Action::Change { path, from, to } => {
-                if !jsonpath_lib::select(config, &format!("$[?(@.{path} == {from})]"))
+                // We query the value directly (`$.<path>`) rather than using a root-level
+                // filter expression (`$[?(@.<path> == <from>)]`) — jsonpath_lib's filter
+                // form does not support traversing paths more than two levels deep.
+                if jsonpath_lib::select(config, &format!("$.{path}"))
                     .unwrap_or_default()
-                    .is_empty()
+                    .into_iter()
+                    .any(|v| v == from)
                 {
                     transformer_builder = transformer_builder
                         .add_action(Parser::parse(&format!(r#"const({to})"#), path)?);

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -1844,7 +1844,7 @@ async fn test_sources_in_context() {
             "url": format!("{}/coprocessor", mock_server.uri()),
             "execution": {
               "request": {
-                "context": true
+                "context": "all"
               }
             }
           }
@@ -1925,7 +1925,7 @@ async fn test_variables() {
             "url": format!("{}/coprocessor", mock_server.uri()),
             "supergraph": {
               "request": {
-                "context": true
+                "context": "all"
               }
             }
           }

--- a/apollo-router/src/plugins/coprocessor/connector.rs
+++ b/apollo-router/src/plugins/coprocessor/connector.rs
@@ -19,7 +19,6 @@ use tower::ServiceExt;
 use super::COPROCESSOR_ERROR_EXTENSION;
 use super::ContextConf;
 use super::EXTERNAL_SPAN_NAME;
-use super::NewContextConf;
 use super::get_coprocessor_timer;
 use super::internalize_header_map;
 use super::record_coprocessor_operation;
@@ -50,7 +49,7 @@ pub(super) struct ConnectorRequestConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: ContextConf,
+    pub(super) context: Option<ContextConf>,
     /// Send the body
     pub(super) body: bool,
     /// Send the connector URI
@@ -72,7 +71,7 @@ pub(super) struct ConnectorResponseConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: ContextConf,
+    pub(super) context: Option<ContextConf>,
     /// Send the body
     pub(super) body: bool,
     /// Send the service name
@@ -262,7 +261,10 @@ where
         serde_json::from_str::<Value>(&body).unwrap_or_else(|_| Value::String(body.clone().into()))
     });
 
-    let context_to_send = request_config.context.get_context(&request.context);
+    let context_to_send = request_config
+        .context
+        .as_ref()
+        .map(|c| c.get_context(&request.context));
     let uri = request_config.uri.then(|| parts.uri.to_string());
     let service_name_to_send = request_config.service_name.then_some(service_name);
 
@@ -341,9 +343,7 @@ where
 
         if let Some(context) = co_processor_output.context {
             for (mut key, value) in context.try_into_iter()? {
-                if let ContextConf::NewContextConf(NewContextConf::Deprecated) =
-                    &request_config.context
-                {
+                if let Some(ContextConf::Deprecated) = &request_config.context {
                     key = context_key_from_deprecated(key);
                 }
                 request
@@ -374,8 +374,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let ContextConf::NewContextConf(NewContextConf::Deprecated) = &request_config.context
-            {
+            if let Some(ContextConf::Deprecated) = &request_config.context {
                 key = context_key_from_deprecated(key);
             }
             request
@@ -447,7 +446,10 @@ where
         None
     };
 
-    let context_to_send = response_config.context.get_context(&context);
+    let context_to_send = response_config
+        .context
+        .as_ref()
+        .map(|c| c.get_context(&context));
     let service_name_to_send = response_config.service_name.then_some(service_name);
 
     let payload = Externalizable::connector_builder()
@@ -497,7 +499,11 @@ where
     }
 
     if let Some(returned_context) = co_processor_output.context {
-        update_context_from_coprocessor(&context, returned_context, &response_config.context)?;
+        update_context_from_coprocessor(
+            &context,
+            returned_context,
+            response_config.context.as_ref(),
+        )?;
     }
 
     if let Some(body) = co_processor_output.body {

--- a/apollo-router/src/plugins/coprocessor/connector.rs
+++ b/apollo-router/src/plugins/coprocessor/connector.rs
@@ -49,7 +49,7 @@ pub(super) struct ConnectorRequestConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: Option<ContextConf>,
+    pub(super) context: ContextConf,
     /// Send the body
     pub(super) body: bool,
     /// Send the connector URI
@@ -71,7 +71,7 @@ pub(super) struct ConnectorResponseConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: Option<ContextConf>,
+    pub(super) context: ContextConf,
     /// Send the body
     pub(super) body: bool,
     /// Send the service name
@@ -261,10 +261,7 @@ where
         serde_json::from_str::<Value>(&body).unwrap_or_else(|_| Value::String(body.clone().into()))
     });
 
-    let context_to_send = request_config
-        .context
-        .as_ref()
-        .map(|c| c.get_context(&request.context));
+    let context_to_send = request_config.context.get_context(&request.context);
     let uri = request_config.uri.then(|| parts.uri.to_string());
     let service_name_to_send = request_config.service_name.then_some(service_name);
 
@@ -343,7 +340,7 @@ where
 
         if let Some(context) = co_processor_output.context {
             for (mut key, value) in context.try_into_iter()? {
-                if let Some(ContextConf::Deprecated) = &request_config.context {
+                if let ContextConf::Deprecated = &request_config.context {
                     key = context_key_from_deprecated(key);
                 }
                 request
@@ -374,7 +371,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let Some(ContextConf::Deprecated) = &request_config.context {
+            if let ContextConf::Deprecated = &request_config.context {
                 key = context_key_from_deprecated(key);
             }
             request
@@ -446,10 +443,7 @@ where
         None
     };
 
-    let context_to_send = response_config
-        .context
-        .as_ref()
-        .map(|c| c.get_context(&context));
+    let context_to_send = response_config.context.get_context(&context);
     let service_name_to_send = response_config.service_name.then_some(service_name);
 
     let payload = Externalizable::connector_builder()
@@ -499,11 +493,7 @@ where
     }
 
     if let Some(returned_context) = co_processor_output.context {
-        update_context_from_coprocessor(
-            &context,
-            returned_context,
-            response_config.context.as_ref(),
-        )?;
+        update_context_from_coprocessor(&context, returned_context, &response_config.context)?;
     }
 
     if let Some(body) = co_processor_output.body {

--- a/apollo-router/src/plugins/coprocessor/connector.rs
+++ b/apollo-router/src/plugins/coprocessor/connector.rs
@@ -340,7 +340,7 @@ where
 
         if let Some(context) = co_processor_output.context {
             for (mut key, value) in context.try_into_iter()? {
-                if let ContextConf::Deprecated = &request_config.context {
+                if request_config.context.is_deprecated() {
                     key = context_key_from_deprecated(key);
                 }
                 request
@@ -371,7 +371,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let ContextConf::Deprecated = &request_config.context {
+            if request_config.context.is_deprecated() {
                 key = context_key_from_deprecated(key);
             }
             request

--- a/apollo-router/src/plugins/coprocessor/execution.rs
+++ b/apollo-router/src/plugins/coprocessor/execution.rs
@@ -285,7 +285,7 @@ where
 
             if let Some(context) = co_processor_output.context {
                 for (mut key, value) in context.try_into_iter()? {
-                    if let ContextConf::Deprecated = &request_config.context {
+                    if request_config.context.is_deprecated() {
                         key = context_key_from_deprecated(key);
                     }
                     execution_response
@@ -311,7 +311,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let ContextConf::Deprecated = &request_config.context {
+            if request_config.context.is_deprecated() {
                 key = context_key_from_deprecated(key);
             }
             request

--- a/apollo-router/src/plugins/coprocessor/execution.rs
+++ b/apollo-router/src/plugins/coprocessor/execution.rs
@@ -25,7 +25,7 @@ pub(super) struct ExecutionRequestConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: ContextConf,
+    pub(super) context: Option<ContextConf>,
     /// Send the body
     pub(super) body: bool,
     /// Send the SDL
@@ -45,7 +45,7 @@ pub(super) struct ExecutionResponseConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: ContextConf,
+    pub(super) context: Option<ContextConf>,
     /// Send the body (can be true/false or selective with data/errors/extensions)
     pub(super) body: BodyConf,
     /// Send the SDL
@@ -216,7 +216,10 @@ where
         .body
         .then(|| serde_json::from_slice::<Value>(&bytes))
         .transpose()?;
-    let context_to_send = request_config.context.get_context(&request.context);
+    let context_to_send = request_config
+        .context
+        .as_ref()
+        .map(|c| c.get_context(&request.context));
     let sdl_to_send = request_config.sdl.then(|| sdl.clone().to_string());
     let method = request_config.method.then(|| parts.method.to_string());
     let query_plan = request_config
@@ -285,9 +288,7 @@ where
 
             if let Some(context) = co_processor_output.context {
                 for (mut key, value) in context.try_into_iter()? {
-                    if let ContextConf::NewContextConf(NewContextConf::Deprecated) =
-                        &request_config.context
-                    {
+                    if let Some(ContextConf::Deprecated) = &request_config.context {
                         key = context_key_from_deprecated(key);
                     }
                     execution_response
@@ -313,8 +314,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let ContextConf::NewContextConf(NewContextConf::Deprecated) = &request_config.context
-            {
+            if let Some(ContextConf::Deprecated) = &request_config.context {
                 key = context_key_from_deprecated(key);
             }
             request
@@ -378,7 +378,10 @@ where
         .then(|| externalize_header_map(&parts.headers));
     let body_to_send = filter_graphql_response_body(&first, &response_config.body);
     let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
-    let context_to_send = response_config.context.get_context(&response.context);
+    let context_to_send = response_config
+        .context
+        .as_ref()
+        .map(|c| c.get_context(&response.context));
     let sdl_to_send = response_config.sdl.then(|| sdl.clone().to_string());
 
     let payload = Externalizable::execution_builder()
@@ -435,7 +438,11 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        update_context_from_coprocessor(&response.context, context, &response_config.context)?;
+        update_context_from_coprocessor(
+            &response.context,
+            context,
+            response_config.context.as_ref(),
+        )?;
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -459,7 +466,9 @@ where
             async move {
                 let body_to_send =
                     filter_graphql_response_body(&deferred_response, &response_config.body);
-                let context_to_send = response_config_context.get_context(&generator_map_context);
+                let context_to_send = response_config_context
+                    .as_ref()
+                    .map(|c| c.get_context(&generator_map_context));
 
                 // Note: We deliberately DO NOT send headers or status_code even if the user has
                 // requested them. That's because they are meaningless on a deferred response and
@@ -510,7 +519,7 @@ where
                     update_context_from_coprocessor(
                         &generator_map_context,
                         context,
-                        &response_config_context,
+                        response_config_context.as_ref(),
                     )?;
                 }
 
@@ -637,7 +646,7 @@ mod tests {
         let execution_stage = ExecutionStage {
             request: ExecutionRequestConf {
                 headers: false,
-                context: ContextConf::Deprecated(false),
+                context: None,
                 body: true,
                 sdl: false,
                 method: false,
@@ -773,7 +782,7 @@ mod tests {
         let execution_stage = ExecutionStage {
             request: ExecutionRequestConf {
                 headers: false,
-                context: ContextConf::Deprecated(false),
+                context: None,
                 body: true,
                 sdl: false,
                 method: false,
@@ -847,7 +856,7 @@ mod tests {
         let execution_stage = ExecutionStage {
             response: ExecutionResponseConf {
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -984,7 +993,7 @@ mod tests {
         let execution_stage = ExecutionStage {
             response: ExecutionResponseConf {
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1096,7 +1105,7 @@ mod tests {
             request: Default::default(),
             response: ExecutionResponseConf {
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1127,7 +1136,7 @@ mod tests {
         ExecutionStage {
             request: ExecutionRequestConf {
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 method: true,

--- a/apollo-router/src/plugins/coprocessor/execution.rs
+++ b/apollo-router/src/plugins/coprocessor/execution.rs
@@ -25,7 +25,7 @@ pub(super) struct ExecutionRequestConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: Option<ContextConf>,
+    pub(super) context: ContextConf,
     /// Send the body
     pub(super) body: bool,
     /// Send the SDL
@@ -45,7 +45,7 @@ pub(super) struct ExecutionResponseConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: Option<ContextConf>,
+    pub(super) context: ContextConf,
     /// Send the body (can be true/false or selective with data/errors/extensions)
     pub(super) body: BodyConf,
     /// Send the SDL
@@ -216,10 +216,7 @@ where
         .body
         .then(|| serde_json::from_slice::<Value>(&bytes))
         .transpose()?;
-    let context_to_send = request_config
-        .context
-        .as_ref()
-        .map(|c| c.get_context(&request.context));
+    let context_to_send = request_config.context.get_context(&request.context);
     let sdl_to_send = request_config.sdl.then(|| sdl.clone().to_string());
     let method = request_config.method.then(|| parts.method.to_string());
     let query_plan = request_config
@@ -288,7 +285,7 @@ where
 
             if let Some(context) = co_processor_output.context {
                 for (mut key, value) in context.try_into_iter()? {
-                    if let Some(ContextConf::Deprecated) = &request_config.context {
+                    if let ContextConf::Deprecated = &request_config.context {
                         key = context_key_from_deprecated(key);
                     }
                     execution_response
@@ -314,7 +311,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let Some(ContextConf::Deprecated) = &request_config.context {
+            if let ContextConf::Deprecated = &request_config.context {
                 key = context_key_from_deprecated(key);
             }
             request
@@ -378,10 +375,7 @@ where
         .then(|| externalize_header_map(&parts.headers));
     let body_to_send = filter_graphql_response_body(&first, &response_config.body);
     let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
-    let context_to_send = response_config
-        .context
-        .as_ref()
-        .map(|c| c.get_context(&response.context));
+    let context_to_send = response_config.context.get_context(&response.context);
     let sdl_to_send = response_config.sdl.then(|| sdl.clone().to_string());
 
     let payload = Externalizable::execution_builder()
@@ -438,11 +432,7 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        update_context_from_coprocessor(
-            &response.context,
-            context,
-            response_config.context.as_ref(),
-        )?;
+        update_context_from_coprocessor(&response.context, context, &response_config.context)?;
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -466,9 +456,7 @@ where
             async move {
                 let body_to_send =
                     filter_graphql_response_body(&deferred_response, &response_config.body);
-                let context_to_send = response_config_context
-                    .as_ref()
-                    .map(|c| c.get_context(&generator_map_context));
+                let context_to_send = response_config_context.get_context(&generator_map_context);
 
                 // Note: We deliberately DO NOT send headers or status_code even if the user has
                 // requested them. That's because they are meaningless on a deferred response and
@@ -519,7 +507,7 @@ where
                     update_context_from_coprocessor(
                         &generator_map_context,
                         context,
-                        response_config_context.as_ref(),
+                        &response_config_context,
                     )?;
                 }
 
@@ -646,7 +634,7 @@ mod tests {
         let execution_stage = ExecutionStage {
             request: ExecutionRequestConf {
                 headers: false,
-                context: None,
+                context: ContextConf::None,
                 body: true,
                 sdl: false,
                 method: false,
@@ -782,7 +770,7 @@ mod tests {
         let execution_stage = ExecutionStage {
             request: ExecutionRequestConf {
                 headers: false,
-                context: None,
+                context: ContextConf::None,
                 body: true,
                 sdl: false,
                 method: false,
@@ -856,7 +844,7 @@ mod tests {
         let execution_stage = ExecutionStage {
             response: ExecutionResponseConf {
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -993,7 +981,7 @@ mod tests {
         let execution_stage = ExecutionStage {
             response: ExecutionResponseConf {
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1105,7 +1093,7 @@ mod tests {
             request: Default::default(),
             response: ExecutionResponseConf {
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1136,7 +1124,7 @@ mod tests {
         ExecutionStage {
             request: ExecutionRequestConf {
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 method: true,

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -273,7 +273,7 @@ pub(super) struct RouterRequestConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: Option<ContextConf>,
+    pub(super) context: ContextConf,
     /// Send the body
     pub(super) body: bool,
     /// Send the SDL
@@ -295,7 +295,7 @@ pub(super) struct RouterResponseConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: Option<ContextConf>,
+    pub(super) context: ContextConf,
     /// Send the body
     pub(super) body: bool,
     /// Send the SDL
@@ -314,7 +314,7 @@ pub(super) struct SubgraphRequestConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: Option<ContextConf>,
+    pub(super) context: ContextConf,
     /// Send the body
     pub(super) body: bool,
     /// Send the subgraph URI
@@ -338,7 +338,7 @@ pub(super) struct SubgraphResponseConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: Option<ContextConf>,
+    pub(super) context: ContextConf,
     /// Send the body (can be true/false or selective with data/errors/extensions)
     pub(super) body: BodyConf,
     /// Send the service name
@@ -424,9 +424,12 @@ pub(super) struct BodyFieldsConf {
 }
 
 /// Configures the context
-#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub(super) enum ContextConf {
+    /// Do not send context to the coprocessor (the default)
+    #[default]
+    None,
     /// Send all context keys to coprocessor
     All,
     /// Send all context keys using deprecated names (from router 1.x) to coprocessor
@@ -436,9 +439,10 @@ pub(super) enum ContextConf {
 }
 
 impl ContextConf {
-    pub(crate) fn get_context(&self, ctx: &Context) -> Context {
+    pub(crate) fn get_context(&self, ctx: &Context) -> Option<Context> {
         match self {
-            Self::All => ctx.clone(),
+            Self::None => None,
+            Self::All => Some(ctx.clone()),
             Self::Deprecated => {
                 let mut new_ctx = Context::from_iter(ctx.iter().map(|elt| {
                     (
@@ -447,7 +451,7 @@ impl ContextConf {
                     )
                 }));
                 new_ctx.id = ctx.id.clone();
-                new_ctx
+                Some(new_ctx)
             }
             Self::Selective(context_keys) => {
                 let mut new_ctx = Context::from_iter(ctx.iter().filter_map(|elt| {
@@ -458,7 +462,7 @@ impl ContextConf {
                     }
                 }));
                 new_ctx.id = ctx.id.clone();
-                new_ctx
+                Some(new_ctx)
             }
         }
     }
@@ -513,12 +517,12 @@ pub(crate) fn validate_coprocessor_url(url: &str, config_path: &str) -> Result<(
 pub(crate) fn update_context_from_coprocessor(
     target_context: &Context,
     context_returned: Context,
-    context_config: Option<&ContextConf>,
+    context_config: &ContextConf,
 ) -> Result<(), BoxError> {
     // Collect keys that are in the returned context
     let mut keys_returned = HashSet::with_capacity(context_returned.len());
 
-    let is_deprecated = matches!(context_config, Some(ContextConf::Deprecated));
+    let is_deprecated = matches!(context_config, ContextConf::Deprecated);
 
     for (mut key, value) in context_returned.try_into_iter()? {
         // Handle deprecated key names - convert back to actual key names
@@ -533,7 +537,7 @@ pub(crate) fn update_context_from_coprocessor(
     // Delete keys that were sent but are missing from the returned context
     // If the context config is selective, only delete keys that are in the selective list
     match context_config {
-        Some(ContextConf::Selective(context_keys)) => {
+        ContextConf::Selective(context_keys) => {
             target_context.retain(|key, _v| {
                 if keys_returned.contains(key) {
                     return true;
@@ -871,10 +875,7 @@ where
 
     let path_to_send = request_config.path.then(|| parts.uri.to_string());
 
-    let context_to_send = request_config
-        .context
-        .as_ref()
-        .map(|c| c.get_context(&request.context));
+    let context_to_send = request_config.context.get_context(&request.context);
     let sdl_to_send = request_config.sdl.then(|| sdl.clone().to_string());
 
     let payload = Externalizable::router_builder()
@@ -961,7 +962,7 @@ where
 
         if let Some(context) = co_processor_output.context {
             for (mut key, value) in context.try_into_iter()? {
-                if let Some(ContextConf::Deprecated) = &request_config.context {
+                if let ContextConf::Deprecated = &request_config.context {
                     key = context_key_from_deprecated(key);
                 }
                 res.context.upsert_json_value(key, move |_current| value);
@@ -984,7 +985,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let Some(ContextConf::Deprecated) = &request_config.context {
+            if let ContextConf::Deprecated = &request_config.context {
                 key = context_key_from_deprecated(key);
             }
             request
@@ -1059,10 +1060,7 @@ where
         .then(|| std::str::from_utf8(&bytes).map(|s| s.to_string()))
         .transpose()?;
     let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
-    let context_to_send = response_config
-        .context
-        .as_ref()
-        .map(|c| c.get_context(&response.context));
+    let context_to_send = response_config.context.get_context(&response.context);
     let sdl_to_send = response_config.sdl.then(|| sdl.clone().to_string());
 
     let payload = Externalizable::router_builder()
@@ -1118,11 +1116,7 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        update_context_from_coprocessor(
-            &response.context,
-            context,
-            response_config.context.as_ref(),
-        )?;
+        update_context_from_coprocessor(&response.context, context, &response_config.context)?;
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -1154,9 +1148,7 @@ where
                     .then(|| String::from_utf8(bytes.clone()))
                     .transpose()?;
                 let generator_map_context = generator_map_context.clone();
-                let context_to_send = context_conf
-                    .as_ref()
-                    .map(|c| c.get_context(&generator_map_context));
+                let context_to_send = context_conf.get_context(&generator_map_context);
 
                 // Note: We deliberately DO NOT send headers or status_code even if the user has
                 // requested them. That's because they are meaningless on a deferred response and
@@ -1199,7 +1191,7 @@ where
                     update_context_from_coprocessor(
                         &generator_map_context,
                         context,
-                        context_conf.as_ref(),
+                        &context_conf,
                     )?;
                 }
 
@@ -1265,10 +1257,7 @@ where
         .body
         .then(|| serde_json_bytes::to_value(&body))
         .transpose()?;
-    let context_to_send = request_config
-        .context
-        .as_ref()
-        .map(|c| c.get_context(&request.context));
+    let context_to_send = request_config.context.get_context(&request.context);
     let uri = request_config.uri.then(|| parts.uri.to_string());
     let subgraph_name = service_name.clone();
     let service_name = request_config.service_name.then_some(service_name);
@@ -1351,7 +1340,7 @@ where
 
             if let Some(context) = co_processor_output.context {
                 for (mut key, value) in context.try_into_iter()? {
-                    if let Some(ContextConf::Deprecated) = &request_config.context {
+                    if let ContextConf::Deprecated = &request_config.context {
                         key = context_key_from_deprecated(key);
                     }
                     subgraph_response
@@ -1377,7 +1366,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let Some(ContextConf::Deprecated) = &request_config.context {
+            if let ContextConf::Deprecated = &request_config.context {
                 key = context_key_from_deprecated(key);
             }
             request
@@ -1437,10 +1426,7 @@ where
     let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
 
     let body_to_send = filter_graphql_response_body(&body, &response_config.body);
-    let context_to_send = response_config
-        .context
-        .as_ref()
-        .map(|c| c.get_context(&response.context));
+    let context_to_send = response_config.context.get_context(&response.context);
     let service_name = response_config.service_name.then_some(service_name);
     let subgraph_request_id = response_config
         .subgraph_request_id
@@ -1505,11 +1491,7 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        update_context_from_coprocessor(
-            &response.context,
-            context,
-            response_config.context.as_ref(),
-        )?;
+        update_context_from_coprocessor(&response.context, context, &response_config.context)?;
     }
 
     if let Some(headers) = co_processor_output.headers {

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -76,87 +76,6 @@ impl PluginPrivate for CoprocessorPlugin<HTTPClientService> {
     async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
         let client_config = init.config.client.clone().unwrap_or_default();
 
-        if matches!(
-            init.config.router.request.context,
-            ContextConf::Deprecated(true)
-        ) {
-            tracing::warn!(
-                "Configuration `coprocessor.router.request.context: true` is deprecated. See https://go.apollo.dev/o/coprocessor-context"
-            );
-        }
-        if matches!(
-            init.config.router.response.context,
-            ContextConf::Deprecated(true)
-        ) {
-            tracing::warn!(
-                "Configuration `coprocessor.router.response.context: true` is deprecated. See https://go.apollo.dev/o/coprocessor-context"
-            );
-        }
-        if matches!(
-            init.config.supergraph.request.context,
-            ContextConf::Deprecated(true)
-        ) {
-            tracing::warn!(
-                "Configuration `coprocessor.supergraph.request.context: true` is deprecated. See https://go.apollo.dev/o/coprocessor-context"
-            );
-        }
-        if matches!(
-            init.config.supergraph.response.context,
-            ContextConf::Deprecated(true)
-        ) {
-            tracing::warn!(
-                "Configuration `coprocessor.supergraph.response.context: true` is deprecated. See https://go.apollo.dev/o/coprocessor-context"
-            );
-        }
-        if matches!(
-            init.config.execution.request.context,
-            ContextConf::Deprecated(true)
-        ) {
-            tracing::warn!(
-                "Configuration `coprocessor.execution.request.context: true` is deprecated. See https://go.apollo.dev/o/coprocessor-context"
-            );
-        }
-        if matches!(
-            init.config.execution.response.context,
-            ContextConf::Deprecated(true)
-        ) {
-            tracing::warn!(
-                "Configuration `coprocessor.execution.response.context: true` is deprecated. See https://go.apollo.dev/o/coprocessor-context"
-            );
-        }
-        if matches!(
-            init.config.subgraph.all.request.context,
-            ContextConf::Deprecated(true)
-        ) {
-            tracing::warn!(
-                "Configuration `coprocessor.subgraph.all.request.context: true` is deprecated. See https://go.apollo.dev/o/coprocessor-context"
-            );
-        }
-        if matches!(
-            init.config.subgraph.all.response.context,
-            ContextConf::Deprecated(true)
-        ) {
-            tracing::warn!(
-                "Configuration `coprocessor.subgraph.all.response.context: true` is deprecated. See https://go.apollo.dev/o/coprocessor-context"
-            );
-        }
-        if matches!(
-            init.config.connector.all.request.context,
-            ContextConf::Deprecated(true)
-        ) {
-            tracing::warn!(
-                "Configuration `coprocessor.connector.all.request.context: true` is deprecated. See https://go.apollo.dev/o/coprocessor-context"
-            );
-        }
-        if matches!(
-            init.config.connector.all.response.context,
-            ContextConf::Deprecated(true)
-        ) {
-            tracing::warn!(
-                "Configuration `coprocessor.connector.all.response.context: true` is deprecated. See https://go.apollo.dev/o/coprocessor-context"
-            );
-        }
-
         // Validate all coprocessor URLs
         validate_coprocessor_url(&init.config.url, "coprocessor.url")?;
         if let Some(ref url) = init.config.router.request.url {
@@ -354,7 +273,7 @@ pub(super) struct RouterRequestConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: ContextConf,
+    pub(super) context: Option<ContextConf>,
     /// Send the body
     pub(super) body: bool,
     /// Send the SDL
@@ -376,7 +295,7 @@ pub(super) struct RouterResponseConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: ContextConf,
+    pub(super) context: Option<ContextConf>,
     /// Send the body
     pub(super) body: bool,
     /// Send the SDL
@@ -395,7 +314,7 @@ pub(super) struct SubgraphRequestConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: ContextConf,
+    pub(super) context: Option<ContextConf>,
     /// Send the body
     pub(super) body: bool,
     /// Send the subgraph URI
@@ -419,7 +338,7 @@ pub(super) struct SubgraphResponseConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: ContextConf,
+    pub(super) context: Option<ContextConf>,
     /// Send the body (can be true/false or selective with data/errors/extensions)
     pub(super) body: BodyConf,
     /// Send the service name
@@ -506,32 +425,8 @@ pub(super) struct BodyFieldsConf {
 
 /// Configures the context
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq)]
-#[serde(deny_unknown_fields, untagged)]
-pub(super) enum ContextConf {
-    /// Deprecated configuration using a boolean
-    Deprecated(bool),
-    NewContextConf(NewContextConf),
-}
-
-impl ContextConf {
-    fn is_deprecated(&self) -> bool {
-        match self {
-            Self::Deprecated(v) => *v,
-            Self::NewContextConf(c) => *c == NewContextConf::Deprecated,
-        }
-    }
-}
-
-impl Default for ContextConf {
-    fn default() -> Self {
-        Self::Deprecated(false)
-    }
-}
-
-/// Configures the context
-#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub(super) enum NewContextConf {
+pub(super) enum ContextConf {
     /// Send all context keys to coprocessor
     All,
     /// Send all context keys using deprecated names (from router 1.x) to coprocessor
@@ -541,10 +436,10 @@ pub(super) enum NewContextConf {
 }
 
 impl ContextConf {
-    pub(crate) fn get_context(&self, ctx: &Context) -> Option<Context> {
+    pub(crate) fn get_context(&self, ctx: &Context) -> Context {
         match self {
-            Self::NewContextConf(NewContextConf::All) => Some(ctx.clone()),
-            Self::NewContextConf(NewContextConf::Deprecated) | Self::Deprecated(true) => {
+            Self::All => ctx.clone(),
+            Self::Deprecated => {
                 let mut new_ctx = Context::from_iter(ctx.iter().map(|elt| {
                     (
                         context_key_to_deprecated(elt.key().clone()),
@@ -552,10 +447,9 @@ impl ContextConf {
                     )
                 }));
                 new_ctx.id = ctx.id.clone();
-
-                Some(new_ctx)
+                new_ctx
             }
-            Self::NewContextConf(NewContextConf::Selective(context_keys)) => {
+            Self::Selective(context_keys) => {
                 let mut new_ctx = Context::from_iter(ctx.iter().filter_map(|elt| {
                     if context_keys.contains(elt.key()) {
                         Some((elt.key().clone(), elt.value().clone()))
@@ -564,10 +458,8 @@ impl ContextConf {
                     }
                 }));
                 new_ctx.id = ctx.id.clone();
-
-                Some(new_ctx)
+                new_ctx
             }
-            Self::Deprecated(false) => None,
         }
     }
 }
@@ -621,14 +513,16 @@ pub(crate) fn validate_coprocessor_url(url: &str, config_path: &str) -> Result<(
 pub(crate) fn update_context_from_coprocessor(
     target_context: &Context,
     context_returned: Context,
-    context_config: &ContextConf,
+    context_config: Option<&ContextConf>,
 ) -> Result<(), BoxError> {
     // Collect keys that are in the returned context
     let mut keys_returned = HashSet::with_capacity(context_returned.len());
 
+    let is_deprecated = matches!(context_config, Some(ContextConf::Deprecated));
+
     for (mut key, value) in context_returned.try_into_iter()? {
         // Handle deprecated key names - convert back to actual key names
-        if context_config.is_deprecated() {
+        if is_deprecated {
             key = context_key_from_deprecated(key);
         }
 
@@ -639,7 +533,7 @@ pub(crate) fn update_context_from_coprocessor(
     // Delete keys that were sent but are missing from the returned context
     // If the context config is selective, only delete keys that are in the selective list
     match context_config {
-        ContextConf::NewContextConf(NewContextConf::Selective(context_keys)) => {
+        Some(ContextConf::Selective(context_keys)) => {
             target_context.retain(|key, _v| {
                 if keys_returned.contains(key) {
                     return true;
@@ -977,7 +871,10 @@ where
 
     let path_to_send = request_config.path.then(|| parts.uri.to_string());
 
-    let context_to_send = request_config.context.get_context(&request.context);
+    let context_to_send = request_config
+        .context
+        .as_ref()
+        .map(|c| c.get_context(&request.context));
     let sdl_to_send = request_config.sdl.then(|| sdl.clone().to_string());
 
     let payload = Externalizable::router_builder()
@@ -1064,9 +961,7 @@ where
 
         if let Some(context) = co_processor_output.context {
             for (mut key, value) in context.try_into_iter()? {
-                if let ContextConf::NewContextConf(NewContextConf::Deprecated) =
-                    &request_config.context
-                {
+                if let Some(ContextConf::Deprecated) = &request_config.context {
                     key = context_key_from_deprecated(key);
                 }
                 res.context.upsert_json_value(key, move |_current| value);
@@ -1089,8 +984,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let ContextConf::NewContextConf(NewContextConf::Deprecated) = &request_config.context
-            {
+            if let Some(ContextConf::Deprecated) = &request_config.context {
                 key = context_key_from_deprecated(key);
             }
             request
@@ -1165,7 +1059,10 @@ where
         .then(|| std::str::from_utf8(&bytes).map(|s| s.to_string()))
         .transpose()?;
     let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
-    let context_to_send = response_config.context.get_context(&response.context);
+    let context_to_send = response_config
+        .context
+        .as_ref()
+        .map(|c| c.get_context(&response.context));
     let sdl_to_send = response_config.sdl.then(|| sdl.clone().to_string());
 
     let payload = Externalizable::router_builder()
@@ -1221,7 +1118,11 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        update_context_from_coprocessor(&response.context, context, &response_config.context)?;
+        update_context_from_coprocessor(
+            &response.context,
+            context,
+            response_config.context.as_ref(),
+        )?;
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -1253,7 +1154,9 @@ where
                     .then(|| String::from_utf8(bytes.clone()))
                     .transpose()?;
                 let generator_map_context = generator_map_context.clone();
-                let context_to_send = context_conf.get_context(&generator_map_context);
+                let context_to_send = context_conf
+                    .as_ref()
+                    .map(|c| c.get_context(&generator_map_context));
 
                 // Note: We deliberately DO NOT send headers or status_code even if the user has
                 // requested them. That's because they are meaningless on a deferred response and
@@ -1296,7 +1199,7 @@ where
                     update_context_from_coprocessor(
                         &generator_map_context,
                         context,
-                        &context_conf,
+                        context_conf.as_ref(),
                     )?;
                 }
 
@@ -1362,7 +1265,10 @@ where
         .body
         .then(|| serde_json_bytes::to_value(&body))
         .transpose()?;
-    let context_to_send = request_config.context.get_context(&request.context);
+    let context_to_send = request_config
+        .context
+        .as_ref()
+        .map(|c| c.get_context(&request.context));
     let uri = request_config.uri.then(|| parts.uri.to_string());
     let subgraph_name = service_name.clone();
     let service_name = request_config.service_name.then_some(service_name);
@@ -1445,9 +1351,7 @@ where
 
             if let Some(context) = co_processor_output.context {
                 for (mut key, value) in context.try_into_iter()? {
-                    if let ContextConf::NewContextConf(NewContextConf::Deprecated) =
-                        &request_config.context
-                    {
+                    if let Some(ContextConf::Deprecated) = &request_config.context {
                         key = context_key_from_deprecated(key);
                     }
                     subgraph_response
@@ -1473,8 +1377,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let ContextConf::NewContextConf(NewContextConf::Deprecated) = &request_config.context
-            {
+            if let Some(ContextConf::Deprecated) = &request_config.context {
                 key = context_key_from_deprecated(key);
             }
             request
@@ -1534,7 +1437,10 @@ where
     let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
 
     let body_to_send = filter_graphql_response_body(&body, &response_config.body);
-    let context_to_send = response_config.context.get_context(&response.context);
+    let context_to_send = response_config
+        .context
+        .as_ref()
+        .map(|c| c.get_context(&response.context));
     let service_name = response_config.service_name.then_some(service_name);
     let subgraph_request_id = response_config
         .subgraph_request_id
@@ -1599,7 +1505,11 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        update_context_from_coprocessor(&response.context, context, &response_config.context)?;
+        update_context_from_coprocessor(
+            &response.context,
+            context,
+            response_config.context.as_ref(),
+        )?;
     }
 
     if let Some(headers) = co_processor_output.headers {

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -439,6 +439,10 @@ pub(super) enum ContextConf {
 }
 
 impl ContextConf {
+    pub(crate) fn is_deprecated(&self) -> bool {
+        matches!(self, Self::Deprecated)
+    }
+
     pub(crate) fn get_context(&self, ctx: &Context) -> Option<Context> {
         match self {
             Self::None => None,
@@ -522,7 +526,7 @@ pub(crate) fn update_context_from_coprocessor(
     // Collect keys that are in the returned context
     let mut keys_returned = HashSet::with_capacity(context_returned.len());
 
-    let is_deprecated = matches!(context_config, ContextConf::Deprecated);
+    let is_deprecated = context_config.is_deprecated();
 
     for (mut key, value) in context_returned.try_into_iter()? {
         // Handle deprecated key names - convert back to actual key names
@@ -962,7 +966,7 @@ where
 
         if let Some(context) = co_processor_output.context {
             for (mut key, value) in context.try_into_iter()? {
-                if let ContextConf::Deprecated = &request_config.context {
+                if request_config.context.is_deprecated() {
                     key = context_key_from_deprecated(key);
                 }
                 res.context.upsert_json_value(key, move |_current| value);
@@ -985,7 +989,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let ContextConf::Deprecated = &request_config.context {
+            if request_config.context.is_deprecated() {
                 key = context_key_from_deprecated(key);
             }
             request
@@ -1340,7 +1344,7 @@ where
 
             if let Some(context) = co_processor_output.context {
                 for (mut key, value) in context.try_into_iter()? {
-                    if let ContextConf::Deprecated = &request_config.context {
+                    if request_config.context.is_deprecated() {
                         key = context_key_from_deprecated(key);
                     }
                     subgraph_response
@@ -1366,7 +1370,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let ContextConf::Deprecated = &request_config.context {
+            if request_config.context.is_deprecated() {
                 key = context_key_from_deprecated(key);
             }
             request

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -28,7 +28,7 @@ pub(super) struct SupergraphRequestConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: ContextConf,
+    pub(super) context: Option<ContextConf>,
     /// Send the body
     pub(super) body: bool,
     /// Send the SDL
@@ -48,7 +48,7 @@ pub(super) struct SupergraphResponseConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: ContextConf,
+    pub(super) context: Option<ContextConf>,
     /// Send the body (can be true/false or selective with data/errors/extensions)
     pub(super) body: BodyConf,
     /// Send the SDL
@@ -222,7 +222,10 @@ where
         .body
         .then(|| serde_json::from_slice::<Value>(&bytes))
         .transpose()?;
-    let context_to_send = request_config.context.get_context(&request.context);
+    let context_to_send = request_config
+        .context
+        .as_ref()
+        .map(|c| c.get_context(&request.context));
     let sdl_to_send = request_config.sdl.then(|| sdl.clone().to_string());
     let method = request_config.method.then(|| parts.method.to_string());
 
@@ -287,9 +290,7 @@ where
 
             if let Some(context) = co_processor_output.context {
                 for (mut key, value) in context.try_into_iter()? {
-                    if let ContextConf::NewContextConf(NewContextConf::Deprecated) =
-                        &request_config.context
-                    {
+                    if let Some(ContextConf::Deprecated) = &request_config.context {
                         key = context_key_from_deprecated(key);
                     }
                     supergraph_response
@@ -315,8 +316,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let ContextConf::NewContextConf(NewContextConf::Deprecated) = &request_config.context
-            {
+            if let Some(ContextConf::Deprecated) = &request_config.context {
                 key = context_key_from_deprecated(key);
             }
             request
@@ -383,7 +383,10 @@ where
         .then(|| externalize_header_map(&parts.headers));
     let body_to_send = filter_graphql_response_body(&first, &response_config.body);
     let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
-    let context_to_send = response_config.context.get_context(&response.context);
+    let context_to_send = response_config
+        .context
+        .as_ref()
+        .map(|c| c.get_context(&response.context));
     let sdl_to_send = response_config.sdl.then(|| sdl.clone().to_string());
 
     let payload = Externalizable::supergraph_builder()
@@ -441,7 +444,11 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        update_context_from_coprocessor(&response.context, context, &response_config.context)?;
+        update_context_from_coprocessor(
+            &response.context,
+            context,
+            response_config.context.as_ref(),
+        )?;
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -470,7 +477,9 @@ where
                 }
                 let body_to_send =
                     filter_graphql_response_body(&deferred_response, &response_config.body);
-                let context_to_send = response_config_context.get_context(&generator_map_context);
+                let context_to_send = response_config_context
+                    .as_ref()
+                    .map(|c| c.get_context(&generator_map_context));
 
                 // Note: We deliberately DO NOT send headers or status_code even if the user has
                 // requested them. That's because they are meaningless on a deferred response and
@@ -524,7 +533,7 @@ where
                     update_context_from_coprocessor(
                         &generator_map_context,
                         context,
-                        &response_config_context,
+                        response_config_context.as_ref(),
                     )?;
                 }
 
@@ -652,7 +661,7 @@ mod tests {
             request: SupergraphRequestConf {
                 condition: Default::default(),
                 headers: false,
-                context: ContextConf::Deprecated(false),
+                context: None,
                 body: true,
                 sdl: false,
                 method: false,
@@ -795,7 +804,7 @@ mod tests {
                     SelectorOrValue::Value("value".to_string().into()),
                 ]),
                 headers: false,
-                context: ContextConf::Deprecated(false),
+                context: None,
                 body: true,
                 sdl: false,
                 method: false,
@@ -933,7 +942,7 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1070,7 +1079,7 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1188,7 +1197,7 @@ mod tests {
                     SelectorOrValue::Value(true.into()),
                 ]),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1302,7 +1311,7 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Condition::True,
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1332,7 +1341,7 @@ mod tests {
             request: SupergraphRequestConf {
                 condition: Condition::True,
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 method: true,

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -287,7 +287,7 @@ where
 
             if let Some(context) = co_processor_output.context {
                 for (mut key, value) in context.try_into_iter()? {
-                    if let ContextConf::Deprecated = &request_config.context {
+                    if request_config.context.is_deprecated() {
                         key = context_key_from_deprecated(key);
                     }
                     supergraph_response
@@ -313,7 +313,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let ContextConf::Deprecated = &request_config.context {
+            if request_config.context.is_deprecated() {
                 key = context_key_from_deprecated(key);
             }
             request

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -28,7 +28,7 @@ pub(super) struct SupergraphRequestConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: Option<ContextConf>,
+    pub(super) context: ContextConf,
     /// Send the body
     pub(super) body: bool,
     /// Send the SDL
@@ -48,7 +48,7 @@ pub(super) struct SupergraphResponseConf {
     /// Send the headers
     pub(super) headers: bool,
     /// Send the context
-    pub(super) context: Option<ContextConf>,
+    pub(super) context: ContextConf,
     /// Send the body (can be true/false or selective with data/errors/extensions)
     pub(super) body: BodyConf,
     /// Send the SDL
@@ -222,10 +222,7 @@ where
         .body
         .then(|| serde_json::from_slice::<Value>(&bytes))
         .transpose()?;
-    let context_to_send = request_config
-        .context
-        .as_ref()
-        .map(|c| c.get_context(&request.context));
+    let context_to_send = request_config.context.get_context(&request.context);
     let sdl_to_send = request_config.sdl.then(|| sdl.clone().to_string());
     let method = request_config.method.then(|| parts.method.to_string());
 
@@ -290,7 +287,7 @@ where
 
             if let Some(context) = co_processor_output.context {
                 for (mut key, value) in context.try_into_iter()? {
-                    if let Some(ContextConf::Deprecated) = &request_config.context {
+                    if let ContextConf::Deprecated = &request_config.context {
                         key = context_key_from_deprecated(key);
                     }
                     supergraph_response
@@ -316,7 +313,7 @@ where
 
     if let Some(context) = co_processor_output.context {
         for (mut key, value) in context.try_into_iter()? {
-            if let Some(ContextConf::Deprecated) = &request_config.context {
+            if let ContextConf::Deprecated = &request_config.context {
                 key = context_key_from_deprecated(key);
             }
             request
@@ -383,10 +380,7 @@ where
         .then(|| externalize_header_map(&parts.headers));
     let body_to_send = filter_graphql_response_body(&first, &response_config.body);
     let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
-    let context_to_send = response_config
-        .context
-        .as_ref()
-        .map(|c| c.get_context(&response.context));
+    let context_to_send = response_config.context.get_context(&response.context);
     let sdl_to_send = response_config.sdl.then(|| sdl.clone().to_string());
 
     let payload = Externalizable::supergraph_builder()
@@ -444,11 +438,7 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        update_context_from_coprocessor(
-            &response.context,
-            context,
-            response_config.context.as_ref(),
-        )?;
+        update_context_from_coprocessor(&response.context, context, &response_config.context)?;
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -477,9 +467,7 @@ where
                 }
                 let body_to_send =
                     filter_graphql_response_body(&deferred_response, &response_config.body);
-                let context_to_send = response_config_context
-                    .as_ref()
-                    .map(|c| c.get_context(&generator_map_context));
+                let context_to_send = response_config_context.get_context(&generator_map_context);
 
                 // Note: We deliberately DO NOT send headers or status_code even if the user has
                 // requested them. That's because they are meaningless on a deferred response and
@@ -533,7 +521,7 @@ where
                     update_context_from_coprocessor(
                         &generator_map_context,
                         context,
-                        response_config_context.as_ref(),
+                        &response_config_context,
                     )?;
                 }
 
@@ -661,7 +649,7 @@ mod tests {
             request: SupergraphRequestConf {
                 condition: Default::default(),
                 headers: false,
-                context: None,
+                context: ContextConf::None,
                 body: true,
                 sdl: false,
                 method: false,
@@ -804,7 +792,7 @@ mod tests {
                     SelectorOrValue::Value("value".to_string().into()),
                 ]),
                 headers: false,
-                context: None,
+                context: ContextConf::None,
                 body: true,
                 sdl: false,
                 method: false,
@@ -942,7 +930,7 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1079,7 +1067,7 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1197,7 +1185,7 @@ mod tests {
                     SelectorOrValue::Value(true.into()),
                 ]),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1311,7 +1299,7 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Condition::True,
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: BodyConf::All(true),
                 sdl: true,
                 status_code: false,
@@ -1341,7 +1329,7 @@ mod tests {
             request: SupergraphRequestConf {
                 condition: Condition::True,
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 method: true,

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -5125,12 +5125,8 @@ mod tests {
         returned_context.insert("k3", "v3".to_string()).unwrap();
 
         // Update context
-        update_context_from_coprocessor(
-            &target_context,
-            returned_context,
-            Some(&ContextConf::All),
-        )
-        .unwrap();
+        update_context_from_coprocessor(&target_context, returned_context, Some(&ContextConf::All))
+            .unwrap();
 
         // k1 should be updated
         assert_eq!(
@@ -5163,12 +5159,8 @@ mod tests {
         returned_context.insert("k2", "v2_new".to_string()).unwrap();
 
         // Update context
-        update_context_from_coprocessor(
-            &target_context,
-            returned_context,
-            Some(&ContextConf::All),
-        )
-        .unwrap();
+        update_context_from_coprocessor(&target_context, returned_context, Some(&ContextConf::All))
+            .unwrap();
 
         // k1 should be updated
         assert_eq!(

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -168,7 +168,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: false,
                 path: false,
@@ -254,7 +254,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 path: false,
@@ -318,7 +318,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 path: false,
@@ -382,7 +382,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 path: false,
@@ -645,7 +645,7 @@ mod tests {
                 condition: Default::default(),
                 body: true,
                 subgraph_request_id: true,
-                context: ContextConf::NewContextConf(NewContextConf::Selective(Arc::new(
+                context: Some(ContextConf::Selective(Arc::new(
                     ["this-is-a-test-context".to_string()].into(),
                 ))),
                 ..Default::default()
@@ -806,7 +806,7 @@ mod tests {
                 condition: Default::default(),
                 body: true,
                 subgraph_request_id: true,
-                context: ContextConf::NewContextConf(NewContextConf::Deprecated),
+                context: Some(ContextConf::Deprecated),
                 ..Default::default()
             },
             response: Default::default(),
@@ -1406,7 +1406,7 @@ mod tests {
                 condition: Default::default(),
                 body: BodyConf::All(true),
                 subgraph_request_id: true,
-                context: ContextConf::NewContextConf(NewContextConf::Selective(Arc::new(
+                context: Some(ContextConf::Selective(Arc::new(
                     ["this-is-a-test-context".to_string()].into(),
                 ))),
                 ..Default::default()
@@ -1556,7 +1556,7 @@ mod tests {
                 condition: Default::default(),
                 body: BodyConf::All(true),
                 subgraph_request_id: true,
-                context: ContextConf::NewContextConf(NewContextConf::Deprecated),
+                context: Some(ContextConf::Deprecated),
                 ..Default::default()
             },
         };
@@ -1831,7 +1831,7 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Default::default(),
                 headers: false,
-                context: ContextConf::Deprecated(false),
+                context: None,
                 body: BodyConf::All(true),
                 status_code: false,
                 sdl: false,
@@ -1895,7 +1895,7 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Default::default(),
                 headers: false,
-                context: ContextConf::NewContextConf(NewContextConf::Selective(Arc::new(
+                context: Some(ContextConf::Selective(Arc::new(
                     ["this-is-a-test-context".to_string()].into(),
                 ))),
                 body: BodyConf::All(true),
@@ -2003,7 +2003,7 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Default::default(),
                 headers: false,
-                context: ContextConf::NewContextConf(NewContextConf::Deprecated),
+                context: Some(ContextConf::Deprecated),
                 body: BodyConf::All(true),
                 status_code: false,
                 sdl: false,
@@ -2105,7 +2105,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 path: true,
@@ -2229,7 +2229,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::Selective(Arc::new(
+                context: Some(ContextConf::Selective(Arc::new(
                     ["this-is-a-test-context".to_string()].into(),
                 ))),
                 body: true,
@@ -2400,7 +2400,7 @@ mod tests {
                 ])
                 .into(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 path: true,
@@ -2511,7 +2511,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 path: true,
@@ -2645,7 +2645,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 path: true,
@@ -2741,7 +2741,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 path: true,
@@ -2828,7 +2828,7 @@ mod tests {
             response: RouterResponseConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 status_code: false,
@@ -3194,7 +3194,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Some(Condition::False),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 path: false,
@@ -3212,7 +3212,7 @@ mod tests {
             response: RouterResponseConf {
                 condition: Condition::False,
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 status_code: false,
@@ -3341,7 +3341,7 @@ mod tests {
             response: RouterResponseConf {
                 condition: Default::default(),
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 sdl: true,
                 status_code: false,
@@ -3625,7 +3625,7 @@ mod tests {
             response: SubgraphResponseConf {
                 condition: Condition::True,
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: BodyConf::All(true),
                 service_name: false,
                 status_code: false,
@@ -3659,7 +3659,7 @@ mod tests {
             request: SubgraphRequestConf {
                 condition: Condition::True,
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 uri: true,
                 method: true,
@@ -3677,7 +3677,7 @@ mod tests {
             request: SubgraphRequestConf {
                 condition: Condition::False,
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: true,
                 uri: true,
                 method: true,
@@ -3696,7 +3696,7 @@ mod tests {
             response: SubgraphResponseConf {
                 condition: Condition::False,
                 headers: true,
-                context: ContextConf::NewContextConf(NewContextConf::All),
+                context: Some(ContextConf::All),
                 body: BodyConf::All(true),
                 service_name: false,
                 status_code: false,
@@ -5128,7 +5128,7 @@ mod tests {
         update_context_from_coprocessor(
             &target_context,
             returned_context,
-            &ContextConf::NewContextConf(NewContextConf::All),
+            Some(&ContextConf::All),
         )
         .unwrap();
 
@@ -5166,7 +5166,7 @@ mod tests {
         update_context_from_coprocessor(
             &target_context,
             returned_context,
-            &ContextConf::NewContextConf(NewContextConf::All),
+            Some(&ContextConf::All),
         )
         .unwrap();
 
@@ -5202,11 +5202,10 @@ mod tests {
 
         // Use Selective config to only send "k1", not "key_not_sent"
         let selective_keys: HashSet<String> = ["k1".to_string()].into();
-        let context_config =
-            ContextConf::NewContextConf(NewContextConf::Selective(Arc::new(selective_keys)));
+        let context_config = ContextConf::Selective(Arc::new(selective_keys));
 
         // Update context
-        update_context_from_coprocessor(&target_context, returned_context, &context_config)
+        update_context_from_coprocessor(&target_context, returned_context, Some(&context_config))
             .unwrap();
 
         // k1 should be deleted (was sent but missing from returned context)
@@ -5221,11 +5220,6 @@ mod tests {
     #[rstest::rstest]
     fn test_update_context_from_coprocessor_handles_deprecated_key_names(
         #[values(DEPRECATED_CLIENT_NAME, CLIENT_NAME)] target_context_key_name: &str,
-        #[values(
-            ContextConf::Deprecated(true),
-            ContextConf::NewContextConf(NewContextConf::Deprecated)
-        )]
-        context_conf: ContextConf,
     ) {
         use crate::Context;
         use crate::plugins::coprocessor::update_context_from_coprocessor;
@@ -5235,7 +5229,12 @@ mod tests {
         let returned_context =
             Context::from_iter([(DEPRECATED_CLIENT_NAME.to_string(), "v2".into())]);
 
-        update_context_from_coprocessor(&target_context, returned_context, &context_conf).unwrap();
+        update_context_from_coprocessor(
+            &target_context,
+            returned_context,
+            Some(&ContextConf::Deprecated),
+        )
+        .unwrap();
 
         assert_eq!(
             target_context.get_json_value(CLIENT_NAME),
@@ -5956,7 +5955,7 @@ mod tests {
                     "url": "http://127.0.0.1:3001/webhook",
                     "router": {
                         "request": {
-                            "context": true,
+                            "context": "all",
                             "headers": true
                         }
                     }
@@ -6259,7 +6258,6 @@ mod tests {
         use crate::metrics::FutureMetricsExt;
         use crate::plugin::test::MockInternalHttpClientService;
         use crate::plugins::coprocessor::ContextConf;
-        use crate::plugins::coprocessor::NewContextConf;
         use crate::plugins::coprocessor::connector::ConnectorRequestConf;
         use crate::plugins::coprocessor::connector::ConnectorResponseConf;
         use crate::plugins::coprocessor::connector::ConnectorStage;
@@ -6670,7 +6668,7 @@ mod tests {
         async fn should_update_context_when_coprocessor_returns_context_entries() {
             let connector_stage = ConnectorStage {
                 request: ConnectorRequestConf {
-                    context: ContextConf::NewContextConf(NewContextConf::All),
+                    context: Some(ContextConf::All),
                     body: true,
                     ..Default::default()
                 },
@@ -7084,7 +7082,7 @@ mod tests {
             let connector_stage = ConnectorStage {
                 request: Default::default(),
                 response: ConnectorResponseConf {
-                    context: ContextConf::NewContextConf(NewContextConf::All),
+                    context: Some(ContextConf::All),
                     body: true,
                     ..Default::default()
                 },
@@ -7134,7 +7132,7 @@ mod tests {
             let connector_stage = ConnectorStage {
                 request: Default::default(),
                 response: ConnectorResponseConf {
-                    context: ContextConf::NewContextConf(NewContextConf::All),
+                    context: Some(ContextConf::All),
                     body: true,
                     ..Default::default()
                 },

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -168,7 +168,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: false,
                 path: false,
@@ -254,7 +254,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 path: false,
@@ -318,7 +318,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 path: false,
@@ -382,7 +382,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 path: false,
@@ -645,9 +645,9 @@ mod tests {
                 condition: Default::default(),
                 body: true,
                 subgraph_request_id: true,
-                context: Some(ContextConf::Selective(Arc::new(
+                context: ContextConf::Selective(Arc::new(
                     ["this-is-a-test-context".to_string()].into(),
-                ))),
+                )),
                 ..Default::default()
             },
             response: Default::default(),
@@ -806,7 +806,7 @@ mod tests {
                 condition: Default::default(),
                 body: true,
                 subgraph_request_id: true,
-                context: Some(ContextConf::Deprecated),
+                context: ContextConf::Deprecated,
                 ..Default::default()
             },
             response: Default::default(),
@@ -1406,9 +1406,9 @@ mod tests {
                 condition: Default::default(),
                 body: BodyConf::All(true),
                 subgraph_request_id: true,
-                context: Some(ContextConf::Selective(Arc::new(
+                context: ContextConf::Selective(Arc::new(
                     ["this-is-a-test-context".to_string()].into(),
-                ))),
+                )),
                 ..Default::default()
             },
         };
@@ -1556,7 +1556,7 @@ mod tests {
                 condition: Default::default(),
                 body: BodyConf::All(true),
                 subgraph_request_id: true,
-                context: Some(ContextConf::Deprecated),
+                context: ContextConf::Deprecated,
                 ..Default::default()
             },
         };
@@ -1831,7 +1831,7 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Default::default(),
                 headers: false,
-                context: None,
+                context: ContextConf::None,
                 body: BodyConf::All(true),
                 status_code: false,
                 sdl: false,
@@ -1895,9 +1895,9 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Default::default(),
                 headers: false,
-                context: Some(ContextConf::Selective(Arc::new(
+                context: ContextConf::Selective(Arc::new(
                     ["this-is-a-test-context".to_string()].into(),
-                ))),
+                )),
                 body: BodyConf::All(true),
                 status_code: false,
                 sdl: false,
@@ -2003,7 +2003,7 @@ mod tests {
             response: SupergraphResponseConf {
                 condition: Default::default(),
                 headers: false,
-                context: Some(ContextConf::Deprecated),
+                context: ContextConf::Deprecated,
                 body: BodyConf::All(true),
                 status_code: false,
                 sdl: false,
@@ -2105,7 +2105,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 path: true,
@@ -2229,9 +2229,9 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::Selective(Arc::new(
+                context: ContextConf::Selective(Arc::new(
                     ["this-is-a-test-context".to_string()].into(),
-                ))),
+                )),
                 body: true,
                 sdl: true,
                 path: true,
@@ -2400,7 +2400,7 @@ mod tests {
                 ])
                 .into(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 path: true,
@@ -2511,7 +2511,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 path: true,
@@ -2645,7 +2645,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 path: true,
@@ -2741,7 +2741,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 path: true,
@@ -2828,7 +2828,7 @@ mod tests {
             response: RouterResponseConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 status_code: false,
@@ -3194,7 +3194,7 @@ mod tests {
             request: RouterRequestConf {
                 condition: Some(Condition::False),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 path: false,
@@ -3212,7 +3212,7 @@ mod tests {
             response: RouterResponseConf {
                 condition: Condition::False,
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 status_code: false,
@@ -3341,7 +3341,7 @@ mod tests {
             response: RouterResponseConf {
                 condition: Default::default(),
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 sdl: true,
                 status_code: false,
@@ -3625,7 +3625,7 @@ mod tests {
             response: SubgraphResponseConf {
                 condition: Condition::True,
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: BodyConf::All(true),
                 service_name: false,
                 status_code: false,
@@ -3659,7 +3659,7 @@ mod tests {
             request: SubgraphRequestConf {
                 condition: Condition::True,
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 uri: true,
                 method: true,
@@ -3677,7 +3677,7 @@ mod tests {
             request: SubgraphRequestConf {
                 condition: Condition::False,
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: true,
                 uri: true,
                 method: true,
@@ -3696,7 +3696,7 @@ mod tests {
             response: SubgraphResponseConf {
                 condition: Condition::False,
                 headers: true,
-                context: Some(ContextConf::All),
+                context: ContextConf::All,
                 body: BodyConf::All(true),
                 service_name: false,
                 status_code: false,
@@ -5125,7 +5125,7 @@ mod tests {
         returned_context.insert("k3", "v3".to_string()).unwrap();
 
         // Update context
-        update_context_from_coprocessor(&target_context, returned_context, Some(&ContextConf::All))
+        update_context_from_coprocessor(&target_context, returned_context, &ContextConf::All)
             .unwrap();
 
         // k1 should be updated
@@ -5159,7 +5159,7 @@ mod tests {
         returned_context.insert("k2", "v2_new".to_string()).unwrap();
 
         // Update context
-        update_context_from_coprocessor(&target_context, returned_context, Some(&ContextConf::All))
+        update_context_from_coprocessor(&target_context, returned_context, &ContextConf::All)
             .unwrap();
 
         // k1 should be updated
@@ -5197,7 +5197,7 @@ mod tests {
         let context_config = ContextConf::Selective(Arc::new(selective_keys));
 
         // Update context
-        update_context_from_coprocessor(&target_context, returned_context, Some(&context_config))
+        update_context_from_coprocessor(&target_context, returned_context, &context_config)
             .unwrap();
 
         // k1 should be deleted (was sent but missing from returned context)
@@ -5224,7 +5224,7 @@ mod tests {
         update_context_from_coprocessor(
             &target_context,
             returned_context,
-            Some(&ContextConf::Deprecated),
+            &ContextConf::Deprecated,
         )
         .unwrap();
 
@@ -6660,7 +6660,7 @@ mod tests {
         async fn should_update_context_when_coprocessor_returns_context_entries() {
             let connector_stage = ConnectorStage {
                 request: ConnectorRequestConf {
-                    context: Some(ContextConf::All),
+                    context: ContextConf::All,
                     body: true,
                     ..Default::default()
                 },
@@ -7074,7 +7074,7 @@ mod tests {
             let connector_stage = ConnectorStage {
                 request: Default::default(),
                 response: ConnectorResponseConf {
-                    context: Some(ContextConf::All),
+                    context: ContextConf::All,
                     body: true,
                     ..Default::default()
                 },
@@ -7124,7 +7124,7 @@ mod tests {
             let connector_stage = ConnectorStage {
                 request: Default::default(),
                 response: ConnectorResponseConf {
-                    context: Some(ContextConf::All),
+                    context: ContextConf::All,
                     body: true,
                     ..Default::default()
                 },

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -1061,13 +1061,13 @@ coprocessor:
   router:
     request:
       headers: true
-      context: true
+      context: all
       url: {}  # Override for router stage
   supergraph:
     request:
       headers: true
       body: true
-      context: true
+      context: all
       url: {}  # Override for supergraph stage
 "#,
         router_uds_url, supergraph_uds_url
@@ -1206,13 +1206,13 @@ coprocessor:
   router:
     request:
       headers: true
-      context: true
+      context: all
       url: {}  # Unix socket for router stage
   supergraph:
     request:
       headers: true
       body: true
-      context: true
+      context: all
       url: {}  # HTTP for supergraph stage
 "#,
         router_uds_url, supergraph_http_url

--- a/apollo-router/tests/integration/lifecycle.rs
+++ b/apollo-router/tests/integration/lifecycle.rs
@@ -333,8 +333,8 @@ async fn test_plugin_ordering() {
                 "coprocessor": {
                     "url": coprocessor_url,
                     "router": {
-                        "request": { "context": true },
-                        "response": { "context": true },
+                        "request": { "context": "all" },
+                        "response": { "context": "all" },
                     }
                 },
             }))

--- a/docs/shared/config/coprocessor.mdx
+++ b/docs/shared/config/coprocessor.mdx
@@ -15,6 +15,7 @@ coprocessor:
           eq:
           - false
           - false
+        context: none
         headers: false
         method: false
         service_name: false
@@ -25,18 +26,21 @@ coprocessor:
           eq:
           - false
           - false
+        context: none
         headers: false
         service_name: false
         status_code: false
   execution:
     request:
       body: false
+      context: none
       headers: false
       method: false
       query_plan: false
       sdl: false
     response:
       body: false
+      context: none
       headers: false
       sdl: false
       status_code: false
@@ -47,6 +51,7 @@ coprocessor:
         eq:
         - false
         - false
+      context: none
       headers: false
       method: false
       path: false
@@ -57,6 +62,7 @@ coprocessor:
         eq:
         - false
         - false
+      context: none
       headers: false
       sdl: false
       status_code: false
@@ -68,6 +74,7 @@ coprocessor:
           eq:
           - false
           - false
+        context: none
         headers: false
         method: false
         service_name: false
@@ -79,6 +86,7 @@ coprocessor:
           eq:
           - false
           - false
+        context: none
         headers: false
         service_name: false
         status_code: false
@@ -90,6 +98,7 @@ coprocessor:
         eq:
         - false
         - false
+      context: none
       headers: false
       method: false
       sdl: false
@@ -99,6 +108,7 @@ coprocessor:
         eq:
         - false
         - false
+      context: none
       headers: false
       sdl: false
       status_code: false

--- a/docs/shared/config/coprocessor.mdx
+++ b/docs/shared/config/coprocessor.mdx
@@ -15,7 +15,6 @@ coprocessor:
           eq:
           - false
           - false
-        context: false
         headers: false
         method: false
         service_name: false
@@ -26,21 +25,18 @@ coprocessor:
           eq:
           - false
           - false
-        context: false
         headers: false
         service_name: false
         status_code: false
   execution:
     request:
       body: false
-      context: false
       headers: false
       method: false
       query_plan: false
       sdl: false
     response:
       body: false
-      context: false
       headers: false
       sdl: false
       status_code: false
@@ -51,7 +47,6 @@ coprocessor:
         eq:
         - false
         - false
-      context: false
       headers: false
       method: false
       path: false
@@ -62,7 +57,6 @@ coprocessor:
         eq:
         - false
         - false
-      context: false
       headers: false
       sdl: false
       status_code: false
@@ -74,7 +68,6 @@ coprocessor:
           eq:
           - false
           - false
-        context: false
         headers: false
         method: false
         service_name: false
@@ -86,7 +79,6 @@ coprocessor:
           eq:
           - false
           - false
-        context: false
         headers: false
         service_name: false
         status_code: false
@@ -98,7 +90,6 @@ coprocessor:
         eq:
         - false
         - false
-      context: false
       headers: false
       method: false
       sdl: false
@@ -108,7 +99,6 @@ coprocessor:
         eq:
         - false
         - false
-      context: false
       headers: false
       sdl: false
       status_code: false

--- a/docs/shared/coproc-typical-config.mdx
+++ b/docs/shared/coproc-typical-config.mdx
@@ -8,24 +8,27 @@ coprocessor:
     request: # By including this key, the `RouterService` sends a coprocessor request whenever it first receives a client request.
       headers: true # These boolean properties indicate which request data to include in the coprocessor request. All are optional and false by default.
       body: false
-      # Omit `context` to skip sending context entries. To send context, use `all`, `deprecated`, or `selective: [keys...]`.
+      context: none # Set to `all`, `deprecated`, or `selective: [keys...]` to send context entries.
       sdl: false
       path: false
       method: false
     response: # By including this key, the `RouterService` sends a coprocessor request whenever it's about to send response data to a client (including incremental data via @defer).
       headers: true
       body: false
+      context: none
       sdl: false
       status_code: false
   supergraph: # This coprocessor hooks into the `SupergraphService`
     request: # By including this key, the `SupergraphService` sends a coprocessor request whenever it first receives a client request.
       headers: true # These boolean properties indicate which request data to include in the coprocessor request. All are optional and false by default.
       body: false
+      context: none
       sdl: false
       method: false
     response: # By including this key, the `SupergraphService` sends a coprocessor request whenever it's about to send response data to a client (including incremental data via @defer).
       headers: true
       body: false
+      context: none
       sdl: false
       status_code: false
   subgraph:
@@ -33,6 +36,7 @@ coprocessor:
       request: # By including this key, the `SubgraphService` sends a coprocessor request whenever it is about to make a request to a subgraph.
         headers: true # These boolean properties indicate which request data to include in the coprocessor request. All are optional and false by default.
         body: false
+        context: none
         uri: false
         method: false
         service_name: false
@@ -40,6 +44,7 @@ coprocessor:
       response: # By including this key, the `SubgraphService` sends a coprocessor request whenever receives a subgraph response.
         headers: true
         body: false
+        context: none
         service_name: false
         status_code: false
         subgraph_request_id: false
@@ -48,12 +53,14 @@ coprocessor:
       request: # By including this key, the coprocessor sends a request before each connector HTTP call.
         headers: true # These boolean properties indicate which request data to include in the coprocessor request. All are optional and false by default.
         body: false
+        context: none
         uri: false
         method: false
         service_name: false
       response: # By including this key, the coprocessor sends a request after each connector HTTP call.
         headers: true
         body: false
+        context: none
         service_name: false
         status_code: false
 ```

--- a/docs/shared/coproc-typical-config.mdx
+++ b/docs/shared/coproc-typical-config.mdx
@@ -8,27 +8,24 @@ coprocessor:
     request: # By including this key, the `RouterService` sends a coprocessor request whenever it first receives a client request.
       headers: true # These boolean properties indicate which request data to include in the coprocessor request. All are optional and false by default.
       body: false
-      context: false
+      # Omit `context` to skip sending context entries. To send context, use `all`, `deprecated`, or `selective: [keys...]`.
       sdl: false
       path: false
       method: false
     response: # By including this key, the `RouterService` sends a coprocessor request whenever it's about to send response data to a client (including incremental data via @defer).
       headers: true
       body: false
-      context: false
       sdl: false
       status_code: false
   supergraph: # This coprocessor hooks into the `SupergraphService`
     request: # By including this key, the `SupergraphService` sends a coprocessor request whenever it first receives a client request.
       headers: true # These boolean properties indicate which request data to include in the coprocessor request. All are optional and false by default.
       body: false
-      context: false
       sdl: false
       method: false
     response: # By including this key, the `SupergraphService` sends a coprocessor request whenever it's about to send response data to a client (including incremental data via @defer).
       headers: true
       body: false
-      context: false
       sdl: false
       status_code: false
   subgraph:
@@ -36,7 +33,6 @@ coprocessor:
       request: # By including this key, the `SubgraphService` sends a coprocessor request whenever it is about to make a request to a subgraph.
         headers: true # These boolean properties indicate which request data to include in the coprocessor request. All are optional and false by default.
         body: false
-        context: false
         uri: false
         method: false
         service_name: false
@@ -44,7 +40,6 @@ coprocessor:
       response: # By including this key, the `SubgraphService` sends a coprocessor request whenever receives a subgraph response.
         headers: true
         body: false
-        context: false
         service_name: false
         status_code: false
         subgraph_request_id: false
@@ -53,14 +48,12 @@ coprocessor:
       request: # By including this key, the coprocessor sends a request before each connector HTTP call.
         headers: true # These boolean properties indicate which request data to include in the coprocessor request. All are optional and false by default.
         body: false
-        context: false
         uri: false
         method: false
         service_name: false
       response: # By including this key, the coprocessor sends a request after each connector HTTP call.
         headers: true
         body: false
-        context: false
         service_name: false
         status_code: false
 ```

--- a/docs/shared/router-config-properties-table.mdx
+++ b/docs/shared/router-config-properties-table.mdx
@@ -155,12 +155,14 @@ coprocessor:
   execution:
     request:
       body: false
+      context: none
       headers: false
       method: false
       query_plan: false
       sdl: false
     response:
       body: false
+      context: none
       headers: false
       sdl: false
       status_code: false
@@ -171,6 +173,7 @@ coprocessor:
         eq:
         - false
         - false
+      context: none
       headers: false
       method: false
       path: false
@@ -181,6 +184,7 @@ coprocessor:
         eq:
         - false
         - false
+      context: none
       headers: false
       sdl: false
       status_code: false
@@ -192,6 +196,7 @@ coprocessor:
           eq:
           - false
           - false
+        context: none
         headers: false
         method: false
         service_name: false
@@ -203,6 +208,7 @@ coprocessor:
           eq:
           - false
           - false
+        context: none
         headers: false
         service_name: false
         status_code: false
@@ -214,6 +220,7 @@ coprocessor:
         eq:
         - false
         - false
+      context: none
       headers: false
       method: false
       sdl: false
@@ -223,6 +230,7 @@ coprocessor:
         eq:
         - false
         - false
+      context: none
       headers: false
       sdl: false
       status_code: false

--- a/docs/shared/router-config-properties-table.mdx
+++ b/docs/shared/router-config-properties-table.mdx
@@ -155,14 +155,12 @@ coprocessor:
   execution:
     request:
       body: false
-      context: false
       headers: false
       method: false
       query_plan: false
       sdl: false
     response:
       body: false
-      context: false
       headers: false
       sdl: false
       status_code: false
@@ -173,7 +171,6 @@ coprocessor:
         eq:
         - false
         - false
-      context: false
       headers: false
       method: false
       path: false
@@ -184,7 +181,6 @@ coprocessor:
         eq:
         - false
         - false
-      context: false
       headers: false
       sdl: false
       status_code: false
@@ -196,7 +192,6 @@ coprocessor:
           eq:
           - false
           - false
-        context: false
         headers: false
         method: false
         service_name: false
@@ -208,7 +203,6 @@ coprocessor:
           eq:
           - false
           - false
-        context: false
         headers: false
         service_name: false
         status_code: false
@@ -220,7 +214,6 @@ coprocessor:
         eq:
         - false
         - false
-      context: false
       headers: false
       method: false
       sdl: false
@@ -230,7 +223,6 @@ coprocessor:
         eq:
         - false
         - false
-      context: false
       headers: false
       sdl: false
       status_code: false

--- a/docs/shared/router-yaml-complete.mdx
+++ b/docs/shared/router-yaml-complete.mdx
@@ -91,14 +91,12 @@ coprocessor:
   execution:
     request:
       body: false
-      context: false
       headers: false
       method: false
       query_plan: false
       sdl: false
     response:
       body: false
-      context: false
       headers: false
       sdl: false
       status_code: false
@@ -109,7 +107,6 @@ coprocessor:
         eq:
           - false
           - false
-      context: false
       headers: false
       method: false
       path: false
@@ -120,7 +117,6 @@ coprocessor:
         eq:
           - false
           - false
-      context: false
       headers: false
       sdl: false
       status_code: false
@@ -132,7 +128,6 @@ coprocessor:
           eq:
             - false
             - false
-        context: false
         headers: false
         method: false
         service_name: false
@@ -144,7 +139,6 @@ coprocessor:
           eq:
             - false
             - false
-        context: false
         headers: false
         service_name: false
         status_code: false
@@ -156,7 +150,6 @@ coprocessor:
         eq:
           - false
           - false
-      context: false
       headers: false
       method: false
       sdl: false
@@ -166,7 +159,6 @@ coprocessor:
         eq:
           - false
           - false
-      context: false
       headers: false
       sdl: false
       status_code: false

--- a/docs/shared/router-yaml-complete.mdx
+++ b/docs/shared/router-yaml-complete.mdx
@@ -91,12 +91,14 @@ coprocessor:
   execution:
     request:
       body: false
+      context: none
       headers: false
       method: false
       query_plan: false
       sdl: false
     response:
       body: false
+      context: none
       headers: false
       sdl: false
       status_code: false
@@ -107,6 +109,7 @@ coprocessor:
         eq:
           - false
           - false
+      context: none
       headers: false
       method: false
       path: false
@@ -117,6 +120,7 @@ coprocessor:
         eq:
           - false
           - false
+      context: none
       headers: false
       sdl: false
       status_code: false
@@ -128,6 +132,7 @@ coprocessor:
           eq:
             - false
             - false
+        context: none
         headers: false
         method: false
         service_name: false
@@ -139,6 +144,7 @@ coprocessor:
           eq:
             - false
             - false
+        context: none
         headers: false
         service_name: false
         status_code: false
@@ -150,6 +156,7 @@ coprocessor:
         eq:
           - false
           - false
+      context: none
       headers: false
       method: false
       sdl: false
@@ -159,6 +166,7 @@ coprocessor:
         eq:
           - false
           - false
+      context: none
       headers: false
       sdl: false
       status_code: false

--- a/docs/source/routing/customization/coprocessor/index.mdx
+++ b/docs/source/routing/customization/coprocessor/index.mdx
@@ -179,7 +179,7 @@ coprocessor:
 ### Context configuration
 
 The router request context is used to share data across stages of the request pipeline. The coprocessor can also use this context.
-By default, the context is not sent to the coprocessor (omit the `context` field).
+By default, the context is not sent to the coprocessor — either omit the `context` field or explicitly set `context: none`.
 You can send _all_ context keys to your coprocessor using `context: all`.
 You can also specify exactly which context keys you wish to send to a coprocessor by listing them under the `selective` key. This will reduce the size of the request/response and may improve performance.
 
@@ -191,7 +191,8 @@ Example:
 coprocessor:
   url: http://127.0.0.1:3000 # mandatory URL which is the address of the coprocessor
   router:
-    request: {} # Omit `context` to skip sending any context entries
+    request:
+      context: none # Do not send any context entries (also the default if `context` is omitted)
   supergraph:
     request:
       headers: true

--- a/docs/source/routing/customization/coprocessor/index.mdx
+++ b/docs/source/routing/customization/coprocessor/index.mdx
@@ -179,18 +179,11 @@ coprocessor:
 ### Context configuration
 
 The router request context is used to share data across stages of the request pipeline. The coprocessor can also use this context.
-By default, the context is not sent to the coprocessor (`context: false`).
+By default, the context is not sent to the coprocessor (omit the `context` field).
 You can send _all_ context keys to your coprocessor using `context: all`.
 You can also specify exactly which context keys you wish to send to a coprocessor by listing them under the `selective` key. This will reduce the size of the request/response and may improve performance.
 
 If you're upgrading from router 1.x, the [context key names changed](/docs/graphos/routing/upgrade/from-router-v1#renamed-context-keys) in router v2.0. You can specify `context: deprecated` to send all context with the old names, compatible with v1.x. Context keys are translated to their v1.x names before being sent to the coprocessor, and translated back to the v2.x names after being received from the coprocessor.
-
-<Note>
-
-`context: true` from router 1.x is still supported by the configuration, and is an alias for `context: deprecated`.
-We strongly recommend using `context: deprecated` or `context: all` instead.
-
-</Note>
 
 Example:
 
@@ -198,8 +191,7 @@ Example:
 coprocessor:
   url: http://127.0.0.1:3000 # mandatory URL which is the address of the coprocessor
   router:
-    request:
-      context: false # Do not send any context entries
+    request: {} # Omit `context` to skip sending any context entries
   supergraph:
     request:
       headers: true

--- a/docs/source/routing/upgrade/from-router-v1.mdx
+++ b/docs/source/routing/upgrade/from-router-v1.mdx
@@ -422,7 +422,8 @@ Example:
 coprocessor:
   url: http://127.0.0.1:3000 # mandatory URL which is the address of the coprocessor
   router:
-    request: {} # Omit `context` to skip sending any context entries
+    request:
+      context: none # Do not send any context entries
   supergraph:
     request:
       headers: true

--- a/docs/source/routing/upgrade/from-router-v1.mdx
+++ b/docs/source/routing/upgrade/from-router-v1.mdx
@@ -412,12 +412,6 @@ The [context key renames](#renamed-context-keys) may impact your coprocessor log
 
 You can specify `context: deprecated` to send all context with the old names, compatible with v1.x. Context keys are translated to their v1.x names before being sent to the coprocessor, and translated back to the v2.x names after being received from the coprocessor.
 
-<Note>
-
-`context: true` is an alias for `context: deprecated`. In a future major release, the `context: true` setting will be removed.
-
-</Note>
-
 You can now also specify exactly which context keys you wish to send to a coprocessor by listing them under the `selective` key. This will reduce the size of the request/response and may improve performance.
 
 **Upgrade step**: Either upgrade your coprocessor to use the new context keys, or add `context: deprecated` to your coprocessor configuration.
@@ -428,8 +422,7 @@ Example:
 coprocessor:
   url: http://127.0.0.1:3000 # mandatory URL which is the address of the coprocessor
   router:
-    request:
-      context: false # Do not send any context entries
+    request: {} # Omit `context` to skip sending any context entries
   supergraph:
     request:
       headers: true

--- a/examples/coprocessor-override-launchdarkly/router.example.yaml
+++ b/examples/coprocessor-override-launchdarkly/router.example.yaml
@@ -4,4 +4,4 @@ coprocessor:
                              # and Unix Domain Socket (unix:///tmp/coprocessor.sock) URLs.
   supergraph: # Hook into the supergraph service
     request:
-      context: true
+      context: all

--- a/examples/coprocessor-subgraph/nodejs/router.yaml
+++ b/examples/coprocessor-subgraph/nodejs/router.yaml
@@ -13,9 +13,9 @@ coprocessor:
   timeout: 2s # optional timeout (2 seconds in this example). If not set, defaults to 1 second
   subgraph:
     all:
-      request: 
+      request:
         headers: true
-        context: true
+        context: all
         uri: true
         service_name: true
         body: true

--- a/examples/coprocessor-subgraph/rust/router.yaml
+++ b/examples/coprocessor-subgraph/rust/router.yaml
@@ -14,7 +14,7 @@ coprocessor:
     all:
       request: # What data should we transmit to the co-processor from the router request?
         headers: true # All of these data content attributes are optional and false by default.
-        context: true
+        context: all
         uri: true
         service_name: true
         body: true

--- a/examples/coprocessor-surrogate-cache-key/nodejs/router.yaml
+++ b/examples/coprocessor-surrogate-cache-key/nodejs/router.yaml
@@ -11,13 +11,13 @@ include_subgraph_errors:
 coprocessor:
   url: http://127.0.0.1:3000 # mandatory URL which is the address of the coprocessor
   supergraph:
-    response: 
-      context: true
+    response:
+      context: all
   subgraph:
     all:
-      response: 
+      response:
         subgraph_request_id: true
-        context: true
+        context: all
 preview_entity_cache:
   enabled: true
   expose_keys_in_context: true

--- a/examples/coprocessor/router.yaml
+++ b/examples/coprocessor/router.yaml
@@ -22,7 +22,7 @@ coprocessor:
   router:
     request:
       headers: true
-      context: true
+      context: all
       body: true
       sdl: true
     response:


### PR DESCRIPTION
The boolean form of the `context` field on each coprocessor stage (`context: true` / `context: false`) was deprecated and has now been removed across all 10 coprocessor stage configurations (`router.{request,response}`, `supergraph.{request,response}`, `execution.{request,response}`, `subgraph.all.{request,response}`, `connector.all.{request,response}`). Use the structured form instead:

- `context: all` — send every context entry with the current key names
- `context: deprecated` — send every context entry using the pre-2.x deprecated key names
- `context: selective: [key1, key2, ...]` — only send the listed context keys
- omit the field — do not send context (the default)

To preserve existing behavior, an automatic configuration migration rewrites `context: true` to `context: deprecated` and drops `context: false` on router startup. See [https://go.apollo.dev/o/coprocessor-context](https://go.apollo.dev/o/coprocessor-context) for details.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
