### PR TITLE
fix(composition): add join spec versions to spec registry

### DIFF
--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -29,6 +29,7 @@ use crate::link::Import;
 use crate::link::Link;
 use crate::link::Purpose;
 use crate::link::federation_spec_definition::FEDERATION_VERSIONS;
+use crate::link::join_spec_definition::JOIN_VERSIONS;
 use crate::link::spec::Identity;
 use crate::link::spec::Url;
 use crate::link::spec::Version;
@@ -358,5 +359,6 @@ pub(crate) static SPEC_REGISTRY: LazyLock<SpecRegistry> = LazyLock::new(|| {
     registry.extend(&POLICY_VERSIONS);
     registry.extend(&REQUIRES_SCOPES_VERSIONS);
     registry.extend(&TAG_VERSIONS);
+    registry.extend(&JOIN_VERSIONS);
     registry
 });

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -400,7 +400,19 @@ impl FederationBlueprint {
     }
 
     fn expand_known_features(schema: &mut FederationSchema) -> Result<(), FederationError> {
+        // PORT_NOTE: Matches JS `expandKnownFeatures` which skips link, federation, and join.
+        // Link and federation are already handled earlier. Join is a supergraph-only spec
+        // whose elements are added by the merger, not during subgraph expansion.
+        // See: https://github.com/apollographql/federation/blob/8200b154/internals-js/src/federation.ts#L2238
+        let skip = [
+            Identity::link_identity(),
+            Identity::federation_identity(),
+            Identity::join_identity(),
+        ];
         for feature in schema.all_features()? {
+            if skip.contains(feature.identity()) {
+                continue;
+            }
             feature.add_elements_to_schema(schema)?;
         }
 


### PR DESCRIPTION
This matches JS behavior ([link](https://github.com/apollographql/federation/blob/main/internals-js/src/specs/joinSpec.ts#L294)).
