### PR TITLE
fix(composition): Suppress false INCONSISTENT_INTERFACE_VALUE_TYPE_FIELD

### DIFF
--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1640,6 +1640,8 @@ impl Merger {
             if !field_is_defined
                 && !self.are_all_fields_external(*idx, source)?
                 && !subgraph.is_interface_object_type(&source.clone().into())
+                && !matches!(dest, ObjectOrInterfaceTypeDefinitionPosition::Interface(_)
+                    if self.is_field_provided_by_an_interface_object(field.field_name(), dest.type_name()))
             {
                 self.error_reporter.report_mismatch_hint(
                         hint_id.clone(),

--- a/apollo-federation/tests/composition/hints.rs
+++ b/apollo-federation/tests/composition/hints.rs
@@ -521,6 +521,44 @@ mod value_type_fields {
     }
 
     #[test]
+    fn no_hint_for_interface_value_type_field_missing_from_interface_object_subgraph() {
+        let subgraph1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+                type Query {
+                    a: Int
+                }
+
+                interface Product {
+                    id: ID!
+                    name: String
+                    price: Int
+                }
+
+                type Book implements Product @key(fields: "id") {
+                    id: ID!
+                    name: String
+                    price: Int
+                }
+            "#,
+        };
+
+        let subgraph2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+                type Product @interfaceObject @key(fields: "id") {
+                    id: ID!
+                    reviews: [String!]!
+                }
+            "#,
+        };
+
+        let result = compose_as_fed2_subgraphs(&[subgraph1, subgraph2])
+            .expect("Expected composition to succeed");
+        assert_no_hints(&result);
+    }
+
+    #[test]
     fn hints_on_input_object_field_missing_from_some_subgraphs() {
         let subgraph1 = ServiceDefinition {
             name: "Subgraph1",


### PR DESCRIPTION
Skip the inconsistent value type field hint when the field is provided by an `@interfaceObject` in another subgraph, since non-`@interfaceObject` subgraphs are not expected to define those fields.
