### PR TITLE
docs(changelog): backfill v2.15.0 entries that lacked changesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,24 +138,6 @@ When the timeout fires, the router returns a `504 Gateway Timeout` response with
 
 By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9243
 
-### Add support for `@connect` directives without an `http` block ([PR #9124](https://github.com/apollographql/router/pull/9124))
-
-The `@connect` directive can now omit the `http` block, producing a "requestless" connector that applies its `selection` mapping without making an outbound HTTP request.  This is useful for shaping data that's already available — on the parent resolver, in `$args`, or as literal values — without standing up an additional subgraph or coprocessor for the transform.
-
-By [@andrewmcgivery](https://github.com/andrewmcgivery) in https://github.com/apollographql/router/pull/9124
-
-### JSONSelection: `->split`, `->trim`/`->trimStart`/`->trimEnd`, and unified `connect/v0.4` literal/subselection syntax ([PR #9199](https://github.com/apollographql/router/pull/9199), [PR #9211](https://github.com/apollographql/router/pull/9211), [PR #9261](https://github.com/apollographql/router/pull/9261))
-
-Several improvements to the Connectors mapping language:
-
-- `->split(separator, [limit])` splits a string into an array of substrings — analogous to JavaScript's `String.prototype.split`.
-- `->trim`, `->trimStart`, `->trimEnd` strip Unicode whitespace from a string.
-- Under `connect/v0.4`, top-level `JSONSelection` unifies the previously separate `SubSelection` (whitespace-separated) and `LitObject` (comma-separated) grammars into a single rule — copy-and-paste any JSON value and it's already a valid `JSONSelection`.  This also eliminates the bare `Eof` parse error that occurred when an inner subselection used a different separator style from its outer container — for example, inside a `->match` branch.
-
-See the [JSONSelection method reference](https://www.apollographql.com/docs/graphos/connectors/mapping/methods) for details on the new arrow methods.
-
-By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/9199, https://github.com/apollographql/router/pull/9211, and https://github.com/apollographql/router/pull/9261
-
 ## 🐛 Fixes
 
 ### Resolve `@connect` field values when a root query alias is combined with field-level aliases ([Issue #9347](https://github.com/apollographql/router/issues/9347))
@@ -284,14 +266,6 @@ When many filesystem events arrived in quick succession, the Rhai script watcher
 The watcher now drops duplicate notifications when the channel is already full, matching the behavior introduced for the configuration file watcher in [PR #8336](https://github.com/apollographql/router/pull/8336). Reloads always re-read the current file from disk, so a single pending notification in the channel is sufficient to guarantee the latest contents will be picked up.
 
 By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9391
-
-### Resolve spurious `CONNECTORS_CANNOT_RESOLVE_KEY` when `@connect(body:)` uses `->filter` with a subselection ([PR #9375](https://github.com/apollographql/router/pull/9375))
-
-Connector key-resolution validation produced a spurious `CONNECTORS_CANNOT_RESOLVE_KEY` error for `@connect` bodies that used an arrow method like `->filter()` followed by a `{ … }` subselection on an entity field with `@requires`.  The selection parsed correctly; only the post-parse validator failed.
-
-The validator now consults each method's `shape()` to determine whether the post-method tail consumes from the input shape or from a transformed shape, fixing the false positive for shape-preserving methods like `->filter` and `->slice` while continuing to correctly bound traversal at shape-transforming boundaries like `->size` and `->jsonStringify`.
-
-By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/9375
 
 ### Resolve entity fields when `cache-control: no-cache` is set with `response_cache` enabled ([PR #9197](https://github.com/apollographql/router/pull/9197))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,19 +342,24 @@ By [@andywgarcia](https://github.com/andywgarcia) in https://github.com/apollogr
 
 ### Surface Redis TLS configuration on every Redis-using feature page ([PR #9172](https://github.com/apollographql/router/pull/9172))
 
-The Redis TLS configuration blurb is now imported as a shared component on every docs page that exposes a Redis configuration section — APQ distributed caching, query plan distributed caching, response cache customization, and the TLS overview — instead of living only on the central TLS overview page.  Duplicate inline TLS content has been replaced by a single source of truth at `docs/shared/redis-tls.mdx`.
+Redis TLS configuration is now documented inline on every feature page that exposes a Redis configuration section — [APQ distributed caching](https://www.apollographql.com/docs/graphos/routing/operations/apq#distributed-caching-with-redis), [query plan distributed caching](https://www.apollographql.com/docs/graphos/routing/query-planning/caching), and [response cache customization](https://www.apollographql.com/docs/graphos/routing/performance/caching/response-caching/customization) — instead of being mentioned only on the central [TLS overview](https://www.apollographql.com/docs/graphos/routing/security/tls#redis-tls-configuration) page.  Operators configuring Redis for any specific feature can now find the TLS guidance directly on the page they're already reading.
 
 By [@bignimbus](https://github.com/bignimbus) in https://github.com/apollographql/router/pull/9172
 
-### Document `http2_max_headers_list_bytes` and fix the shared `limits` partial ([PR #9388](https://github.com/apollographql/router/pull/9388))
+### Document `http2_max_headers_list_bytes` and correct the `limits` config example ([PR #9388](https://github.com/apollographql/router/pull/9388))
 
-The [Request Limits](https://www.apollographql.com/docs/graphos/routing/security/request-limits) page now documents `limits.router.http2_max_headers_list_bytes` (default `16KiB`; the router returns a `431 Request Header Fields Too Large` on overflow).  The shared `limits` YAML partial has also been corrected to use the nested `limits.router.*`, `limits.subgraph.*`, and `limits.connector.*` schema that landed in v2.15.0 — the prior flat layout no longer validates against the live router schema.
+The [Request Limits](https://www.apollographql.com/docs/graphos/routing/security/request-limits) page now documents the `limits.router.http2_max_headers_list_bytes` option, including its default (`16KiB`) and what the router returns on overflow (`431 Request Header Fields Too Large`).  The combined `limits` YAML example on the same page has also been updated to match the nested `limits.router.*` / `limits.subgraph.*` / `limits.connector.*` shape that v2.15.0 introduced — so copy-pasting the example into a router config now produces a configuration the router will accept.
 
 By [@apollo-mateuswgoettems](https://github.com/apollo-mateuswgoettems) in https://github.com/apollographql/router/pull/9388
 
 ### Document `apollo.router.cache.redis.reconnection` and `apollo.router.cache.redis.unresponsive` metrics ([PR #9306](https://github.com/apollographql/router/pull/9306))
 
-The Redis client event counters introduced in [PR #8185](https://github.com/apollographql/router/pull/8185) are now listed on the [standard instruments reference page](https://www.apollographql.com/docs/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments) and the [response cache observability page](https://www.apollographql.com/docs/graphos/routing/performance/caching/response-caching/observability).  `reconnection` fires when a server requires the client to reconnect; `unresponsive` fires when a server stops responding.  Both carry `kind` and `server` attributes.
+Two Redis-health counters that the router already emits are now documented on the [standard instruments reference page](https://www.apollographql.com/docs/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments) and the [response cache observability page](https://www.apollographql.com/docs/graphos/routing/performance/caching/response-caching/observability):
+
+- `apollo.router.cache.redis.reconnection` — increments when a Redis server signals the client to reconnect.
+- `apollo.router.cache.redis.unresponsive` — increments when a Redis server stops responding.
+
+Both carry `kind` (which Redis-backed cache — APQ, query plan, entity cache, response cache) and `server` (the specific Redis endpoint) attributes, making it possible to track Redis health per cache and per endpoint.
 
 By [@apollo-mateuswgoettems](https://github.com/apollo-mateuswgoettems) in https://github.com/apollographql/router/pull/9306
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,24 @@ When the timeout fires, the router returns a `504 Gateway Timeout` response with
 
 By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9243
 
+### Add support for `@connect` directives without an `http` block ([PR #9124](https://github.com/apollographql/router/pull/9124))
+
+The `@connect` directive can now omit the `http` block, producing a "requestless" connector that applies its `selection` mapping without making an outbound HTTP request.  This is useful for shaping data that's already available — on the parent resolver, in `$args`, or as literal values — without standing up an additional subgraph or coprocessor for the transform.
+
+By [@andrewmcgivery](https://github.com/andrewmcgivery) in https://github.com/apollographql/router/pull/9124
+
+### JSONSelection: `->split`, `->trim`/`->trimStart`/`->trimEnd`, and unified `connect/v0.4` literal/subselection syntax ([PR #9199](https://github.com/apollographql/router/pull/9199), [PR #9211](https://github.com/apollographql/router/pull/9211), [PR #9261](https://github.com/apollographql/router/pull/9261))
+
+Several improvements to the Connectors mapping language:
+
+- `->split(separator, [limit])` splits a string into an array of substrings — analogous to JavaScript's `String.prototype.split`.
+- `->trim`, `->trimStart`, `->trimEnd` strip Unicode whitespace from a string.
+- Under `connect/v0.4`, top-level `JSONSelection` unifies the previously separate `SubSelection` (whitespace-separated) and `LitObject` (comma-separated) grammars into a single rule — copy-and-paste any JSON value and it's already a valid `JSONSelection`.  This also eliminates the bare `Eof` parse error that occurred when an inner subselection used a different separator style from its outer container — for example, inside a `->match` branch.
+
+See the [JSONSelection method reference](https://www.apollographql.com/docs/graphos/connectors/mapping/methods) for details on the new arrow methods.
+
+By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/9199, https://github.com/apollographql/router/pull/9211, and https://github.com/apollographql/router/pull/9261
+
 ## 🐛 Fixes
 
 ### Resolve `@connect` field values when a root query alias is combined with field-level aliases ([Issue #9347](https://github.com/apollographql/router/issues/9347))
@@ -267,6 +285,22 @@ The watcher now drops duplicate notifications when the channel is already full, 
 
 By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9391
 
+### Resolve spurious `CONNECTORS_CANNOT_RESOLVE_KEY` when `@connect(body:)` uses `->filter` with a subselection ([PR #9375](https://github.com/apollographql/router/pull/9375))
+
+Connector key-resolution validation produced a spurious `CONNECTORS_CANNOT_RESOLVE_KEY` error for `@connect` bodies that used an arrow method like `->filter()` followed by a `{ … }` subselection on an entity field with `@requires`.  The selection parsed correctly; only the post-parse validator failed.
+
+The validator now consults each method's `shape()` to determine whether the post-method tail consumes from the input shape or from a transformed shape, fixing the false positive for shape-preserving methods like `->filter` and `->slice` while continuing to correctly bound traversal at shape-transforming boundaries like `->size` and `->jsonStringify`.
+
+By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/9375
+
+### Resolve entity fields when `cache-control: no-cache` is set with `response_cache` enabled ([PR #9197](https://github.com/apollographql/router/pull/9197))
+
+When `response_cache` (or `preview_entity_cache`) was enabled and an incoming request carried `cache-control: no-cache`, entity fields resolved via `_entities` queries returned `null`.  Root fields were unaffected.  Regression introduced in v2.13.0.
+
+The cache plugin's `no-cache` path is now treated as all-cache-miss: the cache builds a properly sized result list so `_entities` is assembled correctly, skips the Redis round-trip, and suppresses misleading hit/miss telemetry for requests that intentionally bypass the cache.
+
+By [@OriginLeon](https://github.com/OriginLeon) in https://github.com/apollographql/router/pull/9197
+
 ## 🛠 Maintenance
 
 ### Make `batching.mode` optional and reject unknown subgraph batching fields ([PR #9315](https://github.com/apollographql/router/pull/9315))
@@ -305,6 +339,24 @@ By [@smyrick](https://github.com/smyrick) in https://github.com/apollographql/ro
 The authorization docs now explain what happens when you apply `@authenticated`, `@requiresScopes`, or `@policy` directly to a root operation type (`Query`, `Mutation`, or `Subscription`) in a subgraph. Because root operation types are shared merged types in a federated graph, the directive composes into the supergraph root type and applies to every field on that type, including fields contributed by other subgraphs. To scope authorization reliably, apply the directive to each field rather than to the root type.
 
 By [@andywgarcia](https://github.com/andywgarcia) in https://github.com/apollographql/router/pull/9213
+
+### Surface Redis TLS configuration on every Redis-using feature page ([PR #9172](https://github.com/apollographql/router/pull/9172))
+
+The Redis TLS configuration blurb is now imported as a shared component on every docs page that exposes a Redis configuration section — APQ distributed caching, query plan distributed caching, response cache customization, and the TLS overview — instead of living only on the central TLS overview page.  Duplicate inline TLS content has been replaced by a single source of truth at `docs/shared/redis-tls.mdx`.
+
+By [@bignimbus](https://github.com/bignimbus) in https://github.com/apollographql/router/pull/9172
+
+### Document `http2_max_headers_list_bytes` and fix the shared `limits` partial ([PR #9388](https://github.com/apollographql/router/pull/9388))
+
+The [Request Limits](https://www.apollographql.com/docs/graphos/routing/security/request-limits) page now documents `limits.router.http2_max_headers_list_bytes` (default `16KiB`; the router returns a `431 Request Header Fields Too Large` on overflow).  The shared `limits` YAML partial has also been corrected to use the nested `limits.router.*`, `limits.subgraph.*`, and `limits.connector.*` schema that landed in v2.15.0 — the prior flat layout no longer validates against the live router schema.
+
+By [@apollo-mateuswgoettems](https://github.com/apollo-mateuswgoettems) in https://github.com/apollographql/router/pull/9388
+
+### Document `apollo.router.cache.redis.reconnection` and `apollo.router.cache.redis.unresponsive` metrics ([PR #9306](https://github.com/apollographql/router/pull/9306))
+
+The Redis client event counters introduced in [PR #8185](https://github.com/apollographql/router/pull/8185) are now listed on the [standard instruments reference page](https://www.apollographql.com/docs/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments) and the [response cache observability page](https://www.apollographql.com/docs/graphos/routing/performance/caching/response-caching/observability).  `reconnection` fires when a server requires the client to reconnect; `unresponsive` fires when a server stops responding.  Both carry `kind` and `server` attributes.
+
+By [@apollo-mateuswgoettems](https://github.com/apollo-mateuswgoettems) in https://github.com/apollographql/router/pull/9306
 
 
 


### PR DESCRIPTION
Some PRs that shipped in https://github.com/apollographql/router/releases/tag/v2.15.0 had no changeset files and were therefore missed when the release CHANGELOG was prepped (these are packaged as units with PRs squashed commits both for changelog prep, branch management/backport reasons).

This adds the missing entries to the existing v2.15.0 section in the appropriate subsections (Fixes, Documentation):

- fix: #9197 — Resolve entity fields when `cache-control: no-cache` is set with `response_cache` enabled (v2.13.0 regression)
- docs: #9172 — Surface Redis TLS configuration on every Redis-using docs page (DXM-100)
- docs: #9388 — Document `http2_max_headers_list_bytes` and correct the shared `limits` partial
- docs: #9306 — Document `apollo.router.cache.redis.{reconnection,unresponsive}` metrics

The following Connectors-related items are intentionally **held** until the next composition release ships, at which point they'll be re-added in a follow-up backfill:

- feat: #9124 — Add support for `@connect` directives without an `http` block
- feat: #9199, #9211, #9261 — `JSONSelection` arrow methods (`->split`, `->trim` family) and `connect/v0.4` literal/subselection syntax unification
- fix: #9375 — Resolve spurious `CONNECTORS_CANNOT_RESOLVE_KEY` for `->filter` with a subselection

<!-- start metadata -->