### PR TITLE
deps: pin rhai to minor version range

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -205,7 +205,7 @@ prost = "0.14.0"
 prost-types = "0.14.0"
 proteus = "0.5.0"
 rand = "0.10.0"
-rhai = { version = "1.23.6", features = ["sync", "serde", "internals"] }
+rhai = { version = "~1.23.6", features = ["sync", "serde", "internals"] }
 regex = "1.10.5"
 reqwest = { workspace = true, default-features = false, features = [
     "rustls-tls",


### PR DESCRIPTION
The 100th tweak to Rhai versioning...

Rhai regularly releases breaking changes in minor version bumps, causing
the `test_updated` nightly CI runs to fail, as well as potentially
customer builds using custom plugins.

Using a `~` range, only patch releases within the same minor will be
installed.
