### PR TITLE
test(http_server): drain response body in unix_socket_max_header_list_size case_1

### DIFF
--- a/.changesets/maint_aaron_unix_socket_case_1.md
+++ b/.changesets/maint_aaron_unix_socket_case_1.md
@@ -1,0 +1,9 @@
+### Fix macOS flake in unix_tests::test_unix_socket_max_header_list_size::case_1 ([PR #0](https://github.com/apollographql/router/pull/0))
+
+`integration::http_server::unix_tests::test_unix_socket_max_header_list_size::case_1_header_within_limits_of_config` had a residual flake on macOS arm64 CI even after the `drop(sender) + graceful_shutdown_with_deadline(20s)` pattern from PR #9418 was applied to its shared `#[rstest]` function body.
+
+The companion `case_2_header_bigger_than_config` (server rejects with 431 before reading the body) was fully closed by that prior fix. `case_1` (server accepts the 10 MiB header and returns a successful GraphQL response) has one extra shoulder of the same drain race: the response body was never consumed before drop. In HTTP/2, dropping an unread `Incoming` body sends `RST_STREAM` on the response stream, which forces the server-side response-writer task through an error-path teardown instead of the END_STREAM happy path. On a busy macOS arm64 runner this extra cleanup — stacked on top of the 10 MiB request-header parse the server is still finishing — was enough to push the post-SIGTERM drain past `assert_shutdown`'s budget. `case_2` does not exhibit this shoulder because the 431 response carries no body to leave unread.
+
+Fix: drain the response body to its natural END_STREAM with `body.collect().await` before dropping the sender. Applied unconditionally (it's a no-op on the 431 path's empty body) to keep the test linear and avoid a status-conditional split. The `drop(sender) + graceful_shutdown_with_deadline(20s)` pattern from #9418 stays in place — this is additive, not a replacement.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0

--- a/.changesets/maint_aaron_unix_socket_case_1.md
+++ b/.changesets/maint_aaron_unix_socket_case_1.md
@@ -1,4 +1,4 @@
-### Fix macOS flake in unix_tests::test_unix_socket_max_header_list_size::case_1 ([PR #0](https://github.com/apollographql/router/pull/0))
+### Fix macOS flake in unix_tests::test_unix_socket_max_header_list_size::case_1 ([PR #9491](https://github.com/apollographql/router/pull/9491))
 
 `integration::http_server::unix_tests::test_unix_socket_max_header_list_size::case_1_header_within_limits_of_config` had a residual flake on macOS arm64 CI even after the `drop(sender) + graceful_shutdown_with_deadline(20s)` pattern from PR #9418 was applied to its shared `#[rstest]` function body.
 
@@ -6,4 +6,4 @@ The companion `case_2_header_bigger_than_config` (server rejects with 431 before
 
 Fix: drain the response body to its natural END_STREAM with `body.collect().await` before dropping the sender. Applied unconditionally (it's a no-op on the 431 path's empty body) to keep the test linear and avoid a status-conditional split. The `drop(sender) + graceful_shutdown_with_deadline(20s)` pattern from #9418 stays in place — this is additive, not a replacement.
 
-By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9491

--- a/apollo-router/tests/integration/http_server.rs
+++ b/apollo-router/tests/integration/http_server.rs
@@ -470,6 +470,7 @@ async fn test_http1_connection_persistence(
 
 #[cfg(unix)]
 mod unix_tests {
+    use http_body_util::BodyExt as _;
     use hyper_util::rt::TokioIo;
 
     use super::*;
@@ -518,28 +519,47 @@ mod unix_tests {
 
         let response = sender.send_request(request).await?;
 
+        let (parts, body) = response.into_parts();
+
         assert_eq!(
-            response.status(),
-            status_code,
+            parts.status, status_code,
             "Expected status code {:?} for Unix socket with header size test",
             status_code
         );
         assert_eq!(
-            response.version(),
+            parts.version,
             http::Version::HTTP_2,
             "Expected HTTP/2 to be negotiated for Unix socket"
         );
 
-        // Drop the h2 sender + response before shutdown so the spawned `conn`
-        // task observes the local-half close and the router can drain. Even
-        // then the server-side h2 connection still has to flush GOAWAY and run
-        // out the harness's 5 s `connection_shutdown_timeout` before the
-        // process can exit — and on macOS arm64 CI the
+        // Drain the response body to its natural END_STREAM before dropping it.
+        //
+        // This addresses a flake specific to `case_1_header_within_limits_of_config`
+        // (CircleCI 376297 vs passing 376324 on macOS arm64): the success path
+        // returns a full GraphQL JSON body that the test previously never read.
+        // Dropping an unread h2 `Incoming` body sends `RST_STREAM` on the
+        // response stream, which forces the server's response-writer task to
+        // unwind through an error path instead of the END_STREAM happy path. On
+        // a busy macOS arm64 runner that extra cleanup work — combined with the
+        // 10 MiB request-header parse still completing on the server side —
+        // pushed the shutdown drain past the 10 s `assert_shutdown` default
+        // budget. `case_2_header_bigger_than_config` does not exhibit this
+        // shoulder because the 431 response carries no body to leave unread.
+        //
+        // Draining is unconditional (both cases) because the 431 path either
+        // has no body or has a trivially small one, so the await is essentially
+        // free; the conditional would just be noise.
+        let _ = body.collect().await;
+
+        // Drop the h2 sender before shutdown so the spawned `conn` task
+        // observes the local-half close and the router can drain. Even then
+        // the server-side h2 connection still has to flush GOAWAY and run out
+        // the harness's 5 s `connection_shutdown_timeout` before the process
+        // can exit — and on macOS arm64 CI the
         // `case_2_header_bigger_than_config` variant (21 MiB header) trips the
         // default 10 s `assert_shutdown` budget ~10% of the time. Use a 20 s
         // deadline to absorb macOS scheduling jitter while keeping the
         // upstream timeout honest.
-        drop(response);
         drop(sender);
         router
             .graceful_shutdown_with_deadline(Duration::from_secs(20))

--- a/apollo-router/tests/integration/http_server.rs
+++ b/apollo-router/tests/integration/http_server.rs
@@ -548,8 +548,14 @@ mod unix_tests {
         //
         // Draining is unconditional (both cases) because the 431 path either
         // has no body or has a trivially small one, so the await is essentially
-        // free; the conditional would just be noise.
-        let _ = body.collect().await;
+        // free; the conditional would just be noise. Bound the drain itself
+        // with a 5 s timeout and panic loudly on error/timeout so a real bug
+        // here surfaces instead of being silently swallowed by `let _ =`.
+        match tokio::time::timeout(Duration::from_secs(5), body.collect()).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => panic!("body drain error (non-fatal): {e:?}"),
+            Err(_) => panic!("body drain timed out after 5s (non-fatal)"),
+        }
 
         // Drop the h2 sender before shutdown so the spawned `conn` task
         // observes the local-half close and the router can drain. Even then


### PR DESCRIPTION
ROUTER-1810

## Summary

`integration::http_server::unix_tests::test_unix_socket_max_header_list_size::case_1_header_within_limits_of_config` flaked on macOS arm64 CI (failing job 376297 vs passing 376324 on the same SHA). The companion `case_2_header_bigger_than_config` and the parent shared body already carry the `drop(sender) + graceful_shutdown_with_deadline(20s)` pattern PR #9418 / commit `df65e4ecd` applied. That pattern resolves the bulk of the drain race for both rstest variants but leaves a residual shoulder specific to the success-path code path.

## Root cause specific to case_1

`case_1` returns a full GraphQL JSON response body. The previous test code only checked `response.status()` / `response.version()` and never read the body before dropping the response. In HTTP/2, dropping an unread `Incoming` body sends `RST_STREAM` on the response stream. That forces the server-side response-writer task to unwind through an error path instead of the END_STREAM happy path. On a busy macOS arm64 runner the extra cleanup work — stacked on the 10 MiB request-header parse the server is still finishing — pushed the post-SIGTERM drain past the harness's `assert_shutdown` deadline.

`case_2` does **not** exhibit this shoulder: the 431 response carries no body to leave unread, so the prior fix (drop-sender + 20 s deadline) is sufficient on that path.

## Why this is additive, not a replacement

The drop-client and widened-deadline knobs from #9418 stay in place — they handle the connection-level drain race that affects both cases. This commit closes the per-stream RST_STREAM-on-drop shoulder that's unique to case_1.

```rust
let (parts, body) = response.into_parts();
// ...assertions on parts.status / parts.version...
let _ = body.collect().await;   // ← new: lets the server stream hit END_STREAM cleanly
drop(sender);                    // ← unchanged: triggers GOAWAY
router.graceful_shutdown_with_deadline(Duration::from_secs(20)).await;
```

Draining is unconditional rather than `if status == OK` — the 431 path has no meaningful body, so the await is essentially free, and a status-conditional split would just be noise.

## Constraints honored

- No change to `.config/nextest.toml` retry list (epic ROUTER-1722 drives that to zero).
- No `#[ignore]`.
- No `tokio::time::sleep` band-aid.
- No unrelated production / test edits.

## Test plan

- [ ] CI green on `test-macos_test` (the platform where the flake was observed).
- [ ] CI green on `test-arm_linux_test`, `test-amd_linux_test`, `test-windows_test` — body drain is platform-neutral, so these should be unaffected.
- [ ] No regression in the rest of `http_server.rs` integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)