### PR TITLE
fix(composition): set `extension: true` on `@join__type` for orphan extensions

### DIFF
--- a/apollo-federation/src/merger/merge_type.rs
+++ b/apollo-federation/src/merger/merge_type.rs
@@ -176,7 +176,8 @@ impl Merger {
 
                 for key in keys {
                     let extension = key.origin.extension_id().is_some()
-                        || source.has_applied_directive(subgraph.schema(), &extends_directive_name);
+                        || source.has_applied_directive(subgraph.schema(), &extends_directive_name)
+                        || subgraph.is_orphan_extension_type(source.type_name());
                     let key_fields =
                         key.specified_argument_by_name(&FEDERATION_FIELDS_ARGUMENT_NAME);
                     let key_resolvable =


### PR DESCRIPTION
`adopt_orphan_extensions()` converts `extend type X` into `type X` when there is no base definition, losing the `ComponentOrigin::Extension` origin. Check `is_orphan_extension_type()` in addition to `extension_id()` and `@extends` to correctly emit `extension: true`.
