### PR TITLE
maint(ci): restore cargo-llvm-cov pin in mise config

### DIFF
--- a/.changesets/maint_restore_cargo_llvm_cov_mise.md
+++ b/.changesets/maint_restore_cargo_llvm_cov_mise.md
@@ -1,0 +1,5 @@
+### Restore `cargo-llvm-cov` to mise so nightly macOS coverage stops failing
+
+The `cargo:cargo-llvm-cov` pin was dropped from `.config/mise/config.toml` during the May 2025 mise migration. The `do_coverage` CircleCI step still invokes `cargo llvm-cov nextest`, with no installer anywhere else in the repo. Nightly `coverage-macos_test` has been red on `dev` since 2026-04-09 (~30 consecutive runs) once the macOS executor stopped providing the binary out of band. Re-pin the latest stable (`0.8.7`).
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0

--- a/.changesets/maint_restore_cargo_llvm_cov_mise.md
+++ b/.changesets/maint_restore_cargo_llvm_cov_mise.md
@@ -2,4 +2,4 @@
 
 The `cargo:cargo-llvm-cov` pin was dropped from `.config/mise/config.toml` during the May 2025 mise migration. The `do_coverage` CircleCI step still invokes `cargo llvm-cov nextest`, with no installer anywhere else in the repo. Nightly `coverage-macos_test` has been red on `dev` since 2026-04-09 (~30 consecutive runs) once the macOS executor stopped providing the binary out of band. Re-pin the latest stable (`0.8.7`).
 
-By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9476

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -10,6 +10,7 @@ rust = { version = "1.95.0", profile = "default" }
 "cargo:htmlq" = "0.4.0"
 "cargo:cargo-watch" = "8.5.3"
 "cargo:cargo-machete" = "0.9.0"
+"cargo:cargo-llvm-cov" = "0.8.7"
 "cargo:typos-cli" = "1.31.1"
 protoc = "34.1"
 gh = "2.92.0"


### PR DESCRIPTION
## Summary

`do_coverage` in `.circleci/config.yml` invokes `cargo llvm-cov nextest`, but `cargo-llvm-cov` has had no installer in the repo since `d258b39c9` (May 2025) removed the `cargo:cargo-llvm-cov = "0.6.10"` pin from `.config/mise/config.toml` during the mise migration. The `do_coverage` step itself was added 22 days later (`f307646f3`) and the macOS executor evidently supplied the binary out of band — until 2026-04-09, when nightlies on `dev` started failing the `Run coverage` step.

## What this changes

One line: re-add `"cargo:cargo-llvm-cov" = "0.8.7"` (latest stable) to `.config/mise/config.toml`. Plus a changeset under `maint_`.

## Evidence

CircleCI insights for `nightly` → `coverage-macos_test` on `dev`:

- 2026-02-20 → 2026-04-08: green every run
- 2026-04-09 → 2026-05-20: **red every run** (~30 consecutive failures)
- The "Run coverage" step is what fails; other steps in the job (checkout, setup_environment, fetch, etc.) succeed.
- Workflow-level success rate is **52%** over 67 runs; this single job accounts for the nightly workflow's low overall pass rate.

Only one reference to `llvm-cov` exists in the entire repo: the `cargo llvm-cov nextest …` call site in `.circleci/config.yml:417`. Nothing else installs it.

## Test plan

- [ ] CI: nightly `coverage-macos_test` turns green on this branch's next nightly fire.
- [ ] Verify `codecov-cli` (separate tool used in the "Upload coverage report" step) is reachable on the macOS executor; if not, follow up in a sibling PR.

## Related

- Tracking ticket: ROUTER-1722 (epic: De-flake apollo-router integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)