### PR TITLE
Deprecate `persisted_queries.experimental_local_manifests`

### DIFF
--- a/.changesets/maint_deprecate_experimental_local_manifests.md
+++ b/.changesets/maint_deprecate_experimental_local_manifests.md
@@ -1,0 +1,19 @@
+### Deprecate `persisted_queries.experimental_local_manifests` ([Issue #ROUTER-1760](https://apollographql.atlassian.net/browse/ROUTER-1760))
+
+The `persisted_queries.experimental_local_manifests` configuration key is now deprecated. Operators using this key will see a deprecation warning at router startup directing them to the GA `persisted_queries.local_manifests` key, which has the same behavior. The deprecated key continues to work in 2.x via the existing config migration, but will be removed in 3.x.
+
+```yaml
+# Before
+persisted_queries:
+  enabled: true
+  experimental_local_manifests:
+    - ./manifest.json
+
+# After
+persisted_queries:
+  enabled: true
+  local_manifests:
+    - ./manifest.json
+```
+
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/0

--- a/.changesets/maint_deprecate_experimental_local_manifests.md
+++ b/.changesets/maint_deprecate_experimental_local_manifests.md
@@ -16,4 +16,4 @@ persisted_queries:
     - ./manifest.json
 ```
 
-By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/0
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/9523

--- a/.changesets/maint_deprecate_experimental_local_manifests.md
+++ b/.changesets/maint_deprecate_experimental_local_manifests.md
@@ -1,4 +1,4 @@
-### Deprecate `persisted_queries.experimental_local_manifests` ([Issue #ROUTER-1760](https://apollographql.atlassian.net/browse/ROUTER-1760))
+### Deprecate `persisted_queries.experimental_local_manifests`
 
 The `persisted_queries.experimental_local_manifests` configuration key is now deprecated. Operators using this key will see a deprecation warning at router startup directing them to the GA `persisted_queries.local_manifests` key, which has the same behavior. The deprecated key continues to work in 2.x via the existing config migration, but will be removed in 3.x.
 

--- a/apollo-router/src/configuration/migrations/2046-experimental-local-manifests.yaml
+++ b/apollo-router/src/configuration/migrations/2046-experimental-local-manifests.yaml
@@ -1,0 +1,5 @@
+description: "`persisted_queries.experimental_local_manifests` is deprecated; use `persisted_queries.local_manifests` instead."
+actions:
+  - type: move
+    from: persisted_queries.experimental_local_manifests
+    to: persisted_queries.local_manifests

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@experimental-local-manifests.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@experimental-local-manifests.yaml.snap
@@ -1,0 +1,10 @@
+---
+source: apollo-router/src/configuration/tests.rs
+assertion_line: 680
+expression: new_config
+---
+---
+persisted_queries:
+  enabled: true
+  local_manifests:
+    - "./manifest.json"

--- a/apollo-router/src/configuration/testdata/migrations/experimental-local-manifests.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/experimental-local-manifests.yaml
@@ -1,0 +1,4 @@
+persisted_queries:
+  enabled: true
+  experimental_local_manifests:
+    - ./manifest.json


### PR DESCRIPTION
The `persisted_queries.experimental_local_manifests` configuration key is now deprecated. Operators using this key will see a deprecation warning at router startup directing them to the GA `persisted_queries.local_manifests` key, which has the same behavior. The deprecated key continues to work in 2.x via the existing config migration, but will be removed in 3.x.

```yaml
# Before
persisted_queries:
  enabled: true
  experimental_local_manifests:
    - ./manifest.json

# After
persisted_queries:
  enabled: true
  local_manifests:
    - ./manifest.json
```

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
