### PR TITLE
chore: remove misnamed `apollo.router.operations.jwt` metric

### DIFF
--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -615,18 +615,7 @@ fn authenticate(
         if token_data.claims.get("exp").is_none() {
             tracing::debug!("accepted JWT without `exp` claim");
         }
-        // This is a metric and will not appear in the logs
-        //
-        // Apparently intended to be `apollo.router.operations.authentication.jwt` like above,
-        // but has existed for two years with a buggy name. Keep it for now.
-        u64_counter!(
-            "apollo.router.operations.jwt",
-            "Number of requests with JWT successful authentication (deprecated, \
-                use `apollo.router.operations.authentication.jwt` \
-                with `authentication.jwt.failed = false` instead)",
-            1
-        );
-        // Use the fixed name too:
+
         let failed = false;
         increment_jwt_counter_metric(failed);
 


### PR DESCRIPTION
[ROUTER-1763](https://apollographql.atlassian.net/browse/ROUTER-1763)

This metric has been misnamed (`apollo.router.operations.jwt`) for 2+ years, but was deprecated in a Router 2.x release. It has instead been emitted in parallel under the correct name (`apollo.router.operations.authentication.jwt`) since [PR#7258](https://github.com/apollographql/router/pull/7258). This change removes the deprecated metric.

<!-- [ROUTER-1763] -->

[ROUTER-1763]: https://apollographql.atlassian.net/browse/ROUTER-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROUTER-1763]: https://apollographql.atlassian.net/browse/ROUTER-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ