### PR TITLE
maint(harness): bound dump_stack_traces() with a 10s timeout

### DIFF
--- a/.changesets/maint_aaron_dump_stack_traces_timeout.md
+++ b/.changesets/maint_aaron_dump_stack_traces_timeout.md
@@ -1,0 +1,7 @@
+### Bound `dump_stack_traces()` with a timeout so a wedged child can't eat the panic output
+
+`IntegrationTest::dump_stack_traces` in `apollo-router/tests/common.rs` (Linux-only) is the synchronous diagnostic invoked immediately before a panic in three deadline-expiry sites (`wait_for_log_message`, `assert_log_not_contains`, `assert_shutdown_with_deadline`). It calls `rstack::TraceOptions::trace(pid)`, which has no internal timeout and is backed by `PTRACE_ATTACH`. If the target router child is in `TASK_UNINTERRUPTIBLE` or has wedged signal handling, the attach blocks indefinitely, outliving the panic and letting nextest's slow-timeout kill the whole process without ever surfacing the deadline message.
+
+Wrap the `rstack` call in `tokio::task::spawn_blocking` + `tokio::time::timeout(10s)`. The function becomes `async`; the three callers are already in `async fn` so the migration is mechanical. On timeout, a clear message is logged so the operator knows the diagnostic was skipped — not that nothing happened. Happy-path `rstack::trace` on a responsive process completes in ~100 ms, well under the 10 s ceiling.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0

--- a/.changesets/maint_aaron_dump_stack_traces_timeout.md
+++ b/.changesets/maint_aaron_dump_stack_traces_timeout.md
@@ -4,4 +4,4 @@
 
 Wrap the `rstack` call in `tokio::task::spawn_blocking` + `tokio::time::timeout(10s)`. The function becomes `async`; the three callers are already in `async fn` so the migration is mechanical. On timeout, a clear message is logged so the operator knows the diagnostic was skipped — not that nothing happened. Happy-path `rstack::trace` on a responsive process completes in ~100 ms, well under the 10 s ceiling.
 
-By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/0
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9492

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1649,7 +1649,7 @@ impl IntegrationTest {
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
-        self.dump_stack_traces();
+        self.dump_stack_traces().await;
         panic!(
             "'{msg}' not detected in logs. Log dump below:\n\n{logs}",
             logs = self.logs.join("\n")
@@ -1703,7 +1703,7 @@ impl IntegrationTest {
             if let Ok(line) = self.stdio_rx.try_recv()
                 && line.contains(msg)
             {
-                self.dump_stack_traces();
+                self.dump_stack_traces().await;
                 panic!(
                     "'{msg}' detected in logs. Log dump below:\n\n{logs}",
                     logs = self.logs.join("\n")
@@ -2067,7 +2067,7 @@ impl IntegrationTest {
             }
         }
 
-        self.dump_stack_traces();
+        self.dump_stack_traces().await;
         panic!("unable to shutdown router, this probably means a hang and should be investigated");
     }
 
@@ -2080,33 +2080,55 @@ impl IntegrationTest {
     }
 
     #[cfg(target_os = "linux")]
-    pub fn dump_stack_traces(&self) {
-        if let Ok(trace) = rstack::TraceOptions::new()
-            .symbols(true)
-            .thread_names(true)
-            .trace(self.pid() as u32)
-        {
-            println!("dumped stack traces");
-            for thread in trace.threads() {
-                println!(
-                    "thread id: {}, name: {}",
-                    thread.id(),
-                    thread.name().unwrap_or("<unknown>")
-                );
-
-                for frame in thread.frames() {
+    pub async fn dump_stack_traces(&self) {
+        // rstack uses PTRACE_ATTACH under the hood with no internal timeout.
+        // If the target is in TASK_UNINTERRUPTIBLE or has wedged signal
+        // handling, the attach blocks indefinitely — outliving the panic the
+        // caller was about to fire and letting nextest's slow-timeout kill
+        // the whole process without surfacing the original deadline message.
+        // Bound the diagnostic on a blocking thread so the caller's panic
+        // always gets to run.
+        let pid = self.pid() as u32;
+        let trace_fut = tokio::task::spawn_blocking(move || {
+            rstack::TraceOptions::new()
+                .symbols(true)
+                .thread_names(true)
+                .trace(pid)
+        });
+        match tokio::time::timeout(Duration::from_secs(10), trace_fut).await {
+            Ok(Ok(Ok(trace))) => {
+                println!("dumped stack traces");
+                for thread in trace.threads() {
                     println!(
-                        "  {}",
-                        frame.symbol().map(|s| s.name()).unwrap_or("<unknown>")
+                        "thread id: {}, name: {}",
+                        thread.id(),
+                        thread.name().unwrap_or("<unknown>")
                     );
+
+                    for frame in thread.frames() {
+                        println!(
+                            "  {}",
+                            frame.symbol().map(|s| s.name()).unwrap_or("<unknown>")
+                        );
+                    }
                 }
             }
-        } else {
-            println!("failed to dump stack trace");
+            Ok(Ok(Err(_))) => {
+                println!("failed to dump stack trace");
+            }
+            Ok(Err(_)) => {
+                println!("dump_stack_traces blocking task panicked");
+            }
+            Err(_) => {
+                println!(
+                    "dump_stack_traces timed out after 10s — likely wedged child; \
+                     the panic that follows is authoritative"
+                );
+            }
         }
     }
     #[cfg(not(target_os = "linux"))]
-    pub fn dump_stack_traces(&self) {}
+    pub async fn dump_stack_traces(&self) {}
 
     #[allow(dead_code)]
     pub(crate) fn force_flush(&self) {


### PR DESCRIPTION
## Summary

Closes [ROUTER-1811](https://apollographql.atlassian.net/browse/ROUTER-1811).

`IntegrationTest::dump_stack_traces` in `apollo-router/tests/common.rs` is the synchronous Linux-only diagnostic invoked immediately before a panic in three deadline-expiry sites (`wait_for_log_message`, `assert_log_not_contains`, `assert_shutdown_with_deadline`). It calls `rstack::TraceOptions::trace(pid)` from `rstack 0.3.3`, which has no internal timeout and is backed by `PTRACE_ATTACH`.

If the target router child is in `TASK_UNINTERRUPTIBLE` or has wedged signal handling, the attach blocks indefinitely — outliving the panic that was about to fire and letting nextest's slow-timeout kill the whole process without ever surfacing the deadline message.

## Evidence

[ROUTER-1808](https://apollographql.atlassian.net/browse/ROUTER-1808) (one-shot redis-test flake): test process hung exactly at the 120 s nextest boundary; stdout contained only `INFO Loading supergraph from file`; the 30 s `wait_for_log_message` deadline never produced its panic. This is precisely the signature of `dump_stack_traces` blocking on a `ptrace` attach to a wedged child. Single-incident so causation isn't proven, but the fix is a generic harness improvement regardless of whether that specific flake recurs.

## Fix

Wrap the `rstack` call in `tokio::task::spawn_blocking` + `tokio::time::timeout(10s)`. The function becomes `async`; the three callers were already in `async fn` so the migration is mechanical (`.await` added). On timeout, log a clear "diagnostic timed out — likely wedged child; the panic that follows is authoritative" message so an operator looking at logs can tell why the stack dump is absent without confusing it for silent code.

10 s is generous: happy-path `rstack::trace` on a responsive process typically completes in ~100 ms. The abandoned blocking thread (if the rstack call is genuinely hung) lives until process exit, but the test process is about to panic and die anyway, so no real leak.

## Scope

- `apollo-router/tests/common.rs:2083-2109` — `dump_stack_traces` body (Linux) and `cfg(not(target_os = "linux"))` stub.
- Three caller sites at lines 1652, 1706, 2070 — `.await` added.
- No production code touched.

## Test plan

- [x] `cargo xtask lint` passes locally
- [x] No retry list / `#[ignore]` added
- [ ] CI green across all platforms
- [ ] If ROUTER-1808 reproduces in the wild, the new timeout message should fire and the original panic should surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ROUTER-1811]: https://apollographql.atlassian.net/browse/ROUTER-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROUTER-1808]: https://apollographql.atlassian.net/browse/ROUTER-1808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ