### PR TITLE
Remove `experimental_local_manifests` persisted queries config alias

### DIFF
--- a/.changesets/breaking_zach_router_1761_remove_experimental_local_manifests.md
+++ b/.changesets/breaking_zach_router_1761_remove_experimental_local_manifests.md
@@ -1,0 +1,17 @@
+### Remove `experimental_local_manifests` persisted queries config alias ([Issue #ROUTER-1761](https://apollographql.atlassian.net/browse/ROUTER-1761))
+
+The `persisted_queries.experimental_local_manifests` configuration key — a compatibility alias for `persisted_queries.local_manifests` that emitted a deprecation warning throughout 2.x — has been removed. The stable `local_manifests` key has existed since the feature graduated and is the only supported name in 3.x.
+
+If your router configuration still uses the experimental key, rename it:
+
+```diff
+ persisted_queries:
+   enabled: true
+-  experimental_local_manifests:
++  local_manifests:
+     - ./persisted-queries-manifest.json
+```
+
+Configurations that still reference `experimental_local_manifests` will fail to load with an "unknown field" error on startup.
+
+By [@zachfetters](https://github.com/zachfetters) in https://github.com/apollographql/router/pull/PULL_NUMBER

--- a/.changesets/breaking_zach_router_1761_remove_experimental_local_manifests.md
+++ b/.changesets/breaking_zach_router_1761_remove_experimental_local_manifests.md
@@ -1,4 +1,4 @@
-### Remove `experimental_local_manifests` persisted queries config alias ([Issue #ROUTER-1761](https://apollographql.atlassian.net/browse/ROUTER-1761))
+### Remove `experimental_local_manifests` persisted queries config alias
 
 The `persisted_queries.experimental_local_manifests` configuration key — a compatibility alias for `persisted_queries.local_manifests` that emitted a deprecation warning throughout 2.x — has been removed. The stable `local_manifests` key has existed since the feature graduated and is the only supported name in 3.x.
 
@@ -14,4 +14,4 @@ If your router configuration still uses the experimental key, rename it:
 
 Configurations that still reference `experimental_local_manifests` will fail to load with an "unknown field" error on startup.
 
-By [@zachfetters](https://github.com/zachfetters) in https://github.com/apollographql/router/pull/PULL_NUMBER
+By [@zachfetters](https://github.com/zachfetters) in https://github.com/apollographql/router/pull/9532

--- a/apollo-router/src/configuration/persisted_queries.rs
+++ b/apollo-router/src/configuration/persisted_queries.rs
@@ -19,7 +19,6 @@ pub struct PersistedQueries {
     pub experimental_prewarm_query_plan_cache: PersistedQueriesPrewarmQueryPlanCache,
 
     /// Enables using a local copy of the persisted query manifest to safelist operations
-    #[serde(alias = "experimental_local_manifests")]
     pub local_manifests: Option<Vec<String>>,
 
     /// Enables hot reloading of the local persisted query manifests


### PR DESCRIPTION
The `persisted_queries.experimental_local_manifests` configuration key — a compatibility alias for `persisted_queries.local_manifests` that emitted a deprecation warning throughout 2.x — has been removed. The stable `local_manifests` key has existed since the feature graduated and is the only supported name in 3.x.

If your router configuration still uses the experimental key, rename it:

```diff
 persisted_queries:
   enabled: true
-  experimental_local_manifests:
+  local_manifests:
     - ./persisted-queries-manifest.json
```

Configurations that still reference `experimental_local_manifests` will fail to load with an "unknown field" error on startup.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
