### PR TITLE
docs(routing): update version references to use latest router version

### DIFF
--- a/docs/source/routing/about-v2.mdx
+++ b/docs/source/routing/about-v2.mdx
@@ -4,11 +4,11 @@ subtitle: ""
 description: What's new in Apollo GraphOS Router version 2.x, including Long Term Release (LTS) status, key features, and how to upgrade
 ---
 
-GraphOS Router v{products.router.version("lts_2_latest").version} is the latest Apollo runtime platform. This release introduces changes and enhancements that improve the router’s overall quality and establishes a strong foundation for new innovations, such as Apollo Connectors for REST. It also ships with the new Native Query Planner, optimized for efficiency and performance for high scale mission critical workloads. 
+GraphOS Router v{products.router.latest().version} is the latest Apollo runtime platform. This release introduces changes and enhancements that improve the router’s overall quality and establishes a strong foundation for new innovations, such as Apollo Connectors for REST. It also ships with the new Native Query Planner, optimized for efficiency and performance for high scale mission critical workloads. 
 
 ## Release status of router v2.x
 
-GraphOS Router v2.x is an **Active** release with latest version {products.router.version("lts_2_latest").version}.
+GraphOS Router v2.x is an **Active** release with latest version {products.router.latest().version}.
 
 | Current Status | Release Date | Latest Minor | Active Date    | Maintenance Date | End of Life Date |
 | -------------- | ------------ | ------------ | -------------- | ---------------- | ---------------- |

--- a/docs/source/routing/upgrade/from-router-v1.mdx
+++ b/docs/source/routing/upgrade/from-router-v1.mdx
@@ -636,7 +636,7 @@ This operation has been blocked as a potential Cross-Site Request Forgery (CSRF)
 
 ## Deploy your router
 
-Make sure that you are referencing the correct router release: **v{products.router.version("connectors").version}**
+Make sure that you are referencing the correct router release: **v{products.router.latest().version}**
 
 ## Reporting upgrade issues
 


### PR DESCRIPTION
Update version references to use latest router version.

Currently, a hardcoded string needs to be updated every time a router release ships. This removes that need.