### PR TITLE
fix(composition): fix order-dependent executable directive location intersection

### DIFF
--- a/apollo-federation/src/merger/merge_directive.rs
+++ b/apollo-federation/src/merger/merge_directive.rs
@@ -502,7 +502,7 @@ impl Merger {
     ) -> Result<(), FederationError> {
         let mut repeatable: Option<bool> = None;
         let mut inconsistent_repeatable = false;
-        let mut locations: Vec<DirectiveLocation> = Vec::new();
+        let mut locations: Option<Vec<DirectiveLocation>> = None;
         let mut inconsistent_locations = false;
 
         for (idx, source) in sources {
@@ -543,19 +543,17 @@ impl Merger {
                 "Source locations for executable directive \"@{name}\" in subgraph {}: {:?}",
                 self.subgraphs[*idx].name, source_locations
             );
-            if locations.is_empty() {
-                locations = source_locations;
-            } else {
-                if locations != source_locations {
+            if let Some(ref mut current) = locations {
+                if *current != source_locations {
                     inconsistent_locations = true;
                 }
-                locations.retain(|loc| source_locations.contains(loc));
+                current.retain(|loc| source_locations.contains(loc));
 
                 trace!(
                     "After processing subgraph {}, executable directive \"@{name}\" has locations: {:?}",
-                    self.subgraphs[*idx].name, locations
+                    self.subgraphs[*idx].name, current
                 );
-                if locations.is_empty() {
+                if current.is_empty() {
                     dest.remove(&mut self.merged)?;
                     self.error_reporter.report_mismatch_hint(
                         HintCode::NoExecutableDirectiveLocationsIntersection,
@@ -573,10 +571,12 @@ impl Merger {
                     );
                     return Ok(());
                 }
+            } else {
+                locations = Some(source_locations);
             }
         }
-        dest.set_repeatable(&mut self.merged, repeatable.unwrap_or_default())?; // repeatable will always be Some() here
-        dest.set_locations(&mut self.merged, locations)?;
+        dest.set_repeatable(&mut self.merged, repeatable.unwrap_or_default())?;
+        dest.set_locations(&mut self.merged, locations.unwrap_or_default())?;
 
         self.merge_description(sources, dest)?;
         let supergraph_dest = dest.get(self.merged.schema())?;

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -678,6 +678,58 @@ fn duplicate_link_spec_application_is_rejected() {
 }
 
 #[test]
+fn executable_directive_removed_when_no_executable_locations_intersection() {
+    // Subgraph names are sorted alphabetically during composition. The subgraph WITHOUT
+    // executable locations must sort first to trigger the bug where an empty initial
+    // locations vec was treated as "not yet initialized" instead of "empty intersection".
+    // A third subgraph that doesn't define the directive at all verifies that the hint
+    // is NO_EXECUTABLE_DIRECTIVE_LOCATIONS_INTERSECTION (empty intersection detected first),
+    // not INCONSISTENT_EXECUTABLE_DIRECTIVE_PRESENCE (missing from some subgraphs).
+    let subgraph_a = ServiceDefinition {
+        name: "a-no-exec-locations",
+        type_defs: r#"
+            directive @cacheControl(maxAge: Int) on FIELD_DEFINITION | OBJECT
+            type Query { a: String }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "b-with-exec-locations",
+        type_defs: r#"
+            directive @cacheControl(maxAge: Int!) on QUERY
+            type Query { b: String @shareable }
+        "#,
+    };
+
+    let subgraph_c = ServiceDefinition {
+        name: "c-no-directive",
+        type_defs: r#"
+            type Query { c: String @shareable }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b, subgraph_c])
+        .expect("Composition should succeed");
+    assert!(
+        !result
+            .schema()
+            .schema()
+            .directive_definitions
+            .contains_key("cacheControl"),
+        "Supergraph should not contain @cacheControl when executable locations don't intersect"
+    );
+    assert_eq!(result.hints().len(), 1);
+    assert_eq!(
+        result.hints()[0].definition.code(),
+        "NO_EXECUTABLE_DIRECTIVE_LOCATIONS_INTERSECTION",
+    );
+    assert_eq!(
+        result.hints()[0].message,
+        r#"Executable directive "@cacheControl" has no location that is common to all subgraphs: it will not appear in the supergraph as there no intersection between location "QUERY" in subgraph "b-with-exec-locations"."#,
+    );
+}
+
+#[test]
 fn interface_field_no_implem_error_includes_source_locations() {
     let subgraph_a = ServiceDefinition {
         name: "subgraphA",


### PR DESCRIPTION
The executable directive location intersection used `Vec::is_empty()` to detect both "not yet initialized" and "empty intersection result". When the first subgraph (alphabetically) had no executable locations, the second subgraph's locations were treated as initialization instead of being intersected with the empty set — leaking the directive into the supergraph.

Use `Option<Vec>` to distinguish "not initialized" from "empty intersection", making the result order-independent.
