### PR TITLE
fix(composition): don't emit empty `@policy` on `@interfaceObject` field propagation

### DIFF
--- a/apollo-federation/src/merger/merge_directive.rs
+++ b/apollo-federation/src/merger/merge_directive.rs
@@ -255,6 +255,10 @@ impl Merger {
             }
         }
 
+        if directive_counts.is_empty() {
+            return Ok(());
+        }
+
         if definition.repeatable {
             trace!(
                 "Directive @{name} is repeatable, merging all {} applications at {dest}",

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1870,13 +1870,21 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
         for (dest, ast_node) in fields_to_insert {
             trace!("Filling in missing interface object field {dest} with {ast_node}",);
             dest.insert(&mut self.merged, Component::new(ast_node))?;
-            // now we can merge access control directives
-            for directive_name in &access_control_directive_names {
-                self.merge_applied_directive(
-                    directive_name,
-                    &Default::default(),
-                    &dest.clone().into(),
-                )?;
+            // Merge access control directives only if there are additional sources
+            // (e.g. from @interfaceObject field propagation). Matches JS behavior
+            // which checks `additionalSources.length > 0` before merging.
+            let dest_position: DirectiveTargetPosition = dest.clone().into();
+            let additional_sources = self.access_control_additional_sources()?;
+            let ac_directives_to_merge: Vec<_> = self
+                .access_control_directives_in_supergraph
+                .iter()
+                .filter(|(ac_name, _)| {
+                    additional_sources.contains_key(&format!("{dest_position}_{ac_name}"))
+                })
+                .map(|(_, name_in_supergraph)| name_in_supergraph.clone())
+                .collect();
+            for name in &ac_directives_to_merge {
+                self.merge_applied_directive(name, &Default::default(), &dest_position)?;
             }
 
             // If we had to add a field here, it means that, for this particular implementation, the

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -829,3 +829,49 @@ fn requires_error_locations_include_requires_directive_and_incompatible_fields()
     assert_eq!(locations[0].subgraph, "subgraphA");
     assert_eq!(locations[1].subgraph, "subgraphB");
 }
+
+#[test]
+fn no_empty_policy_on_interface_object_field_propagation() {
+    // When an @interfaceObject adds fields to implementation types, the code previously
+    // called merge_applied_directive for ALL access control directives with empty sources.
+    // The DNF conjunction merger would then produce @policy(policies: []) from zero
+    // applications. This verifies the fix: only merge when additional sources exist.
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+            type Query { product(id: ID!): Product }
+
+            interface Product @key(fields: "id") {
+              id: ID!
+              name: String!
+            }
+
+            type Book implements Product @key(fields: "id") {
+              id: ID!
+              name: String!
+              isbn: String! @policy(policies: [["read"]])
+            }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+            type Product @key(fields: "id") @interfaceObject {
+              id: ID!
+              reviews: [String!]!
+            }
+        "#,
+    };
+
+    use insta::assert_snapshot;
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]).unwrap();
+    let book = result
+        .schema()
+        .schema()
+        .types
+        .get("Book")
+        .expect("Book should exist in supergraph");
+    assert_snapshot!(book.to_string());
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_validation__no_empty_policy_on_interface_object_field_propagation.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_validation__no_empty_policy_on_interface_object_field_propagation.snap
@@ -1,0 +1,11 @@
+---
+source: apollo-federation/tests/composition/compose_validation.rs
+assertion_line: 673
+expression: book.to_string()
+---
+type Book implements Product @join__implements(graph: SUBGRAPHA, interface: "Product") @join__type(graph: SUBGRAPHA, key: "id") {
+  id: ID!
+  name: String!
+  isbn: String! @policy(policies: [["read"]])
+  reviews: [String!]! @join__field
+}


### PR DESCRIPTION
When filling in missing `@interfaceObject` fields on implementation types, the code blindly called `merge_applied_directive` for ALL access control directives with empty sources. The DNF conjunction merger then produced `@policy(policies: [])` from zero applications.

Fix the call site to only merge access control directives when `access_control_additional_sources` has entries for the target field, matching JS behavior at:
https://github.com/apollographql/federation/blob/8200b154/composition-js/src/merging/merge.ts#L1455

Also add a safety-net early return in `merge_applied_directive` when `directive_counts` is empty (zero applications from all sources), matching JS at:
https://github.com/apollographql/federation/blob/8200b154/composition-js/src/merging/merge.ts#L3441
