### PR TITLE
perf(composition): reduce allocations in hot paths (~8-10% faster)

### DIFF
--- a/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
+++ b/apollo-federation/src/composition/satisfiability/satisfiability_error.rs
@@ -319,7 +319,7 @@ fn generate_witness_value(
     // Note: We always generate a non-null value, even if the value's type is nullable.
     let value = match value_def.ty.as_ref() {
         executable::Type::Named(type_name) | executable::Type::NonNullNamed(type_name) => {
-            let type_pos = schema.get_type(type_name.clone())?;
+            let type_pos = schema.get_type(type_name)?;
             match type_pos {
                 TypeDefinitionPosition::Scalar(scalar_type_pos) => {
                     match scalar_type_pos.type_name.as_str() {

--- a/apollo-federation/src/composition/satisfiability/validation_context.rs
+++ b/apollo-federation/src/composition/satisfiability/validation_context.rs
@@ -78,9 +78,7 @@ impl ValidationContext {
         &self,
         field: &FieldDefinitionPosition,
     ) -> Result<bool, FederationError> {
-        let Ok(type_in_supergraph) = self
-            .supergraph_schema
-            .get_type(field.parent().type_name())
+        let Ok(type_in_supergraph) = self.supergraph_schema.get_type(field.parent().type_name())
         else {
             bail!("Type {} should exist in the supergraph", field.parent());
         };

--- a/apollo-federation/src/composition/satisfiability/validation_context.rs
+++ b/apollo-federation/src/composition/satisfiability/validation_context.rs
@@ -80,7 +80,7 @@ impl ValidationContext {
     ) -> Result<bool, FederationError> {
         let Ok(type_in_supergraph) = self
             .supergraph_schema
-            .get_type(field.parent().type_name().clone())
+            .get_type(field.parent().type_name())
         else {
             bail!("Type {} should exist in the supergraph", field.parent());
         };
@@ -240,7 +240,7 @@ type T implements I
     fn is_shareable_field(context: &ValidationContext, type_name: &str, field_name: &str) -> bool {
         let supergraph_schema = &context.supergraph_schema;
         let type_pos = supergraph_schema
-            .get_type(Name::new_unchecked(type_name))
+            .get_type(&Name::new_unchecked(type_name))
             .unwrap();
         let type_pos = CompositeTypeDefinitionPosition::try_from(type_pos).unwrap();
         let field_pos = type_pos.field(Name::new_unchecked(field_name)).unwrap();

--- a/apollo-federation/src/connectors/expand/mod.rs
+++ b/apollo-federation/src/connectors/expand/mod.rs
@@ -958,9 +958,7 @@ mod helpers {
             mutation_alias: &Name,
             parent_type_name: &Name,
         ) -> Result<(), FederationError> {
-            if mutation_alias == parent_type_name
-                && to_schema.get_type(mutation_alias).is_ok()
-            {
+            if mutation_alias == parent_type_name && to_schema.get_type(mutation_alias).is_ok() {
                 let mutation_root = SchemaRootDefinitionPosition {
                     root_kind: SchemaRootDefinitionKind::Mutation,
                 };
@@ -1581,9 +1579,7 @@ mod helpers {
             mutation_alias: &Name,
             parent_type_name: &Name,
         ) -> Result<(), FederationError> {
-            if mutation_alias == parent_type_name
-                && to_schema.get_type(mutation_alias).is_ok()
-            {
+            if mutation_alias == parent_type_name && to_schema.get_type(mutation_alias).is_ok() {
                 let mutation_root = SchemaRootDefinitionPosition {
                     root_kind: SchemaRootDefinitionKind::Mutation,
                 };

--- a/apollo-federation/src/connectors/expand/mod.rs
+++ b/apollo-federation/src/connectors/expand/mod.rs
@@ -420,7 +420,7 @@ mod helpers {
                 } => {
                     let field_type = self
                         .original_schema
-                        .get_type(field_def.ty.inner_named_type().clone())?;
+                        .get_type(field_def.ty.inner_named_type())?;
 
                     // We'll need to make sure that we always process the inputs first, since they need to be present
                     // before any dependent types
@@ -557,7 +557,7 @@ mod helpers {
             // valid subgraphs
             for arg in arguments {
                 let arg_type_name = arg.ty.inner_named_type();
-                let arg_type = self.original_schema.get_type(arg_type_name.clone())?;
+                let arg_type = self.original_schema.get_type(arg_type_name)?;
                 let arg_extended_type = arg_type.get(self.original_schema.schema())?;
 
                 // If the input type isn't built in, then we need to carry it over, making sure to only walk
@@ -607,8 +607,8 @@ mod helpers {
                 return self.copy_interface_object_keys(output_type_name, to_schema);
             };
 
-            let parent_type = self.original_schema.get_type(parent_type_name)?;
-            let output_type = to_schema.get_type(output_type_name)?;
+            let parent_type = self.original_schema.get_type(&parent_type_name)?;
+            let output_type = to_schema.get_type(&output_type_name)?;
             let key_for_type = match &connector.entity_resolver {
                 Some(EntityResolver::Explicit) => output_type,
                 _ => parent_type,
@@ -959,7 +959,7 @@ mod helpers {
             parent_type_name: &Name,
         ) -> Result<(), FederationError> {
             if mutation_alias == parent_type_name
-                && to_schema.get_type(mutation_alias.clone()).is_ok()
+                && to_schema.get_type(mutation_alias).is_ok()
             {
                 let mutation_root = SchemaRootDefinitionPosition {
                     root_kind: SchemaRootDefinitionKind::Mutation,
@@ -1083,7 +1083,7 @@ mod helpers {
                 } => {
                     let field_type = self
                         .original_schema
-                        .get_type(field_def.ty.inner_named_type().clone())?;
+                        .get_type(field_def.ty.inner_named_type())?;
 
                     // We'll need to make sure that we always process the inputs first, since they need to be present
                     // before any dependent types
@@ -1212,7 +1212,7 @@ mod helpers {
             // valid subgraphs
             for arg in arguments {
                 let arg_type_name = arg.ty.inner_named_type();
-                let arg_type = self.original_schema.get_type(arg_type_name.clone())?;
+                let arg_type = self.original_schema.get_type(arg_type_name)?;
                 let arg_extended_type = arg_type.get(self.original_schema.schema())?;
 
                 // If the input type isn't built in, then we need to carry it over, making sure to only walk
@@ -1255,8 +1255,8 @@ mod helpers {
                 return self.copy_interface_object_keys(output_type_name, to_schema);
             };
 
-            let parent_type = self.original_schema.get_type(parent_type_name)?;
-            let output_type = to_schema.get_type(output_type_name)?;
+            let parent_type = self.original_schema.get_type(&parent_type_name)?;
+            let output_type = to_schema.get_type(&output_type_name)?;
             let key_for_type = match &connector.entity_resolver {
                 Some(EntityResolver::Explicit) => output_type,
                 _ => parent_type,
@@ -1582,7 +1582,7 @@ mod helpers {
             parent_type_name: &Name,
         ) -> Result<(), FederationError> {
             if mutation_alias == parent_type_name
-                && to_schema.get_type(mutation_alias.clone()).is_ok()
+                && to_schema.get_type(mutation_alias).is_ok()
             {
                 let mutation_root = SchemaRootDefinitionPosition {
                     root_kind: SchemaRootDefinitionKind::Mutation,

--- a/apollo-federation/src/connectors/expand/visitors/input.rs
+++ b/apollo-federation/src/connectors/expand/visitors/input.rs
@@ -42,7 +42,7 @@ impl FieldVisitor<InputObjectFieldDefinitionPosition>
 
         let input_type = self
             .original_schema
-            .get_type(field_def.ty.inner_named_type().clone())?;
+            .get_type(field_def.ty.inner_named_type())?;
         match input_type {
             TypeDefinitionPosition::Scalar(pos) => {
                 try_pre_insert!(self.to_schema, pos)?;
@@ -90,7 +90,7 @@ impl GroupVisitor<InputObjectTypeDefinitionPosition, InputObjectFieldDefinitionP
         let field_type = field.get(self.original_schema.schema())?;
         let inner_type = self
             .original_schema
-            .get_type(field_type.ty.inner_named_type().clone())?;
+            .get_type(field_type.ty.inner_named_type())?;
         match inner_type {
             TypeDefinitionPosition::InputObject(input) => Ok(Some(input)),
             TypeDefinitionPosition::Scalar(_) | TypeDefinitionPosition::Enum(_) => Ok(None),

--- a/apollo-federation/src/connectors/expand/visitors/mod.rs
+++ b/apollo-federation/src/connectors/expand/visitors/mod.rs
@@ -34,7 +34,7 @@ where
 /// visited multiple times during shape-driven expansion.
 macro_rules! try_pre_insert {
     ($schema:expr, $pos:expr) => {{
-        if let Some(old_pos) = $schema.try_get_type($pos.type_name.clone()) {
+        if let Some(old_pos) = $schema.try_get_type(&$pos.type_name) {
             // Verify that the types match
             let pos = $crate::schema::position::TypeDefinitionPosition::from($pos.clone());
             if old_pos != pos {
@@ -58,7 +58,7 @@ macro_rules! try_pre_insert {
 /// and matches the existing type
 macro_rules! try_insert {
     ($schema:expr, $pos:expr, $def:expr) => {{
-        if let Some(old_pos) = $schema.try_get_type($pos.type_name.clone()) {
+        if let Some(old_pos) = $schema.try_get_type(&$pos.type_name) {
             // Verify that the types match
             let pos = $crate::schema::position::TypeDefinitionPosition::from($pos.clone());
             if old_pos != pos {

--- a/apollo-federation/src/connectors/expand/visitors/selection.rs
+++ b/apollo-federation/src/connectors/expand/visitors/selection.rs
@@ -58,9 +58,7 @@ impl FieldVisitor<NamedSelection> for SchemaVisitor<'_, ObjectTypeDefinitionPosi
             let field = definition
                 .field(field_name.clone())
                 .get(self.original_schema.schema())?;
-            let field_type = self
-                .original_schema
-                .get_type(field.ty.inner_named_type())?;
+            let field_type = self.original_schema.get_type(field.ty.inner_named_type())?;
             let extended_field_type = field_type.get(self.original_schema.schema())?;
 
             // We only need to care about the type of the field if it isn't built-in
@@ -288,9 +286,7 @@ impl<'a> TypeShapeWalker<'a> {
         field_shape: &Shape,
     ) -> Result<(), FederationError> {
         let field = field_position.get(self.original_schema.schema())?;
-        let field_type = self
-            .original_schema
-            .get_type(field.ty.inner_named_type())?;
+        let field_type = self.original_schema.get_type(field.ty.inner_named_type())?;
         let extended_field_type = field_type.get(self.original_schema.schema())?;
 
         if !extended_field_type.is_built_in() {
@@ -620,11 +616,7 @@ impl<'a> TypeShapeWalker<'a> {
             };
 
             // Skip if already inserted (e.g., by another connector in this expansion)
-            if self
-                .to_schema
-                .try_get_type(implementer_name)
-                .is_some()
-            {
+            if self.to_schema.try_get_type(implementer_name).is_some() {
                 continue;
             }
 

--- a/apollo-federation/src/connectors/expand/visitors/selection.rs
+++ b/apollo-federation/src/connectors/expand/visitors/selection.rs
@@ -60,7 +60,7 @@ impl FieldVisitor<NamedSelection> for SchemaVisitor<'_, ObjectTypeDefinitionPosi
                 .get(self.original_schema.schema())?;
             let field_type = self
                 .original_schema
-                .get_type(field.ty.inner_named_type().clone())?;
+                .get_type(field.ty.inner_named_type())?;
             let extended_field_type = field_type.get(self.original_schema.schema())?;
 
             // We only need to care about the type of the field if it isn't built-in
@@ -167,7 +167,7 @@ impl GroupVisitor<JSONSelectionGroup, NamedSelection>
                     .inner_named_type();
 
                 let TypeDefinitionPosition::Object(field_type) =
-                    self.original_schema.get_type(field_type_name.clone())?
+                    self.original_schema.get_type(field_type_name)?
                 else {
                     return Ok(None);
                 };
@@ -290,7 +290,7 @@ impl<'a> TypeShapeWalker<'a> {
         let field = field_position.get(self.original_schema.schema())?;
         let field_type = self
             .original_schema
-            .get_type(field.ty.inner_named_type().clone())?;
+            .get_type(field.ty.inner_named_type())?;
         let extended_field_type = field_type.get(self.original_schema.schema())?;
 
         if !extended_field_type.is_built_in() {
@@ -518,7 +518,7 @@ impl<'a> TypeShapeWalker<'a> {
                         }
 
                         let type_def_pos =
-                            self.original_schema.get_type(Name::new(literal_value)?)?;
+                            self.original_schema.get_type(&Name::new(literal_value)?)?;
 
                         self.walk_type(&type_def_pos, shape)?;
                     } else {
@@ -622,7 +622,7 @@ impl<'a> TypeShapeWalker<'a> {
             // Skip if already inserted (e.g., by another connector in this expansion)
             if self
                 .to_schema
-                .try_get_type(implementer_name.clone())
+                .try_get_type(implementer_name)
                 .is_some()
             {
                 continue;
@@ -678,7 +678,7 @@ impl<'a> TypeShapeWalker<'a> {
 
         for member_name in def.members.iter() {
             if let TypeDefinitionPosition::Object(object_type_pos) =
-                self.original_schema.get_type(member_name.name.clone())?
+                self.original_schema.get_type(&member_name.name)?
             {
                 try_pre_insert!(self.to_schema, object_type_pos)?;
             }
@@ -702,7 +702,7 @@ impl<'a> TypeShapeWalker<'a> {
                     if let ShapeCase::String(Some(literal_value)) = type_name.case() {
                         let member_name = Name::new(literal_value)?;
                         if union_type.members.contains(&member_name) {
-                            let type_def_pos = self.original_schema.get_type(member_name)?;
+                            let type_def_pos = self.original_schema.get_type(&member_name)?;
                             self.walk_type(&type_def_pos, shape)?;
                         } else {
                             return Err(FederationError::internal(format!(

--- a/apollo-federation/src/connectors/spec/type_and_directive_specifications.rs
+++ b/apollo-federation/src/connectors/spec/type_and_directive_specifications.rs
@@ -539,7 +539,7 @@ fn lookup_feature_type_in_schema(
         bail!("Type {name} shouldn't be added without being attached to a @connect spec")
     };
     let actual_name = link.type_name_in_schema(name);
-    schema.get_type(actual_name)
+    schema.get_type(&actual_name)
 }
 
 fn lookup_scalar_in_schema(

--- a/apollo-federation/src/correctness/query_plan_analysis.rs
+++ b/apollo-federation/src/correctness/query_plan_analysis.rs
@@ -728,7 +728,7 @@ fn normalize_type_condition(
     let obj_types: Result<Vec<_>, _> = type_condition
         .iter()
         .map(|name| {
-            let ty: ObjectTypeDefinitionPosition = schema.get_type(name.clone())?.try_into()?;
+            let ty: ObjectTypeDefinitionPosition = schema.get_type(&name)?.try_into()?;
             Ok(ty)
         })
         .collect();

--- a/apollo-federation/src/correctness/query_plan_analysis.rs
+++ b/apollo-federation/src/correctness/query_plan_analysis.rs
@@ -728,7 +728,7 @@ fn normalize_type_condition(
     let obj_types: Result<Vec<_>, _> = type_condition
         .iter()
         .map(|name| {
-            let ty: ObjectTypeDefinitionPosition = schema.get_type(&name)?.try_into()?;
+            let ty: ObjectTypeDefinitionPosition = schema.get_type(name)?.try_into()?;
             Ok(ty)
         })
         .collect();

--- a/apollo-federation/src/correctness/query_plan_soundness.rs
+++ b/apollo-federation/src/correctness/query_plan_soundness.rs
@@ -313,7 +313,7 @@ fn check_require(
     entity_require: &requires_selection::Selection,
 ) -> Result<(), AnalysisError> {
     let subgraph_entity_type_name = entity_response_shape.default_type_condition();
-    let subgraph_entity_type_pos = subgraph_schema.get_type(&subgraph_entity_type_name)?;
+    let subgraph_entity_type_pos = subgraph_schema.get_type(subgraph_entity_type_name)?;
     let directives = match &subgraph_entity_type_pos {
         TypeDefinitionPosition::Object(type_pos) => {
             let type_def = type_pos

--- a/apollo-federation/src/correctness/query_plan_soundness.rs
+++ b/apollo-federation/src/correctness/query_plan_soundness.rs
@@ -189,7 +189,7 @@ fn get_field_definition(
     field_name: &Name,
 ) -> Result<Node<ast::FieldDefinition>, FederationError> {
     let parent_type_pos: CompositeTypeDefinitionPosition =
-        schema.get_type(parent_type.clone())?.try_into()?;
+        schema.get_type(parent_type)?.try_into()?;
     let field_def_pos = parent_type_pos.field(field_name.clone())?;
     field_def_pos
         .get(schema.schema())
@@ -313,7 +313,7 @@ fn check_require(
     entity_require: &requires_selection::Selection,
 ) -> Result<(), AnalysisError> {
     let subgraph_entity_type_name = entity_response_shape.default_type_condition();
-    let subgraph_entity_type_pos = subgraph_schema.get_type(subgraph_entity_type_name.clone())?;
+    let subgraph_entity_type_pos = subgraph_schema.get_type(&subgraph_entity_type_name)?;
     let directives = match &subgraph_entity_type_pos {
         TypeDefinitionPosition::Object(type_pos) => {
             let type_def = type_pos

--- a/apollo-federation/src/correctness/response_shape.rs
+++ b/apollo-federation/src/correctness/response_shape.rs
@@ -148,7 +148,7 @@ impl DisplayTypeCondition {
         name: Name,
         schema: &ValidFederationSchema,
     ) -> Result<Self, FederationError> {
-        let ty: CompositeTypeDefinitionPosition = schema.get_type(name)?.try_into()?;
+        let ty: CompositeTypeDefinitionPosition = schema.get_type(&name)?.try_into()?;
         if self
             .0
             .iter()
@@ -203,7 +203,7 @@ impl NormalizedTypeCondition {
         name: Name,
         schema: &ValidFederationSchema,
     ) -> Result<Option<Self>, FederationError> {
-        let ty: CompositeTypeDefinitionPosition = schema.get_type(name)?.try_into()?;
+        let ty: CompositeTypeDefinitionPosition = schema.get_type(&name)?.try_into()?;
         let ground_set = get_ground_types(&ty, schema)?;
         if ground_set.is_empty() {
             return Ok(None);
@@ -280,7 +280,7 @@ impl NormalizedTypeCondition {
         schema: &ValidFederationSchema,
     ) -> Result<Option<Self>, FederationError> {
         let other_ty: CompositeTypeDefinitionPosition =
-            schema.get_type(name.clone())?.try_into()?;
+            schema.get_type(&name)?.try_into()?;
         let other_types = get_ground_types(&other_ty, schema)?;
         let ground_set: Vec<ObjectTypeDefinitionPosition> = self
             .ground_set
@@ -335,7 +335,7 @@ impl NormalizedTypeCondition {
         // Grind the type names into object types.
         let mut ground_types = IndexSet::default();
         for ty in &types {
-            let pos = schema.get_type(ty.clone())?.try_into()?;
+            let pos = schema.get_type(ty)?.try_into()?;
             let pos_types = schema.possible_runtime_types(pos)?;
             ground_types.extend(pos_types);
         }

--- a/apollo-federation/src/correctness/response_shape.rs
+++ b/apollo-federation/src/correctness/response_shape.rs
@@ -279,8 +279,7 @@ impl NormalizedTypeCondition {
         name: Name,
         schema: &ValidFederationSchema,
     ) -> Result<Option<Self>, FederationError> {
-        let other_ty: CompositeTypeDefinitionPosition =
-            schema.get_type(&name)?.try_into()?;
+        let other_ty: CompositeTypeDefinitionPosition = schema.get_type(&name)?.try_into()?;
         let other_types = get_ground_types(&other_ty, schema)?;
         let ground_set: Vec<ObjectTypeDefinitionPosition> = self
             .ground_set

--- a/apollo-federation/src/correctness/subgraph_constraint.rs
+++ b/apollo-federation/src/correctness/subgraph_constraint.rs
@@ -97,7 +97,7 @@ impl<'a> SubgraphConstraint<'a> {
                     continue;
                 };
                 let field_type_name = field.ty.inner_named_type();
-                let field_type_pos = subgraph_schema.get_type(field_type_name.clone())?;
+                let field_type_pos = subgraph_schema.get_type(field_type_name)?;
                 if let Ok(composite_type) =
                     CompositeTypeDefinitionPosition::try_from(field_type_pos)
                 {

--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -148,10 +148,7 @@ impl Merger {
 
             // we look up the actual type in the subgraph schema as it can be different than the one in the supergraph
             // (i.e. @interfaceObject in subgraph but an interface in supergraph)
-            if let Some(type_position) = subgraph
-                .schema()
-                .try_get_type(obj_or_itf.type_name())
-            {
+            if let Some(type_position) = subgraph.schema().try_get_type(obj_or_itf.type_name()) {
                 let object_or_interface_in_subgraph: ObjectOrInterfaceTypeDefinitionPosition =
                     type_position.try_into()?;
                 for field in object_or_interface_in_subgraph.fields(subgraph.schema().schema())? {
@@ -379,7 +376,7 @@ impl Merger {
             ObjectOrInterfaceFieldDefinitionPosition::Interface(_)
         ) || subgraph
             .schema()
-            .try_get_type(&parent_name_in_supergraph)
+            .try_get_type(parent_name_in_supergraph)
             .is_some()
         {
             return Ok(interface_object_fields);
@@ -1182,11 +1179,7 @@ impl Merger {
                 // to switch `Sources` to be `IndexMap<usize, T>` instead of holding `Option<T>`.
                 _ => {
                     // This subgraph does not have the field, so if it has the field type, we need a join__field.
-                    if subgraph
-                        .schema()
-                        .try_get_type(parent_name)
-                        .is_some()
-                    {
+                    if subgraph.schema().try_get_type(parent_name).is_some() {
                         return Ok(true);
                     }
                 }

--- a/apollo-federation/src/merger/merge_field.rs
+++ b/apollo-federation/src/merger/merge_field.rs
@@ -136,9 +136,9 @@ impl Merger {
             for interface in obj_or_itf.implemented_interfaces(&self.merged)? {
                 if subgraph
                     .schema()
-                    .get_type(interface.name.clone())
+                    .try_get_type(&interface.name)
                     .as_ref()
-                    .is_ok_and(|ty| subgraph.is_interface_object_type(ty))
+                    .is_some_and(|ty| subgraph.is_interface_object_type(ty))
                 {
                     // This marks the subgraph as having a relevant @interfaceObject,
                     // even though we do not actively add that type's fields.
@@ -150,7 +150,7 @@ impl Merger {
             // (i.e. @interfaceObject in subgraph but an interface in supergraph)
             if let Some(type_position) = subgraph
                 .schema()
-                .try_get_type(obj_or_itf.type_name().clone())
+                .try_get_type(obj_or_itf.type_name())
             {
                 let object_or_interface_in_subgraph: ObjectOrInterfaceTypeDefinitionPosition =
                     type_position.try_into()?;
@@ -379,7 +379,7 @@ impl Merger {
             ObjectOrInterfaceFieldDefinitionPosition::Interface(_)
         ) || subgraph
             .schema()
-            .try_get_type(parent_name_in_supergraph.clone())
+            .try_get_type(&parent_name_in_supergraph)
             .is_some()
         {
             return Ok(interface_object_fields);
@@ -1184,7 +1184,7 @@ impl Merger {
                     // This subgraph does not have the field, so if it has the field type, we need a join__field.
                     if subgraph
                         .schema()
-                        .try_get_type(parent_name.clone())
+                        .try_get_type(parent_name)
                         .is_some()
                     {
                         return Ok(true);

--- a/apollo-federation/src/merger/merge_input.rs
+++ b/apollo-federation/src/merger/merge_input.rs
@@ -203,7 +203,7 @@ impl Merger {
 
             if self.subgraphs[*idx]
                 .schema()
-                .try_get_type(dest.type_name.clone())
+                .try_get_type(&dest.type_name)
                 .is_some()
             {
                 // Our needsJoinField logic adds @join__field if any subgraphs define

--- a/apollo-federation/src/merger/merge_interface.rs
+++ b/apollo-federation/src/merger/merge_interface.rs
@@ -148,7 +148,7 @@ impl Merger {
                     .map(|(idx, subgraph)| {
                         let maybe_ty: Option<ObjectOrInterfaceTypeDefinitionPosition> = subgraph
                             .schema()
-                            .get_type(itf.type_name.clone())
+                            .get_type(&itf.type_name)
                             .ok()
                             .and_then(|ty| ty.try_into().ok());
                         (idx, maybe_ty)

--- a/apollo-federation/src/merger/merge_type.rs
+++ b/apollo-federation/src/merger/merge_type.rs
@@ -19,7 +19,7 @@ use crate::schema::position::TypeDefinitionPosition;
 impl Merger {
     #[instrument(skip(self))]
     pub(in crate::merger) fn merge_type(&mut self, type_def: &Name) -> Result<(), FederationError> {
-        let Ok(dest) = self.merged.get_type(type_def.clone()) else {
+        let Ok(dest) = self.merged.get_type(type_def) else {
             bail!(
                 "Type \"{}\" is missing, but it should have been shallow-copied to the supergraph schema",
                 type_def
@@ -28,7 +28,7 @@ impl Merger {
         let mut sources =
             IndexMap::with_capacity_and_hasher(self.subgraphs.len(), Default::default());
         for (idx, subgraph) in self.subgraphs.iter().enumerate() {
-            let source = subgraph.schema().get_type(type_def.clone()).ok();
+            let source = subgraph.schema().try_get_type(type_def);
             sources.insert(idx, source);
         }
 

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -829,14 +829,7 @@ impl Merger {
             .subgraphs
             .iter()
             .enumerate()
-            .map(|(idx, sg)| {
-                (
-                    idx,
-                    sg.schema()
-                        .get_type(mismatched_type.type_name())
-                        .ok(),
-                )
-            })
+            .map(|(idx, sg)| (idx, sg.schema().get_type(mismatched_type.type_name()).ok()))
             .collect();
         let type_kind_to_string = |idx: usize, type_def: &TypeDefinitionPosition| {
             let type_kind_description =

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -734,7 +734,7 @@ impl Merger {
                     subgraphs_with_interface_obj
                         .insert(pos.type_name().clone(), subgraph.name.clone());
                 }
-                if let Ok(previous) = self.merged.get_type(pos.type_name().clone()) {
+                if let Ok(previous) = self.merged.get_type(pos.type_name()) {
                     if expects_interface
                         && !matches!(previous, TypeDefinitionPosition::Interface(_))
                     {
@@ -761,7 +761,7 @@ impl Merger {
                 .get(type_name)
                 .cloned()
                 .unwrap_or_default();
-            if let Ok(mismatched_type) = self.merged.get_type(type_name.clone()) {
+            if let Ok(mismatched_type) = self.merged.get_type(type_name) {
                 self.report_mismatched_type_definitions(&mismatched_type, &subgraphs);
             }
         }
@@ -777,12 +777,12 @@ impl Merger {
             let mut found_interface = false;
             let mut subgraphs_with_type = IndexSet::new();
             for subgraph in &self.subgraphs {
-                let type_in_subgraph = subgraph.schema().get_type(type_name.clone());
-                if matches!(type_in_subgraph, Ok(TypeDefinitionPosition::Interface(_))) {
+                let type_in_subgraph = subgraph.schema().try_get_type(type_name);
+                if matches!(type_in_subgraph, Some(TypeDefinitionPosition::Interface(_))) {
                     found_interface = true;
                     break;
                 }
-                if type_in_subgraph.is_ok() {
+                if type_in_subgraph.is_some() {
                     subgraphs_with_type.insert(subgraph.name.clone());
                 }
             }
@@ -833,7 +833,7 @@ impl Merger {
                 (
                     idx,
                     sg.schema()
-                        .get_type(mismatched_type.type_name().clone())
+                        .get_type(mismatched_type.type_name())
                         .ok(),
                 )
             })
@@ -1030,7 +1030,7 @@ impl Merger {
     }
 
     fn merge_implements(&mut self, type_def: &Name) -> Result<(), FederationError> {
-        let dest = self.merged.get_type(type_def.clone())?;
+        let dest = self.merged.get_type(type_def)?;
         let dest: ObjectOrInterfaceTypeDefinitionPosition = dest.try_into().map_err(|_| {
             internal_error!(
                 "Expected type {} to be an Object or Interface type, but it is not",
@@ -1095,8 +1095,7 @@ impl Merger {
         for (idx, subgraph) in self.subgraphs.iter().enumerate() {
             let maybe_ty: Option<ObjectOrInterfaceTypeDefinitionPosition> = subgraph
                 .schema()
-                .get_type(obj.type_name.clone())
-                .ok()
+                .try_get_type(&obj.type_name)
                 .and_then(|ty| ty.try_into().ok());
             subgraph_types.insert(idx, maybe_ty);
         }

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -612,7 +612,9 @@ mod field_selection {
 
     impl PartialEq for Field {
         fn eq(&self, other: &Self) -> bool {
-            self.key() == other.key() && self.arguments == other.arguments
+            self.field_position.field_name() == other.field_position.field_name()
+                && self.key() == other.key()
+                && self.arguments == other.arguments
         }
     }
 

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -693,8 +693,7 @@ mod field_selection {
 
         pub(crate) fn output_base_type(&self) -> Result<TypeDefinitionPosition, FederationError> {
             let definition = self.field_position.get(self.schema.schema())?;
-            self.schema
-                .get_type(definition.ty.inner_named_type())
+            self.schema.get_type(definition.ty.inner_named_type())
         }
 
         pub(crate) fn is_leaf(&self) -> Result<bool, FederationError> {
@@ -2203,10 +2202,9 @@ impl FieldSelection {
         // Operation creation and the creation of the ValidFederationSchema, it's safer to just
         // confirm it exists in this schema.
         field_position.get(schema.schema())?;
-        let is_composite = CompositeTypeDefinitionPosition::try_from(
-            schema.get_type(&field.selection_set.ty)?,
-        )
-        .is_ok();
+        let is_composite =
+            CompositeTypeDefinitionPosition::try_from(schema.get_type(&field.selection_set.ty)?)
+                .is_ok();
 
         Ok(Some(FieldSelection {
             field: Field {

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -612,9 +612,7 @@ mod field_selection {
 
     impl PartialEq for Field {
         fn eq(&self, other: &Self) -> bool {
-            self.field_position.field_name() == other.field_position.field_name()
-                && self.key() == other.key()
-                && self.arguments == other.arguments
+            self.key() == other.key() && self.arguments == other.arguments
         }
     }
 
@@ -696,7 +694,7 @@ mod field_selection {
         pub(crate) fn output_base_type(&self) -> Result<TypeDefinitionPosition, FederationError> {
             let definition = self.field_position.get(self.schema.schema())?;
             self.schema
-                .get_type(definition.ty.inner_named_type().clone())
+                .get_type(definition.ty.inner_named_type())
         }
 
         pub(crate) fn is_leaf(&self) -> Result<bool, FederationError> {
@@ -1128,7 +1126,7 @@ impl SelectionSet {
         check_cancellation: &dyn Fn() -> Result<(), SingleFederationError>,
     ) -> Result<SelectionSet, FederationError> {
         let type_position: CompositeTypeDefinitionPosition =
-            schema.get_type(selection_set.ty.clone())?.try_into()?;
+            schema.get_type(&selection_set.ty)?.try_into()?;
         let mut normalized_selections = vec![];
         SelectionSet::normalize_selections(
             &selection_set.selections,
@@ -2045,7 +2043,7 @@ fn compute_aliases_for_non_merging_fields(
                 if &previous.field_name == field_name
                     && types_can_be_merged(&previous.field_type, field_type, schema.schema())?
                 {
-                    let output_type = schema.get_type(field_type.inner_named_type().clone())?;
+                    let output_type = schema.get_type(field_type.inner_named_type())?;
                     // If the type is non-composite, then we're all set. But if it is composite, we need to record the sub-selection to that response name
                     // as we need to "recurse" on the merged of both the previous and this new field.
                     if output_type.is_composite_type() {
@@ -2206,7 +2204,7 @@ impl FieldSelection {
         // confirm it exists in this schema.
         field_position.get(schema.schema())?;
         let is_composite = CompositeTypeDefinitionPosition::try_from(
-            schema.get_type(field.selection_set.ty.clone())?,
+            schema.get_type(&field.selection_set.ty)?,
         )
         .is_ok();
 
@@ -2291,7 +2289,7 @@ impl InlineFragmentSelection {
     ) -> Result<InlineFragmentSelection, FederationError> {
         let type_condition_position: Option<CompositeTypeDefinitionPosition> =
             if let Some(type_condition) = &inline_fragment.type_condition {
-                Some(schema.get_type(type_condition.clone())?.try_into()?)
+                Some(schema.get_type(type_condition)?.try_into()?)
             } else {
                 None
             };

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -177,9 +177,7 @@ impl Field {
                 .get(schema.schema())?
                 .ty
                 .inner_named_type();
-            return Ok(Some(
-                data.schema.get_type(base_ty_name)?.try_into()?,
-            ));
+            return Ok(Some(data.schema.get_type(base_ty_name)?.try_into()?));
         }
         if data.name() == &TYPENAME_FIELD {
             let Some(type_name) = parent_type

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -178,7 +178,7 @@ impl Field {
                 .ty
                 .inner_named_type();
             return Ok(Some(
-                data.schema.get_type(base_ty_name.clone())?.try_into()?,
+                data.schema.get_type(base_ty_name)?.try_into()?,
             ));
         }
         if data.name() == &TYPENAME_FIELD {
@@ -189,7 +189,7 @@ impl Field {
             else {
                 return Ok(None);
             };
-            return Ok(Some(schema.get_type(type_name.clone())?.try_into()?));
+            return Ok(Some(schema.get_type(type_name)?.try_into()?));
         }
         if !self.can_rebase_on(parent_type)? {
             return Ok(None);
@@ -226,7 +226,7 @@ impl Field {
         }
         Ok(Some(
             schema
-                .get_type(field_definition.ty.inner_named_type().clone())?
+                .get_type(field_definition.ty.inner_named_type())?
                 .try_into()?,
         ))
     }
@@ -258,7 +258,7 @@ impl FieldSelection {
             .ty
             .inner_named_type();
         let rebased_base_type: CompositeTypeDefinitionPosition =
-            schema.get_type(rebased_type_name.clone())?.try_into()?;
+            schema.get_type(rebased_type_name)?.try_into()?;
 
         let selection_set_type = &selection_set.type_position;
         if self.field.schema == rebased.schema && &rebased_base_type == selection_set_type {
@@ -317,7 +317,7 @@ impl InlineFragment {
         };
 
         let rebased_type = schema
-            .get_type(ty.type_name().clone())
+            .get_type(ty.type_name())
             .ok()
             .and_then(|ty| CompositeTypeDefinitionPosition::try_from(ty).ok())?;
 
@@ -368,7 +368,7 @@ impl InlineFragment {
             .type_condition_position
             .clone()
             .and_then(|condition_position| {
-                parent_schema.try_get_type(condition_position.type_name().clone())
+                parent_schema.try_get_type(condition_position.type_name())
             })
             .map(|rebased_condition_position| {
                 CompositeTypeDefinitionPosition::try_from(rebased_condition_position)

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -464,7 +464,7 @@ impl SchemaQueryGraphBuilder {
             .base
             .query_graph
             .schema()?
-            .get_type(root_type_name.name.clone())?
+            .get_type(&root_type_name.name)?
         {
             TypeDefinitionPosition::Object(pos) => pos,
             _ => {
@@ -609,7 +609,7 @@ impl SchemaQueryGraphBuilder {
             .base
             .query_graph
             .schema()?
-            .get_type(field.ty.inner_named_type().clone())?
+            .get_type(field.ty.inner_named_type())?
             .try_into()?;
         let tail = self.add_type_recursively(tail_pos)?;
         if !skip_edge {
@@ -1394,7 +1394,7 @@ impl FederatedQueryGraphBuilder {
                     if is_interface_object {
                         let type_in_supergraph_pos = self
                             .supergraph_schema
-                            .get_type(type_pos.type_name().clone())?;
+                            .get_type(type_pos.type_name())?;
                         let TypeDefinitionPosition::Interface(type_in_supergraph_pos) =
                             type_in_supergraph_pos
                         else {
@@ -1450,7 +1450,7 @@ impl FederatedQueryGraphBuilder {
                             let other_schema =
                                 self.base.query_graph.schema_by_source(other_source)?;
                             let implementation_type_in_other_subgraph_pos: CompositeTypeDefinitionPosition =
-                                other_schema.get_type(implementation_type_in_supergraph_pos.type_name.clone())?.try_into()?;
+                                other_schema.get_type(&implementation_type_in_supergraph_pos.type_name)?.try_into()?;
                             let Ok(implementation_conditions) = parse_field_set(
                                 other_schema,
                                 implementation_type_in_other_subgraph_pos
@@ -1883,7 +1883,7 @@ impl FederatedQueryGraphBuilder {
             let schema = self.base.query_graph.schema_by_source(&source)?;
             let subgraph_data = self.subgraphs.get(&source)?;
             let field = field_definition_position.get(schema.schema())?;
-            let field_type_pos = schema.get_type(field.ty.inner_named_type().clone())?;
+            let field_type_pos = schema.get_type(field.ty.inner_named_type())?;
             let mut all_conditions = Vec::new();
             for directive in field
                 .directives
@@ -2294,7 +2294,7 @@ impl FederatedQueryGraphBuilder {
                 };
                 let type_in_supergraph_pos = self
                     .supergraph_schema
-                    .get_type(type_pos.type_name.clone())?;
+                    .get_type(&type_pos.type_name)?;
                 let TypeDefinitionPosition::Interface(type_in_supergraph_pos) =
                     type_in_supergraph_pos
                 else {

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1392,9 +1392,8 @@ impl FederatedQueryGraphBuilder {
                     // used when an entity of a specific implementation is queried first, but then
                     // some of the requested fields are only provided by that @interfaceObject.
                     if is_interface_object {
-                        let type_in_supergraph_pos = self
-                            .supergraph_schema
-                            .get_type(type_pos.type_name())?;
+                        let type_in_supergraph_pos =
+                            self.supergraph_schema.get_type(type_pos.type_name())?;
                         let TypeDefinitionPosition::Interface(type_in_supergraph_pos) =
                             type_in_supergraph_pos
                         else {
@@ -2292,9 +2291,8 @@ impl FederatedQueryGraphBuilder {
                     }
                     .into());
                 };
-                let type_in_supergraph_pos = self
-                    .supergraph_schema
-                    .get_type(&type_pos.type_name)?;
+                let type_in_supergraph_pos =
+                    self.supergraph_schema.get_type(&type_pos.type_name)?;
                 let TypeDefinitionPosition::Interface(type_in_supergraph_pos) =
                     type_in_supergraph_pos
                 else {

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -1170,7 +1170,7 @@ where
                     let supergraph_schema = self.graph.supergraph_schema()?;
                     let parent_type_in_supergraph: CompositeTypeDefinitionPosition =
                         supergraph_schema
-                            .get_type(parent_type.type_name().clone())?
+                            .get_type(parent_type.type_name())?
                             .try_into()?;
                     if !ctx.types_with_context_set.iter().fallible_any(|pos| {
                         if pos.type_name() == parent_type_in_supergraph.type_name() {
@@ -1199,7 +1199,7 @@ where
                             _ => {}
                         }
                         let pos_in_supergraph: CompositeTypeDefinitionPosition = supergraph_schema
-                            .get_type(pos.type_name().clone())?
+                            .get_type(pos.type_name())?
                             .try_into()?;
                         if let CompositeTypeDefinitionPosition::Union(pos_in_supergraph) =
                             &pos_in_supergraph
@@ -1248,7 +1248,7 @@ where
                             };
                             let type_condition_pos: ObjectTypeDefinitionPosition =
                                 supergraph_schema
-                                    .get_type(type_condition.clone())?
+                                    .get_type(type_condition)?
                                     .try_into()?;
                             if possible_runtime_types.contains(&type_condition_pos) {
                                 return Ok(Some(selection));
@@ -2036,7 +2036,7 @@ where
                     // we want to check if the field is overridden in the source of the edge. Hence,
                     // we get the matching definition in the input schema.
                     let Ok(type_pos_in_subgraph) =
-                        subgraph_schema.get_type(field_pos.type_name().clone())
+                        subgraph_schema.get_type(field_pos.type_name())
                     else {
                         continue;
                     };

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -1198,9 +1198,8 @@ where
                             }
                             _ => {}
                         }
-                        let pos_in_supergraph: CompositeTypeDefinitionPosition = supergraph_schema
-                            .get_type(pos.type_name())?
-                            .try_into()?;
+                        let pos_in_supergraph: CompositeTypeDefinitionPosition =
+                            supergraph_schema.get_type(pos.type_name())?.try_into()?;
                         if let CompositeTypeDefinitionPosition::Union(pos_in_supergraph) =
                             &pos_in_supergraph
                             && pos_in_supergraph
@@ -1247,9 +1246,7 @@ where
                                 return Ok(Some(selection));
                             };
                             let type_condition_pos: ObjectTypeDefinitionPosition =
-                                supergraph_schema
-                                    .get_type(type_condition)?
-                                    .try_into()?;
+                                supergraph_schema.get_type(type_condition)?.try_into()?;
                             if possible_runtime_types.contains(&type_condition_pos) {
                                 return Ok(Some(selection));
                             }
@@ -2035,8 +2032,7 @@ where
                     // conditions on key edges are those of the destination of the edge, and here
                     // we want to check if the field is overridden in the source of the edge. Hence,
                     // we get the matching definition in the input schema.
-                    let Ok(type_pos_in_subgraph) =
-                        subgraph_schema.get_type(field_pos.type_name())
+                    let Ok(type_pos_in_subgraph) = subgraph_schema.get_type(field_pos.type_name())
                     else {
                         continue;
                     };

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -257,7 +257,8 @@ impl ExcludedDestinations {
 impl PartialEq for ExcludedDestinations {
     /// See if two `ExcludedDestinations` have the same set of values, regardless of their ordering.
     fn eq(&self, other: &ExcludedDestinations) -> bool {
-        self.0.len() == other.0.len() && self.0.iter().all(|x| other.0.contains(x))
+        Arc::ptr_eq(&self.0, &other.0)
+            || (self.0.len() == other.0.len() && self.0.iter().all(|x| other.0.contains(x)))
     }
 }
 

--- a/apollo-federation/src/query_graph/graph_path/operation.rs
+++ b/apollo-federation/src/query_graph/graph_path/operation.rs
@@ -1042,7 +1042,7 @@ impl OpGraphPath {
                     return Ok(true);
                 }
                 let node_field_base_type_pos =
-                    node_fed_schema.get_type(node_field_base_type_name.clone())?;
+                    node_fed_schema.get_type(node_field_base_type_name)?;
                 let Some(node_field_base_type_pos): Option<
                     ObjectOrInterfaceTypeDefinitionPosition,
                 > = node_field_base_type_pos.try_into().ok() else {
@@ -1267,7 +1267,7 @@ impl OpGraphPath {
                             let is_operation_field_type_leaf = matches!(
                                 operation_field
                                     .schema
-                                    .get_type(operation_field_type_name.clone())?,
+                                    .get_type(operation_field_type_name)?,
                                 TypeDefinitionPosition::Scalar(_) | TypeDefinitionPosition::Enum(_)
                             );
                             if is_operation_field_type_leaf
@@ -1546,7 +1546,7 @@ impl OpGraphPath {
                         let from_types = self.runtime_types_of_tail.clone();
                         let to_types = supergraph_schema.possible_runtime_types(
                             supergraph_schema
-                                .get_type(type_condition_name.clone())?
+                                .get_type(&type_condition_name)?
                                 .try_into()?,
                         )?;
                         let intersection = from_types.intersection(&to_types);
@@ -1631,7 +1631,7 @@ impl OpGraphPath {
                         //   super-type of the tail type (since GraphQL allows a fragment as long as
                         //   there is an intersection). In that case, the whole operation element
                         //   simply cannot ever return anything.
-                        let type_condition_pos = supergraph_schema.get_type(type_condition_name)?;
+                        let type_condition_pos = supergraph_schema.get_type(&type_condition_name)?;
                         let abstract_type_condition_pos: Option<AbstractTypeDefinitionPosition> =
                             type_condition_pos.clone().try_into().ok();
                         if let Some(type_condition_pos) = abstract_type_condition_pos
@@ -2398,7 +2398,7 @@ impl OpPath {
             match element.as_ref() {
                 OpPathElement::InlineFragment(fragment) => {
                     if let Some(type_condition) = &fragment.type_condition_position {
-                        if schema.get_type(type_condition.type_name().clone()).is_err() {
+                        if schema.get_type(type_condition.type_name()).is_err() {
                             if element.directives().is_empty() {
                                 continue; // skip this element
                             } else {

--- a/apollo-federation/src/query_graph/graph_path/operation.rs
+++ b/apollo-federation/src/query_graph/graph_path/operation.rs
@@ -1265,9 +1265,7 @@ impl OpGraphPath {
                                 .ty
                                 .inner_named_type();
                             let is_operation_field_type_leaf = matches!(
-                                operation_field
-                                    .schema
-                                    .get_type(operation_field_type_name)?,
+                                operation_field.schema.get_type(operation_field_type_name)?,
                                 TypeDefinitionPosition::Scalar(_) | TypeDefinitionPosition::Enum(_)
                             );
                             if is_operation_field_type_leaf
@@ -1631,7 +1629,8 @@ impl OpGraphPath {
                         //   super-type of the tail type (since GraphQL allows a fragment as long as
                         //   there is an intersection). In that case, the whole operation element
                         //   simply cannot ever return anything.
-                        let type_condition_pos = supergraph_schema.get_type(&type_condition_name)?;
+                        let type_condition_pos =
+                            supergraph_schema.get_type(&type_condition_name)?;
                         let abstract_type_condition_pos: Option<AbstractTypeDefinitionPosition> =
                             type_condition_pos.clone().try_into().ok();
                         if let Some(type_condition_pos) = abstract_type_condition_pos

--- a/apollo-federation/src/query_graph/graph_path/transition.rs
+++ b/apollo-federation/src/query_graph/graph_path/transition.rs
@@ -203,8 +203,8 @@ impl TransitionGraphPath {
                 if other_subgraph == field_subgraph {
                     return Ok(None);
                 }
-                let Some(type_pos_in_other_subgraph) = other_subgraph_schema
-                    .try_get_type(field_pos_in_subgraph.parent().type_name())
+                let Some(type_pos_in_other_subgraph) =
+                    other_subgraph_schema.try_get_type(field_pos_in_subgraph.parent().type_name())
                 else {
                     return Ok(None);
                 };

--- a/apollo-federation/src/query_graph/graph_path/transition.rs
+++ b/apollo-federation/src/query_graph/graph_path/transition.rs
@@ -204,7 +204,7 @@ impl TransitionGraphPath {
                     return Ok(None);
                 }
                 let Some(type_pos_in_other_subgraph) = other_subgraph_schema
-                    .try_get_type(field_pos_in_subgraph.parent().type_name().clone())
+                    .try_get_type(field_pos_in_subgraph.parent().type_name())
                 else {
                     return Ok(None);
                 };
@@ -416,7 +416,7 @@ impl TransitionGraphPath {
                                     graph.schema_by_source(&head_weight.source)?;
                                 let parent_type_pos_in_subgraph: CompositeTypeDefinitionPosition =
                                     subgraph_schema.get_type(
-                                        field_definition_position.parent().type_name().clone()
+                                        field_definition_position.parent().type_name()
                                     )?.try_into()?;
                                 let details = match reason {
                                     Some(UnsatisfiedConditionReason::NoPostRequireKey) => {
@@ -534,7 +534,7 @@ impl TransitionGraphPath {
                             .name;
                         let parent_type_pos = field_definition_position.parent();
                         let parent_type_pos_in_subgraph =
-                            subgraph_schema.try_get_type(parent_type_pos.type_name().clone());
+                            subgraph_schema.try_get_type(parent_type_pos.type_name());
                         if parent_type_pos_in_subgraph.is_none()
                             && tail_type_pos.type_name() != parent_type_pos.type_name()
                         {
@@ -917,7 +917,7 @@ impl TransitionPathWithLazyIndirectPaths {
                             continue;
                         }
                         let parent_type_pos_in_subgraph =
-                            subgraph_schema.try_get_type(parent_type_pos.type_name().clone());
+                            subgraph_schema.try_get_type(parent_type_pos.type_name());
                         let Some(Ok(parent_type_pos_in_subgraph)) = parent_type_pos_in_subgraph
                             .map(CompositeTypeDefinitionPosition::try_from)
                         else {
@@ -940,7 +940,7 @@ impl TransitionPathWithLazyIndirectPaths {
                         //    for is an implementation of that interface, and there are no keys on
                         //    the interface.
                         let tail_type_pos_in_subgraph =
-                            subgraph_schema.try_get_type(tail_type_pos.type_name().clone());
+                            subgraph_schema.try_get_type(tail_type_pos.type_name());
                         if let Some(tail_type_pos_in_subgraph) = tail_type_pos_in_subgraph {
                             // `tail_type_pos_in_subgraph` exists, so it's either equal to
                             // `parent_type_pos_in_subgraph`, or it's an interface of it. In any

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -1003,9 +1003,8 @@ impl QueryGraph {
                     let Some(field) = field_pos.try_get(schema.schema()) else {
                         continue;
                     };
-                    let field_type_pos: CompositeTypeDefinitionPosition = schema
-                        .get_type(field.ty.inner_named_type())?
-                        .try_into()?;
+                    let field_type_pos: CompositeTypeDefinitionPosition =
+                        schema.get_type(field.ty.inner_named_type())?.try_into()?;
                     new_possible_runtime_types
                         .extend(schema.possible_runtime_types(field_type_pos)?);
                 }

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -1004,7 +1004,7 @@ impl QueryGraph {
                         continue;
                     };
                     let field_type_pos: CompositeTypeDefinitionPosition = schema
-                        .get_type(field.ty.inner_named_type().clone())?
+                        .get_type(field.ty.inner_named_type())?
                         .try_into()?;
                     new_possible_runtime_types
                         .extend(schema.possible_runtime_types(field_type_pos)?);

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -1071,10 +1071,7 @@ impl FetchDependencyGraph {
         &self,
         type_name: &Name,
     ) -> Result<CompositeTypeDefinitionPosition, FederationError> {
-        Ok(self
-            .supergraph_schema
-            .get_type(type_name)?
-            .try_into()?)
+        Ok(self.supergraph_schema.get_type(type_name)?.try_into()?)
     }
 
     /// Find redundant edges coming out of a node. See `remove_redundant_edges`. This method assumes
@@ -1370,9 +1367,8 @@ impl FetchDependencyGraph {
             };
 
             if condition.is_object_type() {
-                let Ok(condition_in_supergraph) = self
-                    .supergraph_schema
-                    .get_type(condition.type_name())
+                let Ok(condition_in_supergraph) =
+                    self.supergraph_schema.get_type(condition.type_name())
                 else {
                     // Note that we're checking the true supergraph, not the API schema, so even
                     // @inaccessible types will be found.
@@ -1408,8 +1404,7 @@ impl FetchDependencyGraph {
                         let p_node = self.node_weight(p)?;
                         let p_subgraph_name = &p_node.subgraph_name;
                         let p_subgraph_schema = get_subgraph_schema(p_subgraph_name)?;
-                        let Ok(type_in_parent) =
-                            p_subgraph_schema.get_type(condition.type_name())
+                        let Ok(type_in_parent) = p_subgraph_schema.get_type(condition.type_name())
                         else {
                             return Ok(false);
                         };
@@ -3012,7 +3007,7 @@ fn operation_for_entities_fetch(
         message: "Subgraphs should always have a query root (they should at least provides _entities)".to_string()
     })?;
 
-    let query_type = match subgraph_schema.get_type(&query_type_name)? {
+    let query_type = match subgraph_schema.get_type(query_type_name)? {
         TypeDefinitionPosition::Object(o) => o,
         _ => {
             return Err(SingleFederationError::InvalidSubgraph {
@@ -3050,9 +3045,8 @@ fn operation_for_entities_fetch(
         Some(selection_set),
     )?;
 
-    let type_position: CompositeTypeDefinitionPosition = subgraph_schema
-        .get_type(&query_type_name)?
-        .try_into()?;
+    let type_position: CompositeTypeDefinitionPosition =
+        subgraph_schema.get_type(query_type_name)?.try_into()?;
 
     let mut map = SelectionMap::new();
     map.insert(entities_call);
@@ -5271,8 +5265,9 @@ mod tests {
             .unwrap()
             .try_into()
             .unwrap();
-        let type_condition =
-            type_condition_name.as_ref().map(|n| schema.get_type(n).unwrap().try_into().unwrap());
+        let type_condition = type_condition_name
+            .as_ref()
+            .map(|n| schema.get_type(n).unwrap().try_into().unwrap());
         OpPathElement::InlineFragment(InlineFragment {
             schema: schema.clone(),
             parent_type_position: parent_type,

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -601,12 +601,12 @@ impl FetchDependencyGraphNodePath {
             .clone()
             .into_iter()
             .map(|pt| {
-                let field = CompositeTypeDefinitionPosition::try_from(self.schema.get_type(pt)?)?
+                let field = CompositeTypeDefinitionPosition::try_from(self.schema.get_type(&pt)?)?
                     .field(element.name().clone())?
                     .get(self.schema.schema())?;
                 let typ = self
                     .schema
-                    .get_type(field.ty.inner_named_type().clone())?
+                    .get_type(field.ty.inner_named_type())?
                     .try_into()?;
                 Ok(self
                     .schema
@@ -1073,7 +1073,7 @@ impl FetchDependencyGraph {
     ) -> Result<CompositeTypeDefinitionPosition, FederationError> {
         Ok(self
             .supergraph_schema
-            .get_type(type_name.clone())?
+            .get_type(type_name)?
             .try_into()?)
     }
 
@@ -1372,7 +1372,7 @@ impl FetchDependencyGraph {
             if condition.is_object_type() {
                 let Ok(condition_in_supergraph) = self
                     .supergraph_schema
-                    .get_type(condition.type_name().clone())
+                    .get_type(condition.type_name())
                 else {
                     // Note that we're checking the true supergraph, not the API schema, so even
                     // @inaccessible types will be found.
@@ -1409,7 +1409,7 @@ impl FetchDependencyGraph {
                         let p_subgraph_name = &p_node.subgraph_name;
                         let p_subgraph_schema = get_subgraph_schema(p_subgraph_name)?;
                         let Ok(type_in_parent) =
-                            p_subgraph_schema.get_type(condition.type_name().clone())
+                            p_subgraph_schema.get_type(condition.type_name())
                         else {
                             return Ok(false);
                         };
@@ -2354,7 +2354,7 @@ impl FetchDependencyGraph {
                     let field_definition = field_position.get(schema.schema())?;
                     let field_type = field_definition.ty.inner_named_type();
                     type_ = schema
-                        .get_type(field_type.clone())?
+                        .get_type(field_type)?
                         .try_into()
                         .map_or_else(
                             |_| {
@@ -2368,7 +2368,7 @@ impl FetchDependencyGraph {
                 OpPathElement::InlineFragment(fragment) => {
                     if let Some(type_condition_position) = &fragment.type_condition_position {
                         type_ = schema
-                            .get_type(type_condition_position.type_name().clone())?
+                            .get_type(type_condition_position.type_name())?
                             .try_into()
                             .map_or_else(
                                 |_| {
@@ -3012,7 +3012,7 @@ fn operation_for_entities_fetch(
         message: "Subgraphs should always have a query root (they should at least provides _entities)".to_string()
     })?;
 
-    let query_type = match subgraph_schema.get_type(query_type_name.clone())? {
+    let query_type = match subgraph_schema.get_type(&query_type_name)? {
         TypeDefinitionPosition::Object(o) => o,
         _ => {
             return Err(SingleFederationError::InvalidSubgraph {
@@ -3051,7 +3051,7 @@ fn operation_for_entities_fetch(
     )?;
 
     let type_position: CompositeTypeDefinitionPosition = subgraph_schema
-        .get_type(query_type_name.clone())?
+        .get_type(&query_type_name)?
         .try_into()?;
 
     let mut map = SelectionMap::new();
@@ -4050,7 +4050,7 @@ fn compute_nodes_for_op_path_element<'a>(
             let Ok(input_type) = CompositeTypeDefinitionPosition::try_from(
                 dependency_graph
                     .supergraph_schema
-                    .get_type(source_type.type_name().clone())?,
+                    .get_type(source_type.type_name())?,
             ) else {
                 bail!(
                     "Type {} should exist in the supergraph and be a composite type",
@@ -4218,7 +4218,7 @@ fn wrap_selection_with_type_and_conditions<T>(
     // TODO: remove the `unwrap` with proper error handling, and ensure we have some intersection
     // between the wrapping_type type and the new type condition.
     let type_condition: CompositeTypeDefinitionPosition = supergraph_schema
-        .get_type(wrapping_type.type_name().clone())
+        .get_type(wrapping_type.type_name())
         .unwrap()
         .try_into()
         .unwrap();
@@ -4306,7 +4306,7 @@ fn create_fetch_initial_path(
     // supergraph). Doing this make sure we can rely on things like checking subtyping between
     // the types of a given path.
     let rebased_type: CompositeTypeDefinitionPosition = supergraph_schema
-        .get_type(dest_type.type_name().clone())?
+        .get_type(dest_type.type_name())?
         .try_into()?;
     Ok(Arc::new(wrap_selection_with_type_and_conditions(
         supergraph_schema,
@@ -4962,7 +4962,7 @@ fn inputs_for_require(
 
     let input_type: CompositeTypeDefinitionPosition = fetch_dependency_graph
         .supergraph_schema
-        .get_type(input_type_name.clone())?
+        .get_type(&input_type_name)?
         .try_into()
         .map_or_else(
             |_| {
@@ -5001,7 +5001,7 @@ fn inputs_for_require(
             // condition on the supergraph type (which is an interface) first, which lets the `mergeIn` work.
             let supergraph_intf_type: CompositeTypeDefinitionPosition = fetch_dependency_graph
                 .supergraph_schema
-                .get_type(entity_type_position.type_name.clone())?
+                .get_type(&entity_type_position.type_name)?
                 .try_into()?;
             if !supergraph_intf_type.is_interface_type() {
                 return Err(FederationError::internal(format!(
@@ -5166,7 +5166,7 @@ mod tests {
         let baz = object_field_element(&valid_schema, name!("Bar_1"), name!("baz"));
 
         let query_root = valid_schema
-            .get_type(name!("Query"))
+            .get_type(&name!("Query"))
             .unwrap()
             .try_into()
             .unwrap();
@@ -5228,7 +5228,7 @@ mod tests {
         let baz = object_field_element(&valid_schema, name!("Bar_1"), name!("baz"));
 
         let query_root = valid_schema
-            .get_type(name!("Query"))
+            .get_type(&name!("Query"))
             .unwrap()
             .try_into()
             .unwrap();
@@ -5267,12 +5267,12 @@ mod tests {
         type_condition_name: Option<Name>,
     ) -> OpPathElement {
         let parent_type = schema
-            .get_type(parent_type_name)
+            .get_type(&parent_type_name)
             .unwrap()
             .try_into()
             .unwrap();
         let type_condition =
-            type_condition_name.map(|n| schema.get_type(n).unwrap().try_into().unwrap());
+            type_condition_name.as_ref().map(|n| schema.get_type(n).unwrap().try_into().unwrap());
         OpPathElement::InlineFragment(InlineFragment {
             schema: schema.clone(),
             parent_type_position: parent_type,

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -296,7 +296,7 @@ impl QueryPlanner {
                 let is_interface_object = query_graph
                     .subgraphs()
                     .map(|(_name, schema)| {
-                        let Some(position) = schema.try_get_type(position.type_name.clone()) else {
+                        let Some(position) = schema.try_get_type(&position.type_name) else {
                             return Ok(false);
                         };
                         schema.is_interface_object_type(position)
@@ -317,7 +317,7 @@ impl QueryPlanner {
 
         let is_inconsistent = |position: AbstractTypeDefinitionPosition| {
             let mut sources = query_graph.subgraphs().filter_map(|(_name, subgraph)| {
-                match subgraph.try_get_type(position.type_name().clone())? {
+                match subgraph.try_get_type(position.type_name())? {
                     // This is only called for type names that are abstract in the supergraph, so it
                     // can only be an object in a subgraph if it is an `@interfaceObject`. And as `@interfaceObject`s
                     // "stand-in" for all possible runtime types, they don't create inconsistencies by themselves
@@ -605,7 +605,7 @@ fn compute_root_serial_dependency_graph_for_mutation(
         supergraph_schema
             .schema()
             .root_operation(operation.root_kind.into())
-            .and_then(|name| supergraph_schema.get_type(name.clone()).ok())
+            .and_then(|name| supergraph_schema.get_type(name).ok())
             .and_then(|ty| ty.try_into().ok())
     } else {
         None

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -190,7 +190,7 @@ pub(crate) fn convert_type_from_subgraph(
 ) -> Result<CompositeTypeDefinitionPosition, FederationError> {
     if subgraph_schema.is_interface_object_type(ty.clone().into())? {
         let type_in_supergraph_pos: CompositeTypeDefinitionPosition = supergraph_schema
-            .get_type(ty.type_name().clone())?
+            .get_type(ty.type_name())?
             .try_into()?;
         ensure!(
             matches!(

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -189,9 +189,8 @@ pub(crate) fn convert_type_from_subgraph(
     supergraph_schema: &ValidFederationSchema,
 ) -> Result<CompositeTypeDefinitionPosition, FederationError> {
     if subgraph_schema.is_interface_object_type(ty.clone().into())? {
-        let type_in_supergraph_pos: CompositeTypeDefinitionPosition = supergraph_schema
-            .get_type(ty.type_name())?
-            .try_into()?;
+        let type_in_supergraph_pos: CompositeTypeDefinitionPosition =
+            supergraph_schema.get_type(ty.type_name())?.try_into()?;
         ensure!(
             matches!(
                 type_in_supergraph_pos,

--- a/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
@@ -464,7 +464,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                             let type_condition_in_supergraph_pos = self
                                 .parameters
                                 .supergraph_schema
-                                .get_type(type_condition_pos.type_name().clone())?;
+                                .get_type(type_condition_pos.type_name())?;
                             possible_runtime_types.insert(
                                 self.parameters.supergraph_schema.possible_runtime_types(
                                     type_condition_in_supergraph_pos.try_into()?,

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -168,21 +168,41 @@ impl FederationSchema {
         &self,
         type_name: &Name,
     ) -> Result<TypeDefinitionPosition, FederationError> {
-        self.try_get_type(type_name)
-            .ok_or_else(|| SingleFederationError::Internal {
+        self.try_get_type(type_name).ok_or_else(|| {
+            SingleFederationError::Internal {
                 message: format!("Schema has no type \"{type_name}\""),
-            }.into())
+            }
+            .into()
+        })
     }
 
     pub(crate) fn try_get_type(&self, type_name: &Name) -> Option<TypeDefinitionPosition> {
         let type_ = self.schema.types.get(type_name)?;
         Some(match type_ {
-            ExtendedType::Scalar(_) => ScalarTypeDefinitionPosition { type_name: type_name.clone() }.into(),
-            ExtendedType::Object(_) => ObjectTypeDefinitionPosition { type_name: type_name.clone() }.into(),
-            ExtendedType::Interface(_) => InterfaceTypeDefinitionPosition { type_name: type_name.clone() }.into(),
-            ExtendedType::Union(_) => UnionTypeDefinitionPosition { type_name: type_name.clone() }.into(),
-            ExtendedType::Enum(_) => EnumTypeDefinitionPosition { type_name: type_name.clone() }.into(),
-            ExtendedType::InputObject(_) => InputObjectTypeDefinitionPosition { type_name: type_name.clone() }.into(),
+            ExtendedType::Scalar(_) => ScalarTypeDefinitionPosition {
+                type_name: type_name.clone(),
+            }
+            .into(),
+            ExtendedType::Object(_) => ObjectTypeDefinitionPosition {
+                type_name: type_name.clone(),
+            }
+            .into(),
+            ExtendedType::Interface(_) => InterfaceTypeDefinitionPosition {
+                type_name: type_name.clone(),
+            }
+            .into(),
+            ExtendedType::Union(_) => UnionTypeDefinitionPosition {
+                type_name: type_name.clone(),
+            }
+            .into(),
+            ExtendedType::Enum(_) => EnumTypeDefinitionPosition {
+                type_name: type_name.clone(),
+            }
+            .into(),
+            ExtendedType::InputObject(_) => InputObjectTypeDefinitionPosition {
+                type_name: type_name.clone(),
+            }
+            .into(),
         })
     }
 

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -178,31 +178,14 @@ impl FederationSchema {
 
     pub(crate) fn try_get_type(&self, type_name: &Name) -> Option<TypeDefinitionPosition> {
         let type_ = self.schema.types.get(type_name)?;
+        let type_name = type_name.clone();
         Some(match type_ {
-            ExtendedType::Scalar(_) => ScalarTypeDefinitionPosition {
-                type_name: type_name.clone(),
-            }
-            .into(),
-            ExtendedType::Object(_) => ObjectTypeDefinitionPosition {
-                type_name: type_name.clone(),
-            }
-            .into(),
-            ExtendedType::Interface(_) => InterfaceTypeDefinitionPosition {
-                type_name: type_name.clone(),
-            }
-            .into(),
-            ExtendedType::Union(_) => UnionTypeDefinitionPosition {
-                type_name: type_name.clone(),
-            }
-            .into(),
-            ExtendedType::Enum(_) => EnumTypeDefinitionPosition {
-                type_name: type_name.clone(),
-            }
-            .into(),
-            ExtendedType::InputObject(_) => InputObjectTypeDefinitionPosition {
-                type_name: type_name.clone(),
-            }
-            .into(),
+            ExtendedType::Scalar(_) => ScalarTypeDefinitionPosition { type_name }.into(),
+            ExtendedType::Object(_) => ObjectTypeDefinitionPosition { type_name }.into(),
+            ExtendedType::Interface(_) => InterfaceTypeDefinitionPosition { type_name }.into(),
+            ExtendedType::Union(_) => UnionTypeDefinitionPosition { type_name }.into(),
+            ExtendedType::Enum(_) => EnumTypeDefinitionPosition { type_name }.into(),
+            ExtendedType::InputObject(_) => InputObjectTypeDefinitionPosition { type_name }.into(),
         })
     }
 

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -166,27 +166,24 @@ impl FederationSchema {
 
     pub(crate) fn get_type(
         &self,
-        type_name: Name,
+        type_name: &Name,
     ) -> Result<TypeDefinitionPosition, FederationError> {
-        let type_ =
-            self.schema
-                .types
-                .get(&type_name)
-                .ok_or_else(|| SingleFederationError::Internal {
-                    message: format!("Schema has no type \"{type_name}\""),
-                })?;
-        Ok(match type_ {
-            ExtendedType::Scalar(_) => ScalarTypeDefinitionPosition { type_name }.into(),
-            ExtendedType::Object(_) => ObjectTypeDefinitionPosition { type_name }.into(),
-            ExtendedType::Interface(_) => InterfaceTypeDefinitionPosition { type_name }.into(),
-            ExtendedType::Union(_) => UnionTypeDefinitionPosition { type_name }.into(),
-            ExtendedType::Enum(_) => EnumTypeDefinitionPosition { type_name }.into(),
-            ExtendedType::InputObject(_) => InputObjectTypeDefinitionPosition { type_name }.into(),
-        })
+        self.try_get_type(type_name)
+            .ok_or_else(|| SingleFederationError::Internal {
+                message: format!("Schema has no type \"{type_name}\""),
+            }.into())
     }
 
-    pub(crate) fn try_get_type(&self, type_name: Name) -> Option<TypeDefinitionPosition> {
-        self.get_type(type_name).ok()
+    pub(crate) fn try_get_type(&self, type_name: &Name) -> Option<TypeDefinitionPosition> {
+        let type_ = self.schema.types.get(type_name)?;
+        Some(match type_ {
+            ExtendedType::Scalar(_) => ScalarTypeDefinitionPosition { type_name: type_name.clone() }.into(),
+            ExtendedType::Object(_) => ObjectTypeDefinitionPosition { type_name: type_name.clone() }.into(),
+            ExtendedType::Interface(_) => InterfaceTypeDefinitionPosition { type_name: type_name.clone() }.into(),
+            ExtendedType::Union(_) => UnionTypeDefinitionPosition { type_name: type_name.clone() }.into(),
+            ExtendedType::Enum(_) => EnumTypeDefinitionPosition { type_name: type_name.clone() }.into(),
+            ExtendedType::InputObject(_) => InputObjectTypeDefinitionPosition { type_name: type_name.clone() }.into(),
+        })
     }
 
     pub(crate) fn is_root_type(&self, type_name: &Name) -> bool {

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -201,7 +201,7 @@ impl SchemaUpgrader {
         orphan_extension_types
             .into_iter()
             .filter(|type_name| {
-                schema.try_get_type((*type_name).clone()).is_some_and(|ty| {
+                schema.try_get_type(type_name).is_some_and(|ty| {
                     let Ok(ty) = ty.get(schema.schema()) else {
                         return false;
                     };
@@ -655,7 +655,7 @@ impl SchemaUpgrader {
             let field = obj_field_pos.get(schema.schema())?;
             let return_type = field.ty.inner_named_type();
             if schema
-                .try_get_type(return_type.clone())
+                .try_get_type(return_type)
                 .is_some_and(|t| !t.is_composite_type())
             {
                 candidates.insert(obj_field_pos.clone());

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -165,7 +165,7 @@ impl TypeAndDirectiveSpecification for ScalarTypeSpecification {
         link: Option<&Arc<Link>>,
     ) -> Result<(), FederationError> {
         let actual_name = actual_type_name(&self.name, link);
-        let existing = schema.try_get_type(actual_name.clone());
+        let existing = schema.try_get_type(&actual_name);
         if let Some(existing) = existing {
             // Ignore redundant type specifications if they are are both scalar types.
             return ensure_expected_type_kind(TypeKind::Scalar, &existing);
@@ -207,7 +207,7 @@ impl TypeAndDirectiveSpecification for ObjectTypeSpecification {
     ) -> Result<(), FederationError> {
         let actual_name = actual_type_name(&self.name, link);
         let field_specs = (self.fields)(schema);
-        let existing = schema.try_get_type(actual_name.clone());
+        let existing = schema.try_get_type(&actual_name);
         if let Some(existing) = existing {
             // ensure existing definition is an object type
             ensure_expected_type_kind(TypeKind::Object, &existing)?;
@@ -272,7 +272,7 @@ impl TypeAndDirectiveSpecification for UnionTypeSpecification {
         let members = (self.members)(schema);
         // PORT_NOTE: The JS version sorts the members by name.
         // TODO(ROUTER-1223): Sort members here. Currently, doing it breaks `plugins::cache` tests.
-        let existing = schema.try_get_type(actual_name.clone());
+        let existing = schema.try_get_type(&actual_name);
 
         // ensure new union has at least one member
         if members.is_empty() {
@@ -356,7 +356,7 @@ impl TypeAndDirectiveSpecification for EnumTypeSpecification {
         link: Option<&Arc<Link>>,
     ) -> Result<(), FederationError> {
         let actual_name = actual_type_name(&self.name, link);
-        let existing = schema.try_get_type(actual_name.clone());
+        let existing = schema.try_get_type(&actual_name);
         if let Some(existing) = existing {
             ensure_expected_type_kind(TypeKind::Enum, &existing)?;
             let existing_type = existing.get(schema.schema())?;
@@ -460,7 +460,7 @@ impl TypeAndDirectiveSpecification for InputObjectTypeSpecification {
             .into_iter()
             .map(|spec| spec.resolve(schema, link).map(|r| (r.name.clone(), r)))
             .collect::<Result<IndexMap<Name, ResolvedArgumentSpecification>, FederationError>>()?;
-        let existing = schema.try_get_type(actual_name.clone());
+        let existing = schema.try_get_type(&actual_name);
         if let Some(existing) = existing {
             let mut errors: Vec<SingleFederationError> = vec![];
             // ensure existing definition is InputObject

--- a/apollo-federation/src/schema/validators/access_control.rs
+++ b/apollo-federation/src/schema/validators/access_control.rs
@@ -326,8 +326,7 @@ impl<'validator> AccessControlValidator<'validator> {
                     if let Some(target_type_names) = self.contexts.get(context_arg.context) {
                         // we need to verify against all possible contexts
                         for target_type_name in target_type_names {
-                            let target_type =
-                                self.valid_schema.get_type(target_type_name)?;
+                            let target_type = self.valid_schema.get_type(target_type_name)?;
                             let target_type_auth_requirements =
                                 self.read_auth_requirements_from_element(&target_type)?;
                             if !auth_requirements_on_context

--- a/apollo-federation/src/schema/validators/access_control.rs
+++ b/apollo-federation/src/schema/validators/access_control.rs
@@ -121,7 +121,7 @@ pub(crate) fn validate_transitive_access_control_requirements_in_the_supergraph(
         for field in &requires_referencers.object_fields {
             fields_with_requires.insert(
                 ObjectOrInterfaceTypeDefinitionPosition::try_from(
-                    supergraph_schema.get_type(field.type_name.clone())?,
+                    supergraph_schema.get_type(&field.type_name)?,
                 )?
                 .field(field.field_name.clone()),
             );
@@ -143,7 +143,7 @@ pub(crate) fn validate_transitive_access_control_requirements_in_the_supergraph(
             for argument in &from_context_referencers.object_field_arguments {
                 fields_with_from_context.insert(
                     ObjectOrInterfaceTypeDefinitionPosition::try_from(
-                        supergraph_schema.get_type(argument.type_name.clone())?,
+                        supergraph_schema.get_type(&argument.type_name)?,
                     )?
                     .field(argument.field_name.clone()),
                 );
@@ -327,7 +327,7 @@ impl<'validator> AccessControlValidator<'validator> {
                         // we need to verify against all possible contexts
                         for target_type_name in target_type_names {
                             let target_type =
-                                self.valid_schema.get_type(target_type_name.clone())?;
+                                self.valid_schema.get_type(target_type_name)?;
                             let target_type_auth_requirements =
                                 self.read_auth_requirements_from_element(&target_type)?;
                             if !auth_requirements_on_context

--- a/apollo-federation/src/schema/validators/cache_tag.rs
+++ b/apollo-federation/src/schema/validators/cache_tag.rs
@@ -252,11 +252,12 @@ fn validate_args_selection(
                 })?;
 
         let type_name = field.inner_named_type();
-        let type_def = schema.get_type(type_name).map_err(|e| {
-            SingleFederationError::InvalidGraphQL {
-                message: e.to_string(),
-            }
-        })?;
+        let type_def =
+            schema
+                .get_type(type_name)
+                .map_err(|e| SingleFederationError::InvalidGraphQL {
+                    message: e.to_string(),
+                })?;
         if !sel.is_leaf() {
             let type_def = ObjectOrInterfaceTypeDefinitionPosition::try_from(type_def).map_err(
                 |_| SingleFederationError::CacheTagInvalidFormat {
@@ -473,11 +474,12 @@ fn build_selection_set(
             .map_err(|_| SingleFederationError::CacheTagInvalidFormat {
                 message: format!("cannot create selection set with \"{key}\""),
             })?;
-        let new_field_type_def = schema
-            .get_type(new_field.ty().inner_named_type())
-            .map_err(|e| SingleFederationError::InvalidGraphQL {
-                message: e.to_string(),
-            })?;
+        let new_field_type_def =
+            schema
+                .get_type(new_field.ty().inner_named_type())
+                .map_err(|e| SingleFederationError::InvalidGraphQL {
+                    message: e.to_string(),
+                })?;
 
         if !sel.is_leaf() {
             ObjectOrInterfaceTypeDefinitionPosition::try_from(new_field_type_def).map_err(

--- a/apollo-federation/src/schema/validators/cache_tag.rs
+++ b/apollo-federation/src/schema/validators/cache_tag.rs
@@ -252,7 +252,7 @@ fn validate_args_selection(
                 })?;
 
         let type_name = field.inner_named_type();
-        let type_def = schema.get_type(type_name.clone()).map_err(|e| {
+        let type_def = schema.get_type(type_name).map_err(|e| {
             SingleFederationError::InvalidGraphQL {
                 message: e.to_string(),
             }
@@ -474,7 +474,7 @@ fn build_selection_set(
                 message: format!("cannot create selection set with \"{key}\""),
             })?;
         let new_field_type_def = schema
-            .get_type(new_field.ty().inner_named_type().clone())
+            .get_type(new_field.ty().inner_named_type())
             .map_err(|e| SingleFederationError::InvalidGraphQL {
                 message: e.to_string(),
             })?;

--- a/apollo-federation/src/schema/validators/external.rs
+++ b/apollo-federation/src/schema/validators/external.rs
@@ -25,7 +25,7 @@ fn validate_no_external_on_interface_fields(
 ) -> Result<(), FederationError> {
     for type_name in schema.referencers().interface_types.keys() {
         let type_pos: InterfaceTypeDefinitionPosition =
-            schema.get_type(type_name.clone())?.try_into()?;
+            schema.get_type(type_name)?.try_into()?;
         for field_pos in type_pos.fields(schema.schema())? {
             let is_external = metadata
                 .external_metadata()

--- a/apollo-federation/src/schema/validators/external.rs
+++ b/apollo-federation/src/schema/validators/external.rs
@@ -24,8 +24,7 @@ fn validate_no_external_on_interface_fields(
     errors: &mut MultipleFederationErrors,
 ) -> Result<(), FederationError> {
     for type_name in schema.referencers().interface_types.keys() {
-        let type_pos: InterfaceTypeDefinitionPosition =
-            schema.get_type(type_name)?.try_into()?;
+        let type_pos: InterfaceTypeDefinitionPosition = schema.get_type(type_name)?.try_into()?;
         for field_pos in type_pos.fields(schema.schema())? {
             let is_external = metadata
                 .external_metadata()

--- a/apollo-federation/src/schema/validators/merged.rs
+++ b/apollo-federation/src/schema/validators/merged.rs
@@ -335,8 +335,7 @@ fn add_requires_error(
             if other_subgraph.name == subgraph_name {
                 return Ok(None);
             }
-            let Ok(type_pos_in_other_subgraph) =
-                other_subgraph.schema().get_type(&type_name)
+            let Ok(type_pos_in_other_subgraph) = other_subgraph.schema().get_type(&type_name)
             else {
                 return Ok(None);
             };

--- a/apollo-federation/src/schema/validators/merged.rs
+++ b/apollo-federation/src/schema/validators/merged.rs
@@ -152,7 +152,7 @@ pub(crate) fn validate_merged_schema(
             // happens for some reason. And of course, the type should be composite since it's also
             // one in at least the subgraph we're currently checking.
             let parent_type_pos_in_supergraph: CompositeTypeDefinitionPosition = supergraph_schema
-                .get_type(parent_field_pos.type_name.clone())?
+                .get_type(&parent_field_pos.type_name)?
                 .try_into()?;
 
             let Err(error) = FieldSet::parse_and_validate(
@@ -336,7 +336,7 @@ fn add_requires_error(
                 return Ok(None);
             }
             let Ok(type_pos_in_other_subgraph) =
-                other_subgraph.schema().get_type(type_name.clone())
+                other_subgraph.schema().get_type(&type_name)
             else {
                 return Ok(None);
             };

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -420,7 +420,7 @@ impl Subgraph<Expanded> {
         let mut schema: FederationSchema = self.state.schema.into();
         let field_set_scalar_name =
             schema.federation_type_name_in_schema(FEDERATION_FIELDSET_TYPE_NAME_IN_SPEC)?;
-        if let Some(field_set_scalar) = schema.try_get_type(field_set_scalar_name) {
+        if let Some(field_set_scalar) = schema.try_get_type(&field_set_scalar_name) {
             // rename _FieldSet scalar to federation__FieldSet
             field_set_scalar.rename(
                 &mut schema,
@@ -470,7 +470,7 @@ impl Subgraph<Expanded> {
             let default_name = default_operation_name(&op_type);
             if op_name.name != default_name {
                 operation_types_to_rename.insert(op_name.name.clone(), default_name.clone());
-                if self.schema().try_get_type(default_name.clone()).is_some() {
+                if self.schema().try_get_type(&default_name).is_some() {
                     return Err(SingleFederationError::root_already_used(
                         op_type,
                         default_name,
@@ -496,7 +496,7 @@ impl Subgraph<Expanded> {
         let mut schema: FederationSchema = schema.into();
         for (current_name, new_name) in &operation_types_to_rename {
             schema
-                .get_type(current_name.clone())?
+                .get_type(current_name)?
                 .rename(&mut schema, new_name.clone())?;
         }
         let schema = validate_subgraph_schema(schema)?;
@@ -574,7 +574,7 @@ fn normalize_root_types_in_subgraph_schema(
         let default_name = default_operation_name(&op_type);
         if op_name.name != default_name {
             operation_types_to_rename.insert(op_name.name.clone(), default_name.clone());
-            if schema.try_get_type(default_name.clone()).is_some() {
+            if schema.try_get_type(&default_name).is_some() {
                 return Err(SingleFederationError::root_already_used(
                     op_type,
                     default_name,
@@ -587,7 +587,7 @@ fn normalize_root_types_in_subgraph_schema(
     let changed = !operation_types_to_rename.is_empty();
     for (current_name, new_name) in &operation_types_to_rename {
         schema
-            .get_type(current_name.clone())?
+            .get_type(current_name)?
             .rename(schema, new_name.clone())?;
         // Update metadata to reflect the type rename
         metadata.update_type_references(current_name, new_name);

--- a/apollo-federation/src/supergraph/join_directive.rs
+++ b/apollo-federation/src/supergraph/join_directive.rs
@@ -145,7 +145,7 @@ pub(super) fn extract(
 
                 if subgraph
                     .schema
-                    .try_get_type(intf_pos.type_name.clone())
+                    .try_get_type(&intf_pos.type_name)
                     .map(|t| matches!(t, TypeDefinitionPosition::Interface(_)))
                     .unwrap_or_default()
                 {
@@ -191,7 +191,7 @@ pub(super) fn extract(
 
                 if subgraph
                     .schema
-                    .try_get_type(intf_field_pos.type_name.clone())
+                    .try_get_type(&intf_field_pos.type_name)
                     .map(|t| matches!(t, TypeDefinitionPosition::Interface(_)))
                     .unwrap_or_default()
                 {
@@ -234,7 +234,7 @@ pub(super) fn extract(
 
                 if subgraph
                     .schema
-                    .try_get_type(obj_pos.type_name.clone())
+                    .try_get_type(&obj_pos.type_name)
                     .map(|t| matches!(t, TypeDefinitionPosition::Object(_)))
                     .unwrap_or_default()
                 {

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -866,7 +866,7 @@ fn add_empty_type(
             }
             let subgraph_type_definition_position = subgraph
                 .schema
-                .get_type(type_definition_position.type_name().clone())?;
+                .get_type(type_definition_position.type_name())?;
             match &subgraph_type_definition_position {
                 TypeDefinitionPosition::Scalar(_) => {
                     return Err(SingleFederationError::Internal {
@@ -913,7 +913,7 @@ fn add_empty_type(
                 .context_directive(&subgraph.schema, context_name.to_owned())?;
             let subgraph_type_definition_position: CompositeTypeDefinitionPosition = subgraph
                 .schema
-                .get_type(type_definition_position.type_name().clone())?
+                .get_type(type_definition_position.type_name())?
                 .try_into()?;
             subgraph_type_definition_position
                 .insert_directive(&mut subgraph.schema, Component::new(context_directive))?;
@@ -1120,7 +1120,7 @@ fn extract_interface_type_content(
                     ),
                 }
             })?;
-            Ok(match subgraph.schema.get_type(type_name)? {
+            Ok(match subgraph.schema.get_type(&type_name)? {
                 TypeDefinitionPosition::Object(pos) => {
                     if !is_interface_object {
                         return Err(
@@ -2087,7 +2087,7 @@ fn remove_inactive_applications(
                     .provides_directive_arguments(directive)?
                     .fields;
                 let Ok(parent_type_pos) = CompositeTypeDefinitionPosition::try_from(
-                    schema.get_type(field.ty.inner_named_type().clone())?,
+                    schema.get_type(field.ty.inner_named_type())?,
                 ) else {
                     // PORT_NOTE: JS composition ignores this error. A proper field set validation
                     //            should be done elsewhere.
@@ -2269,7 +2269,7 @@ fn is_external_or_has_external_implementations(
     selection: &Node<executable::Field>,
 ) -> Result<bool, FederationError> {
     let type_pos: CompositeTypeDefinitionPosition =
-        schema.get_type(parent_type_name.clone())?.try_into()?;
+        schema.get_type(parent_type_name)?.try_into()?;
     let field_pos = type_pos.field(selection.name.clone())?;
     let field = field_pos.get(schema.schema())?;
     if field.directives.has(external_directive_definition_name) {

--- a/apollo-federation/tests/dhat_profiling/query_plan.rs
+++ b/apollo-federation/tests/dhat_profiling/query_plan.rs
@@ -44,24 +44,24 @@ fn valid_query_plan() {
     ";
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
-    // Actual number: 815_603.
-    const MAX_BYTES_QUERY_PLANNER: usize = 856_383; // ~836 KiB
+    // Actual number: 803_785.
+    const MAX_BYTES_QUERY_PLANNER: usize = 843_974; // ~824 KiB
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 14_462.
-    const MAX_ALLOCATIONS_QUERY_PLANNER: u64 = 15_185;
+    // Actual number: 14_243.
+    const MAX_ALLOCATIONS_QUERY_PLANNER: u64 = 14_955;
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
-    // Actual number: 940_525.
+    // Actual number: 928_923.
     //
-    // Planning adds 124_922 bytes to heap max (940_525-815_603=124_922).
-    const MAX_BYTES_QUERY_PLAN: usize = 987_551; // ~964 KiB
+    // Planning adds 125_138 bytes to heap max (928_923-803_785=125_138).
+    const MAX_BYTES_QUERY_PLAN: usize = 975_369; // ~953 KiB
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 21_649.
+    // Actual number: 21_438.
     //
-    // Planning adds 7_187 allocations (21_649-14_462=7_187).
-    const MAX_ALLOCATIONS_QUERY_PLAN: u64 = 22_731;
+    // Planning adds 7_195 allocations (21_438-14_243=7_195).
+    const MAX_ALLOCATIONS_QUERY_PLAN: u64 = 22_510;
 
     let schema = std::fs::read_to_string(SCHEMA).unwrap();
 
@@ -78,6 +78,7 @@ fn valid_query_plan() {
         apollo_federation::query_plan::query_planner::QueryPlanner::new(&supergraph, qp_config)
             .expect("query planner should be created");
     let stats = dhat::HeapStats::get();
+    println!("QueryPlanner::new: {stats:?}");
     dhat::assert!(stats.max_bytes < MAX_BYTES_QUERY_PLANNER);
     dhat::assert!(stats.total_blocks < MAX_ALLOCATIONS_QUERY_PLANNER);
 
@@ -92,6 +93,7 @@ fn valid_query_plan() {
         .build_query_plan(&document, None, qp_options)
         .expect("valid query plan");
     let stats = dhat::HeapStats::get();
+    println!("QueryPlanner::build_query_plan: {stats:?}");
     dhat::assert!(stats.max_bytes < MAX_BYTES_QUERY_PLAN);
     dhat::assert!(stats.total_blocks < MAX_ALLOCATIONS_QUERY_PLAN);
 }

--- a/apollo-federation/tests/dhat_profiling/supergraph.rs
+++ b/apollo-federation/tests/dhat_profiling/supergraph.rs
@@ -11,36 +11,36 @@ fn valid_supergraph_schema() {
     const SCHEMA: &str = "../examples/graphql/supergraph.graphql";
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
-    // Actual number: 155_862.
-    const MAX_BYTES_SUPERGRAPH: usize = 163_655; // ~160 KiB
+    // Actual number: 143_792.
+    const MAX_BYTES_SUPERGRAPH: usize = 150_982; // ~147 KiB
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 5_136.
-    const MAX_ALLOCATIONS_SUPERGRAPH: u64 = 5_393;
+    // Actual number: 4_961.
+    const MAX_ALLOCATIONS_SUPERGRAPH: u64 = 5_209;
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
-    // Actual number: 215_189.
+    // Actual number: 203_359.
     //
-    // API schema generation allocates additional 59_327 bytes (215_189-155_862=59_327).
-    const MAX_BYTES_API_SCHEMA: usize = 225_948; // ~221 KiB
+    // API schema generation allocates additional 59_567 bytes (203_359-143_792=59_567).
+    const MAX_BYTES_API_SCHEMA: usize = 213_527; // ~209 KiB
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 5_702.
+    // Actual number: 5_526.
     //
-    // API schema has an additional 566 allocations (= 5_702 - 5_136).
-    const MAX_ALLOCATIONS_API_SCHEMA: u64 = 5_987;
+    // API schema has an additional 565 allocations (= 5_526 - 4_961).
+    const MAX_ALLOCATIONS_API_SCHEMA: u64 = 5_802;
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
-    // Actual number: 641_583.
+    // Actual number: 629_765.
     //
-    // Extract subgraphs allocates additional 426_394 bytes (641_583-215_189=426_394).
-    const MAX_BYTES_SUBGRAPHS: usize = 673_662; // ~658 KiB
+    // Extract subgraphs allocates additional 416_238 bytes (629_765-213_527=416_238).
+    const MAX_BYTES_SUBGRAPHS: usize = 661_253; // ~646 KiB
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 11_989.
+    // Actual number: 11_770.
     //
     // Extract subgraphs from supergraph has an additional 6_287 allocations (= 11_989 - 5_702).
-    const MAX_ALLOCATIONS_SUBGRAPHS: u64 = 12_588;
+    const MAX_ALLOCATIONS_SUBGRAPHS: u64 = 12_359;
 
     let schema = std::fs::read_to_string(SCHEMA).unwrap();
 


### PR DESCRIPTION
Three targeted optimizations to reduce unnecessary work during composition:

- Change `FederationSchema::get_type`/`try_get_type` to take `&Name` instead of owned `Name`, eliminating ~120 unnecessary `Arc<str>` clone/drop cycles
- Make `try_get_type` the primary implementation returning `Option`, so the `format!` error string is only allocated on actual lookup failures
- Add `Arc::ptr_eq` short-circuit to `ExcludedDestinations::eq`, skipping O(n²) content comparison when both sides share the same allocation

Benchmarked with a large (~320K line) supergraph: median composition time improved ~8.9%.
