### PR TITLE
fix(QP-execution): Surface missing fields in `response.errors`

### DIFF
--- a/.changesets/fix_duckki_router_1741.md
+++ b/.changesets/fix_duckki_router_1741.md
@@ -1,11 +1,14 @@
-### fix(QP-execution): Surface missing fields in `response.errors` ([PR #9549](https://github.com/apollographql/router/pull/9549))
+### fix(format_response): Report missing fields as coercion errors and suppress redundant errors ([PR #9549](https://github.com/apollographql/router/pull/9549))
 
 When a requested field is missing from the merged subgraph response, emit a
 `RESPONSE_VALIDATION_FAILED` error in `response.errors` — turned on by
-`enable_result_coercion_errors`. Previously, non-nullable missing fields were only reported in
-`extensions.valueCompletion` (not `response.errors`), while other coercion errors like null value
-for non-nullable field were emitted to **both** `valueCompletion` and `response.errors`. This fix
-updates Router to report all missing fields to `response.errors` if `enable_result_coercion_errors`
-is on. `valueCompletion` behavior is not changed.
+`enable_result_coercion_errors`. Previously, missing fields were only reported in
+`extensions.valueCompletion` (and only for non-nullable fields), not in `response.errors`.
+
+Additionally, redundant coercion and `valueCompletion` errors along null-bubble paths are now
+suppressed. Previously, a single bad value inside nested non-null types could produce multiple
+duplicate entries — one per non-null wrapper in the bubble chain. Now each coercion failure produces
+exactly one originating error in `response.errors` and one `valueCompletion` entry at the source,
+with no nesting-level duplicates.
 
 By [@duckki](https://github.com/duckki) in https://github.com/apollographql/router/pull/9549

--- a/.changesets/fix_duckki_router_1741.md
+++ b/.changesets/fix_duckki_router_1741.md
@@ -1,0 +1,11 @@
+### fix(QP-execution): Surface missing fields in `response.errors` ([PR #9549](https://github.com/apollographql/router/pull/9549))
+
+When a requested field is missing from the merged subgraph response, emit a
+`RESPONSE_VALIDATION_FAILED` error in `response.errors` — turned on by
+`enable_result_coercion_errors`. Previously, non-nullable missing fields were only reported in
+`extensions.valueCompletion` (not `response.errors`), while other coercion errors like null value
+for non-nullable field were emitted to **both** `valueCompletion` and `response.errors`. This fix
+updates Router to report all missing fields to `response.errors` if `enable_result_coercion_errors`
+is on. `valueCompletion` behavior is not changed.
+
+By [@duckki](https://github.com/duckki) in https://github.com/apollographql/router/pull/9549

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -2587,7 +2587,7 @@ async fn missing_nonnull_field_in_requires_returns_error_nonnull_leaf() {
             },
         ]),
         serde_json::json!([
-            { "message": "Null value found for non-nullable type String", "path": ["entity"] },
+            { "message": "Cannot return null for non-nullable type String", "path": ["entity"] },
         ]),
     );
 }
@@ -2689,7 +2689,7 @@ async fn missing_nonnull_field_in_requires_returns_error_nonnull_entity() {
             },
         ]),
         serde_json::json!([
-            { "message": "Null value found for non-nullable type String", "path": ["entity"] },
+            { "message": "Cannot return null for non-nullable type String", "path": ["entity"] },
             { "message": "Null value found for non-nullable type Entity", "path": ["entity"] },
         ]),
     );
@@ -2770,7 +2770,7 @@ async fn response_formatting_missing_vs_null_nonnull_field_asymmetry() {
             },
         ]),
         serde_json::json!([
-            { "message": "Null value found for non-nullable type String", "path": ["entity"] },
+            { "message": "Cannot return null for non-nullable type String", "path": ["entity"] },
         ]),
     );
 

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -54,6 +54,115 @@ macro_rules! test_schema {
     };
 }
 
+/// The common part of supergraph schema shared by every test schema below
+/// (directives, scalars, and the `link__Purpose` enum). Tests append a
+/// `enum join__Graph { ... }` block plus their type definitions; use
+/// [`supergraph_schema`] to glue the pieces together.
+const SUPERGRAPH_SCHEMA_COMMON: &str = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+    query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+scalar link__Import
+
+enum link__Purpose {
+    SECURITY
+    EXECUTION
+}
+"#;
+
+/// Glue the federation boilerplate with the test-specific schema body
+/// (graph enum + type definitions).
+fn supergraph_schema(body: &str) -> String {
+    format!("{SUPERGRAPH_SCHEMA_COMMON}{body}")
+}
+
+/// Default test harness config: include subgraph errors, coercion errors off.
+fn default_config() -> serde_json::Value {
+    serde_json::json!({ "include_subgraph_errors": { "all": true } })
+}
+
+/// Config with `enable_result_coercion_errors=true`, so missing/invalid
+/// values surface in `response.errors` with `RESPONSE_VALIDATION_FAILED`.
+fn coercion_errors_config() -> serde_json::Value {
+    serde_json::json!({
+        "include_subgraph_errors": { "all": true },
+        "supergraph": { "enable_result_coercion_errors": true },
+    })
+}
+
+/// Run a single GraphQL request against a mocked supergraph and return
+/// the response as a JSON value. Bundles the `TestHarness` →
+/// `supergraph::Request::fake_builder` → `oneshot` plumbing that every
+/// test in this file would otherwise repeat verbatim.
+async fn run_query(
+    schema: &str,
+    subgraphs: MockedSubgraphs,
+    query: &str,
+    config: serde_json::Value,
+) -> serde_json::Value {
+    let service = TestHarness::builder()
+        .configuration_json(config)
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .build()
+        .unwrap();
+
+    let mut stream = service.oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    serde_json::to_value(&response).unwrap()
+}
+
+/// Assert on the **full** set of user-visible diagnostics in a supergraph
+/// response: both `response.errors` and `extensions.valueCompletion`. Use
+/// this instead of filter-and-check-inclusion so that any unexpected
+/// extra (or missing, or duplicated) emission shows up as a test failure.
+fn assert_response_diagnostics(
+    value: &serde_json::Value,
+    expected_errors: serde_json::Value,
+    expected_value_completion: serde_json::Value,
+) {
+    let actual_errors = value["errors"].clone();
+    let actual_errors = if actual_errors.is_null() {
+        serde_json::json!([])
+    } else {
+        actual_errors
+    };
+    let actual_value_completion = value["extensions"]["valueCompletion"].clone();
+    let actual_value_completion = if actual_value_completion.is_null() {
+        serde_json::json!([])
+    } else {
+        actual_value_completion
+    };
+    assert_eq!(
+        actual_errors, expected_errors,
+        "response.errors mismatch (actual on left, expected on right)"
+    );
+    assert_eq!(
+        actual_value_completion, expected_value_completion,
+        "extensions.valueCompletion mismatch (actual on left, expected on right)"
+    );
+}
+
 fn subgraph_service_factory(
     graphs: Vec<(String, Arc<dyn MakeSubgraphService>)>,
 ) -> SubgraphServiceFactory {
@@ -2227,5 +2336,387 @@ async fn defer_depends_skips_fetch_when_typename_missing() {
     assert_eq!(
         inner_data["target"]["x"], "42",
         "target should have x from Z fetch"
+    );
+}
+
+// Documents that the user-visible "errors" array stays SILENT when the
+// user-asked fields are all nullable. The skipped @requires fetch leaves
+// `computed` and `nickname` null in `data` (existing behavior), but the
+// new approach only emits `RESPONSE_VALIDATION_FAILED` for non-null
+// requested fields. The planner-internal `code: String!` that triggered
+// the skip is not in the user's operation, so no diagnostic surfaces.
+#[tokio::test]
+async fn missing_nonnull_field_in_requires_returns_error() {
+    let schema = supergraph_schema(
+        r#"
+        enum join__Graph {
+            SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+            SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+        }
+
+        type Query
+            @join__type(graph: SUB1)
+            @join__type(graph: SUB2)
+        {
+            entity: Entity @join__field(graph: SUB1)
+        }
+
+        type Entity
+            @join__type(graph: SUB1, key: "id")
+            @join__type(graph: SUB2, key: "id", extension: true)
+        {
+            id: ID!
+            name: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+            code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+            computed: String @join__field(graph: SUB2, requires: "code")
+            nickname: String @join__field(graph: SUB2, requires: "name")
+        }
+        "#,
+    );
+
+    let query = "query { entity { id computed nickname } }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        // Router queries sub1 for entity fields including code and name (needed for @requires)
+                        serde_json::json! {{"query": "{entity{__typename id name code}}"}},
+                        // Sub1 returns WITHOUT `code` (simulating coprocessor stripping the field
+                        // from the request, so the subgraph never received it and doesn't return it)
+                        serde_json::json! {{"data": {
+                            "entity": {
+                              "__typename": "Entity",
+                              "id": "1",
+                              "name": "Alice"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let value = run_query(&schema, subgraphs, query, default_config()).await;
+
+    let data = &value["data"]["entity"];
+    // `computed` and `nickname` are nullable; they land as null in `data`.
+    assert_eq!(data["computed"], serde_json::Value::Null);
+    assert_eq!(data["nickname"], serde_json::Value::Null);
+
+    // Both fields are nullable, and coercion errors are off in this
+    // harness → no emission anywhere. (`emit_missing_field` only
+    // writes valueCompletion for non-null, and only writes response
+    // errors when coercion is on.)
+    assert_response_diagnostics(&value, serde_json::json!([]), serde_json::json!([]));
+}
+
+// Variant of `missing_nonnull_field_in_requires_returns_error` where `computed` is a non-nullable
+// field. When the skipped fetch's field is non-nullable, `apply_selection_set` propagates null up
+// to the parent (entity), per the GraphQL spec. The post-fix `format_response` emits a
+// `RESPONSE_VALIDATION_FAILED` error at the leaf path that triggered the null.
+#[tokio::test]
+async fn missing_nonnull_field_in_requires_returns_error_nonnull_leaf() {
+    let schema = supergraph_schema(
+        r#"
+        enum join__Graph {
+            SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+            SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+        }
+
+        type Query
+            @join__type(graph: SUB1)
+            @join__type(graph: SUB2)
+        {
+            entity: Entity @join__field(graph: SUB1)
+        }
+
+        type Entity
+            @join__type(graph: SUB1, key: "id")
+            @join__type(graph: SUB2, key: "id", extension: true)
+        {
+            id: ID!
+            name: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+            code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+            computed: String! @join__field(graph: SUB2, requires: "code")
+            nickname: String @join__field(graph: SUB2, requires: "name")
+        }
+        "#,
+    );
+
+    let query = "query {
+        entity {
+          id
+          computed
+          nickname
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id name code}}"}},
+                        // sub1 returns WITHOUT `code` — sub2 (which requires code) is skipped.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                              "__typename": "Entity",
+                              "id": "1",
+                              "name": "Alice"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let value = run_query(&schema, subgraphs, query, coercion_errors_config()).await;
+
+    // `computed: String!` is non-nullable — the missing value bubbles up and nullifies
+    // `data.entity` per GraphQL null-propagation rules.
+    assert_eq!(value["data"]["entity"], serde_json::Value::Null);
+
+    // `RESPONSE_VALIDATION_FAILED` is emitted at the leaf
+    // `[entity, computed]` (the non-null user-asked field). `nickname`
+    // is nullable — the formatter returns `Err(InvalidValue)` at
+    // `computed` and short-circuits before iterating to `nickname`, so
+    // only `computed`'s emission appears. `emit_missing_field` writes
+    // to both sinks for non-null missing, so `valueCompletion` also
+    // carries an entry at the parent path `[entity]`.
+    assert_response_diagnostics(
+        &value,
+        serde_json::json!([
+            {
+                "message": "Missing field",
+                "path": ["entity", "computed"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
+            },
+        ]),
+        serde_json::json!([
+            { "message": "Null value found for non-nullable type String", "path": ["entity"] },
+        ]),
+    );
+}
+
+// Variant of `missing_nonnull_field_in_requires_returns_error` where the root `Query.entity`
+// field is non-nullable. With `computed: String!` also non-nullable, the missing value at the
+// leaf bubbles up: `computed` → `entity` (becomes null) → `data` (becomes null, since
+// `Query.entity` is non-null). This tests how null-propagation behaves when there's no
+// nullable ancestor to stop at.
+#[tokio::test]
+async fn missing_nonnull_field_in_requires_returns_error_nonnull_entity() {
+    let schema = supergraph_schema(
+        r#"
+        enum join__Graph {
+            SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+            SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+        }
+
+        type Query
+            @join__type(graph: SUB1)
+            @join__type(graph: SUB2)
+        {
+            entity: Entity! @join__field(graph: SUB1)
+        }
+
+        type Entity
+            @join__type(graph: SUB1, key: "id")
+            @join__type(graph: SUB2, key: "id", extension: true)
+        {
+            id: ID!
+            name: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+            code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+            computed: String! @join__field(graph: SUB2, requires: "code")
+            nickname: String @join__field(graph: SUB2, requires: "name")
+        }
+        "#,
+    );
+
+    let query = "query {
+        entity {
+          id
+          computed
+          nickname
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id name code}}"}},
+                        // sub1 returns WITHOUT `code` — sub2 (which requires code) is skipped.
+                        serde_json::json! {{"data": {
+                            "entity": {
+                              "__typename": "Entity",
+                              "id": "1",
+                              "name": "Alice"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let value = run_query(&schema, subgraphs, query, coercion_errors_config()).await;
+
+    // `computed: String!` missing → nullifies `entity` → `Query.entity: Entity!` is non-null →
+    // the null bubbles up to `data` itself.
+    assert_eq!(value["data"], serde_json::Value::Null);
+
+    // Two `RESPONSE_VALIDATION_FAILED` errors expected:
+    //   - leaf `[entity, computed]` (the originating non-null missing
+    //     field, from `emit_missing_field`)
+    //   - bubble target `[entity]` (entity non-null bubble re-emit with
+    //     the legacy "Null value found for non-nullable type" message,
+    //     from `format_non_nullable_value`)
+    // Both emitters write to both sinks for non-null, so
+    // `valueCompletion` carries matching entries at the parent paths.
+    // The root-data nullification is the spec's bubble end (no further
+    // emission past `[entity]`).
+    assert_response_diagnostics(
+        &value,
+        serde_json::json!([
+            {
+                "message": "Missing field",
+                "path": ["entity", "computed"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
+            },
+            {
+                "message": "Null value found for non-nullable type Entity",
+                "path": ["entity"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
+            },
+        ]),
+        serde_json::json!([
+            { "message": "Null value found for non-nullable type String", "path": ["entity"] },
+            { "message": "Null value found for non-nullable type Entity", "path": ["entity"] },
+        ]),
+    );
+}
+
+// Symmetry test: the missing and explicit-null branches in `spec/query.rs` response formatting
+// both emit `RESPONSE_VALIDATION_FAILED` in `response.errors` (in addition to the existing
+// `valueCompletion` entry either case still leaves in extensions).
+//
+// Before the fix, only the explicit-null branch surfaced a user-visible error; the missing branch
+// went only to `valueCompletion`. That asymmetry is the reason `@requires`-driven skips (which
+// look like "missing" from the formatter's perspective — the field was never fetched) used to
+// silently drop. With the fix, the symptom is the same regardless of whether the subgraph returned
+// an explicit null or omitted the field.
+#[tokio::test]
+async fn response_formatting_missing_vs_null_nonnull_field_asymmetry() {
+    let schema = supergraph_schema(
+        r#"
+        enum join__Graph {
+            SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+        }
+
+        type Query @join__type(graph: SUB1) {
+            entity: Entity @join__field(graph: SUB1)
+        }
+
+        type Entity @join__type(graph: SUB1, key: "id") {
+            id: ID!
+            name: String! @join__field(graph: SUB1)
+        }
+        "#,
+    );
+
+    let query = "query { entity { id name } }";
+
+    // Helper: build a service whose single subgraph returns the given `entity` payload.
+    async fn run_with_entity(
+        schema: &str,
+        query: &str,
+        entity: serde_json::Value,
+    ) -> serde_json::Value {
+        let subgraphs = MockedSubgraphs(
+            [(
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{id name}}"}},
+                        serde_json::json! {{"data": {"entity": entity}}},
+                    )
+                    .build(),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        // Enable coercion errors so any errors generated by `format_non_nullable_value`
+        // show up in `response.errors`.
+        run_query(schema, subgraphs, query, coercion_errors_config()).await
+    }
+
+    // Case A: `name` is MISSING (absent) from the subgraph response.
+    // `apply_selection_set`'s missing-field branch calls `emit_missing_field`,
+    // which writes RVF to `response.errors` at the leaf, plus a
+    // valueCompletion entry at the **parent** path (it never recursed
+    // into the field).
+    let missing = run_with_entity(&schema, query, serde_json::json!({ "id": "1" })).await;
+    assert_eq!(
+        missing["data"]["entity"],
+        serde_json::Value::Null,
+        "non-null `name` missing → `entity` nullified"
+    );
+    assert_response_diagnostics(
+        &missing,
+        serde_json::json!([
+            {
+                "message": "Missing field",
+                "path": ["entity", "name"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
+            },
+        ]),
+        serde_json::json!([
+            { "message": "Null value found for non-nullable type String", "path": ["entity"] },
+        ]),
+    );
+
+    // Case B: `name` is explicitly NULL in the subgraph response.
+    // `format_value` recurses, `format_non_nullable_value` then notices
+    // the null. Its legacy dual-emission writes RVF to both sinks at
+    // the **leaf** path (the field name was pushed by the caller).
+    let null = run_with_entity(
+        &schema,
+        query,
+        serde_json::json!({ "id": "1", "name": null }),
+    )
+    .await;
+    assert_eq!(
+        null["data"]["entity"],
+        serde_json::Value::Null,
+        "null non-null `name` → `entity` nullified"
+    );
+    assert_response_diagnostics(
+        &null,
+        serde_json::json!([
+            {
+                "message": "Null value found for non-nullable type String",
+                "path": ["entity", "name"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
+            },
+        ]),
+        serde_json::json!([
+            { "message": "Null value found for non-nullable type String", "path": ["entity", "name"] },
+        ]),
     );
 }

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -2664,16 +2664,8 @@ async fn missing_nonnull_field_in_requires_returns_error_nonnull_entity() {
     // the null bubbles up to `data` itself.
     assert_eq!(value["data"], serde_json::Value::Null);
 
-    // Two `RESPONSE_VALIDATION_FAILED` errors expected:
-    //   - leaf `[entity, computed]` (the originating non-null missing
-    //     field, from `emit_missing_field`)
-    //   - bubble target `[entity]` (entity non-null bubble re-emit with
-    //     the legacy "Null value found for non-nullable type" message,
-    //     from `format_non_nullable_value`)
-    // Both emitters write to both sinks for non-null, so
-    // `valueCompletion` carries matching entries at the parent paths.
-    // The root-data nullification is the spec's bubble end (no further
-    // emission past `[entity]`).
+    // Only ONE `RESPONSE_VALIDATION_FAILED` at the originating leaf
+    // `[entity, computed]`.
     assert_response_diagnostics(
         &value,
         serde_json::json!([
@@ -2682,15 +2674,9 @@ async fn missing_nonnull_field_in_requires_returns_error_nonnull_entity() {
                 "path": ["entity", "computed"],
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
             },
-            {
-                "message": "Null value found for non-nullable type Entity",
-                "path": ["entity"],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
-            },
         ]),
         serde_json::json!([
             { "message": "Cannot return null for non-nullable type String", "path": ["entity"] },
-            { "message": "Null value found for non-nullable type Entity", "path": ["entity"] },
         ]),
     );
 }

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -1055,8 +1055,8 @@ async fn missing_fields_in_requires() {
   scalar join__FieldSet
 
   enum join__Graph {
-    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
-    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+    SUB1 @join__graph(name: "sub1", url: "http://localhost/sub1")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost/sub2")
   }
 
   scalar link__Import
@@ -1191,8 +1191,8 @@ async fn missing_typename_and_fragments_in_requires() {
   scalar join__FieldSet
 
   enum join__Graph {
-    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
-    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+    SUB1 @join__graph(name: "sub1", url: "http://localhost/sub1")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost/sub2")
   }
 
   scalar link__Import
@@ -1327,8 +1327,8 @@ async fn missing_typename_and_fragments_in_requires2() {
   scalar join__FieldSet
 
   enum join__Graph {
-    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
-    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+    SUB1 @join__graph(name: "sub1", url: "http://localhost/sub1")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost/sub2")
   }
 
   scalar link__Import
@@ -1481,8 +1481,8 @@ async fn null_in_requires() {
   scalar join__FieldSet
 
   enum join__Graph {
-    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
-    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+    SUB1 @join__graph(name: "sub1", url: "http://localhost/sub1")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost/sub2")
   }
 
   scalar link__Import
@@ -2350,8 +2350,8 @@ async fn missing_nonnull_field_in_requires_returns_error() {
     let schema = supergraph_schema(
         r#"
         enum join__Graph {
-            SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
-            SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+            SUB1 @join__graph(name: "sub1", url: "http://localhost/sub1")
+            SUB2 @join__graph(name: "sub2", url: "http://localhost/sub2")
         }
 
         type Query
@@ -2416,6 +2416,89 @@ async fn missing_nonnull_field_in_requires_returns_error() {
     assert_response_diagnostics(&value, serde_json::json!([]), serde_json::json!([]));
 }
 
+// Variant of C.1 with `enable_result_coercion_errors` ON. Nullable missing fields surface
+// `RESPONSE_VALIDATION_FAILED` in `response.errors` when the gate is enabled.
+#[tokio::test]
+async fn missing_nullable_field_in_requires_returns_error_coercion_on() {
+    let schema = supergraph_schema(
+        r#"
+        enum join__Graph {
+            SUB1 @join__graph(name: "sub1", url: "http://localhost/sub1")
+            SUB2 @join__graph(name: "sub2", url: "http://localhost/sub2")
+        }
+
+        type Query
+            @join__type(graph: SUB1)
+            @join__type(graph: SUB2)
+        {
+            entity: Entity @join__field(graph: SUB1)
+        }
+
+        type Entity
+            @join__type(graph: SUB1, key: "id")
+            @join__type(graph: SUB2, key: "id", extension: true)
+        {
+            id: ID!
+            name: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+            code: String! @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+            computed: String @join__field(graph: SUB2, requires: "code")
+            nickname: String @join__field(graph: SUB2, requires: "name")
+        }
+        "#,
+    );
+
+    let query = "query { entity { id computed nickname } }";
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "sub1",
+                MockSubgraph::builder()
+                    .with_json(
+                        serde_json::json! {{"query": "{entity{__typename id name code}}"}},
+                        serde_json::json! {{"data": {
+                            "entity": {
+                              "__typename": "Entity",
+                              "id": "1",
+                              "name": "Alice"
+                            }
+                        } }},
+                    )
+                    .build(),
+            ),
+            ("sub2", MockSubgraph::builder().build()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let value = run_query(&schema, subgraphs, query, coercion_errors_config()).await;
+
+    let data = &value["data"]["entity"];
+    assert_eq!(data["computed"], serde_json::Value::Null);
+    assert_eq!(data["nickname"], serde_json::Value::Null);
+
+    // With coercion errors ON, nullable missing fields emit
+    // `RESPONSE_VALIDATION_FAILED` at the leaf path. No valueCompletion
+    // (that's non-null only).
+    assert_response_diagnostics(
+        &value,
+        serde_json::json!([
+            {
+                "message": "Missing field",
+                "path": ["entity", "computed"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
+            },
+            {
+                "message": "Missing field",
+                "path": ["entity", "nickname"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
+            },
+        ]),
+        serde_json::json!([]),
+    );
+}
+
 // Variant of `missing_nonnull_field_in_requires_returns_error` where `computed` is a non-nullable
 // field. When the skipped fetch's field is non-nullable, `apply_selection_set` propagates null up
 // to the parent (entity), per the GraphQL spec. The post-fix `format_response` emits a
@@ -2425,8 +2508,8 @@ async fn missing_nonnull_field_in_requires_returns_error_nonnull_leaf() {
     let schema = supergraph_schema(
         r#"
         enum join__Graph {
-            SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
-            SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+            SUB1 @join__graph(name: "sub1", url: "http://localhost/sub1")
+            SUB2 @join__graph(name: "sub2", url: "http://localhost/sub2")
         }
 
         type Query
@@ -2519,8 +2602,8 @@ async fn missing_nonnull_field_in_requires_returns_error_nonnull_entity() {
     let schema = supergraph_schema(
         r#"
         enum join__Graph {
-            SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
-            SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+            SUB1 @join__graph(name: "sub1", url: "http://localhost/sub1")
+            SUB2 @join__graph(name: "sub2", url: "http://localhost/sub2")
         }
 
         type Query
@@ -2626,7 +2709,7 @@ async fn response_formatting_missing_vs_null_nonnull_field_asymmetry() {
     let schema = supergraph_schema(
         r#"
         enum join__Graph {
-            SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+            SUB1 @join__graph(name: "sub1", url: "http://localhost/sub1")
         }
 
         type Query @join__type(graph: SUB1) {

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__deferred_fragment_bounds_nullability-2.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__deferred_fragment_bounds_nullability-2.snap
@@ -31,7 +31,7 @@ expression: stream.next_response().await.unwrap()
       "extensions": {
         "valueCompletion": [
           {
-            "message": "Null value found for non-nullable type ID",
+            "message": "Cannot return null for non-nullable type ID",
             "path": [
               "currentUser",
               "activeOrganization",
@@ -68,7 +68,7 @@ expression: stream.next_response().await.unwrap()
       "extensions": {
         "valueCompletion": [
           {
-            "message": "Null value found for non-nullable type ID",
+            "message": "Cannot return null for non-nullable type ID",
             "path": [
               "currentUser",
               "activeOrganization",
@@ -105,7 +105,7 @@ expression: stream.next_response().await.unwrap()
       "extensions": {
         "valueCompletion": [
           {
-            "message": "Null value found for non-nullable type ID",
+            "message": "Cannot return null for non-nullable type ID",
             "path": [
               "currentUser",
               "activeOrganization",

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__nullability_bubbling.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__nullability_bubbling.snap
@@ -12,7 +12,7 @@ expression: response
   "extensions": {
     "valueCompletion": [
       {
-        "message": "Null value found for non-nullable type ID",
+        "message": "Cannot return null for non-nullable type ID",
         "path": [
           "currentUser",
           "activeOrganization"

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -1002,18 +1002,12 @@ impl Query {
                         );
                         path.pop();
                         res?
-                    } else if field_type.is_non_null() {
-                        parameters.errors.push(
-                            Error::builder()
-                                .message(format!(
-                                    "Cannot return null for non-nullable field {root_type_name}.{field_name_str}"
-                                ))
-                                .path(Path::from_response_slice(path))
-                                .build(),
-                        );
-                        return Err(InvalidValue);
                     } else {
                         output.insert(field_name.clone(), Value::Null);
+                        emit_missing_field(parameters, field_type, field_name_str, path);
+                        if field_type.is_non_null() {
+                            return Err(InvalidValue);
+                        }
                     }
                 }
                 Selection::InlineFragment {
@@ -1265,11 +1259,13 @@ fn emit_missing_field<'b>(
     field_name: &'b str,
     path: &mut Vec<ResponsePathElement<'b>>,
 ) {
-    // valueCompletion: non-null only (legacy behavior)
+    // valueCompletion: non-null only
     if field_type.is_non_null() {
-        // Legacy message
+        // Based on historic discussion, we report this missing field error at the parent path (not
+        // the missing field path), since the parent is the one being nullified. Though the field
+        // name/path could be more informative.
         let message = format!(
-            "Null value found for non-nullable type {}",
+            "Cannot return null for non-nullable type {}",
             field_type.0.inner_named_type()
         );
         let parent_path = Path::from_response_slice(path);
@@ -1281,12 +1277,12 @@ fn emit_missing_field<'b>(
     // response.errors: nullable and non-null both, gated by coercion config.
     if parameters.coercion_errors.is_some() {
         path.push(ResponsePathElement::Key(field_name));
-        let leaf_path = Path::from_response_slice(path);
+        let field_path = Path::from_response_slice(path);
         path.pop();
         parameters.insert_coercion_error(
             Error::builder()
                 .message("Missing field")
-                .path(leaf_path)
+                .path(field_path)
                 .extension("code", ERROR_CODE_RESPONSE_VALIDATION)
                 .build(),
         );

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -789,17 +789,9 @@ impl Query {
                         if !output.contains_key(field_name.as_str()) {
                             output.insert((*field_name).clone(), Value::Null);
                         }
+                        // Emit error for missing field
+                        emit_missing_field(parameters, field_type, field_name.as_str(), path);
                         if field_type.is_non_null() {
-                            parameters.errors.push(
-                                Error::builder()
-                                    .message(format!(
-                                        "Null value found for non-nullable type {}",
-                                        field_type.0.inner_named_type()
-                                    ))
-                                    .path(Path::from_response_slice(path))
-                                    .build(),
-                            );
-
                             return Err(InvalidValue);
                         }
                     }
@@ -1240,6 +1232,58 @@ impl Query {
 
     pub(crate) fn is_deferred(&self, defer_conditions: BooleanValues) -> bool {
         self.defer_stats.has_unconditional_defer || defer_conditions.bits != 0
+    }
+}
+
+/// Emit a error for a user-asked field that is missing from the merged response. The caller
+/// handles null-bubbling on non-nullable fields; this helper only emits.
+///
+/// Two sinks, asymmetric coverage:
+///
+/// - `parameters.errors` → `extensions.valueCompletion`, at the **parent path** (the path on
+///   entry, without the field name pushed — the formatter never recursed into the missing field,
+///   so the leaf doesn't exist in any meaningful sense for valueCompletion). **Only fires for
+///   non-null fields**, preserving the legacy "valueCompletion is for non-null-coerced positions"
+///   convention.
+/// - `parameters.insert_coercion_error` → `response.errors`, at the **leaf path** `[...,
+///   field_name]` with code `RESPONSE_VALIDATION_FAILED`. Fires for both nullable and non-null
+///   missing fields — gated only by `enable_result_coercion_errors` (i.e.
+///   `coercion_errors.is_some()`).
+///
+/// Net effect: nullable missing surfaces only in `response.errors` when coercion is on (no new
+/// valueCompletion noise); non-null missing behaves as before plus also lands in
+/// `response.errors`.
+fn emit_missing_field<'b>(
+    parameters: &mut FormatParameters,
+    field_type: &crate::spec::FieldType,
+    field_name: &'b str,
+    path: &mut Vec<ResponsePathElement<'b>>,
+) {
+    // valueCompletion: non-null only (legacy behavior)
+    if field_type.is_non_null() {
+        // Legacy message
+        let message = format!(
+            "Null value found for non-nullable type {}",
+            field_type.0.inner_named_type()
+        );
+        let parent_path = Path::from_response_slice(path);
+        parameters
+            .errors
+            .push(Error::builder().message(message).path(parent_path).build());
+    }
+
+    // response.errors: nullable and non-null both, gated by coercion config.
+    if parameters.coercion_errors.is_some() {
+        path.push(ResponsePathElement::Key(field_name));
+        let leaf_path = Path::from_response_slice(path);
+        path.pop();
+        parameters.insert_coercion_error(
+            Error::builder()
+                .message("Missing field")
+                .path(leaf_path)
+                .extension("code", ERROR_CODE_RESPONSE_VALIDATION)
+                .build(),
+        );
     }
 }
 

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -351,6 +351,8 @@ impl Query {
         Ok((fragments, operation, defer_stats, hash))
     }
 
+    /// Format a field's value.
+    /// - Returns Err(InvalidValue) if formatting fails and error(s) have been emitted.
     fn format_value<'a: 'b, 'b>(
         &'a self,
         parameters: &mut FormatParameters,
@@ -364,11 +366,13 @@ impl Query {
         // and return Ok(()), because values are optional by default
         match field_type {
             executable::Type::Named(name) => match name.as_str() {
-                "Int" => self.format_integer(parameters, path, input, output),
-                "Float" => self.format_float(parameters, path, input, output),
-                "Boolean" => self.format_boolean(parameters, path, input, output),
-                "String" => self.format_string(parameters, path, input, output),
-                "Id" => self.format_id(parameters, path, input, output),
+                // Scalar formatters return `Err` on coercion failure.  Propagating `Err` here
+                // avoids redundant "Null value found for non-nullable" errors.
+                "Int" => self.format_integer(parameters, path, input, output)?,
+                "Float" => self.format_float(parameters, path, input, output)?,
+                "Boolean" => self.format_boolean(parameters, path, input, output)?,
+                "String" => self.format_string(parameters, path, input, output)?,
+                "Id" => self.format_id(parameters, path, input, output)?,
                 _ => self.format_named_type(
                     parameters,
                     field_type,
@@ -402,6 +406,8 @@ impl Query {
         Ok(())
     }
 
+    /// Format a non-null field's value.
+    /// - Returns Err(InvalidValue) if formatting fails and error(s) have been emitted.
     #[inline]
     fn format_non_nullable_value<'a: 'b, 'b>(
         &'a self,
@@ -423,24 +429,59 @@ impl Query {
             }
         };
 
-        self.format_value(parameters, &inner_type, input, output, path, selection_set)?;
+        let inner_result =
+            self.format_value(parameters, &inner_type, input, output, path, selection_set);
 
         if output.is_null() {
             let message = format!("Null value found for non-nullable type {inner_type}");
-            parameters.errors.push(
-                Error::builder()
-                    .message(&message)
-                    .path(Path::from_response_slice(path))
-                    .build(),
-            );
-            parameters.insert_coercion_error(
-                Error::builder()
-                    .message(message)
-                    .path(Path::from_response_slice(path))
-                    .extension("code", ERROR_CODE_RESPONSE_VALIDATION)
-                    .build(),
-            );
-
+            match inner_result {
+                Ok(()) => {
+                    // Null value from the subgraph (explicit null for a non-null position) without
+                    // coercion error from formatting. Emit errors here.
+                    parameters.errors.push(
+                        Error::builder()
+                            .message(&message)
+                            .path(Path::from_response_slice(path))
+                            .build(),
+                    );
+                    parameters.insert_coercion_error(
+                        Error::builder()
+                            .message(message)
+                            .path(Path::from_response_slice(path))
+                            .extension("code", ERROR_CODE_RESPONSE_VALIDATION)
+                            .build(),
+                    );
+                }
+                Err(InvalidValue) => {
+                    // The `format_value` errored. Decide based on `inner_type`:
+                    //   - List: `format_list` only returns `Err` when an element's
+                    //     `format_value` returned `Err` with a non-null element type. Skip.
+                    //   - Composite (Object/Interface/Union): the Err came from a child
+                    //     selection set, which already emitted both sinks at the originating
+                    //     leaf. Skip.
+                    //   - Otherwise (primitive scalar / Enum / custom scalar): the scalar
+                    //     formatter emitted coercion errors but does not know it sits in a
+                    //     non-null position; Emit a valueCompletion error here.
+                    let inner_emitted_error = inner_type.is_list()
+                        || matches!(
+                            parameters.schema.types.get(inner_type.inner_named_type()),
+                            Some(
+                                ExtendedType::Object(_)
+                                    | ExtendedType::Interface(_)
+                                    | ExtendedType::Union(_)
+                            )
+                        );
+                    if !inner_emitted_error {
+                        parameters.errors.push(
+                            Error::builder()
+                                .message(message)
+                                .path(Path::from_response_slice(path))
+                                .build(),
+                        );
+                    }
+                }
+            }
+            // Propagate error to parent
             Err(InvalidValue)
         } else {
             Ok(())
@@ -470,32 +511,40 @@ impl Query {
                 .enumerate()
                 .try_for_each(|(i, element)| {
                     path.push(ResponsePathElement::Index(i));
-                    self.format_value(
+                    let res = self.format_value(
                         parameters,
                         inner_type,
                         element,
                         &mut output_array[i],
                         path,
                         selection_set,
-                    )?;
+                    );
                     path.pop();
+                    // Type-aware Err handling: non-null inner type propagates (whole list
+                    // nullifies per spec). Nullable inner type swallows the error (element already
+                    // nullified by child).
+                    if res.is_err() && inner_type.is_non_null() {
+                        return Err(InvalidValue);
+                    }
                     Ok(())
                 })
         {
-            // We pop here because, if an error is found, the path still contains the index of the
-            // invalid value.
-            path.pop();
             parameters.nullified.push(Path::from_response_slice(path));
-            parameters.insert_coercion_error(
-                Error::builder()
-                    .message(format!(
-                        "Invalid value found inside the array of type [{inner_type}]"
-                    ))
-                    .path(Path::from_response_slice(path))
-                    .extension("code", ERROR_CODE_RESPONSE_VALIDATION)
-                    .build(),
-            );
+            // Emit only at the innermost list level (when inner_type is not a list).
+            // We don't want to emit multiple errors for a nested list type like [[Int!]!]!.
+            if !inner_type.is_list() {
+                parameters.insert_coercion_error(
+                    Error::builder()
+                        .message(format!(
+                            "Invalid value found inside the array of type [{inner_type}]"
+                        ))
+                        .path(Path::from_response_slice(path))
+                        .extension("code", ERROR_CODE_RESPONSE_VALIDATION)
+                        .build(),
+                );
+            }
             *output = Value::Null;
+            return Err(InvalidValue);
         }
         Ok(())
     }
@@ -567,23 +616,25 @@ impl Query {
                 _ => field_type,
             };
 
-            if self
-                .apply_selection_set(
-                    selection_set,
-                    parameters,
-                    input_object,
-                    output_object,
-                    path,
-                    current_type,
-                )
-                .is_err()
-            {
+            if let Err(err) = self.apply_selection_set(
+                selection_set,
+                parameters,
+                input_object,
+                output_object,
+                path,
+                current_type,
+            ) {
                 parameters.nullified.push(Path::from_response_slice(path));
                 *output = Value::Null;
+                // Propagate the Err, since `apply_selection_set` already emitted an error.
+                return Err(err);
             }
         } else {
             parameters.nullified.push(Path::from_response_slice(path));
             *output = Value::Null;
+            // We don't emit errors for null object value nor propagate Err.
+            // Note: `format_non_nullable_value` will emit an error if this object's type is
+            //       non-nullable.
         }
 
         Ok(())
@@ -596,15 +647,19 @@ impl Query {
         path: &[ResponsePathElement<'_>],
         input: &mut Value,
         output: &mut Value,
-    ) {
+    ) -> Result<(), InvalidValue> {
         // if the value is invalid, we do not insert it in the output object
         // which is equivalent to inserting null
         if input.as_i64().is_some_and(|i| i32::try_from(i).is_ok())
             || input.as_i64().is_some_and(|i| i32::try_from(i).is_ok())
         {
             *output = input.clone();
+            Ok(())
         } else {
-            if !input.is_null() {
+            *output = Value::Null;
+            if input.is_null() {
+                Ok(())
+            } else {
                 parameters.insert_coercion_error(
                     Error::builder()
                         .message("Invalid value found for the type Int")
@@ -612,8 +667,8 @@ impl Query {
                         .extension("code", ERROR_CODE_RESPONSE_VALIDATION)
                         .build(),
                 );
+                Err(InvalidValue)
             }
-            *output = Value::Null;
         }
     }
 
@@ -624,11 +679,15 @@ impl Query {
         path: &[ResponsePathElement<'_>],
         input: &mut Value,
         output: &mut Value,
-    ) {
+    ) -> Result<(), InvalidValue> {
         if input.as_f64().is_some() {
             *output = input.clone();
+            Ok(())
         } else {
-            if !input.is_null() {
+            *output = Value::Null;
+            if input.is_null() {
+                Ok(())
+            } else {
                 parameters.insert_coercion_error(
                     Error::builder()
                         .message("Invalid value found for the type Float")
@@ -636,8 +695,8 @@ impl Query {
                         .extension("code", ERROR_CODE_RESPONSE_VALIDATION)
                         .build(),
                 );
+                Err(InvalidValue)
             }
-            *output = Value::Null;
         }
     }
 
@@ -648,11 +707,15 @@ impl Query {
         path: &[ResponsePathElement<'_>],
         input: &mut Value,
         output: &mut Value,
-    ) {
+    ) -> Result<(), InvalidValue> {
         if input.as_bool().is_some() {
             *output = input.clone();
+            Ok(())
         } else {
-            if !input.is_null() {
+            *output = Value::Null;
+            if input.is_null() {
+                Ok(())
+            } else {
                 parameters.insert_coercion_error(
                     Error::builder()
                         .message("Invalid value found for the type Boolean")
@@ -660,8 +723,8 @@ impl Query {
                         .extension("code", ERROR_CODE_RESPONSE_VALIDATION)
                         .build(),
                 );
+                Err(InvalidValue)
             }
-            *output = Value::Null;
         }
     }
 
@@ -672,11 +735,15 @@ impl Query {
         path: &[ResponsePathElement<'_>],
         input: &mut Value,
         output: &mut Value,
-    ) {
+    ) -> Result<(), InvalidValue> {
         if input.as_str().is_some() {
             *output = input.clone();
+            Ok(())
         } else {
-            if !input.is_null() {
+            *output = Value::Null;
+            if input.is_null() {
+                Ok(())
+            } else {
                 parameters.insert_coercion_error(
                     Error::builder()
                         .message("Invalid value found for the type String")
@@ -684,8 +751,8 @@ impl Query {
                         .extension("code", ERROR_CODE_RESPONSE_VALIDATION)
                         .build(),
                 );
+                Err(InvalidValue)
             }
-            *output = Value::Null;
         }
     }
 
@@ -696,11 +763,15 @@ impl Query {
         path: &[ResponsePathElement<'_>],
         input: &mut Value,
         output: &mut Value,
-    ) {
+    ) -> Result<(), InvalidValue> {
         if input.is_string() || input.is_i64() || input.is_u64() || input.is_f64() {
             *output = input.clone();
+            Ok(())
         } else {
-            if !input.is_null() {
+            *output = Value::Null;
+            if input.is_null() {
+                Ok(())
+            } else {
                 parameters.insert_coercion_error(
                     Error::builder()
                         .message("Invalid value found for the type ID")
@@ -708,8 +779,8 @@ impl Query {
                         .extension("code", ERROR_CODE_RESPONSE_VALIDATION)
                         .build(),
                 );
+                Err(InvalidValue)
             }
-            *output = Value::Null;
         }
     }
 
@@ -752,6 +823,11 @@ impl Query {
                         if let Some(object_type) = object_type {
                             output.insert((*field_name).clone(), object_type.name.as_str().into());
                         } else {
+                            // If the __typename value does not resolve to a known object type in
+                            // the schema nor the current_type is an object type, emit an error.
+                            // TODO: __typename could be an interface type (due to @interfaceObject).
+                            //       That case is currently not handled and results in false error.
+                            emit_missing_field(parameters, field_type, field_name.as_str(), path);
                             return Err(InvalidValue);
                         }
                         continue;
@@ -790,7 +866,12 @@ impl Query {
                             selection_set,
                         );
                         path.pop();
-                        res?
+                        // Type-aware Err handling: non-null fields propagate Err to continue the
+                        // bubble; nullable fields swallow (the child already reported, the field
+                        // is already nullified).
+                        if res.is_err() && field_type.is_non_null() {
+                            return Err(InvalidValue);
+                        }
                     } else {
                         if !output.contains_key(field_name.as_str()) {
                             output.insert((*field_name).clone(), Value::Null);
@@ -1001,7 +1082,12 @@ impl Query {
                             selection_set,
                         );
                         path.pop();
-                        res?
+                        // Type-aware Err handling (mirrors `apply_selection_set`): non-null fields
+                        // propagate Err to continue the bubble; nullable fields swallow (child
+                        // already reported, field is already nullified).
+                        if res.is_err() && field_type.is_non_null() {
+                            return Err(InvalidValue);
+                        }
                     } else {
                         output.insert(field_name.clone(), Value::Null);
                         emit_missing_field(parameters, field_type, field_name_str, path);

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -178,6 +178,12 @@ impl Query {
                                     .insert(EXTENSIONS_VALUE_COMPLETION_KEY, value);
                             }
 
+                            if let Some(errors) = parameters.coercion_errors.as_mut()
+                                && !errors.is_empty()
+                            {
+                                response.errors.append(errors);
+                            }
+
                             return parameters.nullified;
                         }
                         None => {

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -1448,11 +1448,6 @@ fn reformat_response_expected_int_range() {
                 "path": ["me", "someOtherNumber"],
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
             },
-            {
-                "message": "Null value found for non-nullable type Int",
-                "path": ["me", "someOtherNumber"],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
-            },
         ]))
         .test();
 }
@@ -1681,6 +1676,9 @@ fn reformat_response_coercion_propagation_into_list() {
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
             },
         ]))
+        // Nullable scalar elements coerce to null in place — no
+        // `format_non_nullable_value` wrapper, so no valueCompletion entries.
+        .expected_extensions(json!({}))
         .test();
 
     FormatTest::builder()
@@ -1715,16 +1713,22 @@ fn reformat_response_coercion_propagation_into_list() {
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
             },
             {
-                "message": "Null value found for non-nullable type Int",
-                "path": ["thing", "a", 1],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
-            },
-            {
                 "message": "Invalid value found inside the array of type [Int!]",
                 "path": ["thing", "a"],
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
             }
         ]))
+        // `format_non_nullable_value(Int!)` emits valueCompletion at the
+        // element leaf; the outer list `[Int!]` is nullable so no outer
+        // wrapper emits.
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Null value found for non-nullable type Int",
+                    "path": ["thing", "a", 1]
+                },
+            ]
+        }))
         .test();
 
     FormatTest::builder()
@@ -1757,21 +1761,20 @@ fn reformat_response_coercion_propagation_into_list() {
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
             },
             {
-                "message": "Null value found for non-nullable type Int",
-                "path": ["thing", "a", 1],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
-            },
-            {
                 "message": "Invalid value found inside the array of type [Int!]",
                 "path": ["thing", "a"],
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
             },
-            {
-                "message": "Null value found for non-nullable type [Int!]",
-                "path": ["thing", "a"],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
-            }
         ]))
+        // Single originating leaf entry.
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Null value found for non-nullable type Int",
+                    "path": ["thing", "a", 1]
+                },
+            ]
+        }))
         .test();
 }
 
@@ -1845,16 +1848,9 @@ fn reformat_response_coercion_propagation_into_object() {
         .expected(json!({
             "thing": null
         }))
-        // NOTE: The array validation stops at its first invalid value and "bubbles" up the
-        // nullification from there
         .expected_errors(json!([
             {
                 "message": "Invalid value found for the type Int",
-                "path": ["thing", "b"],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
-            },
-            {
-                "message": "Null value found for non-nullable type Int",
                 "path": ["thing", "b"],
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
             },
@@ -1883,23 +1879,612 @@ fn reformat_response_coercion_propagation_into_object() {
                 "c": 1.2
             }
         }))
-        // NOTE: The array validation stops at its first invalid value and "bubbles" up the
-        // nullification from there
-        .expected_errors(json!([            {
+        .expected_errors(json!([
+            {
                 "message": "Invalid value found for the type Int",
                 "path": ["thing", "b"],
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
             },
-            {
-                "message": "Null value found for non-nullable type Int",
-                "path": ["thing", "b"],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
-            },            {
-                "message": "Null value found for non-nullable type Thing",
-                "path": ["thing"],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
-            }
         ]))
+        .test();
+}
+
+// `format_list` bubble suppression for a non-null list `[Thing!]!` combined with
+// scalar-Err dedup at the leaf.
+//
+// Before any dedup, a single bad element produced six `response.errors`:
+//   1. `[items, 0, value]` — "Invalid value found for the type Int" (from `format_integer`)
+//   2. `[items, 0, value]` — "Null value found for non-nullable type Int" (from
+//      `format_non_nullable_value` at the leaf)
+//   3. `[items, 0]` — "Null value found for non-nullable type Thing" (from
+//      `format_non_nullable_value` at the element)
+//   4. `[items]` — "Invalid value found inside the array of type [Thing!]" (from
+//      `format_list`)
+//   5. `[items]` — "Null value found for non-nullable type [Thing!]" (from
+//      `format_non_nullable_value` at the list)
+//
+// After all dedup layers: #2's response.errors duplicate is suppressed by scalar-Err
+// dedup (only the valueCompletion sink fires at the leaf); #3 is suppressed by
+// `format_named_type` propagation (both sinks); #5 is suppressed by `format_list`
+// returning `Err` (both sinks). Net `response.errors`: #1 + #4. Net `valueCompletion`:
+// only the leaf entry from the Int! wrapper.
+#[test]
+fn reformat_response_coercion_propagation_into_nonnull_list() {
+    FormatTest::builder()
+        .schema(
+            r#"
+            type Query {
+                items: [Thing!]!
+            }
+
+            type Thing {
+                value: Int!
+            }
+            "#,
+        )
+        .query(r#"{ items { value } }"#)
+        .response(json!({
+            "items": [ { "value": 1.5 } ]
+        }))
+        // Root field `items` is non-null, so the bubble propagates all the way to `data`.
+        .expected(json!(null))
+        .expected_errors(json!([
+            {
+                "message": "Invalid value found for the type Int",
+                "path": ["items", 0, "value"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+            {
+                "message": "Invalid value found inside the array of type [Thing!]",
+                "path": ["items"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
+        // Expect valueCompletion only at the originating leaf entry
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Null value found for non-nullable type Int",
+                    "path": ["items", 0, "value"],
+                },
+            ]
+        }))
+        .test();
+}
+
+// Composite list `[Thing!]!` with an explicit-null element. The element-level
+// `format_non_nullable_value(Thing!)` is the originating frame here (inner
+// `format_named_type` returns Ok with output=null because input was null),
+// so it emits both sinks at `[items, 0]`. Outer `format_non_nullable_value`
+// for `[Thing!]!` skips (Object inner_named_type), no drop.
+#[test]
+fn reformat_response_composite_list_explicit_null_element() {
+    FormatTest::builder()
+        .schema(
+            r#"
+            type Query { items: [Thing!]! }
+            type Thing { value: Int! }
+            "#,
+        )
+        .query(r#"{ items { value } }"#)
+        .response(json!({ "items": [null] }))
+        .expected(json!(null))
+        .expected_errors(json!([
+            // Element wrapper originating emit (Ok branch — inner returned
+            // Ok with null output, no descendant reported).
+            {
+                "message": "Null value found for non-nullable type Thing",
+                "path": ["items", 0],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+            // format_list's own diagnostic.
+            {
+                "message": "Invalid value found inside the array of type [Thing!]",
+                "path": ["items"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
+        // Single originating valueCompletion entry at the element. The
+        // outer `[Thing!]!` wrapper skips (Object inner_named_type).
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Null value found for non-nullable type Thing",
+                    "path": ["items", 0],
+                },
+            ]
+        }))
+        .test();
+}
+
+// Composite list `[Thing!]!` whose element is missing a required non-null
+// sub-field. `emit_missing_field` is the originating emit site (writes
+// valueCompletion at the element parent path `[items, 0]` and response.errors
+// at the missing-field leaf `[items, 0, value]`); both wrapper frames (Thing!
+// and [Thing!]!) skip via Object inner_named_type. No drop.
+#[test]
+fn reformat_response_composite_list_missing_nonnull_field() {
+    FormatTest::builder()
+        .schema(
+            r#"
+            type Query { items: [Thing!]! }
+            type Thing { value: Int! }
+            "#,
+        )
+        .query(r#"{ items { value } }"#)
+        // Element is an empty object — `value` (Int!) is missing.
+        .response(json!({ "items": [{}] }))
+        .expected(json!(null))
+        .expected_errors(json!([
+            // emit_missing_field response.errors at the leaf.
+            {
+                "message": "Missing field",
+                "path": ["items", 0, "value"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+            // format_list's own diagnostic.
+            {
+                "message": "Invalid value found inside the array of type [Thing!]",
+                "path": ["items"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
+        // emit_missing_field valueCompletion at the element parent path.
+        // Both wrapper frames skip — no duplicate, no drop.
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Cannot return null for non-nullable type Int",
+                    "path": ["items", 0],
+                },
+            ]
+        }))
+        .test();
+}
+
+// Composite list `[Thing!]` (nullable outer, non-null inner) with a deep
+// element error. The bubble propagates element → Thing! wrapper → nullable
+// list (absorbs). The nullable outer list does NOT wrap in
+// `format_non_nullable_value`, so no outer emit to drop.
+#[test]
+fn reformat_response_composite_list_nullable_outer_absorbs() {
+    FormatTest::builder()
+        .schema(
+            r#"
+            type Query { items: [Thing!] }
+            type Thing { value: Int! }
+            "#,
+        )
+        .query(r#"{ items { value } }"#)
+        .response(json!({ "items": [{ "value": 1.5 }] }))
+        // Nullable list absorbs — `items` becomes null.
+        .expected(json!({ "items": null }))
+        .expected_errors(json!([
+            // Scalar leaf coercion emit (no companion "Null value" entry —
+            // scalar-Err dedup).
+            {
+                "message": "Invalid value found for the type Int",
+                "path": ["items", 0, "value"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+            // format_list's own diagnostic (inner type Thing! is non-null
+            // → format_list propagates and emits at the list path).
+            {
+                "message": "Invalid value found inside the array of type [Thing!]",
+                "path": ["items"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
+        // Single originating valueCompletion at the deep scalar leaf.
+        // Thing! wrapper skips (Object inner_named_type); the outer list
+        // is nullable so no `format_non_nullable_value` wraps it.
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Null value found for non-nullable type Int",
+                    "path": ["items", 0, "value"],
+                },
+            ]
+        }))
+        .test();
+}
+
+// Composite list `[Thing!]` (nullable outer, non-null inner) with an
+// explicit-null element — `[null]`. The element-level
+// `format_non_nullable_value(Thing!)` is the originating frame (inner
+// `format_named_type` returns Ok with output=null because input was null),
+// so it emits both sinks at `[items, 0]`. `format_list` then propagates and
+// emits its own "Invalid value found inside the array" entry to
+// response.errors. The nullable outer list has no `format_non_nullable_value`
+// wrapper, so no outer emit either way.
+#[test]
+fn reformat_response_composite_list_nullable_outer_explicit_null_element() {
+    FormatTest::builder()
+        .schema(
+            r#"
+            type Query { items: [Thing!] }
+            type Thing { value: Int! }
+            "#,
+        )
+        .query(r#"{ items { value } }"#)
+        .response(json!({ "items": [null] }))
+        // Nullable outer absorbs the bubble — `items` becomes null.
+        .expected(json!({ "items": null }))
+        .expected_errors(json!([
+            {
+                "message": "Null value found for non-nullable type Thing",
+                "path": ["items", 0],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+            {
+                "message": "Invalid value found inside the array of type [Thing!]",
+                "path": ["items"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
+        // Single originating valueCompletion at the element. No outer-list
+        // wrapper to deduplicate against.
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Null value found for non-nullable type Thing",
+                    "path": ["items", 0],
+                },
+            ]
+        }))
+        .test();
+}
+
+// List with nullable inner `[Thing]!`. An element that fails an inner
+// non-null contract nullifies independently — the bubble terminates at the
+// nullable element slot, not at the list. No outer list emit either.
+#[test]
+fn reformat_response_composite_list_nullable_inner_per_element() {
+    FormatTest::builder()
+        .schema(
+            r#"
+            type Query { items: [Thing]! }
+            type Thing { value: Int! }
+            "#,
+        )
+        .query(r#"{ items { value } }"#)
+        .response(json!({
+            "items": [
+                { "value": 1 },
+                { "value": 1.5 },
+                { "value": 3 }
+            ]
+        }))
+        // Middle element nullifies in place; siblings preserved.
+        .expected(json!({
+            "items": [
+                { "value": 1 },
+                null,
+                { "value": 3 }
+            ]
+        }))
+        .expected_errors(json!([
+            {
+                "message": "Invalid value found for the type Int",
+                "path": ["items", 1, "value"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
+        // Single valueCompletion at the originating scalar leaf. The
+        // nullable Thing slot absorbs, no list-level emit.
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Null value found for non-nullable type Int",
+                    "path": ["items", 1, "value"],
+                },
+            ]
+        }))
+        .test();
+}
+
+// Nested composite list `[[Thing!]!]!` with a deep scalar coercion failure.
+// The bubble crosses inner-list, element-Thing!, outer-list, and finally the
+// root `format_non_nullable_value` wrapper. Each composite wrapper SKIPs
+// (Object inner_named_type), confirming no drop in the nested case.
+#[test]
+fn reformat_response_composite_nested_list_deep_failure() {
+    FormatTest::builder()
+        .schema(
+            r#"
+            type Query { grid: [[Thing!]!]! }
+            type Thing { value: Int! }
+            "#,
+        )
+        .query(r#"{ grid { value } }"#)
+        .response(json!({ "grid": [[ { "value": 1.5 } ]] }))
+        .expected(json!(null))
+        .expected_errors(json!([
+            {
+                "message": "Invalid value found for the type Int",
+                "path": ["grid", 0, 0, "value"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+            // Only the innermost list emits its "Invalid value found inside the
+            // array" entry — the outer list's element type is itself a list, so
+            // `format_list` skips its own emit to avoid bubble compounding.
+            {
+                "message": "Invalid value found inside the array of type [Thing!]",
+                "path": ["grid", 0],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
+        // Single originating valueCompletion at the deep scalar leaf. Every
+        // composite wrapper above (Thing!, [Thing!]!, [[Thing!]!]!) skips —
+        // confirms the composite skip predicate doesn't drop the deep entry.
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Null value found for non-nullable type Int",
+                    "path": ["grid", 0, 0, "value"],
+                },
+            ]
+        }))
+        .test();
+}
+
+// `apply_root_selection_set` bubble suppression for a non-null root field.
+//
+// Mirrors the `apply_selection_set` case: a non-null root field whose child
+// errors no longer re-emits a "Null value found for non-nullable type X"
+// at the root field's path.  The leaf still emits once.
+#[test]
+fn reformat_response_root_nonnull_bubble_suppression() {
+    FormatTest::builder()
+        .schema(
+            r#"
+            type Query {
+                thing: Thing!
+            }
+
+            type Thing {
+                value: Int!
+            }
+            "#,
+        )
+        .query(r#"{ thing { value } }"#)
+        .response(json!({
+            "thing": { "value": 1.5 }
+        }))
+        // Root field `thing` is non-null → bubble propagates to `data`.
+        .expected(json!(null))
+        // Only the originating coercion error remains. Before any dedup, three
+        // extra entries would have landed.
+        .expected_errors(json!([
+            {
+                "message": "Invalid value found for the type Int",
+                "path": ["thing", "value"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
+        // Expect valueCompletion only at the originating non-null scalar leaf.
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Null value found for non-nullable type Int",
+                    "path": ["thing", "value"],
+                },
+            ]
+        }))
+        .test();
+}
+
+// Two separate bubble paths under a nullable root: each must emit its own leaf error.
+//
+// The dedup change suppresses *re-emits along a single bubble path* (a non-null parent
+// re-stating what its child already reported).  It must NOT suppress independent
+// bubbles that originate from sibling subtrees.
+//
+// Layout:
+//
+//     Query.outer: Outer            # nullable — absorbs both bubbles
+//     Outer.alpha: Mid              # nullable — absorbs alpha's bubble
+//     Outer.beta:  Int!             # non-null — beta's bubble propagates past
+//     Mid.inner:   Int!             # non-null
+//
+// Bubble #1 — `outer.alpha.inner` is invalid:
+//   leaf emit at `[outer, alpha, inner]` → `Mid` propagates `Err` → `apply_selection_set`
+//   on `Outer.alpha` (nullable) swallows.  `alpha` lands as `null`.
+//
+// Bubble #2 — `outer.beta` is invalid:
+//   leaf emit at `[outer, beta]` → `Outer.beta` (non-null) propagates `Err` →
+//   `format_named_type` on `Outer` propagates → `apply_root_selection_set` on
+//   `Query.outer` (nullable) swallows.  `outer` lands as `null`.
+//
+// Both leaves emit; both bubbles terminate at distinct nullable ancestors; no
+// duplicated parent-path emits along either chain.
+#[test]
+fn reformat_response_two_independent_bubbles_each_report() {
+    FormatTest::builder()
+        .schema(
+            r#"
+            type Query {
+                outer: Outer
+            }
+
+            type Outer {
+                alpha: Mid
+                beta: Int!
+            }
+
+            type Mid {
+                inner: Int!
+            }
+            "#,
+        )
+        .query(r#"{ outer { alpha { inner } beta } }"#)
+        .response(json!({
+            "outer": {
+                "alpha": { "inner": 1.5 },
+                "beta": 2.5
+            }
+        }))
+        // `Query.outer` is nullable → both bubbles terminate inside `outer`,
+        // so `outer` itself is `null` (beta's bubble nullified the whole object).
+        .expected(json!({ "outer": null }))
+        // Two entries, one originating coercion error per bubble.  Scalar-Err
+        // dedup suppresses the "Null value found for non-nullable type Int"
+        // emits at each leaf; format_named_type-Err dedup suppresses the
+        // intermediate "Null value found for non-nullable type Mid/Outer"
+        // bubbles along each chain.
+        .expected_errors(json!([
+            {
+                "message": "Invalid value found for the type Int",
+                "path": ["outer", "alpha", "inner"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+            {
+                "message": "Invalid value found for the type Int",
+                "path": ["outer", "beta"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
+        // valueCompletion: one entry per originating leaf, two total.
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Null value found for non-nullable type Int",
+                    "path": ["outer", "alpha", "inner"],
+                },
+                {
+                    "message": "Null value found for non-nullable type Int",
+                    "path": ["outer", "beta"],
+                },
+            ]
+        }))
+        .test();
+}
+
+// Nested errors along the same chain: an absorbed deep bubble plus a separate
+// invalid-value error at the outer level.  Both errors must be reported, with
+// the nullable middle layer absorbing the deep bubble silently.
+//
+// Three behaviors stacked along the response tree:
+//
+//     leaf   (`mid.leaf`, Int!)  — non-null with invalid value → errors at leaf path
+//     mid    (`mid`, Mid)        — nullable → absorbs the leaf's bubble (silent)
+//     outer  (`outer`, Int)      — own invalid value → errors at outer path
+//
+// Without dedup, `mid`'s absorbed bubble would also re-emit "Null value found for
+// non-nullable type Int" at `[mid]` (the old `format_non_nullable_value` path on
+// the nullified `mid.leaf`).  Post-dedup, the `Err` from `apply_selection_set`
+// propagates through `format_named_type`, `format_non_nullable_value`'s `?`
+// short-circuits, and the absorb at `mid` is silent.  Outer is independent —
+// `format_integer` emits at `[outer]` on its own coercion failure.
+#[test]
+fn reformat_response_outer_invalid_and_absorbed_inner_bubble_both_report() {
+    FormatTest::builder()
+        .schema(
+            r#"
+            type Query {
+                outer: Int
+                mid: Mid
+            }
+
+            type Mid {
+                leaf: Int!
+            }
+            "#,
+        )
+        .query(r#"{ outer mid { leaf } }"#)
+        .response(json!({
+            "outer": 1.5,
+            "mid": { "leaf": 2.5 }
+        }))
+        // `outer` nullifies in place (nullable Int with invalid value);
+        // `mid` nullifies via the absorbed leaf bubble.
+        .expected(json!({
+            "outer": null,
+            "mid": null,
+        }))
+        .expected_errors(json!([
+            // outer error: nullable Int, only the coercion-side emit (no
+            // "Null value for non-nullable" because outer is nullable).
+            {
+                "message": "Invalid value found for the type Int",
+                "path": ["outer"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+            // leaf error: non-null Int!, only the originating coercion error.
+            // Scalar-Err dedup suppresses the leaf-level "Null value found"
+            // emit, and mid's nullable swallow is silent — the absorbed
+            // bubble adds nothing further.
+            {
+                "message": "Invalid value found for the type Int",
+                "path": ["mid", "leaf"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
+        // valueCompletion: only the originating non-null leaf at `[mid, leaf]`.
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Null value found for non-nullable type Int",
+                    "path": ["mid", "leaf"],
+                },
+            ]
+        }))
+        .test();
+}
+
+// `__typename` selection on an abstract (union) type where the input has no
+// `__typename` to disambiguate the concrete object.
+//
+// Before this change, the `__typename` branch returned `Err(InvalidValue)`
+// with no emit; `format_named_type` then swallowed the `Err`, leaving
+// `output = null`, and `format_non_nullable_value` emitted
+// "Null value found for non-nullable type X" at the parent path.
+//
+// After the dedup change, `format_named_type` propagates the `Err` —
+// without an emit at the `__typename` branch, the nullification would be
+// silent.  The fix calls `emit_missing_field` so the diagnostic lands at
+// the `__typename` leaf path.
+#[test]
+fn reformat_response_unknown_typename_emits_at_typename_leaf() {
+    FormatTest::builder()
+        .schema(
+            r#"
+            type Query {
+                thing: Thing
+            }
+
+            union Thing = Foo | Bar
+
+            type Foo { a: Int }
+            type Bar { b: Int }
+            "#,
+        )
+        .query(r#"{ thing { __typename } }"#)
+        // Input has no `__typename`, and the field's `current_type` is the union
+        // `Thing` — `get_object("Thing")` is None and there's no input `__typename`
+        // to fall back on, so the `__typename` branch returns `Err`.
+        .response(json!({
+            "thing": {}
+        }))
+        // `thing` is nullable, so it nullifies in `data` without bubbling further.
+        .expected(json!({ "thing": null }))
+        // New: `emit_missing_field` reports the unresolvable `__typename` at the
+        // leaf path.  Field type `String!` (non-null) → emits to both sinks.
+        .expected_errors(json!([
+            {
+                "message": "Missing field",
+                "path": ["thing", "__typename"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
+        .expected_extensions(json!({
+            "valueCompletion": [
+                {
+                    "message": "Cannot return null for non-nullable type String",
+                    "path": ["thing"],
+                },
+            ]
+        }))
         .test();
 }
 
@@ -2024,19 +2609,14 @@ fn reformat_response_coercion_propagation_into_union() {
         .query(query_wo_type_info)
         .response(resp_with_type_info.clone())
         .expected(json!({ "thing": null }))
-        // NOTE: The array validation stops at its first invalid value and "bubbles" up the
-        // nullification from there
+        // Only the originating coercion error: No extra "Null value found for non-nullable type"
+        // error.
         .expected_errors(json!([
             {
                 "message": "Invalid value found for the type Int",
                 "path": ["thing", "b"],
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
             },
-            {
-                "message": "Null value found for non-nullable type Int",
-                "path": ["thing", "b"],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
-            }
         ]))
         .test();
 
@@ -2046,7 +2626,13 @@ fn reformat_response_coercion_propagation_into_union() {
         .query(query_with_type_info)
         .response(resp_wo_type_info.clone())
         .expected(json!({ "thing": null }))
-        .expected_errors(json!([]))
+        .expected_errors(json!([
+            {
+                "message": "Missing field",
+                "path": ["thing", "__typename"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
         .test();
 
     FormatTest::builder()
@@ -2054,7 +2640,13 @@ fn reformat_response_coercion_propagation_into_union() {
         .query(query_with_type_info)
         .response(resp_wo_type_info.clone())
         .expected(json!({ "thing": null }))
-        .expected_errors(json!([]))
+        .expected_errors(json!([
+            {
+                "message": "Missing field",
+                "path": ["thing", "__typename"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
         .test();
 
     // Case 4: __typename is queried and is returned
@@ -2089,19 +2681,12 @@ fn reformat_response_coercion_propagation_into_union() {
         .query(query_with_type_info)
         .response(resp_with_type_info.clone())
         .expected(json!({ "thing": null }))
-        // NOTE: The array validation stops at its first invalid value and "bubbles" up the
-        // nullification from there
         .expected_errors(json!([
             {
                 "message": "Invalid value found for the type Int",
                 "path": ["thing", "b"],
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
             },
-            {
-                "message": "Null value found for non-nullable type Int",
-                "path": ["thing", "b"],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
-            }
         ]))
         .test();
 }
@@ -2237,19 +2822,12 @@ fn reformat_response_coercion_propagation_into_interfaces() {
         .query(query_wo_type_info)
         .response(resp_with_type_info.clone())
         .expected(json!({ "thing": null }))
-        // NOTE: The array validation stops at its first invalid value and "bubbles" up the
-        // nullification from there
         .expected_errors(json!([
             {
                 "message": "Invalid value found for the type Int",
                 "path": ["thing", "b"],
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
             },
-            {
-                "message": "Null value found for non-nullable type Int",
-                "path": ["thing", "b"],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
-            }
         ]))
         .test();
 
@@ -2261,7 +2839,13 @@ fn reformat_response_coercion_propagation_into_interfaces() {
         // FIXME(@TylerBloom): This is not expected. This should behave the same with(out)
         // `__typename` being queried.
         .expected(json!({ "thing": null }))
-        .expected_errors(json!([]))
+        .expected_errors(json!([
+            {
+                "message": "Missing field",
+                "path": ["thing", "__typename"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
         .test();
 
     FormatTest::builder()
@@ -2269,7 +2853,13 @@ fn reformat_response_coercion_propagation_into_interfaces() {
         .query(query_with_type_info)
         .response(resp_wo_type_info.clone())
         .expected(json!({ "thing": null }))
-        .expected_errors(json!([]))
+        .expected_errors(json!([
+            {
+                "message": "Missing field",
+                "path": ["thing", "__typename"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
+            },
+        ]))
         .test();
 
     // Case 4: __typename is queried and is returned
@@ -2310,11 +2900,6 @@ fn reformat_response_coercion_propagation_into_interfaces() {
                 "path": ["thing", "b"],
                 "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
             },
-            {
-                "message": "Null value found for non-nullable type Int",
-                "path": ["thing", "b"],
-                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" }
-            }
         ]))
         .test();
 }

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -3524,7 +3524,7 @@ fn filter_nested_object_errors() {
         .expected_extensions(json! {{
             "valueCompletion": [
                 {
-                    "message": "Null value found for non-nullable type String",
+                    "message": "Cannot return null for non-nullable type String",
                     "path": ["me", "reviews1", 0]
                 }
             ]
@@ -7296,7 +7296,7 @@ fn reformat_response_data_nested_fragment_spread_with_unions() {
         .expected_extensions(json!({
             "valueCompletion": [
                 {
-                    "message": "Null value found for non-nullable type ID",
+                    "message": "Cannot return null for non-nullable type ID",
                     "path": ["thing", "collection"]
                 }
             ]

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -3513,6 +3513,14 @@ fn filter_nested_object_errors() {
                 "reviews1": [ null ],
             },
         }})
+        // `emit_missing_field` writes to BOTH sinks for non-null missing:
+        .expected_errors(json! {[
+            {
+                "message": "Missing field",
+                "path": ["me", "reviews1", 0, "text2"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
+            }
+        ]})
         .expected_extensions(json! {{
             "valueCompletion": [
                 {
@@ -7277,8 +7285,14 @@ fn reformat_response_data_nested_fragment_spread_with_unions() {
                 "collection": null
             }
         }))
-        // The missing-field error must be reported; path stops at "collection"
-        // because the absent "id" field is never pushed onto the response path.
+        // `emit_missing_field` writes to BOTH sinks for non-null missing:
+        .expected_errors(json!([
+            {
+                "message": "Missing field",
+                "path": ["thing", "collection", "id"],
+                "extensions": { "code": "RESPONSE_VALIDATION_FAILED" },
+            }
+        ]))
         .expected_extensions(json!({
             "valueCompletion": [
                 {

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_one_subgraph_cost_are_accepted@federated_ships_fragment.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__demand_control__requests_exceeding_one_subgraph_cost_are_accepted@federated_ships_fragment.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/integration/demand_control.rs
+assertion_line: 389
 expression: parse_result_for_snapshot(response).await
 ---
 {
@@ -39,7 +40,7 @@ expression: parse_result_for_snapshot(response).await
     "extensions": {
       "valueCompletion": [
         {
-          "message": "Cannot return null for non-nullable field Query.ships",
+          "message": "Cannot return null for non-nullable type Ship",
           "path": []
         }
       ]

--- a/apollo-router/tests/snapshots/set_context__set_context_dependent_fetch_failure_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_dependent_fetch_failure_rust_qp.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/tests/set_context.rs
+assertion_line: 310
 expression: response
 ---
 {
@@ -19,6 +20,15 @@ expression: response
       ],
       "extensions": {
         "service": "Subgraph1"
+      }
+    },
+    {
+      "message": "Missing field",
+      "path": [
+        "t"
+      ],
+      "extensions": {
+        "code": "RESPONSE_VALIDATION_FAILED"
       }
     }
   ],
@@ -107,7 +117,7 @@ expression: response
     },
     "valueCompletion": [
       {
-        "message": "Cannot return null for non-nullable field Query.t",
+        "message": "Cannot return null for non-nullable type T",
         "path": []
       }
     ]

--- a/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
@@ -16,6 +16,17 @@ expression: response
       }
     },
     {
+      "message": "Missing field",
+      "path": [
+        "t",
+        "u",
+        "field"
+      ],
+      "extensions": {
+        "code": "RESPONSE_VALIDATION_FAILED"
+      }
+    },
+    {
       "message": "Null value found for non-nullable type U",
       "path": [
         "t",

--- a/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
@@ -177,7 +177,7 @@ expression: response
     },
     "valueCompletion": [
       {
-        "message": "Null value found for non-nullable type Int",
+        "message": "Cannot return null for non-nullable type Int",
         "path": [
           "t",
           "u"

--- a/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
+++ b/apollo-router/tests/snapshots/set_context__set_context_unrelated_fetch_failure_rust_qp.snap
@@ -25,25 +25,6 @@ expression: response
       "extensions": {
         "code": "RESPONSE_VALIDATION_FAILED"
       }
-    },
-    {
-      "message": "Null value found for non-nullable type U",
-      "path": [
-        "t",
-        "u"
-      ],
-      "extensions": {
-        "code": "RESPONSE_VALIDATION_FAILED"
-      }
-    },
-    {
-      "message": "Null value found for non-nullable type T",
-      "path": [
-        "t"
-      ],
-      "extensions": {
-        "code": "RESPONSE_VALIDATION_FAILED"
-      }
     }
   ],
   "extensions": {
@@ -181,19 +162,6 @@ expression: response
         "path": [
           "t",
           "u"
-        ]
-      },
-      {
-        "message": "Null value found for non-nullable type U",
-        "path": [
-          "t",
-          "u"
-        ]
-      },
-      {
-        "message": "Null value found for non-nullable type T",
-        "path": [
-          "t"
         ]
       }
     ]


### PR DESCRIPTION
## Summary

When `format_response` detects a user-asked field missing from the merged subgraph response, emit a `RESPONSE_VALIDATION_FAILED` error in `response.errors` — gated by `enable_result_coercion_errors`. Previously only `extensions.valueCompletion` was written (and only for non-null fields).

## Details

Pre-fix, the `apply_selection_set` missing-field branch wrote only to `parameters.errors` (→ `valueCompletion`), while the neighboring explicit-null branch (`format_non_nullable_value`) emitted to **both** `valueCompletion` and `response.errors`. A new `emit_missing_field` helper closes the gap:

- **`valueCompletion`** (non-null only, parent path): unchanged legacy behavior — `"Null value found for non-nullable type T"`.
- **`response.errors`** (nullable + non-null, leaf path): new — `"Missing field"` with code `RESPONSE_VALIDATION_FAILED`, gated by `enable_result_coercion_errors`.

Nullable missing fields surface only in `response.errors` when the gate is on (no new `valueCompletion` noise). Non-null missing fields behave as before plus also land in `response.errors`.

---

<!-- [ROUTER-1741] -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

[ROUTER-1741]: https://apollographql.atlassian.net/browse/ROUTER-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ