### PR TITLE
maint(ci): retry mise install to absorb transient GitHub release flakes

### DIFF
--- a/.changesets/maint_aaron_mise_install_retry.md
+++ b/.changesets/maint_aaron_mise_install_retry.md
@@ -4,4 +4,4 @@ The `install_mise` step in `.circleci/config.yml` ran `mise install` exactly onc
 
 Wrap both invocations (Linux/macOS and Windows) in a 3-attempt loop with linear 5s/10s backoff. On the third failure the step still exits non-zero so genuine configuration errors are not masked.
 
-By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9478

--- a/.changesets/maint_aaron_mise_install_retry.md
+++ b/.changesets/maint_aaron_mise_install_retry.md
@@ -1,0 +1,7 @@
+### Retry `mise install` in CircleCI to absorb transient GitHub release fetch failures
+
+The `install_mise` step in `.circleci/config.yml` ran `mise install` exactly once, so any transient 404 from GitHub releases (mise's aqua backend pulls each pinned tool from `github.com/.../releases/download/...`) failed an otherwise-healthy job. We've seen this surface as three different jobs failing in the same workflow, each on a different tool (kubeconform, protoc, gh) — the signature of intermittent CDN/rate-limit flakes rather than a config bug.
+
+Wrap both invocations (Linux/macOS and Windows) in a 3-attempt loop with linear 5s/10s backoff. On the third failure the step still exits non-zero so genuine configuration errors are not masked.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,17 @@ commands:
                 command: |
                   curl https://mise.jdx.dev/install.sh | sh
                   mise activate bash >> "$BASH_ENV"
-                  mise install --yes --quiet
+                  for i in 1 2 3; do
+                    if mise install --yes --quiet; then
+                      break
+                    fi
+                    if [ $i -eq 3 ]; then
+                      echo "mise install failed after 3 attempts"
+                      exit 1
+                    fi
+                    echo "mise install failed (attempt $i/3), retrying in $((i*5))s..."
+                    sleep $((i*5))
+                  done
       - when:
           condition:
             or:
@@ -271,7 +281,17 @@ commands:
                 name: Install mise
                 command: |
                   scoop install mise@${MISE_VERSION#v}
-                  mise install --yes --quiet
+                  for i in 1 2 3; do
+                    if mise install --yes --quiet; then
+                      break
+                    fi
+                    if [ $i -eq 3 ]; then
+                      echo "mise install failed after 3 attempts"
+                      exit 1
+                    fi
+                    echo "mise install failed (attempt $i/3), retrying in $((i*5))s..."
+                    sleep $((i*5))
+                  done
   fetch_dependencies:
     steps:
       - run:


### PR DESCRIPTION
## Summary

- Wrap `mise install` in a 3-attempt loop with 5s/10s linear backoff in both `install_mise` branches (Linux/macOS and Windows) of `.circleci/config.yml`.
- Motivated by today's #9476 run, where three jobs (`check_compliance`, `check_helm`, `fmt_check`) each 404'd on a *different* pre-existing tool fetch (kubeconform, protoc, gh) from GitHub releases during `mise install` — the signature of intermittent CDN/rate-limit flakes, not a config bug.
- On the third failure the step still exits non-zero, so genuine configuration errors are not masked.

## Test plan

- [ ] CircleCI green for this PR (every job's `Install mise` step still finishes in roughly the same time on the happy path).
- [ ] If a future run hits a release-fetch 404, the retry message appears in the step log and the step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- jira: ROUTER-1805 -->