### PR TITLE
fix(composition): expand default values in argument merger

### DIFF
--- a/apollo-federation/src/merger/merge_directive.rs
+++ b/apollo-federation/src/merger/merge_directive.rs
@@ -166,6 +166,8 @@ impl Merger {
                     .into_iter()
                     .map(|d| (**d).clone())
                     .collect_vec();
+                // PORT NOTE: JS applies transforms for repeatable directives only
+                // this might have been a miss as it is currently only used for @context
                 if let Some(transform) =
                     &directive_in_supergraph.and_then(|d| d.static_argument_transform.as_ref())
                 {
@@ -272,10 +274,12 @@ impl Merger {
                 let values = directive_counts
                     .keys()
                     .filter_map(|d| {
-                        d.specified_argument_by_name(&arg_def.name)
-                            .map(|v| v.as_ref())
+                        self.directive_arguments_with_defaults(d, &definition)
+                            .get(&arg_def.name)
+                            .copied()
+                            .flatten()
+                            .map(|v| v.as_ref().clone())
                     })
-                    .cloned()
                     .collect_vec();
                 if let Some(merged_value) = (merger.merge)(&arg_def.name, &values)? {
                     let merged_arg = Argument {

--- a/apollo-federation/tests/composition/directive_argument_merge_strategies.rs
+++ b/apollo-federation/tests/composition/directive_argument_merge_strategies.rs
@@ -400,7 +400,7 @@ mod tests {
             .expect("@listSize directive should be present on T");
         assert_eq!(
             t_requires_scopes_directive.to_string(),
-            r#"@listSize(assumedSize: 20)"#
+            r#"@listSize(assumedSize: 20, requireOneSlicingArgument: true)"#
         );
 
         let k = coord!(T.k)
@@ -413,7 +413,7 @@ mod tests {
             .expect("@listSize directive should be present on T.k");
         assert_eq!(
             k_requires_scopes_directive.to_string(),
-            r#"@listSize(assumedSize: 3)"#
+            r#"@listSize(assumedSize: 3, requireOneSlicingArgument: true)"#
         );
 
         let b = coord!(T.b)
@@ -536,7 +536,7 @@ mod tests {
             .expect("@listSize directive should be present on T.k");
         assert_eq!(
             k_requires_scopes_directive.to_string(),
-            r#"@listSize(slicingArguments: ["first", "last"])"#
+            r#"@listSize(slicingArguments: ["first", "last"], requireOneSlicingArgument: true)"#
         );
 
         let b = coord!(T.b)
@@ -549,7 +549,7 @@ mod tests {
             .expect("@listSize directive should be present on T.b");
         assert_eq!(
             b_requires_scopes_directive.to_string(),
-            r#"@listSize(sizedFields: ["page", "nextPageToken"])"#
+            r#"@listSize(sizedFields: ["page", "nextPageToken"], requireOneSlicingArgument: true)"#
         );
 
         let c = coord!(T.c)
@@ -563,6 +563,70 @@ mod tests {
         assert_eq!(
             c_requires_scopes_directive.to_string(),
             r#"@listSize(sizedFields: ["nextPageToken"])"#
+        );
+    }
+
+    #[test]
+    fn argument_merger_includes_default_values() {
+        // Verifies that when the argument merger is invoked, default argument values
+        // are included in the merge (matching JS behavior). Both subgraphs apply
+        // @listSize with different assumedSize but neither specifies
+        // requireOneSlicingArgument (which defaults to true). The merger should
+        // expand the default and include it in the merged result.
+
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+                type Query {
+                    items: [T!] @shareable @listSize(assumedSize: 10)
+                }
+
+                type T @key(fields: "id") {
+                    id: ID
+                }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+                type Query {
+                    items: [T!] @shareable @listSize(assumedSize: 20)
+                }
+
+                type T @key(fields: "id") {
+                    id: ID
+                }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2]);
+        let result_sg = result.expect("Composition should succeed");
+
+        let expected_hints = vec![CompositionHint {
+            definition: HintCode::MergedNonRepeatableDirectiveArguments.definition(),
+            message: String::from(
+                r#"Directive @listSize is applied to "Query.items" in multiple subgraphs with different arguments. Merging strategies used by arguments: { assumedSize: NULLABLE_MAX, slicingArguments: NULLABLE_UNION, sizedFields: NULLABLE_UNION, requireOneSlicingArgument: NULLABLE_AND }"#,
+            ),
+            locations: Vec::new(),
+        }];
+        assert_hints_equal(result_sg.hints(), &expected_hints);
+
+        let schema = result_sg.schema().schema();
+        let items = coord!(Query.items)
+            .lookup_field(schema)
+            .expect("Query.items should be defined on the supergraph");
+        let list_size_directive = items
+            .directives
+            .iter()
+            .find(|d| d.name == "listSize")
+            .expect("@listSize directive should be present on Query.items");
+
+        // assumedSize: NULLABLE_MAX(10, 20) = 20
+        // requireOneSlicingArgument: NULLABLE_AND(true, true) = true (from defaults)
+        assert_eq!(
+            list_size_directive.to_string(),
+            r#"@listSize(assumedSize: 20, requireOneSlicingArgument: true)"#
         );
     }
 }


### PR DESCRIPTION
The argument merger in `merge_applied_directive` was using `specified_argument_by_name` which only returns explicitly specified arguments, skipping default values. This caused the merger to receive fewer values than the JS implementation which uses `arguments(true)` to expand defaults. Switch to `directive_arguments_with_defaults` so that default argument values are included when merging, matching JS behavior.

JS equivalent: https://github.com/apollographql/federation/blob/main/composition-js/src/merging/merge.ts#L3488-L3491
