### PR TITLE
maint: fix Linux flake in connectors::tests::test_operation_counter

### DIFF
--- a/.changesets/maint_aaron_connectors_operation_counter.md
+++ b/.changesets/maint_aaron_connectors_operation_counter.md
@@ -10,4 +10,4 @@ The test issues `query { users { id name username } }` against a mocked subgraph
 
 The fix swaps the positional matcher list for the existing `Plan::Sequence(Plan::Fetch, Plan::Parallel(...))` helper — the same pattern already used by `test_root_field_plus_entity_plus_requires` and `test_entity_references` for exactly this scenario. The parallel branch matches by set membership rather than position, so request ordering between the two entity fetches no longer affects the result. The counter assertion is unchanged.
 
-By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9488

--- a/.changesets/maint_aaron_connectors_operation_counter.md
+++ b/.changesets/maint_aaron_connectors_operation_counter.md
@@ -1,0 +1,13 @@
+### Fix Linux flake in connectors::tests::test_operation_counter
+
+`plugins::connectors::tests::test_operation_counter` was intermittently failing on Linux CI with:
+
+```
+[Request 1]: Expected path /users/1, got /users/2
+```
+
+The test issues `query { users { id name username } }` against a mocked subgraph. Connectors resolves this as a root `/users` fetch followed by two entity fetches — `/users/1` and `/users/2` — that run in parallel. Wiremock records requests in the order they actually arrive at the mock server, which is non-deterministic for concurrent in-flight requests. The test was using `req_asserts::matches`, which compares the recorded sequence positionally to the matcher list, so any time `/users/2` won the race it failed the assertion.
+
+The fix swaps the positional matcher list for the existing `Plan::Sequence(Plan::Fetch, Plan::Parallel(...))` helper — the same pattern already used by `test_root_field_plus_entity_plus_requires` and `test_entity_references` for exactly this scenario. The parallel branch matches by set membership rather than position, so request ordering between the two entity fetches no longer affects the result. The counter assertion is unchanged.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0

--- a/apollo-router/src/plugins/connectors/tests/connect_on_type.rs
+++ b/apollo-router/src/plugins/connectors/tests/connect_on_type.rs
@@ -641,10 +641,13 @@ async fn batch_with_max_size_over_batch_size() {
     }
     "#);
 
-    super::req_asserts::matches(
-        &mock_server.received_requests().await.unwrap(),
-        vec![
-            Matcher::new().method("GET").path("/users"),
+    // The two `/users-batch` POSTs have no inter-dependency (different `ids`
+    // bodies, neither references the other's result), so their wire arrival
+    // order is non-deterministic. Use Plan::Sequence + Plan::Parallel to
+    // assert without depending on order.
+    let plan = Plan::Sequence(vec![
+        Plan::Fetch(Matcher::new().method("GET").path("/users")),
+        Plan::Parallel(vec![
             Matcher::new()
                 .method("POST")
                 .path("/users-batch")
@@ -653,6 +656,7 @@ async fn batch_with_max_size_over_batch_size() {
                 .method("POST")
                 .path("/users-batch")
                 .body(serde_json::json!({ "ids": [6,7] })),
-        ],
-    );
+        ]),
+    ]);
+    plan.assert_matches(&mock_server.received_requests().await.unwrap());
 }

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -286,14 +286,17 @@ async fn test_root_field_plus_entity() {
     }
     "###);
 
-    req_asserts::matches(
-        &mock_server.received_requests().await.unwrap(),
-        vec![
-            Matcher::new().method("GET").path("/users"),
+    // The `/users/1` and `/users/2` entity fetches run in parallel after the
+    // root `/users` fetch resolves, so we can't rely on their wire ordering.
+    // Use Plan::Sequence + Plan::Parallel to assert without depending on order.
+    let plan = Plan::Sequence(vec![
+        Plan::Fetch(Matcher::new().method("GET").path("/users")),
+        Plan::Parallel(vec![
             Matcher::new().method("GET").path("/users/1"),
             Matcher::new().method("GET").path("/users/2"),
-        ],
-    );
+        ]),
+    ]);
+    plan.assert_matches(&mock_server.received_requests().await.unwrap());
 }
 
 #[tokio::test]

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -1132,14 +1132,17 @@ async fn test_operation_counter() {
             None,
         )
         .await;
-        req_asserts::matches(
-            &mock_server.received_requests().await.unwrap(),
-            vec![
-                Matcher::new().method("GET").path("/users"),
+        // The `/users/1` and `/users/2` entity fetches run in parallel after the
+        // root `/users` fetch resolves, so we can't rely on their wire ordering.
+        // Use Plan::Sequence + Plan::Parallel to assert without depending on order.
+        let plan = Plan::Sequence(vec![
+            Plan::Fetch(Matcher::new().method("GET").path("/users")),
+            Plan::Parallel(vec![
                 Matcher::new().method("GET").path("/users/1"),
                 Matcher::new().method("GET").path("/users/2"),
-            ],
-        );
+            ]),
+        ]);
+        plan.assert_matches(&mock_server.received_requests().await.unwrap());
         assert_counter!(
             "apollo.router.operations.connectors",
             3,

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -1013,25 +1013,28 @@ async fn test_args_and_this_in_header() {
     )
     .await;
 
-    req_asserts::matches(
-        &mock_server.received_requests().await.unwrap(),
-        vec![
-            Matcher::new()
-                .method("GET")
-                .header(
-                    HeaderName::from_str("x-from-args").unwrap(),
-                    HeaderValue::from_str("before 2 after").unwrap(),
-                )
-                .path("/users/2"),
-            Matcher::new()
-                .method("GET")
-                .header(
-                    HeaderName::from_str("x-from-this").unwrap(),
-                    HeaderValue::from_str("before 2 after").unwrap(),
-                )
-                .path("/users/2/nicknames"),
-        ],
-    );
+    // The user fetch (`/users/2`) and the nickname fetch (`/users/2/nicknames`)
+    // are both gated only on the `id` argument from the query — neither
+    // depends on the other's response — so the planner can dispatch them in
+    // parallel and wire-arrival order is non-deterministic. Use Plan::Parallel
+    // to assert without depending on order.
+    let plan = Plan::Parallel(vec![
+        Matcher::new()
+            .method("GET")
+            .header(
+                HeaderName::from_str("x-from-args").unwrap(),
+                HeaderValue::from_str("before 2 after").unwrap(),
+            )
+            .path("/users/2"),
+        Matcher::new()
+            .method("GET")
+            .header(
+                HeaderName::from_str("x-from-this").unwrap(),
+                HeaderValue::from_str("before 2 after").unwrap(),
+            )
+            .path("/users/2/nicknames"),
+    ]);
+    plan.assert_matches(&mock_server.received_requests().await.unwrap());
 }
 
 mock! {


### PR DESCRIPTION
## Summary

Closes [ROUTER-1807](https://apollographql.atlassian.net/browse/ROUTER-1807).

`plugins::connectors::tests::test_operation_counter` has been flaky on Linux CI. Example failure: [job 376492](https://circleci.com/gh/apollographql/router/376492) (`Expected path /users/1, got /users/2`), passing on retry at the same SHA in [job 376506](https://circleci.com/gh/apollographql/router/376506). A subsequent audit of `req_asserts::matches` callers in `plugins/connectors/tests/` surfaced three more sites with the same latent shape — those are also fixed in this PR. See "Scope expansion" below.

## Root cause

The affected tests issue parallel fetches and assert the wiremock recorded-request list **positionally** via `req_asserts::matches(...)`. Positional comparison fails non-deterministically when the parallel branch's wire-arrival order doesn't match the matcher list.

Concretely, the pattern is some variant of:
1. one root request (single, deterministic), then
2. N **parallel** requests that have no inter-dependency (e.g. two entity-resolution fetches with different IDs, or two batch POSTs with disjoint payloads).

No production code is involved — this is purely a test-side ordering bug.

## Fix

Swap the positional matcher list for the existing `Plan::Sequence(Plan::Fetch, Plan::Parallel(...))` / `Plan::Parallel(...)` helpers in `req_asserts`. The parallel branch matches the recorded requests by set membership, so the order between the parallel fetches no longer affects the assertion. This is the same pattern already used by `test_root_field_plus_entity_plus_requires` (line 361) and `test_entity_references` (line 420) for exactly this scenario. Behavior-side assertions (insta snapshots, `assert_counter!`) are unchanged.

## Scope expansion

The original PR fixed `test_operation_counter` only. A full audit of the 32 `req_asserts::matches` callers in `apollo-router/src/plugins/connectors/tests/` (the helper is private to that module, no usage outside it) classified them by parallel-fetch risk:

**Fixed in this PR (3 HIGH + 1 MEDIUM):**

| File | Test | Shape |
|---|---|---|
| `mod.rs` | `test_operation_counter` (line 1132) | `/users` + parallel `/users/1, /users/2` |
| `mod.rs` | `test_root_field_plus_entity` (line 251) | `/users` + parallel `/users/1, /users/2` |
| `connect_on_type.rs` | `batch_with_max_size_over_batch_size` (line 644) | `/users` + parallel `POST /users-batch` ×2 with disjoint bodies |
| `mod.rs` | `test_args_and_this_in_header` (line 1013) | parallel `/users/2` + `/users/2/nicknames` (both gated only on query arg) |

**Intentionally NOT changed (audit flagged as MEDIUM but on inspection the matcher anti-pattern isn't the actual flake surface):**

| File | Test | Why left alone |
|---|---|---|
| `mod.rs` | `max_requests` (line 165) | Cap enforced client-side before send → dispatch must be sequential. The insta snapshot also pins `user_1` first, so any racy dispatch would flake the snapshot too. Converting only `req_asserts` doesn't help. |
| `mod.rs` | `source_max_requests` (line 241) | Same shape as `max_requests`, same reasoning. |
| `mod.rs` | `test_variables` (line 1979) | Outer `/f` returns the `sibling=D` value that the inner `/f`'s query string requires — sequential by data dependency, not by accident. |

## Test plan

- [x] `cargo test -p apollo-router --lib plugins::connectors::tests::{test_operation_counter,test_root_field_plus_entity,connect_on_type::batch_with_max_size_over_batch_size,test_args_and_this_in_header}` passes locally
- [x] The three NOT-changed tests above still pass locally
- [x] `cargo xtask lint` clean locally
- [x] No retry list / `#[ignore]` / `#[serial]` added — fixes are deterministic at the assertion level
- [ ] CI green on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ROUTER-1807]: https://apollographql.atlassian.net/browse/ROUTER-1807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ