### PR TITLE
fix(composition): honor `@link` spec imports during bootstrap

### DIFF
--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -55,16 +55,33 @@ impl FederationBlueprint {
         schema: &mut FederationSchema,
         directive: &Component<Directive>,
     ) -> Result<Option<DirectiveDefinitionPosition>, FederationError> {
-        if directive.name == DEFAULT_LINK_NAME {
-            let (alias, imports) =
-                LinkSpecDefinition::extract_alias_and_imports_on_missing_link_directive_definition(
-                    directive,
-                )?;
-            LinkSpecDefinition::latest().add_definitions_to_schema(schema, alias, imports)?;
-            Ok(schema.get_directive_definition(&directive.name))
-        } else {
-            Ok(None)
+        if directive.name != DEFAULT_LINK_NAME {
+            return Ok(None);
         }
+
+        // Scan all @link directives on the schema definition to find one targeting the link
+        // spec and extract its alias/imports. This ensures that when a subgraph has e.g.
+        // `@link(url: "link/v1.0", import: ["Purpose"])`, the imported name is used instead
+        // of the namespaced `link__Purpose`.
+        let (alias, imports) = schema
+            .schema()
+            .schema_definition
+            .directives
+            .iter()
+            .filter(|d| d.name == directive.name)
+            .find_map(|d| {
+                let (alias, imports) =
+                    LinkSpecDefinition::extract_alias_and_imports_on_missing_link_directive_definition(d).ok()?;
+                if alias.is_some() || !imports.is_empty() {
+                    Some((alias, imports))
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default();
+
+        LinkSpecDefinition::latest().add_definitions_to_schema(schema, alias, imports)?;
+        Ok(schema.get_directive_definition(&directive.name))
     }
 
     pub(crate) fn on_directive_definition_and_schema_parsed(

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -628,6 +628,56 @@ fn satisfiability_validation_handles_indirectly_reachable_keys() {
 }
 
 #[test]
+fn link_spec_purpose_import_uses_imported_name() {
+    use apollo_federation::subgraph::typestate::Subgraph;
+    use insta::assert_snapshot;
+
+    let a = Subgraph::parse(
+        "subgraphA",
+        "http://a",
+        r#"
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
+          @link(url: "https://specs.apollo.dev/link/v1.0", import: ["@link", "Purpose"])
+        type Query { a: A }
+        type A @key(fields: "id") @shareable { id: ID!, name: String }
+    "#,
+    )
+    .unwrap();
+
+    let validated = a.expand_links().unwrap().assume_validated();
+    assert_snapshot!(validated.schema_string());
+}
+
+#[test]
+fn duplicate_link_spec_application_is_rejected() {
+    use apollo_federation::subgraph::typestate::Subgraph;
+
+    let subgraph = Subgraph::parse(
+        "subgraphA",
+        "http://a",
+        r#"
+            extend schema
+              @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+              @link(url: "https://specs.apollo.dev/link/v1.0", import: ["@link", "Purpose"])
+              @link(url: "https://specs.apollo.dev/link/v1.0", import: ["@link", "Import"])
+            type Query { a: String }
+        "#,
+    )
+    .unwrap();
+    let err = subgraph
+        .expand_links()
+        .expect_err("Duplicate @link to the same spec should be rejected");
+    assert_eq!(
+        err.format_errors(),
+        vec![(
+            "INVALID_LINK_DIRECTIVE_USAGE".to_string(),
+            r#"[subgraphA] Invalid use of @link in schema: the @link specification itself ("https://specs.apollo.dev/link/v1.0") is applied multiple times"#.to_string(),
+        )],
+    );
+}
+
+#[test]
 fn interface_field_no_implem_error_includes_source_locations() {
     let subgraph_a = ServiceDefinition {
         name: "subgraphA",

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_validation__link_spec_purpose_import_uses_imported_name.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_validation__link_spec_purpose_import_uses_imported_name.snap
@@ -1,0 +1,64 @@
+---
+source: apollo-federation/tests/composition/compose_validation.rs
+assertion_line: 649
+expression: validated.schema_string()
+---
+schema {
+  query: Query
+}
+
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"]) @link(url: "https://specs.apollo.dev/link/v1.0", import: ["@link", "Purpose"])
+
+directive @link(url: String, as: String, for: Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @shareable on OBJECT | FIELD_DEFINITION
+
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @federation__override(from: String!) on FIELD_DEFINITION
+
+type Query {
+  a: A
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+}
+
+type A @key(fields: "id") @shareable {
+  id: ID!
+  name: String
+}
+
+enum Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar federation__FieldSet
+
+scalar _Any
+
+type _Service {
+  sdl: String
+}
+
+union _Entity = A


### PR DESCRIPTION
The link spec bootstrap creates types like `Purpose` and `Import` before processing all `@link` directives, so it used namespaced names (e.g. `link__Purpose`) even when the subgraph explicitly imports `Purpose`.

Scan all `@link` directives on the schema definition upfront to find one targeting the link spec and use its imports when creating types.
