### PR TITLE
fix(composition): use subgraph definitions when merging applied directives

### DIFF
--- a/apollo-federation/src/merger/merge_directive.rs
+++ b/apollo-federation/src/merger/merge_directive.rs
@@ -161,38 +161,54 @@ impl Merger {
                 };
 
                 let subgraph = &self.subgraphs[*idx];
+                let Some(subgraph_definition) =
+                    subgraph.schema().schema().directive_definitions.get(name)
+                else {
+                    return vec![];
+                };
+
                 let mut applications = source
                     .get_applied_directives(subgraph.schema(), name)
                     .into_iter()
-                    .map(|d| (**d).clone())
+                    .map(|d| ((**d).clone(), subgraph_definition))
                     .collect_vec();
                 // PORT NOTE: JS applies transforms for repeatable directives only
                 // this might have been a miss as it is currently only used for @context
                 if let Some(transform) =
                     &directive_in_supergraph.and_then(|d| d.static_argument_transform.as_ref())
                 {
-                    for application in &mut applications {
+                    for (application, _) in &mut applications {
                         self.transform_arguments(application, subgraph, transform.as_ref());
                     }
                 }
                 applications
             })
-            .fold(Default::default(), |mut acc, directive| {
-                // Note that when comparing arguments, we include default values. This means that we
-                // consider it the same thing (as far as merging application goes) to rely on a default
-                // value or to pass that very exact value explicitly.
-                let args = self.directive_arguments_with_defaults(&directive, &definition);
-                if let Some((_, count)) = acc.iter_mut().find(|(existing, _)| {
-                    let existing_args =
-                        self.directive_arguments_with_defaults(existing, &definition);
-                    existing_args == args
-                }) {
-                    *count += 1;
-                } else {
-                    acc.insert(directive, 1);
-                }
-                acc
-            });
+            .fold(
+                Default::default(),
+                |mut acc: IndexMap<(Directive, &Node<DirectiveDefinition>), usize>,
+                 (directive, subgraph_definition)| {
+                    // Note that when comparing arguments, we include default values. This means that we
+                    // consider it the same thing (as far as merging application goes) to rely on a default
+                    // value or to pass that very exact value explicitly.
+                    let args =
+                        self.directive_arguments_with_defaults(&directive, subgraph_definition);
+                    if let Some((_, count)) =
+                        acc.iter_mut().find(|((existing, existing_def), _)| {
+                            let existing_args =
+                                self.directive_arguments_with_defaults(existing, existing_def);
+                            existing_args == args
+                        })
+                    {
+                        *count += 1;
+                    } else {
+                        acc.insert((directive, subgraph_definition), 1);
+                    }
+                    acc
+                },
+            )
+            .into_iter()
+            .map(|((directive, _), count)| (directive, count))
+            .collect();
 
         // PORT NOTE: in JS version we were populating additional sources for access control in record_applied_directives_to_merge
         // without any changes in the merge_applied_directive_logic.
@@ -219,7 +235,9 @@ impl Merger {
                         .iter()
                         .flat_map(|(index, sources)| {
                             let subgraph = &self.subgraphs[*index];
-                            let mut applications = sources
+                            // access control directives do not specify static argument transforms
+                            // we'll need to update the logic below if this changes in the future
+                            sources
                                 .iter()
                                 .flat_map(|source| {
                                     source
@@ -227,19 +245,7 @@ impl Merger {
                                         .into_iter()
                                         .map(|d| (**d).clone())
                                 })
-                                .collect_vec();
-                            if let Some(transform) = &directive_in_supergraph
-                                .and_then(|d| d.static_argument_transform.as_ref())
-                            {
-                                for application in &mut applications {
-                                    self.transform_arguments(
-                                        application,
-                                        subgraph,
-                                        transform.as_ref(),
-                                    );
-                                }
-                            }
-                            applications
+                                .collect_vec()
                         })
                         .for_each(|d| {
                             // access control directives don't have default args so we don't need to transform them

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -1151,6 +1151,7 @@ mod validation {
 }
 
 mod composition {
+    use insta::assert_snapshot;
     use test_log::test;
 
     use super::*;
@@ -1379,6 +1380,54 @@ mod composition {
             r#"@auth(scope: ["VIEWER"])"#
         );
         assert_eq!(auth_directives[1].to_string(), "@auth");
+    }
+
+    #[test]
+    fn deduplicates_directive_using_subgraph_definition_defaults() {
+        // Subgraph A defines @foo with a default value for `debug` and applies
+        // it without specifying the argument (relying on the default).
+        // Subgraph B defines @foo without a default value for `debug` and
+        // applies it explicitly with the value matching subgraph A's default.
+        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+            extend schema @composeDirective(name: "@foo")
+              @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
+              @link(url: "https://custom.dev/foo/v1.0", import: ["@foo"])
+            directive @foo(name: String!, debug: Boolean = false) on FIELD_DEFINITION
+
+            type Query {
+              shared: String @shareable @foo(name: "test")
+            }
+        "#).expect("valid subgraph");
+        let subgraph_b = Subgraph::parse("subgraphB", "", r#"
+            extend schema @composeDirective(name: "@foo")
+              @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
+              @link(url: "https://custom.dev/foo/v1.1", import: ["@foo"])
+            directive @foo(name: String!, debug: Boolean) on FIELD_DEFINITION
+
+            type Query {
+              shared: String @shareable @foo(name: "test", debug: false)
+            }
+        "#).expect("valid subgraph");
+
+        let result = compose(vec![subgraph_a, subgraph_b]).expect("composed successfully");
+        let schema = result.schema().schema();
+
+        let shared_field = coord!(Query.shared)
+            .lookup_field(schema)
+            .expect("field exists");
+        assert_snapshot!(
+            shared_field.to_string(),
+            r#"shared_field: shared: String @foo(name: "test")"#
+        );
+
+        let has_inconsistent_hint = result
+            .hints()
+            .iter()
+            .any(|h| h.definition.code() == "INCONSISTENT_NON_REPEATABLE_DIRECTIVE_ARGUMENTS");
+        assert!(
+            !has_inconsistent_hint,
+            "Should not produce INCONSISTENT_NON_REPEATABLE_DIRECTIVE_ARGUMENTS hint — applications are identical when resolved with correct subgraph defaults"
+        );
     }
 }
 

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -1151,7 +1151,6 @@ mod validation {
 }
 
 mod composition {
-    use insta::assert_snapshot;
     use test_log::test;
 
     use super::*;
@@ -1415,9 +1414,9 @@ mod composition {
         let shared_field = coord!(Query.shared)
             .lookup_field(schema)
             .expect("field exists");
-        assert_snapshot!(
+        assert_eq!(
             shared_field.to_string(),
-            r#"shared_field: shared: String @foo(name: "test")"#
+            r#"shared: String @foo(name: "test")"#
         );
 
         let has_inconsistent_hint = result

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_directive__composition__shared: String @foo(name: "test").snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_directive__composition__shared: String @foo(name: "test").snap
@@ -1,0 +1,5 @@
+---
+source: apollo-federation/tests/composition/compose_directive.rs
+expression: "r#\"shared_field: shared: String @foo(name: \"test\")\"#"
+---
+shared_field: shared: String @foo(name: "test")

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_directive__composition__shared: String @foo(name: "test").snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_directive__composition__shared: String @foo(name: "test").snap
@@ -1,5 +1,0 @@
----
-source: apollo-federation/tests/composition/compose_directive.rs
-expression: "r#\"shared_field: shared: String @foo(name: \"test\")\"#"
----
-shared_field: shared: String @foo(name: "test")


### PR DESCRIPTION
Use subgraph directive definition when merging applied directives instead of relying on supergraph definition. Subgraphs can have slightly different but compatible definitions, e.g. one of them can specify some defaults and other may omit it and as a result supergraph definition may not have the same defaults.
