### PR TITLE
docs: document evaluated_paths metric and experimental_{plans,paths}_limit knobs

### DIFF
--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -183,7 +183,7 @@ The `apollo.router.cache.redis.errors` metric also includes an `error_type` attr
 - `apollo.router.query_planning.plan.duration` - Histogram of plan durations isolated to query planning time only.
 - `apollo.router.query_planning.total.duration` - Histogram of plan durations including queue time.
 - `apollo.router.query_planning.plan.evaluated_plans` - Histogram of the number of evaluated query plans.
-- `apollo.router.query_planning.plan.evaluated_paths` - Histogram of the number of paths (including intermediate ones) the planner considers before generating a plan. High values often correlate with long planning times on complex schemas or queries. See [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits).
+- `apollo.router.query_planning.plan.evaluated_paths` - Histogram of the number of paths (including intermediate ones) the planner considers before generating a plan. High values often correlate with long planning times on complex schemas or queries. [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits) explains how to bound them.
 - `apollo.router.query_planner.memory` - Histogram of memory allocated during query planning, in bytes. Tracks memory allocation patterns specifically for query planning operations executed in the compute job thread pool. Attributes:
   - `allocation.type`: The type of memory operation (`allocated`, `deallocated`, `zeroed`, `reallocated`)
   - `context`: The context name where the allocation occurred (e.g., `query_planning`)

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -183,6 +183,7 @@ The `apollo.router.cache.redis.errors` metric also includes an `error_type` attr
 - `apollo.router.query_planning.plan.duration` - Histogram of plan durations isolated to query planning time only.
 - `apollo.router.query_planning.total.duration` - Histogram of plan durations including queue time.
 - `apollo.router.query_planning.plan.evaluated_plans` - Histogram of the number of evaluated query plans.
+- `apollo.router.query_planning.plan.evaluated_paths` - Histogram of the number of paths (including intermediate ones) considered to plan a query before generating a plan. High values often correlate with long planning times on complex schemas or queries; see [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits).
 - `apollo.router.query_planner.memory` - Histogram of memory allocated during query planning, in bytes. Tracks memory allocation patterns specifically for query planning operations executed in the compute job thread pool. Attributes:
   - `allocation.type`: The type of memory operation (`allocated`, `deallocated`, `zeroed`, `reallocated`)
   - `context`: The context name where the allocation occurred (e.g., `query_planning`)

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -183,7 +183,7 @@ The `apollo.router.cache.redis.errors` metric also includes an `error_type` attr
 - `apollo.router.query_planning.plan.duration` - Histogram of plan durations isolated to query planning time only.
 - `apollo.router.query_planning.total.duration` - Histogram of plan durations including queue time.
 - `apollo.router.query_planning.plan.evaluated_plans` - Histogram of the number of evaluated query plans.
-- `apollo.router.query_planning.plan.evaluated_paths` - Histogram of the number of paths (including intermediate ones) considered to plan a query before generating a plan. High values often correlate with long planning times on complex schemas or queries; see [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits).
+- `apollo.router.query_planning.plan.evaluated_paths` - Histogram of the number of paths (including intermediate ones) the planner considers before generating a plan. High values often correlate with long planning times on complex schemas or queries. See [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits).
 - `apollo.router.query_planner.memory` - Histogram of memory allocated during query planning, in bytes. Tracks memory allocation patterns specifically for query planning operations executed in the compute job thread pool. Attributes:
   - `allocation.type`: The type of memory operation (`allocated`, `deallocated`, `zeroed`, `reallocated`)
   - `context`: The context name where the allocation occurred (e.g., `query_planning`)

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -183,7 +183,7 @@ The `apollo.router.cache.redis.errors` metric also includes an `error_type` attr
 - `apollo.router.query_planning.plan.duration` - Histogram of plan durations isolated to query planning time only.
 - `apollo.router.query_planning.total.duration` - Histogram of plan durations including queue time.
 - `apollo.router.query_planning.plan.evaluated_plans` - Histogram of the number of evaluated query plans.
-- `apollo.router.query_planning.plan.evaluated_paths` - Histogram of the number of paths (including intermediate ones) the planner considers before generating a plan. High values often correlate with long planning times on complex schemas or queries. [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits) explains how to bound them.
+- `apollo.router.query_planning.plan.evaluated_paths` - Histogram of the number of paths (including intermediate ones) the planner considers before generating a plan. High values often correlate with long planning times on complex schemas or queries. Tune the limits as described in [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits).
 - `apollo.router.query_planner.memory` - Histogram of memory allocated during query planning, in bytes. Tracks memory allocation patterns specifically for query planning operations executed in the compute job thread pool. Attributes:
   - `allocation.type`: The type of memory operation (`allocated`, `deallocated`, `zeroed`, `reallocated`)
   - `context`: The context name where the allocation occurred (e.g., `query_planning`)

--- a/docs/source/routing/query-planning/caching.mdx
+++ b/docs/source/routing/query-planning/caching.mdx
@@ -32,7 +32,7 @@ supergraph:
 
 <Note>
 
-The `supergraph.query_planning` namespace also exposes configuration options that limit the planner's work itself, separate from caching: `experimental_plans_limit` and `experimental_paths_limit`. [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits) explains when and how to adjust them.
+The `supergraph.query_planning` namespace also exposes configuration options that limit the planner's work itself, separate from caching: `experimental_plans_limit` and `experimental_paths_limit`. Adjust them as described in [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits).
 
 </Note>
 

--- a/docs/source/routing/query-planning/caching.mdx
+++ b/docs/source/routing/query-planning/caching.mdx
@@ -32,7 +32,7 @@ supergraph:
 
 <Note>
 
-The `supergraph.query_planning` namespace also exposes knobs that bound the planner's work itself (separate from caching), such as `experimental_plans_limit` and `experimental_paths_limit`. See [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits) in the best-practices guide.
+The `supergraph.query_planning` namespace also exposes configuration options that limit the planner's work itself, separate from caching: `experimental_plans_limit` and `experimental_paths_limit`. See [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits) in the best-practices guide.
 
 </Note>
 

--- a/docs/source/routing/query-planning/caching.mdx
+++ b/docs/source/routing/query-planning/caching.mdx
@@ -32,7 +32,7 @@ supergraph:
 
 <Note>
 
-The `supergraph.query_planning` namespace also exposes configuration options that limit the planner's work itself, separate from caching: `experimental_plans_limit` and `experimental_paths_limit`. See [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits) in the best-practices guide.
+The `supergraph.query_planning` namespace also exposes configuration options that limit the planner's work itself, separate from caching: `experimental_plans_limit` and `experimental_paths_limit`. [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits) explains when and how to adjust them.
 
 </Note>
 

--- a/docs/source/routing/query-planning/caching.mdx
+++ b/docs/source/routing/query-planning/caching.mdx
@@ -30,6 +30,12 @@ supergraph:
         limit: 512 # This is the default value.
 ```
 
+<Note>
+
+The `supergraph.query_planning` namespace also exposes knobs that bound the planner's work itself (separate from caching), such as `experimental_plans_limit` and `experimental_paths_limit`. See [Tuning query planner limits](/graphos/routing/query-planning/query-planning-best-practices#tuning-query-planner-limits) in the best-practices guide.
+
+</Note>
+
 ### Cache warm-up
 
 When loading a new schema, a query plan might change for some queries, so cached query plans cannot be reused.

--- a/docs/source/routing/query-planning/query-planning-best-practices.mdx
+++ b/docs/source/routing/query-planning/query-planning-best-practices.mdx
@@ -293,33 +293,33 @@ supergraph:
     experimental_paths_limit: null  # default — no limit
 ```
 
-These options behave very differently under stress, and choosing one over the other has real production consequences. Combine them with the [`apollo.router.query_planning.plan.evaluated_plans` and `apollo.router.query_planning.plan.evaluated_paths`](/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments#query-planning) histograms to decide which to tune.
+These options behave differently under stress, and your choice between them affects production behavior. Use the [`apollo.router.query_planning.plan.evaluated_plans` and `apollo.router.query_planning.plan.evaluated_paths`](/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments#query-planning) histograms to choose between them.
 
 ### `experimental_plans_limit`
 
-Limits the number of query plans the planner generates while exploring the graph.
+Limits the number of query plans the planner generates while exploring your graph.
 
-- **Default:** `10000`.
-- **When exceeded:** the planner silently prunes branches and continues. It still returns a valid plan, but it might not be the optimal one.
+- **Default:** 10,000
+- **When exceeded:** The planner silently prunes branches and continues. It still returns a valid plan, but it might not be the optimal one.
 - **Use case:** Reduce this value to bound planning time and memory at the cost of plan optimality.
 
 ### `experimental_paths_limit`
 
 Limits the number of subgraph options the planner considers for any single field path during planning. Field paths can produce many options because fields might be provided by multiple subgraphs, and abstract types (unions and interfaces) require the planner to traverse each constituent object type. On complex schemas or queries, the per-path option count can grow large and dominate planning time.
 
-- **Default:** `None` — no limit.
-- **When exceeded:** planning aborts and the operation fails with `QueryPlanComplexityExceeded`.
-- **Use case:** Set this value to abort planning quickly on pathological queries rather than allowing them to dominate the planner.
+- **Default:** `None` — no limit
+- **When exceeded:** Planning aborts and the operation fails with `QueryPlanComplexityExceeded`.
+- **Use case:** Set this value to abort planning quickly on complex queries instead of allowing them to dominate the planner.
 
-### Choosing a configuration option based on symptoms
+### Choose a configuration option based on symptoms
 
 | Symptom | What to look at | Configuration option |
 | --- | --- | --- |
 | Planner takes too long but produces a plan | High `evaluated_paths`, high `evaluated_plans` | Reduce `experimental_plans_limit` to bound exploration |
-| Planner OOMs or memory spikes during planning | `evaluated_plans` near the limit, high `apollo.router.query_planner.memory` peaks | Reduce `experimental_plans_limit` (e.g., `1000`) |
+| Planner OOMs or memory spikes during planning | `evaluated_plans` near the limit, high `apollo.router.query_planner.memory` peaks | Reduce `experimental_plans_limit` (e.g., 1,000) |
 | Specific queries fail with `QueryPlanComplexityExceeded` | `evaluated_paths` hitting `experimental_paths_limit` | Review the offending query, or raise `experimental_paths_limit` if intentional |
 
-To track the limits each router instance applies, the router emits `apollo.router.config.experimental_plans_limit` and `apollo.router.config.experimental_paths_limit` gauges (added in v2.14.1).
+To track the limits each router instance applies, your router emits `apollo.router.config.experimental_plans_limit` and `apollo.router.config.experimental_paths_limit` gauges (added in v2.14.1).
 
 ## Use recommended features
 

--- a/docs/source/routing/query-planning/query-planning-best-practices.mdx
+++ b/docs/source/routing/query-planning/query-planning-best-practices.mdx
@@ -316,7 +316,7 @@ Limits the number of subgraph options the planner considers for any single field
 | Symptom | What to look at | Configuration option |
 | --- | --- | --- |
 | Planner takes too long but produces a plan | High `evaluated_paths`, high `evaluated_plans` | Reduce `experimental_plans_limit` to bound exploration |
-| Planner OOMs or memory spikes during planning | `evaluated_plans` near the limit, high `apollo.router.query_planner.memory` peaks | Reduce `experimental_plans_limit` (e.g., `1000`) |
+| Planner runs out of memory or memory usage spikes during planning | `evaluated_plans` near the limit, high `apollo.router.query_planner.memory` peaks | Reduce `experimental_plans_limit` (e.g., `1000`) |
 | Specific queries fail with `QueryPlanComplexityExceeded` | `evaluated_paths` hitting `experimental_paths_limit` | Review the offending query, or raise `experimental_paths_limit` if intentional |
 
 To track the limits each router instance applies, the router emits `apollo.router.config.experimental_plans_limit` and `apollo.router.config.experimental_paths_limit` gauges (added in v2.14.1).

--- a/docs/source/routing/query-planning/query-planning-best-practices.mdx
+++ b/docs/source/routing/query-planning/query-planning-best-practices.mdx
@@ -282,6 +282,45 @@ The router handles <code>@Skip</code> and <code>@include</code> directives throu
 
 During response processing, the router's [<code>Query::format_response</code>](https://github.com/apollographql/router/blob/115d7a1a170c415a5a3dfa03fa9261406c7e7868/apollo-router/src/spec/query.rs#L124) logic validates that subgraphs properly handled the conditional directives. If a subgraph fails to correctly apply <code>@Skip</code> or <code>@include</code> logic, the router automatically prunes unrequested fields and reorders the response to match the expected shape. This dual-layer approach ensures reliable execution even when subgraphs have inconsistent directive handling.
 
+## Tuning query planner limits
+
+Two experimental config knobs bound the work the query planner does before emitting a plan: `experimental_plans_limit` and `experimental_paths_limit`. Both live under `supergraph.query_planning` in your router YAML, alongside the cache configuration.
+
+```yaml title="router.yaml"
+supergraph:
+  query_planning:
+    experimental_plans_limit: 10000 # default
+    experimental_paths_limit: null  # default — no limit
+```
+
+These knobs behave very differently under stress, and choosing one over the other has real production consequences. Use them in combination with the [`apollo.router.query_planning.plan.evaluated_plans` and `apollo.router.query_planning.plan.evaluated_paths`](/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments#query-planning) histograms to decide which to tune.
+
+### `experimental_plans_limit`
+
+Caps the number of query plans the planner generates while exploring the graph.
+
+- **Default:** `10000`.
+- **When exceeded:** the planner silently prunes branches and continues. It still returns a valid plan, but it may not be the optimal one.
+- **Use case:** tune this _down_ to bound planning time and memory at the cost of plan optimality.
+
+### `experimental_paths_limit`
+
+Caps the number of subgraph options considered for any single field path during planning. Field paths can produce many options because fields may be provided by multiple subgraphs, and abstract types (unions and interfaces) require the planner to traverse each constituent object type. On complex schemas or queries, the per-path option count can grow large and dominate planning time.
+
+- **Default:** `None` — no limit.
+- **When exceeded:** planning aborts and the operation fails with `QueryPlanComplexityExceeded`.
+- **Use case:** set this to fail fast on pathological queries rather than letting them dominate the planner.
+
+### Choosing a knob based on symptoms
+
+| Symptom | What to look at | Knob to consider |
+| --- | --- | --- |
+| Planner takes too long but produces a plan | High `evaluated_paths`, high `evaluated_plans` | Tune `experimental_plans_limit` _down_ to bound exploration |
+| Planner OOMs or memory spikes during planning | `evaluated_plans` near the limit, high `apollo.router.query_planner.memory` peaks | Lower `experimental_plans_limit` (e.g. `1000`) |
+| Specific queries fail with `QueryPlanComplexityExceeded` | `evaluated_paths` hitting `experimental_paths_limit` | Review the offending query, or raise `experimental_paths_limit` if intentional |
+
+To track which limits each router instance is running with, the router emits `apollo.router.config.experimental_plans_limit` and `apollo.router.config.experimental_paths_limit` gauges (added in v2.14.1).
+
 ## Use recommended features
 
 GraphOS and router provide many features that help monitor and improve query planning performance, both at build time and runtime. 

--- a/docs/source/routing/query-planning/query-planning-best-practices.mdx
+++ b/docs/source/routing/query-planning/query-planning-best-practices.mdx
@@ -284,7 +284,7 @@ During response processing, the router's [<code>Query::format_response</code>](h
 
 ## Tuning query planner limits
 
-Two experimental config knobs bound the work the query planner does before emitting a plan: `experimental_plans_limit` and `experimental_paths_limit`. Both live under `supergraph.query_planning` in your router YAML, alongside the cache configuration.
+Two experimental configuration options limit the work the query planner does before emitting a plan: `experimental_plans_limit` and `experimental_paths_limit`. Both live under `supergraph.query_planning` in your router YAML, alongside the cache configuration.
 
 ```yaml title="router.yaml"
 supergraph:
@@ -293,33 +293,33 @@ supergraph:
     experimental_paths_limit: null  # default — no limit
 ```
 
-These knobs behave very differently under stress, and choosing one over the other has real production consequences. Use them in combination with the [`apollo.router.query_planning.plan.evaluated_plans` and `apollo.router.query_planning.plan.evaluated_paths`](/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments#query-planning) histograms to decide which to tune.
+These options behave very differently under stress, and choosing one over the other has real production consequences. Combine them with the [`apollo.router.query_planning.plan.evaluated_plans` and `apollo.router.query_planning.plan.evaluated_paths`](/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments#query-planning) histograms to decide which to tune.
 
 ### `experimental_plans_limit`
 
-Caps the number of query plans the planner generates while exploring the graph.
+Limits the number of query plans the planner generates while exploring the graph.
 
 - **Default:** `10000`.
-- **When exceeded:** the planner silently prunes branches and continues. It still returns a valid plan, but it may not be the optimal one.
-- **Use case:** tune this _down_ to bound planning time and memory at the cost of plan optimality.
+- **When exceeded:** the planner silently prunes branches and continues. It still returns a valid plan, but it might not be the optimal one.
+- **Use case:** Reduce this value to bound planning time and memory at the cost of plan optimality.
 
 ### `experimental_paths_limit`
 
-Caps the number of subgraph options considered for any single field path during planning. Field paths can produce many options because fields may be provided by multiple subgraphs, and abstract types (unions and interfaces) require the planner to traverse each constituent object type. On complex schemas or queries, the per-path option count can grow large and dominate planning time.
+Limits the number of subgraph options the planner considers for any single field path during planning. Field paths can produce many options because fields might be provided by multiple subgraphs, and abstract types (unions and interfaces) require the planner to traverse each constituent object type. On complex schemas or queries, the per-path option count can grow large and dominate planning time.
 
 - **Default:** `None` — no limit.
 - **When exceeded:** planning aborts and the operation fails with `QueryPlanComplexityExceeded`.
-- **Use case:** set this to fail fast on pathological queries rather than letting them dominate the planner.
+- **Use case:** Set this value to abort planning quickly on pathological queries rather than allowing them to dominate the planner.
 
-### Choosing a knob based on symptoms
+### Choosing a configuration option based on symptoms
 
-| Symptom | What to look at | Knob to consider |
+| Symptom | What to look at | Configuration option |
 | --- | --- | --- |
-| Planner takes too long but produces a plan | High `evaluated_paths`, high `evaluated_plans` | Tune `experimental_plans_limit` _down_ to bound exploration |
-| Planner OOMs or memory spikes during planning | `evaluated_plans` near the limit, high `apollo.router.query_planner.memory` peaks | Lower `experimental_plans_limit` (e.g. `1000`) |
+| Planner takes too long but produces a plan | High `evaluated_paths`, high `evaluated_plans` | Reduce `experimental_plans_limit` to bound exploration |
+| Planner OOMs or memory spikes during planning | `evaluated_plans` near the limit, high `apollo.router.query_planner.memory` peaks | Reduce `experimental_plans_limit` (e.g., `1000`) |
 | Specific queries fail with `QueryPlanComplexityExceeded` | `evaluated_paths` hitting `experimental_paths_limit` | Review the offending query, or raise `experimental_paths_limit` if intentional |
 
-To track which limits each router instance is running with, the router emits `apollo.router.config.experimental_plans_limit` and `apollo.router.config.experimental_paths_limit` gauges (added in v2.14.1).
+To track the limits each router instance applies, the router emits `apollo.router.config.experimental_plans_limit` and `apollo.router.config.experimental_paths_limit` gauges (added in v2.14.1).
 
 ## Use recommended features
 

--- a/docs/source/routing/query-planning/query-planning-best-practices.mdx
+++ b/docs/source/routing/query-planning/query-planning-best-practices.mdx
@@ -284,7 +284,7 @@ During response processing, the router's [<code>Query::format_response</code>](h
 
 ## Tuning query planner limits
 
-Two experimental configuration options limit the work the query planner does before emitting a plan: `experimental_plans_limit` and `experimental_paths_limit`. Both live under `supergraph.query_planning` in your router YAML, alongside the cache configuration.
+Two experimental configuration options limit the work the query planner does before emitting a plan: `experimental_plans_limit` and `experimental_paths_limit`. Both live under `supergraph.query_planning` in the YAML config, alongside the cache configuration.
 
 ```yaml title="router.yaml"
 supergraph:
@@ -293,33 +293,33 @@ supergraph:
     experimental_paths_limit: null  # default — no limit
 ```
 
-These options behave differently under stress, and your choice between them affects production behavior. Use the [`apollo.router.query_planning.plan.evaluated_plans` and `apollo.router.query_planning.plan.evaluated_paths`](/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments#query-planning) histograms to choose between them.
+These options behave differently under stress, and the choice between them affects production behavior. Use the [`apollo.router.query_planning.plan.evaluated_plans` and `apollo.router.query_planning.plan.evaluated_paths`](/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments#query-planning) histograms to choose between them.
 
 ### `experimental_plans_limit`
 
-Limits the number of query plans the planner generates while exploring your graph.
+Limits the number of query plans the planner generates while exploring the supergraph.
 
-- **Default:** 10,000
-- **When exceeded:** The planner silently prunes branches and continues. It still returns a valid plan, but it might not be the optimal one.
-- **Use case:** Reduce this value to bound planning time and memory at the cost of plan optimality.
+- Default: `10000`
+- When exceeded: Silently prunes branches and returns a valid but possibly suboptimal plan
+- Use case: Bound planning time and memory by reducing this value
 
 ### `experimental_paths_limit`
 
 Limits the number of subgraph options the planner considers for any single field path during planning. Field paths can produce many options because fields might be provided by multiple subgraphs, and abstract types (unions and interfaces) require the planner to traverse each constituent object type. On complex schemas or queries, the per-path option count can grow large and dominate planning time.
 
-- **Default:** `None` — no limit
-- **When exceeded:** Planning aborts and the operation fails with `QueryPlanComplexityExceeded`.
-- **Use case:** Set this value to abort planning quickly on complex queries instead of allowing them to dominate the planner.
+- Default: `None` — no limit
+- When exceeded: Aborts planning and fails the operation with `QueryPlanComplexityExceeded`
+- Use case: Abort planning quickly on complex queries instead of allowing them to dominate the planner
 
-### Choose a configuration option based on symptoms
+### Choosing a configuration option based on symptoms
 
 | Symptom | What to look at | Configuration option |
 | --- | --- | --- |
 | Planner takes too long but produces a plan | High `evaluated_paths`, high `evaluated_plans` | Reduce `experimental_plans_limit` to bound exploration |
-| Planner OOMs or memory spikes during planning | `evaluated_plans` near the limit, high `apollo.router.query_planner.memory` peaks | Reduce `experimental_plans_limit` (e.g., 1,000) |
+| Planner OOMs or memory spikes during planning | `evaluated_plans` near the limit, high `apollo.router.query_planner.memory` peaks | Reduce `experimental_plans_limit` (e.g., `1000`) |
 | Specific queries fail with `QueryPlanComplexityExceeded` | `evaluated_paths` hitting `experimental_paths_limit` | Review the offending query, or raise `experimental_paths_limit` if intentional |
 
-To track the limits each router instance applies, your router emits `apollo.router.config.experimental_plans_limit` and `apollo.router.config.experimental_paths_limit` gauges (added in v2.14.1).
+To track the limits each router instance applies, the router emits `apollo.router.config.experimental_plans_limit` and `apollo.router.config.experimental_paths_limit` gauges (added in v2.14.1).
 
 ## Use recommended features
 


### PR DESCRIPTION
## Summary

Adds docs coverage for three closely-related query-planner observability and configuration features that operators previously had to read source code to find:

- `apollo.router.query_planning.plan.evaluated_paths` added to the [Standard Instruments](docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx) reference (next to its sibling `evaluated_plans`).
- New **Tuning query planner limits** section in [`query-planning-best-practices.mdx`](docs/source/routing/query-planning/query-planning-best-practices.mdx) documenting `experimental_plans_limit` (default `10000`, silently prunes branches when exceeded) and `experimental_paths_limit` (default `None`, aborts with `QueryPlanComplexityExceeded` when exceeded), plus a symptom → metric → knob table.
- Cross-link from [`caching.mdx`](docs/source/routing/query-planning/caching.mdx) since both knobs share the `supergraph.query_planning` YAML namespace as the cache config.

## Tickets

- Jira: [ROUTER-1832](https://apollographql.atlassian.net/browse/ROUTER-1832)
- Surfaced via: [RH-1362](https://apollographql.atlassian.net/browse/RH-1362) (linked as "resolves" on the Jira side)

## Test plan

- [ ] Local docs preview renders the new section in `query-planning-best-practices.mdx` and the new bullet in `standard-instruments.mdx`
- [ ] Anchor link `#tuning-query-planner-limits` resolves from both `standard-instruments.mdx` and `caching.mdx`

## Notes

- I deliberately did **not** add inline descriptions to `docs/shared/router-yaml-complete.mdx`, `docs/shared/router-config-properties-table.mdx`, or `docs/shared/config/supergraph.mdx`. Those files are pure YAML reference dumps and no other key in them carries inline prose. Happy to revisit if reviewers prefer YAML comments next to the two keys.
- The "added in v2.14.1" version reference in the new section for the `apollo.router.config.experimental_{plans,paths}_limit` adoption gauges comes from RH-1362's triage comment; I verified the gauges exist (`apollo-router/src/configuration/metrics.rs:492,497`) but didn't independently verify the version. Easy to drop the version reference if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ROUTER-1832]: https://apollographql.atlassian.net/browse/ROUTER-1832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ