### PR TITLE
Update `astral-tokio-tar` to 0.6.2 to address PAX header desynchronization advisory

### DIFF
--- a/.changesets/fix_zach_astral_tokio_tar_pax_header.md
+++ b/.changesets/fix_zach_astral_tokio_tar_pax_header.md
@@ -2,4 +2,4 @@
 
 Bumps the `astral-tokio-tar` dependency from 0.6.1 to 0.6.2 to pick up the fix for [GHSA-3cv2-h65g-fgmm](https://github.com/astral-sh/tokio-tar/security/advisories/GHSA-3cv2-h65g-fgmm). Versions prior to 0.6.2 contain a PAX header interpretation bug that allows manipulated entries to be selectively visible or invisible during extraction with `astral-tokio-tar` versus other tar implementations, which an attacker could use to smuggle unexpected files onto a victim's filesystem during archive extraction.
 
-By [@zachfettersmoore](https://github.com/zachfettersmoore) in https://github.com/apollographql/router/pull/PULL_NUMBER
+By [@zachfettersmoore](https://github.com/zachfettersmoore) in https://github.com/apollographql/router/pull/9475

--- a/.changesets/fix_zach_astral_tokio_tar_pax_header.md
+++ b/.changesets/fix_zach_astral_tokio_tar_pax_header.md
@@ -1,5 +1,0 @@
-### Update `astral-tokio-tar` to 0.6.2 to address PAX header desynchronization advisory ([RUSTSEC-2026-0145](https://rustsec.org/advisories/RUSTSEC-2026-0145))
-
-Bumps the `astral-tokio-tar` dependency from 0.6.1 to 0.6.2 to pick up the fix for [GHSA-3cv2-h65g-fgmm](https://github.com/astral-sh/tokio-tar/security/advisories/GHSA-3cv2-h65g-fgmm). Versions prior to 0.6.2 contain a PAX header interpretation bug that allows manipulated entries to be selectively visible or invisible during extraction with `astral-tokio-tar` versus other tar implementations, which an attacker could use to smuggle unexpected files onto a victim's filesystem during archive extraction.
-
-By [@zachfettersmoore](https://github.com/zachfettersmoore) in https://github.com/apollographql/router/pull/9475

--- a/.changesets/fix_zach_astral_tokio_tar_pax_header.md
+++ b/.changesets/fix_zach_astral_tokio_tar_pax_header.md
@@ -1,0 +1,5 @@
+### Update `astral-tokio-tar` to 0.6.2 to address PAX header desynchronization advisory ([RUSTSEC-2026-0145](https://rustsec.org/advisories/RUSTSEC-2026-0145))
+
+Bumps the `astral-tokio-tar` dependency from 0.6.1 to 0.6.2 to pick up the fix for [GHSA-3cv2-h65g-fgmm](https://github.com/astral-sh/tokio-tar/security/advisories/GHSA-3cv2-h65g-fgmm). Versions prior to 0.6.2 contain a PAX header interpretation bug that allows manipulated entries to be selectively visible or invisible during extraction with `astral-tokio-tar` versus other tar implementations, which an attacker could use to smuggle unexpected files onto a victim's filesystem during archive extraction.
+
+By [@zachfettersmoore](https://github.com/zachfettersmoore) in https://github.com/apollographql/router/pull/PULL_NUMBER

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -2236,7 +2236,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3475,7 +3475,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -4438,7 +4438,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6131,7 +6131,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6647,7 +6647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6880,7 +6880,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -294,7 +294,7 @@ ryu = "1.0.15"
 apollo-environment-detector = "0.1.0"
 log = "0.4.22"
 scopeguard = "1.2.0"
-tokio-tar = { package = "astral-tokio-tar", version = "0.6.1" }
+tokio-tar = { package = "astral-tokio-tar", version = "0.6.2" }
 blake3 = { version = "1.8.2", features = ["serde"] }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Bumps the `astral-tokio-tar` dependency from 0.6.1 to 0.6.2 to pick up the fix for [GHSA-3cv2-h65g-fgmm](https://github.com/astral-sh/tokio-tar/security/advisories/GHSA-3cv2-h65g-fgmm). Versions prior to 0.6.2 contain a PAX header interpretation bug that allows manipulated entries to be selectively visible or invisible during extraction with `astral-tokio-tar` versus other tar implementations, which an attacker could use to smuggle unexpected files onto a victim's filesystem during archive extraction.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
