### PR TITLE
fix(test): disable keepalive in file_upload body_limits to fix Linux shutdown flake

### DIFF
--- a/.changesets/maint_aaron_file_upload_body_limits.md
+++ b/.changesets/maint_aaron_file_upload_body_limits.md
@@ -1,0 +1,9 @@
+### Fix Linux flake in file_upload::body_limits::rejects_oversized_operations_field
+
+The `chunk_size_1_None` variant of `file_upload::body_limits::rejects_oversized_operations_field` flaked on Linux CI by panicking at the harness's 10 s `assert_shutdown` deadline with "unable to shutdown router".
+
+The test built a single-shot streaming body and posted it through the default `reqwest::Client`, whose connection pool keeps the inbound TCP connection idle after the response. When the body arrives in one frame, the router fully drains it before multer trips the operations-field `SizeLimit` and returns 413, so the connection is pool-eligible from hyper's perspective. After the test calls `router.graceful_shutdown()`, the per-connection task in `handle_connection!` (`src/axum_factory/listeners.rs`) waits the full `connection_shutdown_timeout` (5 s default injected by the harness) for the idle client connection to close. On a loaded 2xlarge Linux runner that 5 s plus CI scheduling slack pushes total shutdown past the 10 s budget. The 100-byte chunked sibling variants escape because the body is aborted mid-upload, forcing the connection closed immediately.
+
+The fix builds the request with `reqwest::Client::builder().pool_max_idle_per_host(0)`, matching the existing `no_keepalive_reqwest_client` pattern already used in `tests/integration/subgraph_response.rs` and `tests/integration/coprocessor.rs` for the same race. The test now closes its TCP connection as soon as the response is consumed, so the router exits within its normal shutdown window.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0

--- a/.changesets/maint_aaron_file_upload_body_limits.md
+++ b/.changesets/maint_aaron_file_upload_body_limits.md
@@ -6,4 +6,4 @@ The test built a single-shot streaming body and posted it through the default `r
 
 The fix builds the request with `reqwest::Client::builder().pool_max_idle_per_host(0)`, matching the existing `no_keepalive_reqwest_client` pattern already used in `tests/integration/subgraph_response.rs` and `tests/integration/coprocessor.rs` for the same race. The test now closes its TCP connection as soon as the response is consumed, so the router exits within its normal shutdown window.
 
-By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9490

--- a/apollo-router/tests/integration/file_upload.rs
+++ b/apollo-router/tests/integration/file_upload.rs
@@ -1215,7 +1215,24 @@ mod body_limits {
         };
 
         let url = format!("http://{}", router.bind_address());
-        let response = reqwest::Client::new()
+        // Disable HTTP keep-alive so the test's inbound connection closes as soon as the
+        // response is consumed. With pooling enabled (reqwest's default), the connection
+        // sits idle in the client's pool past `graceful_shutdown()`; the router then has
+        // to wait out `connection_shutdown_timeout` (5 s default in this harness) before
+        // its per-connection task exits. That delay plus CI scheduling slack can push
+        // total shutdown past `assert_shutdown`'s 10 s budget and panic the test as
+        // "unable to shutdown router". The race only fires for the `chunk_size_1_None`
+        // variants because they finish uploading the body before the router responds
+        // 413 (so the connection is fully drained and pool-eligible), unlike the
+        // 100-byte-chunked variants which abort mid-upload and force the connection
+        // closed. See `no_keepalive_reqwest_client` in
+        // `tests/integration/subgraph_response.rs` and `tests/integration/coprocessor.rs`
+        // for the same pattern applied elsewhere.
+        let client = reqwest::Client::builder()
+            .pool_max_idle_per_host(0)
+            .build()
+            .expect("reqwest client build");
+        let response = client
             .post(url)
             .header(
                 CONTENT_TYPE,


### PR DESCRIPTION
## Summary

Fixes the Linux CI flake in `integration::file_upload::body_limits::rejects_oversized_operations_field::chunk_size_1_None` (ROUTER-1806). Observed at https://circleci.com/gh/apollographql/router/376427.

## Root cause

The test in `apollo-router/tests/integration/file_upload.rs::body_limits::run()` posts a single-frame streaming body via the default `reqwest::Client`, then calls `router.graceful_shutdown()`.

Flow on the failing variant (`chunk_size_1_None`, i.e. one chunk = whole body):

1. Reqwest writes the entire ~1 KB multipart body in one frame.
2. The router fully drains the body before multer's per-field `SizeLimit` on `"operations"` trips (set in `apollo-router/src/plugins/file_uploads/mod.rs`).
3. The file_uploads checkpoint returns 413 from a clean state: the connection is fully drained and pool-eligible.
4. The default `reqwest::Client` parks the connection in its idle pool.
5. `router.graceful_shutdown()` sends SIGTERM. The per-connection task in `handle_connection!` (`apollo-router/src/axum_factory/listeners.rs`) hits the `connection_shutdown.cancelled()` branch and waits the full `connection_shutdown_timeout` (5 s default the harness injects in `merge_overrides`) for the idle inbound connection to close.
6. On a loaded 2xlarge Linux runner that 5 s plus CI scheduling slack pushes total process exit past `assert_shutdown`'s 10 s budget. The harness panics with "unable to shutdown router".

The `chunk_size_2_Some(100)` sibling variants pass because the body is aborted mid-upload (only the early chunks fit before SizeLimit fires), forcing hyper to mark the connection non-reusable and close it immediately.

CI fingerprint matches: stack-trace dump shows the router process parked on the main thread's `Runtime::block_on`, no in-flight request, and the failure resolves on nextest retry without any code change (PR #9473 only touched composition).

## Fix

Build the test client with `pool_max_idle_per_host(0)` so the connection closes when the response is consumed. The router then exits within its normal shutdown window.

This is the same pattern already used in:

- `apollo-router/tests/integration/subgraph_response.rs::no_keepalive_reqwest_client`
- `apollo-router/tests/integration/coprocessor.rs::no_keepalive_reqwest_client`

both of which document the identical hyper-client pool drain race.

No production code change. No retry-list change. No widened deadline.

## Test plan

- [ ] CI runs `file_upload::body_limits::rejects_oversized_operations_field::chunk_size_1_None` green on Linux without nextest retry.
- [ ] `chunk_size_2_Some_100_` and the sibling `succeeds_when_file_larger_than_http_limit` / `rejects_file_exceeding_max_file_size` cases remain green.

ROUTER-1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)