### PR TITLE
fix: ensure `client.name` and `client.version` attributes on router metrics can use selectors

### DIFF
--- a/.changesets/fix_rohan_b99_allow_selectors_for_router_span_client_name_version.md
+++ b/.changesets/fix_rohan_b99_allow_selectors_for_router_span_client_name_version.md
@@ -1,0 +1,12 @@
+### Ensure `client.name` and `client.version` attributes on router metrics can use selectors ([PR #9502](https://github.com/apollographql/router/pull/9502))
+
+A recent change added `client.name` and `client.version` as standard attributes on `RouterAttributes` to support aliasing. This inadvertently caused the JSON schema to reject selector-based overrides e.g.
+
+```yaml
+client.name: 
+  request_header: x-my-header
+```
+
+for those fields. We now support both the boolean/alias form, as well as the custom selector syntax.
+
+By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9502

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -4369,10 +4369,17 @@ expression: "&schema"
         "client.name": {
           "anyOf": [
             {
-              "$ref": "#/definitions/StandardAttribute"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StandardAttribute"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             {
-              "type": "null"
+              "$ref": "#/definitions/ConditionalRouterSelector"
             }
           ],
           "description": "Optional client name populated from the request headers."
@@ -4380,10 +4387,17 @@ expression: "&schema"
         "client.version": {
           "anyOf": [
             {
-              "$ref": "#/definitions/StandardAttribute"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StandardAttribute"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             {
-              "type": "null"
+              "$ref": "#/definitions/ConditionalRouterSelector"
             }
           ],
           "description": "Optional client version populated from the request headers."
@@ -4650,10 +4664,17 @@ expression: "&schema"
         "client.name": {
           "anyOf": [
             {
-              "$ref": "#/definitions/StandardAttribute"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StandardAttribute"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             {
-              "type": "null"
+              "$ref": "#/definitions/RouterSelector"
             }
           ],
           "description": "Optional client name populated from the request headers."
@@ -4661,10 +4682,17 @@ expression: "&schema"
         "client.version": {
           "anyOf": [
             {
-              "$ref": "#/definitions/StandardAttribute"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StandardAttribute"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             {
-              "type": "null"
+              "$ref": "#/definitions/RouterSelector"
             }
           ],
           "description": "Optional client version populated from the request headers."

--- a/apollo-router/src/plugins/telemetry/config_new/extendable.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/extendable.rs
@@ -151,6 +151,38 @@ where
             && let Some(additional_properties) = custom.get("additionalProperties")
         {
             object["additionalProperties"] = additional_properties.clone();
+
+            // Properties marked with `x-allow-selector` can also accept an Ext
+            // (selector) value in addition to their declared type. This reflects the
+            // Extendable serde deserializer which tries Ext first for every key.
+            if let Some(props) = object.get_mut("properties").and_then(|p| p.as_object_mut()) {
+                for (_key, prop_schema) in props.iter_mut() {
+                    let dominated_by_selector = prop_schema
+                        .as_object()
+                        .and_then(|o| o.get("x-allow-selector"))
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if !dominated_by_selector {
+                        continue;
+                    }
+                    let mut original = prop_schema.clone();
+                    if let Some(o) = original.as_object_mut() {
+                        o.remove("x-allow-selector");
+                    }
+                    // Hoist the description to the outer schema so documentation
+                    // checks still find it at the property level.
+                    let description = original
+                        .as_object_mut()
+                        .and_then(|o| o.remove("description"));
+                    let mut wrapped = serde_json::json!({
+                        "anyOf": [original, additional_properties]
+                    });
+                    if let Some(desc) = description {
+                        wrapped["description"] = desc;
+                    }
+                    *prop_schema = wrapped;
+                }
+            }
         }
         schema
     }
@@ -337,6 +369,43 @@ mod test {
             }),
         )
         .expect_err("Should have errored");
+    }
+
+    #[test]
+    fn test_extendable_selector_for_known_attribute() {
+        // Regression: using a selector for a known attribute like `client.name` must work.
+        // Both serde deserialization and schema validation must accept this.
+        let json = serde_json::json!({
+            "http.response.status_code": true,
+            "client.name": {
+                "request_header": "x-my-header"
+            }
+        });
+
+        // Verify serde deserialization succeeds
+        let extendable_conf =
+            serde_json::from_value::<Extendable<RouterAttributes, RouterSelector>>(json.clone())
+                .expect("selector for client.name should deserialize");
+        assert_eq!(extendable_conf.attributes.client_name, None);
+        assert_eq!(
+            extendable_conf.custom.get("client.name"),
+            Some(&RouterSelector::RequestHeader {
+                request_header: String::from("x-my-header"),
+                redact: None,
+                default: None
+            })
+        );
+
+        // Verify JSON schema validation accepts this config
+        let schema = schemars::generate::SchemaSettings::draft07()
+            .into_generator()
+            .into_root_schema_for::<Extendable<RouterAttributes, RouterSelector>>();
+        let schema_value = serde_json::to_value(&schema).unwrap();
+        let validator = jsonschema::draft7::new(&schema_value).expect("schema should compile");
+        assert!(
+            validator.is_valid(&json),
+            "schema should accept a selector value for client.name"
+        );
     }
 
     #[test]

--- a/apollo-router/src/plugins/telemetry/config_new/router/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/attributes.rs
@@ -38,10 +38,14 @@ pub(crate) struct RouterAttributes {
     pub(crate) baggage: Option<bool>,
 
     /// Optional client name populated from the request headers.
+    // x-allow-selector is used to allow overriding this with a custom selector.
     #[serde(rename = "client.name")]
+    #[schemars(extend("x-allow-selector" = true))]
     pub(crate) client_name: Option<StandardAttribute>,
     /// Optional client version populated from the request headers.
+    // x-allow-selector is used to allow overriding this with a custom selector.
     #[serde(rename = "client.version")]
+    #[schemars(extend("x-allow-selector" = true))]
     pub(crate) client_version: Option<StandardAttribute>,
 
     /// Http attributes from Open Telemetry semantic conventions.

--- a/apollo-router/src/plugins/telemetry/config_new/router/spans.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/spans.rs
@@ -481,8 +481,7 @@ mod test {
             }
         });
 
-        let mut spans: RouterSpans =
-            serde_json::from_value(json).expect("should deserialize");
+        let mut spans: RouterSpans = serde_json::from_value(json).expect("should deserialize");
 
         assert!(spans.attributes.attributes.client_name.is_none());
         assert!(spans.attributes.custom.contains_key("client.name"));

--- a/apollo-router/src/plugins/telemetry/config_new/router/spans.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/spans.rs
@@ -23,6 +23,18 @@ impl DefaultForLevel for RouterSpans {
         kind: TelemetryDataKind,
     ) {
         self.attributes.defaults_for_level(requirement_level, kind);
+
+        // When a user overrides client.name or client.version with a custom
+        // selector (e.g. `request_header`), the Extendable deserializer places
+        // it in `custom` and leaves the typed attribute field as None.
+        // defaults_for_level then mistakenly fills that None with Some(true).
+        // Clear it back so the custom selector is the sole source for the key.
+        if self.attributes.custom.contains_key("client.name") {
+            self.attributes.attributes.client_name = None;
+        }
+        if self.attributes.custom.contains_key("client.version") {
+            self.attributes.attributes.client_version = None;
+        }
     }
 }
 
@@ -455,5 +467,56 @@ mod test {
         assert!(values.iter().any(|key_val| key_val.key
             == opentelemetry::Key::from_static_str(OTEL_NAME)
             && key_val.value == opentelemetry::Value::String(String::from("new_name").into())));
+    }
+
+    #[test]
+    fn test_defaults_do_not_duplicate_custom_client_name_selector() {
+        use crate::plugins::telemetry::config_new::attributes::StandardAttribute;
+
+        let json = serde_json::json!({
+            "attributes": {
+                "client.name": {
+                    "request_header": "x-custom-client"
+                }
+            }
+        });
+
+        let mut spans: RouterSpans =
+            serde_json::from_value(json).expect("should deserialize");
+
+        assert!(spans.attributes.attributes.client_name.is_none());
+        assert!(spans.attributes.custom.contains_key("client.name"));
+
+        spans.defaults_for_levels(
+            DefaultAttributeRequirementLevel::Required,
+            TelemetryDataKind::Traces,
+        );
+
+        assert!(
+            spans.attributes.attributes.client_name.is_none(),
+            "defaults_for_level must not set client_name when a custom selector already covers it"
+        );
+
+        // client.version has no custom selector, so it should still get the default.
+        assert_eq!(
+            spans.attributes.attributes.client_version,
+            Some(StandardAttribute::Bool(true)),
+        );
+
+        let request = router::Request::fake_builder()
+            .header("x-custom-client", "from-selector")
+            .build()
+            .unwrap();
+        let attrs = spans.attributes.on_request(&request);
+        let client_names: Vec<_> = attrs
+            .iter()
+            .filter(|kv| kv.key.as_str() == "client.name")
+            .collect();
+
+        assert_eq!(
+            client_names.len(),
+            1,
+            "on_request should produce exactly one client.name (from the custom selector), got {client_names:?}"
+        );
     }
 }


### PR DESCRIPTION
A recent change added `client.name` and `client.version` as standard attributes on `RouterAttributes` to support aliasing. This inadvertently caused the JSON schema to reject selector-based overrides e.g.

```yaml
client.name: 
  request_header: x-my-header
```

for those fields. We now support both the boolean/alias form, as well as the custom selector syntax.

<!-- start metadata -->

<!-- [ROUTER-1817] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1817]: https://apollographql.atlassian.net/browse/ROUTER-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ