### PR TITLE
fix(composition): serialize default values inline in hint messages

### DIFF
--- a/apollo-federation/src/merger/merge_argument.rs
+++ b/apollo-federation/src/merger/merge_argument.rs
@@ -363,10 +363,10 @@ impl Merger {
                 dest_default,
                 sources,
                 &self.subgraphs,
-                |v| Some(format!("default value {v}")),
+                |v| Some(format!("default value {}", v.serialize().no_indent())),
                 |pos, idx| {
                     Some(pos.get_default_value(self.subgraphs[idx].schema())
-                            .map(|v| format!("default value {v}"))
+                            .map(|v| format!("default value {}", v.serialize().no_indent()))
                             .unwrap_or_else(|| "no default value".to_string()))
                 },
             );
@@ -386,7 +386,7 @@ impl Merger {
                 |pos, idx| {
                     Some(
                         pos.get_default_value(self.subgraphs[idx].schema())
-                            .map(|v| v.to_string())
+                            .map(|v| v.serialize().no_indent().to_string())
                             .unwrap_or_else(|| "no default value".to_string()),
                     )
                 },


### PR DESCRIPTION
`Value::Display` uses apollo-compiler's default config which pretty-prints object values with newlines and indentation. Use `.serialize().no_indent()` to match JS composition's inline format (e.g. `{input: ""}` instead of multi-line output) in `INCONSISTENT_DEFAULT_VALUE_PRESENCE` hints and `ArgumentDefaultMismatch`/`InputFieldDefaultMismatch` errors.
