### PR TITLE
fix(coprocessor): only delete context keys from those that were sent in a given stage

### DIFF
--- a/.changesets/fix_rohan_b99_coprocessor_context_keys_race_condition.md
+++ b/.changesets/fix_rohan_b99_coprocessor_context_keys_race_condition.md
@@ -1,0 +1,6 @@
+### Only delete coprocessor context keys from those that were sent in a given stage ([PR #9519](https://github.com/apollographql/router/pull/9519))
+
+Addresses a race condition where context keys added by concurrent parallel subgraph stages could unintenionally be deleted.
+
+
+By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9519

--- a/.changesets/fix_rohan_b99_coprocessor_context_keys_race_condition.md
+++ b/.changesets/fix_rohan_b99_coprocessor_context_keys_race_condition.md
@@ -1,6 +1,6 @@
 ### Only delete coprocessor context keys from those that were sent in a given stage ([PR #9519](https://github.com/apollographql/router/pull/9519))
 
-Addresses a race condition where context keys added by concurrent parallel subgraph stages could unintenionally be deleted.
+Addresses a race condition where context keys added by concurrent parallel subgraph stages could unintentionally be deleted.
 
 
 By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9519

--- a/apollo-router/src/plugins/coprocessor/connector.rs
+++ b/apollo-router/src/plugins/coprocessor/connector.rs
@@ -1,5 +1,6 @@
 //! Connector coprocessor stage implementation
 
+use std::collections::HashSet;
 use std::ops::ControlFlow;
 
 use apollo_federation::connectors::runtime::errors::Error as ConnectorError;
@@ -262,7 +263,10 @@ where
         serde_json::from_str::<Value>(&body).unwrap_or_else(|_| Value::String(body.clone().into()))
     });
 
-    let context_to_send = request_config.context.get_context(&request.context);
+    let context_to_send = request_config
+        .context
+        .get_context(&request.context)
+        .map(|(ctx, _keys)| ctx);
     let uri = request_config.uri.then(|| parts.uri.to_string());
     let service_name_to_send = request_config.service_name.then_some(service_name);
 
@@ -447,7 +451,10 @@ where
         None
     };
 
-    let context_to_send = response_config.context.get_context(&context);
+    let (context_to_send, keys_sent) = match response_config.context.get_context(&context) {
+        Some((ctx, keys)) => (Some(ctx), keys),
+        None => (None, HashSet::new()),
+    };
     let service_name_to_send = response_config.service_name.then_some(service_name);
 
     let payload = Externalizable::connector_builder()
@@ -497,7 +504,12 @@ where
     }
 
     if let Some(returned_context) = co_processor_output.context {
-        update_context_from_coprocessor(&context, returned_context, &response_config.context)?;
+        update_context_from_coprocessor(
+            &context,
+            returned_context,
+            &response_config.context,
+            &keys_sent,
+        )?;
     }
 
     if let Some(body) = co_processor_output.body {

--- a/apollo-router/src/plugins/coprocessor/execution.rs
+++ b/apollo-router/src/plugins/coprocessor/execution.rs
@@ -216,7 +216,10 @@ where
         .body
         .then(|| serde_json::from_slice::<Value>(&bytes))
         .transpose()?;
-    let context_to_send = request_config.context.get_context(&request.context);
+    let context_to_send = request_config
+        .context
+        .get_context(&request.context)
+        .map(|(ctx, _keys)| ctx);
     let sdl_to_send = request_config.sdl.then(|| sdl.clone().to_string());
     let method = request_config.method.then(|| parts.method.to_string());
     let query_plan = request_config
@@ -378,7 +381,11 @@ where
         .then(|| externalize_header_map(&parts.headers));
     let body_to_send = filter_graphql_response_body(&first, &response_config.body);
     let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
-    let context_to_send = response_config.context.get_context(&response.context);
+    let (context_to_send, keys_sent) = match response_config.context.get_context(&response.context)
+    {
+        Some((ctx, keys)) => (Some(ctx), keys),
+        None => (None, HashSet::new()),
+    };
     let sdl_to_send = response_config.sdl.then(|| sdl.clone().to_string());
 
     let payload = Externalizable::execution_builder()
@@ -435,7 +442,12 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        update_context_from_coprocessor(&response.context, context, &response_config.context)?;
+        update_context_from_coprocessor(
+            &response.context,
+            context,
+            &response_config.context,
+            &keys_sent,
+        )?;
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -459,7 +471,11 @@ where
             async move {
                 let body_to_send =
                     filter_graphql_response_body(&deferred_response, &response_config.body);
-                let context_to_send = response_config_context.get_context(&generator_map_context);
+                let (context_to_send, keys_sent) =
+                    match response_config_context.get_context(&generator_map_context) {
+                        Some((ctx, keys)) => (Some(ctx), keys),
+                        None => (None, HashSet::new()),
+                    };
 
                 // Note: We deliberately DO NOT send headers or status_code even if the user has
                 // requested them. That's because they are meaningless on a deferred response and
@@ -514,6 +530,7 @@ where
                             &generator_map_context,
                             context,
                             &response_config_context,
+                            &keys_sent,
                         )?;
                     }
 

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -533,31 +533,41 @@ pub(super) enum NewContextConf {
 }
 
 impl ContextConf {
-    pub(crate) fn get_context(&self, ctx: &Context) -> Option<Context> {
+    pub(crate) fn get_context(&self, ctx: &Context) -> Option<(Context, HashSet<String>)> {
         match self {
-            Self::NewContextConf(NewContextConf::All) => Some(ctx.clone()),
-            Self::NewContextConf(NewContextConf::Deprecated) | Self::Deprecated(true) => {
+            Self::NewContextConf(NewContextConf::All) => {
+                let mut keys_sent = HashSet::new();
                 let mut new_ctx = Context::from_iter(ctx.iter().map(|elt| {
+                    keys_sent.insert(elt.key().clone());
+                    (elt.key().clone(), elt.value().clone())
+                }));
+                new_ctx.id = ctx.id.clone();
+                Some((new_ctx, keys_sent))
+            }
+            Self::NewContextConf(NewContextConf::Deprecated) | Self::Deprecated(true) => {
+                let mut keys_sent = HashSet::new();
+                let mut new_ctx = Context::from_iter(ctx.iter().map(|elt| {
+                    keys_sent.insert(elt.key().clone());
                     (
                         context_key_to_deprecated(elt.key().clone()),
                         elt.value().clone(),
                     )
                 }));
                 new_ctx.id = ctx.id.clone();
-
-                Some(new_ctx)
+                Some((new_ctx, keys_sent))
             }
             Self::NewContextConf(NewContextConf::Selective(context_keys)) => {
+                let mut keys_sent = HashSet::new();
                 let mut new_ctx = Context::from_iter(ctx.iter().filter_map(|elt| {
                     if context_keys.contains(elt.key()) {
+                        keys_sent.insert(elt.key().clone());
                         Some((elt.key().clone(), elt.value().clone()))
                     } else {
                         None
                     }
                 }));
                 new_ctx.id = ctx.id.clone();
-
-                Some(new_ctx)
+                Some((new_ctx, keys_sent))
             }
             Self::Deprecated(false) => None,
         }
@@ -614,12 +624,11 @@ pub(crate) fn update_context_from_coprocessor(
     target_context: &Context,
     context_returned: Context,
     context_config: &ContextConf,
+    keys_sent: &HashSet<String>,
 ) -> Result<(), BoxError> {
-    // Collect keys that are in the returned context
     let mut keys_returned = HashSet::with_capacity(context_returned.len());
 
     for (mut key, value) in context_returned.try_into_iter()? {
-        // Handle deprecated key names - convert back to actual key names
         if context_config.is_deprecated() {
             key = context_key_from_deprecated(key);
         }
@@ -628,21 +637,9 @@ pub(crate) fn update_context_from_coprocessor(
         target_context.insert_json_value(key, value);
     }
 
-    // Delete keys that were sent but are missing from the returned context
-    // If the context config is selective, only delete keys that are in the selective list
-    match context_config {
-        ContextConf::NewContextConf(NewContextConf::Selective(context_keys)) => {
-            target_context.retain(|key, _v| {
-                if keys_returned.contains(key) {
-                    return true;
-                } else if context_keys.contains(key) {
-                    return false;
-                }
-                true
-            });
-        }
-        _ => target_context.retain(|key, _v| keys_returned.contains(key)),
-    }
+    // Only delete keys that were SENT to the coprocessor but NOT returned.
+    // Keys never sent (e.g. added concurrently by parallel subgraph stages) are preserved.
+    target_context.retain(|key, _v| keys_returned.contains(key) || !keys_sent.contains(key));
 
     Ok(())
 }
@@ -969,7 +966,10 @@ where
 
     let path_to_send = request_config.path.then(|| parts.uri.to_string());
 
-    let context_to_send = request_config.context.get_context(&request.context);
+    let context_to_send = request_config
+        .context
+        .get_context(&request.context)
+        .map(|(ctx, _keys)| ctx);
     let sdl_to_send = request_config.sdl.then(|| sdl.clone().to_string());
 
     let payload = Externalizable::router_builder()
@@ -1166,7 +1166,10 @@ where
             .then(|| std::str::from_utf8(&bytes).map(|s| s.to_string()))
             .transpose()?;
         let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
-        let context_to_send = response_config.context.get_context(&context);
+        let (context_to_send, keys_sent) = match response_config.context.get_context(&context) {
+            Some((ctx, keys)) => (Some(ctx), keys),
+            None => (None, HashSet::new()),
+        };
 
         let payload = Externalizable::router_builder()
             .stage(PipelineStep::RouterResponse)
@@ -1207,7 +1210,7 @@ where
             parts.status = control.get_http_status()?;
         }
         if let Some(ctx) = co_processor_output.context {
-            update_context_from_coprocessor(&context, ctx, &response_config.context)?;
+            update_context_from_coprocessor(&context, ctx, &response_config.context, &keys_sent)?;
         }
         if let Some(headers) = co_processor_output.headers {
             parts.headers = internalize_header_map(headers)?;
@@ -1249,7 +1252,11 @@ where
                 let body_to_send = stream_body
                     .then(|| String::from_utf8(bytes.clone()))
                     .transpose()?;
-                let context_to_send = context_conf.get_context(&generator_map_context);
+                let (context_to_send, keys_sent) =
+                    match context_conf.get_context(&generator_map_context) {
+                        Some((ctx, keys)) => (Some(ctx), keys),
+                        None => (None, HashSet::new()),
+                    };
 
                 // Note: We deliberately DO NOT send headers or status_code even if the user has
                 // requested them. That's because they are meaningless on a deferred response and
@@ -1293,6 +1300,7 @@ where
                             &generator_map_context,
                             ctx,
                             &context_conf,
+                            &keys_sent,
                         )?;
                     }
 
@@ -1358,7 +1366,10 @@ where
         .body
         .then(|| serde_json_bytes::to_value(&body))
         .transpose()?;
-    let context_to_send = request_config.context.get_context(&request.context);
+    let context_to_send = request_config
+        .context
+        .get_context(&request.context)
+        .map(|(ctx, _keys)| ctx);
     let uri = request_config.uri.then(|| parts.uri.to_string());
     let subgraph_name = service_name.clone();
     let service_name = request_config.service_name.then_some(service_name);
@@ -1529,7 +1540,11 @@ where
     let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
 
     let body_to_send = filter_graphql_response_body(&body, &response_config.body);
-    let context_to_send = response_config.context.get_context(&response.context);
+    let (context_to_send, keys_sent) = match response_config.context.get_context(&response.context)
+    {
+        Some((ctx, keys)) => (Some(ctx), keys),
+        None => (None, HashSet::new()),
+    };
     let service_name = response_config.service_name.then_some(service_name);
     let subgraph_request_id = response_config
         .subgraph_request_id
@@ -1593,7 +1608,12 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        update_context_from_coprocessor(&response.context, context, &response_config.context)?;
+        update_context_from_coprocessor(
+            &response.context,
+            context,
+            &response_config.context,
+            &keys_sent,
+        )?;
     }
 
     if let Some(headers) = co_processor_output.headers {

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -222,7 +222,10 @@ where
         .body
         .then(|| serde_json::from_slice::<Value>(&bytes))
         .transpose()?;
-    let context_to_send = request_config.context.get_context(&request.context);
+    let context_to_send = request_config
+        .context
+        .get_context(&request.context)
+        .map(|(ctx, _keys)| ctx);
     let sdl_to_send = request_config.sdl.then(|| sdl.clone().to_string());
     let method = request_config.method.then(|| parts.method.to_string());
 
@@ -392,7 +395,11 @@ where
             .then(|| externalize_header_map(&parts.headers));
         let body_to_send = filter_graphql_response_body(&first, &response_config.body);
         let status_to_send = response_config.status_code.then(|| parts.status.as_u16());
-        let context_to_send = response_config.context.get_context(&response.context);
+        let (context_to_send, keys_sent) =
+            match response_config.context.get_context(&response.context) {
+                Some((ctx, keys)) => (Some(ctx), keys),
+                None => (None, HashSet::new()),
+            };
 
         let payload = Externalizable::supergraph_builder()
             .stage(PipelineStep::SupergraphResponse)
@@ -445,7 +452,12 @@ where
         }
 
         if let Some(context) = co_processor_output.context {
-            update_context_from_coprocessor(&response.context, context, &response_config.context)?;
+            update_context_from_coprocessor(
+                &response.context,
+                context,
+                &response_config.context,
+                &keys_sent,
+            )?;
         }
 
         if let Some(headers) = co_processor_output.headers {
@@ -479,7 +491,11 @@ where
                 }
                 let body_to_send =
                     filter_graphql_response_body(&deferred_response, &response_config.body);
-                let context_to_send = response_config_context.get_context(&generator_map_context);
+                let (context_to_send, keys_sent) =
+                    match response_config_context.get_context(&generator_map_context) {
+                        Some((ctx, keys)) => (Some(ctx), keys),
+                        None => (None, HashSet::new()),
+                    };
 
                 // Note: We deliberately DO NOT send headers or status_code even if the user has
                 // requested them. That's because they are meaningless on a deferred response and
@@ -536,6 +552,7 @@ where
                             &generator_map_context,
                             context,
                             &response_config_context,
+                            &keys_sent,
                         )?;
                     }
 

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -5107,6 +5107,8 @@ mod tests {
 
     #[test]
     fn test_update_context_from_coprocessor_deletes_missing_keys() {
+        use std::collections::HashSet;
+
         use crate::Context;
         use crate::plugins::coprocessor::update_context_from_coprocessor;
 
@@ -5115,6 +5117,8 @@ mod tests {
         target_context.insert("k1", "v1".to_string()).unwrap();
         target_context.insert("k2", "v2".to_string()).unwrap();
         target_context.insert("k3", "v3".to_string()).unwrap();
+
+        let keys_sent: HashSet<String> = ["k1", "k2", "k3"].into_iter().map(String::from).collect();
 
         // Coprocessor returns context without k2 (deleted)
         let returned_context = Context::new();
@@ -5129,6 +5133,7 @@ mod tests {
             &target_context,
             returned_context,
             &ContextConf::NewContextConf(NewContextConf::All),
+            &keys_sent,
         )
         .unwrap();
 
@@ -5148,12 +5153,16 @@ mod tests {
 
     #[test]
     fn test_update_context_from_coprocessor_adds_new_keys() {
+        use std::collections::HashSet;
+
         use crate::Context;
         use crate::plugins::coprocessor::update_context_from_coprocessor;
 
         // Create a context with some keys
         let target_context = Context::new();
         target_context.insert("k1", "v1".to_string()).unwrap();
+
+        let keys_sent: HashSet<String> = ["k1"].into_iter().map(String::from).collect();
 
         // Coprocessor returns context with a new key
         let returned_context = Context::new();
@@ -5167,6 +5176,7 @@ mod tests {
             &target_context,
             returned_context,
             &ContextConf::NewContextConf(NewContextConf::All),
+            &keys_sent,
         )
         .unwrap();
 
@@ -5204,10 +5214,16 @@ mod tests {
         let selective_keys: HashSet<String> = ["k1".to_string()].into();
         let context_config =
             ContextConf::NewContextConf(NewContextConf::Selective(Arc::new(selective_keys)));
+        let keys_sent: HashSet<String> = ["k1"].into_iter().map(String::from).collect();
 
         // Update context
-        update_context_from_coprocessor(&target_context, returned_context, &context_config)
-            .unwrap();
+        update_context_from_coprocessor(
+            &target_context,
+            returned_context,
+            &context_config,
+            &keys_sent,
+        )
+        .unwrap();
 
         // k1 should be deleted (was sent but missing from returned context)
         assert!(!target_context.contains_key("k1"));
@@ -5227,6 +5243,8 @@ mod tests {
         )]
         context_conf: ContextConf,
     ) {
+        use std::collections::HashSet;
+
         use crate::Context;
         use crate::plugins::coprocessor::update_context_from_coprocessor;
 
@@ -5234,8 +5252,18 @@ mod tests {
             Context::from_iter([(target_context_key_name.to_string(), "v1".into())]);
         let returned_context =
             Context::from_iter([(DEPRECATED_CLIENT_NAME.to_string(), "v2".into())]);
+        let keys_sent: HashSet<String> = [target_context_key_name]
+            .into_iter()
+            .map(String::from)
+            .collect();
 
-        update_context_from_coprocessor(&target_context, returned_context, &context_conf).unwrap();
+        update_context_from_coprocessor(
+            &target_context,
+            returned_context,
+            &context_conf,
+            &keys_sent,
+        )
+        .unwrap();
 
         assert_eq!(
             target_context.get_json_value(CLIENT_NAME),
@@ -5246,6 +5274,100 @@ mod tests {
             !target_context.contains_key(DEPRECATED_CLIENT_NAME),
             "DEPRECATED_CLIENT_NAME should not be present"
         );
+    }
+
+    #[test]
+    fn test_update_context_from_coprocessor_preserves_concurrently_added_keys() {
+        use std::collections::HashSet;
+
+        use crate::Context;
+        use crate::plugins::coprocessor::update_context_from_coprocessor;
+
+        // Simulate: keys_sent = {k1, k2} (snapshot at time T1), then k3 is added
+        // to target concurrently (at time T2), coprocessor returns {k1} (deleted k2).
+        // Result: k1 kept, k2 deleted, k3 preserved (was never sent).
+        let target_context = Context::new();
+        target_context.insert("k1", "v1".to_string()).unwrap();
+        target_context.insert("k2", "v2".to_string()).unwrap();
+        // k3 simulates a key added by a concurrent parallel subgraph stage after the
+        // snapshot was taken but before the retain runs
+        target_context
+            .insert("k3", "concurrent_value".to_string())
+            .unwrap();
+
+        let keys_sent: HashSet<String> = ["k1", "k2"].into_iter().map(String::from).collect();
+        let returned_context = Context::new();
+        returned_context.insert("k1", "v1".to_string()).unwrap();
+        // k2 intentionally removed by coprocessor
+        // k3 was never sent, must survive
+
+        update_context_from_coprocessor(
+            &target_context,
+            returned_context,
+            &ContextConf::NewContextConf(NewContextConf::All),
+            &keys_sent,
+        )
+        .unwrap();
+
+        assert!(target_context.contains_key("k1"));
+        assert!(!target_context.contains_key("k2")); // deleted by coprocessor
+        assert!(target_context.contains_key("k3")); // preserved (never sent)
+    }
+
+    #[test]
+    fn test_sibling_subgraph_response_does_not_delete_other_subgraphs_keys() {
+        use std::collections::HashSet;
+
+        use crate::Context;
+        use crate::plugins::coprocessor::update_context_from_coprocessor;
+
+        // Simulate the parallel fanout scenario:
+        // - accounts SubgraphRequest added accounts_request_start to shared context
+        // - book SubgraphResponse fires, its snapshot didn't include accounts_request_start
+        // - book's coprocessor returns without accounts_request_start
+        // - accounts_request_start must survive in the shared context
+        let shared_context = Context::new();
+        shared_context
+            .insert("base_key", "base".to_string())
+            .unwrap();
+        shared_context
+            .insert("accounts_request_start", 1234i64)
+            .unwrap();
+        shared_context
+            .insert("book_request_start", 5678i64)
+            .unwrap();
+
+        // book's snapshot only had base_key and book_request_start at the time
+        let keys_sent: HashSet<String> = ["base_key", "book_request_start"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+
+        let returned_context = Context::new();
+        returned_context
+            .insert("base_key", "base".to_string())
+            .unwrap();
+        returned_context
+            .insert("book_request_start", 5678i64)
+            .unwrap();
+        returned_context
+            .insert("book_request_end", 5700i64)
+            .unwrap();
+
+        update_context_from_coprocessor(
+            &shared_context,
+            returned_context,
+            &ContextConf::NewContextConf(NewContextConf::All),
+            &keys_sent,
+        )
+        .unwrap();
+
+        // accounts_request_start was never sent to book's coprocessor, so it must survive
+        assert!(shared_context.contains_key("accounts_request_start"));
+        assert!(shared_context.contains_key("book_request_start"));
+        // new key added by coprocessor
+        assert!(shared_context.contains_key("book_request_end"));
+        assert!(shared_context.contains_key("base_key"));
     }
 
     // Subgraph stage metrics test

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -621,6 +621,124 @@ async fn test_coprocessor_context_key_deletion() -> Result<(), BoxError> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_coprocessor_context_keys_survive_parallel_fanout() -> Result<(), BoxError> {
+    // Regression test: when subgraph requests fan out in parallel, each SubgraphRequest
+    // writes service-scoped keys into the shared context. Previously, a sibling's
+    // SubgraphResponse merge would delete those keys via a broad `retain` call.
+    // This test verifies that keys written by one subgraph's request survive another
+    // subgraph's response processing.
+    if !graph_os_enabled() {
+        return Ok(());
+    }
+
+    let mock_server = wiremock::MockServer::start().await;
+    let coprocessor_address = mock_server.uri();
+
+    // Track whether SubgraphResponse stages see the keys from sibling SubgraphRequests
+    let subgraph_response_errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let errors_clone = subgraph_response_errors.clone();
+
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(move |req: &wiremock::Request| {
+            let body = req.body_json::<serde_json::Value>().expect("body");
+            let stage = body.get("stage").and_then(|s| s.as_str()).unwrap_or("");
+
+            let mut response = body.clone();
+
+            // Ensure Request stages have a control field
+            if stage.ends_with("Request")
+                && !response.as_object().unwrap().contains_key("control")
+                && let Some(obj) = response.as_object_mut()
+            {
+                obj.insert("control".to_string(), serde_json::json!("continue"));
+            }
+
+            if stage == "SubgraphRequest" {
+                // Write a service-scoped key into context (simulating timestamp writes)
+                let service_name = body
+                    .get("serviceName")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("unknown");
+                let key = format!("{service_name}_request_start");
+                if let Some(ctx) = response
+                    .as_object_mut()
+                    .and_then(|o| o.get_mut("context"))
+                    .and_then(|c| c.as_object_mut())
+                    .and_then(|c| c.get_mut("entries"))
+                    .and_then(|e| e.as_object_mut())
+                {
+                    ctx.insert(key, serde_json::json!(12345));
+                }
+            } else if stage == "SubgraphResponse" {
+                // Verify service-scoped keys from ALL subgraphs are present in context
+                let service_name = body
+                    .get("serviceName")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("unknown");
+                let expected_key = format!("{service_name}_request_start");
+                let has_own_key = body
+                    .get("context")
+                    .and_then(|c| c.get("entries"))
+                    .and_then(|e| e.as_object())
+                    .is_some_and(|entries| entries.contains_key(&expected_key));
+
+                if !has_own_key {
+                    errors_clone.lock().unwrap().push(format!(
+                        "SubgraphResponse for {service_name} missing key {expected_key}"
+                    ));
+                }
+            }
+
+            ResponseTemplate::new(200).set_body_json(response)
+        })
+        .mount(&mock_server)
+        .await;
+
+    let mut router = IntegrationTest::builder()
+        .config(
+            include_str!("fixtures/coprocessor_context.router.yaml")
+                .replace("<replace>", &coprocessor_address),
+        )
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    // Execute a query that fans out to multiple subgraphs in parallel.
+    // The default query hits "accounts" subgraph; use topProducts to fan out to
+    // products + reviews/inventory in parallel.
+    let query = Query::builder()
+        .body(json!({"query": "{ topProducts { name reviews { id author { name } } } }"}))
+        .build();
+    let (_trace_id, response) = router.execute_query(query).await;
+    assert_eq!(response.status(), 200);
+
+    let body: serde_json::Value = response.json().await.unwrap();
+    // The response should not contain errors from missing context keys
+    let errors = body.get("errors").and_then(|e| e.as_array());
+    assert!(
+        errors.is_none() || errors.unwrap().is_empty(),
+        "Expected no GraphQL errors but got: {:?}",
+        errors
+    );
+
+    // Verify our coprocessor didn't detect any missing keys
+    {
+        let missing_key_errors = subgraph_response_errors.lock().unwrap();
+        assert!(
+            missing_key_errors.is_empty(),
+            "Context keys were lost during parallel fanout: {:?}",
+            *missing_key_errors
+        );
+    }
+
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_coprocessor_receives_response_cache_keys() -> Result<(), BoxError> {
     // GIVEN:
     //   - graphos


### PR DESCRIPTION
Addresses a TOCTOU race condition where update_context_from_coprocessor would delete context keys added by concurrent parallel subgraph stages.

* ContextConf::get_context now returns Option<(Context, HashSet<String>)> — the context snapshot plus the set of keys that were sent. For All mode, it now creates a deep-copy snapshot (previously returned a shared Arc<DashMap> reference).
* update_context_from_coprocessor now accepts keys_sent: &HashSet<String> and uses a unified retain expression: keys_returned.contains(key) || !keys_sent.contains(key) — only deletes keys that were sent but not returned; keys added concurrently are preserved.


<!-- start metadata -->

<!-- [ROUTER-1819] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1819]: https://apollographql.atlassian.net/browse/ROUTER-1819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ