### PR TITLE
fix(federation): preserve port in `@link` URL identity parsing

### DIFF
--- a/apollo-federation/src/link/spec.rs
+++ b/apollo-federation/src/link/spec.rs
@@ -413,5 +413,45 @@ mod tests {
                 version: Version { major: 0, minor: 1 }
             }
         );
+
+        // Non-default port is preserved in the identity domain.
+        assert_eq!(
+            "http://localhost:8080/foo/v1.0".parse::<Url>().unwrap(),
+            Url {
+                identity: Identity {
+                    domain: "http://localhost:8080".to_string(),
+                    name: name!("foo")
+                },
+                version: Version { major: 1, minor: 0 }
+            }
+        );
+
+        // Non-default port is preserved alongside a path remainder.
+        assert_eq!(
+            "http://localhost:8080/extra/foo/v1.0"
+                .parse::<Url>()
+                .unwrap(),
+            Url {
+                identity: Identity {
+                    domain: "http://localhost:8080/extra".to_string(),
+                    name: name!("foo")
+                },
+                version: Version { major: 1, minor: 0 }
+            }
+        );
+
+        // Default https port is omitted, so existing identities are unaffected.
+        assert_eq!(
+            "https://specs.apollo.dev:443/federation/v2.3"
+                .parse::<Url>()
+                .unwrap(),
+            Url {
+                identity: Identity {
+                    domain: "https://specs.apollo.dev".to_string(),
+                    name: name!("federation")
+                },
+                version: Version { major: 2, minor: 3 }
+            }
+        );
     }
 }

--- a/apollo-federation/src/link/spec.rs
+++ b/apollo-federation/src/link/spec.rs
@@ -283,18 +283,21 @@ impl str::FromStr for Url {
                     // namespaced name because it's not valid GraphQL to do so--but you can
                     // explicitly import elements from a spec with an invalid name.
                     .map(Name::new_unchecked)?;
-                let scheme = url.scheme();
-                if !scheme.starts_with("http") {
+                if !url.scheme().starts_with("http") {
                     return Err(SpecError::ParseError("invalid `@link` specification url: only http(s) urls are supported currently".to_string()));
                 }
-                let url_domain = url.domain().ok_or(SpecError::ParseError(
-                    "invalid `@link` specification url".to_string(),
-                ))?;
+                let origin = url.origin();
+                if !origin.is_tuple() {
+                    return Err(SpecError::ParseError(
+                        "invalid `@link` specification url: missing host".to_string(),
+                    ));
+                }
+                let origin = origin.ascii_serialization();
                 let path_remainder = segments.collect::<Vec<&str>>();
                 let domain = if path_remainder.is_empty() {
-                    format!("{scheme}://{url_domain}")
+                    origin
                 } else {
-                    format!("{}://{}/{}", scheme, url_domain, path_remainder.join("/"))
+                    format!("{origin}/{}", path_remainder.join("/"))
                 };
                 Ok(Url {
                     identity: Identity { domain, name },


### PR DESCRIPTION
`url.domain()` strips the port, so `http://localhost:8080/foo/v1.0` produced identity `http://localhost` instead of `http://localhost:8080`. Use `url.origin().ascii_serialization()` which preserves the full scheme, host, and port.
