### PR TITLE
test(harness): widen default assert_shutdown budget 10 s → 20 s (close T17 class)

### DIFF
--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -2034,24 +2034,33 @@ impl IntegrationTest {
         //   3. CI scheduling slack between the router process draining its
         //      connections and the OS actually reaping the process.
         //
-        // Previously 3 s. Raised to 10 s when the harness began injecting
-        // a `connection_shutdown_timeout` default to prevent the 60 s
+        // History: 3 s → 10 s (when the harness began injecting a
+        // `connection_shutdown_timeout` default to prevent the 60 s
         // production default from hanging tests that hold HTTP/2 client
-        // connections open past the response (see `merge_overrides`).
-        self.assert_shutdown_with_deadline(Duration::from_secs(10))
+        // connections open past the response — see `merge_overrides`) →
+        // 20 s (this change). Three tests independently flaked at the 10 s
+        // boundary in the May 2026 de-flake cycle
+        // (test_http2_max_header_list_size_exceeded fixed in `4d1b3e04e`;
+        // test_unix_socket_max_header_list_size in the same commit;
+        // test_http1_connection_persistence in #9472), each one fixed via a
+        // per-test `graceful_shutdown_with_deadline(20)` override. An audit
+        // then surfaced ~75 more structurally-identical sites across the
+        // telemetry, coprocessor, and subscriptions integration files —
+        // far more than the per-test override pattern can sustainably cover.
+        // Widening the default closes the bug class for the whole harness;
+        // 20 s is still ≪ the production 60 s ceiling, so a real router-exit
+        // regression still surfaces via the panic + thread-dump below, just
+        // 10 s later than before. See T17 in `blog-details.md`.
+        self.assert_shutdown_with_deadline(Duration::from_secs(20))
             .await;
     }
 
-    /// Variant of `assert_shutdown` that lets a specific test widen the
-    /// shutdown-budget when its shutdown path has a documented drain race
-    /// the default 10 s budget cannot beat.
+    /// Variant of `assert_shutdown` with an explicit per-call deadline.
     ///
-    /// Used by tests that trip the default 10 s deadline with a known
-    /// fingerprint (typically a hyper-client pool drain race or
-    /// OpenTelemetry SDK shutdown ordering bug, neither of which can be
-    /// pinned without Linux `dump_stack_traces`). Widening the budget
-    /// per-test rather than via the shared default keeps the rest of the
-    /// harness honest about shutdown regressions.
+    /// Kept for tests that genuinely need a deadline different from the
+    /// default 20 s (either tighter — to assert a specific shutdown bound —
+    /// or wider for documented-slow paths). Most call sites should prefer
+    /// the bare `graceful_shutdown()` and let the default budget handle it.
     #[allow(dead_code)]
     pub async fn assert_shutdown_with_deadline(&mut self, deadline: Duration) {
         let router = self.router.as_mut().expect("router must have been started");


### PR DESCRIPTION
ROUTER-1798

## Summary

Reverses the per-test-override policy for the T17 shutdown-drain class. Widens the shared default `assert_shutdown` budget in `IntegrationTest` from 10 s to 20 s.

The per-test override pattern (`graceful_shutdown_with_deadline(20)`) was sized for the belief that only a handful of tests needed the wider deadline. The post-#9472 re-grep without `head -20` truncation found **157 bare `router.graceful_shutdown().await` sites** in `apollo-router/tests/`, of which **~75–90 are structurally T17-vulnerable** by composition. At that scope, the per-test fix no longer scales — widening the shared default is the right shape.

## Why this is safe

- All 157 sites resolve to the same `IntegrationTest::graceful_shutdown` in `apollo-router/tests/common.rs` (Unix at L1567, Windows at L1589). One production-code `graceful_shutdown` reference exists at `apollo-router/src/axum_factory/listeners.rs:222`, but it's the hyper `connection`'s method — unrelated and unaffected by this change.
- 20 s is still ≪ the production 60 s `connection_shutdown_timeout` ceiling, so a real router-exit regression still surfaces via the harness's panic + thread-dump in `assert_shutdown_with_deadline`. The trade-off is **10 s of additional failure-detection latency on the rare genuine hang**, in exchange for closing the T17 class across the harness.
- `graceful_shutdown_with_deadline(Duration)` is retained for tests that genuinely need a tighter (assertion-style) or wider per-call deadline.

## T17 class history

| When | Fix shape | Sites |
|---|---|---|
| #9337 (P11 fold-in) | Disable client-side keep-alive + `_with_deadline(30 s)` | 2 (OTel reqwest tests) |
| #9418 (`4d1b3e04e`) | `drop(client) + _with_deadline(20 s)` | 2 (`test_http2_max_header_list_size_exceeded`, `test_unix_socket_max_header_list_size`) |
| #9472 (current) | `drop(client) + _with_deadline(20 s)` | 3 (`test_router_server_negotiates_http2_with_client`, `test_router_server_falls_back_to_http1_with_client`, `test_http1_connection_persistence`) |
| This PR | Widen shared default to 20 s | All 157 sites (closes the class) |

## Existing `_with_deadline(20)` calls become redundant

Five tests now have explicit `graceful_shutdown_with_deadline(Duration::from_secs(20))` calls that match the new default exactly:

- `test_http2_max_header_list_size_exceeded` (already on dev)
- `test_unix_socket_max_header_list_size::case_2_header_bigger_than_config` (already on dev)
- `test_router_server_negotiates_http2_with_client` (in #9472)
- `test_router_server_falls_back_to_http1_with_client` (in #9472)
- `test_http1_connection_persistence` (in #9472)

These are harmless once this lands but redundant. Worth a follow-up cleanup pass that reverts them to bare `graceful_shutdown()` — kept out of this PR to keep the diff scoped to the single intent.

## Doc updates

Updates T17 in `flaky-test-phases/blog-details.md` (local-only doc — not in this diff) to reflect:
- The policy reversal
- The audit-completeness lesson (the original `head -20` hid 88% of the candidate surface)
- A new anti-pattern note: don't widen *individual-test* deadlines past 20 s without strong evidence — the shared 20 s default should cover the documented T17 class.

## Test plan

- [ ] CI green on every test job — this is a test-harness change, so a wide passing CI run is the validation
- [ ] No new failures attributable to the deadline widening (tests that previously passed should still pass; tests that flaked at the 10 s boundary should now pass reliably)

🤖 Generated with [Claude Code](https://claude.com/claude-code)