### PR TITLE
test(http_server): close shutdown-drain race in 3 keep-alive client tests (T17)

### DIFF
--- a/apollo-router/tests/integration/http_server.rs
+++ b/apollo-router/tests/integration/http_server.rs
@@ -77,7 +77,14 @@ async fn test_router_server_negotiates_http2_with_client() -> Result<(), BoxErro
         "Expected HTTP/2 to be negotiated"
     );
 
-    router.graceful_shutdown().await;
+    // T17: drop client before shutdown so the keep-alive pool releases its idle
+    // inbound socket; widen the budget to absorb slow-runner shutdown variance
+    // (matches the pattern in test_http2_max_header_list_size_exceeded).
+    drop(response);
+    drop(client);
+    router
+        .graceful_shutdown_with_deadline(Duration::from_secs(20))
+        .await;
     Ok(())
 }
 
@@ -127,7 +134,14 @@ async fn test_router_server_falls_back_to_http1_with_client() -> Result<(), BoxE
         "Expected HTTP/1.1 to be negotiated as fallback"
     );
 
-    router.graceful_shutdown().await;
+    // T17: drop client before shutdown so the HTTP/1 keep-alive pool closes its
+    // idle inbound socket; widen the budget to absorb slow-runner shutdown
+    // variance. Same shape as the test_http2_negotiates_with_client fix above.
+    drop(response);
+    drop(client);
+    router
+        .graceful_shutdown_with_deadline(Duration::from_secs(20))
+        .await;
     Ok(())
 }
 
@@ -464,7 +478,17 @@ async fn test_http1_connection_persistence(
         num_requests
     );
 
-    router.graceful_shutdown().await;
+    // T17: drop client before shutdown so its pooled keep-alive connections
+    // close and the router can drain. Without this, the server-side
+    // per-connection tasks block waiting for the local-half close and the
+    // harness's 10 s assert_shutdown budget trips on slow CI runners — observed
+    // on arm_linux at ~16 s wall clock the day after #9418 merged. Same shape
+    // as the fixes in test_http2_max_header_list_size_exceeded and
+    // test_unix_socket_max_header_list_size.
+    drop(client);
+    router
+        .graceful_shutdown_with_deadline(Duration::from_secs(20))
+        .await;
     Ok(())
 }
 


### PR DESCRIPTION
ROUTER-1798

## Summary

After #9418 merged to dev, `test_http1_connection_persistence::case_1_http1_conn_persistence` flaked on `test-arm_linux_test` on 2026-05-19 at 16.04 s wall clock with the canonical *"unable to shutdown router, this probably means a hang"* thread-dump signature. Same shutdown-drain bug class (T17) as the two siblings the bundle already fixed — `test_http2_max_header_list_size_exceeded` and `test_unix_socket_max_header_list_size::case_2_header_bigger_than_config` — just a third site that wasn't in the bundle's scope.

This PR fixes the headline site plus two structurally-identical sites surfaced by audit, applying the per-test `drop(client) + graceful_shutdown_with_deadline(20)` pattern that's now the established T17 prescription for `hyper_util::client::legacy::Client`-based tests.

## What changed

Three tests in `apollo-router/tests/integration/http_server.rs`:

| Line | Test | Status before this PR |
|---|---|---|
| 80 | `test_router_server_negotiates_http2_with_client` | Not observed flaking — preventive fix surfaced by audit |
| 130 | `test_router_server_falls_back_to_http1_with_client` | Not observed flaking — preventive fix surfaced by audit |
| 467 | `test_http1_connection_persistence::case_1_http1_conn_persistence` | Flaked on `test-arm_linux_test` 2026-05-19 |

All three build a `hyper_util::client::legacy::Client` in the test body and were calling bare `router.graceful_shutdown().await` without dropping the client first. The client's keep-alive pool holds an idle inbound TCP socket the router is still draining; the server-side per-connection task blocks waiting for the local-half close; the harness's 10 s `assert_shutdown` deadline trips on slow runners.

Fix: `drop(client)` before shutdown (releases pooled keep-alive sockets immediately), plus `graceful_shutdown_with_deadline(Duration::from_secs(20))` to absorb slow-runner variance. Same shape as `4d1b3e04e` already used for `test_http2_max_header_list_size_exceeded` and `test_unix_socket_max_header_list_size`.

## Audit scope

`grep -rn '\.graceful_shutdown()\.await' apollo-router/tests/` found 18 sites. Classifying each by 20-line context:

- **6 vulnerable** total — 3 already fixed by #9418's `4d1b3e04e`, 3 newly fixed here
- **12 safe** — use `router.execute_query()` / `router.assert_metrics_*` helpers that manage their own client lifecycle

Per existing T17 guidance in our internal docs, deliberately **not** widening the default `assert_shutdown` budget — the 10 s default is load-bearing for catching real router-exit regressions. Per-test override pattern preserved.

## Why these other two were preventive

`test_router_server_negotiates_http2_with_client` and `test_router_server_falls_back_to_http1_with_client` hadn't been observed flaking in our CI sample, but they hold the exact same `hyper_util` client live at shutdown. Fixing all three in one commit to close the audit and avoid leaving known landmines.

## Test plan

- [ ] CI green on `test-arm_linux_test`, `test-amd_linux_test`, `test-macos_test`, `test-windows_test`
- [ ] No regression on the rest of `http_server.rs` integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)