### PR TITLE
docs: clarify default setting for OpenTelemetry standard instruments

### DIFF
--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/instruments.mdx
@@ -40,7 +40,16 @@ OpenTelemetry specifies multiple [standard metric instruments](https://opentelem
 
 <Note>
 
-The [`default_requirement_level` setting](#default_requirement_level) configures whether or not these instruments are enabled by default. Out of the box, its default value of `required` enables them. You must explicitly configure an instrument for different behavior. 
+The [`default_requirement_level` setting](#default_requirement_level) configures whether or not these instruments are enabled by default. Out of the box, its default value of `required` enables them.
+<br />
+<br />
+| Value of `default_requirement_level` | Value of standard instruments |
+|-------------------------------------|--------------------------------|
+| `none`                              | `false`                        |
+| `required`                          | `true`                         |
+| `recommended`                       | `true`                         |
+
+You must explicitly configure an individual instrument for different behavior.
 
 </Note>
 
@@ -50,19 +59,20 @@ These instruments are configurable in `router.yaml`:
 telemetry:
   instrumentation:
     instruments:
+      default_requirement_level: required # (default is required)
       router:
-        http.server.active_requests: true # (default false)
-        http.server.request.body.size: true # (default false)
-        http.server.request.duration: true # (default false)
-        http.server.response.body.size: true # (default false)
+        http.server.active_requests: false # (default is true)
+        http.server.request.body.size: false # (default is true)
+        http.server.request.duration: false # (default is true)
+        http.server.response.body.size: false # (default is true)
       subgraph:
-        http.client.request.body.size: true # (default false)
-        http.client.request.duration: true # (default false)
-        http.client.response.body.size: true # (default false)
+        http.client.request.body.size: false # (default is true)
+        http.client.request.duration: false # (default is true)
+        http.client.response.body.size: false # (default is true)
       connector:
-        http.client.request.body.size: true # (default false)
-        http.client.request.duration: true # (default false)
-        http.client.response.body.size: true # (default false)
+        http.client.request.body.size: false # (default is true)
+        http.client.request.duration: false # (default is true)
+        http.client.response.body.size: false # (default is true)
 ```
 
 They can be customized by attaching or removing attributes. See [attributes](#attributes) to learn more about configuring attributes.
@@ -192,6 +202,7 @@ Valid values:
 
 * `required` (default, Apollo recommended) - required attributes will be attached to standard instruments by default.
 * `recommended` - experimental attributes from OpenTelemetry's development-status conventions will be attached to standard instruments by default.
+* `none` - standard instruments will be disabled by default; no attributes will be set unless configured individually.
 
 <Note>
 
@@ -557,7 +568,7 @@ telemetry:
 | `<instrument-name>`         |                                                                                |            | The name of the custom instrument.            |
 | `attributes`                | [standard attributes](/router/configuration/telemetry/instrumentation/standard-attributes) or [selectors](/router/configuration/telemetry/instrumentation/selectors)       |            | The attributes of the custom instrument.      |
 | `condition`                 | [conditions](/router/configuration/telemetry/instrumentation/conditions)                                                     |            | The condition for mutating the instrument.    |
-| `default_requirement_level` | `required` \| `recommended`                                                      | `required` | The default attribute requirement level.      |
+| `default_requirement_level` | `required` \| `recommended` \| `none`                                          | `required` | The default attribute requirement level.      |
 | `type`                      | `counter` \| `histogram`                                                         |            | The name of the custom instrument.            |
 | `unit`                      |                                                                                |            | A unit name, for example `By` or `{request}`. |
 | `description`               |                                                                                |            | The description of the custom instrument.     |


### PR DESCRIPTION
[jira/ROUTER-1317](https://apollographql.atlassian.net/browse/ROUTER-1317)
<!-- [ROUTER-1317] -->

The Router's telemetry docs currently suggest that the [standard instruments](https://www.apollographql.com/docs/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/instruments#opentelemetry-standard-instruments) are set to `false` by default, but the [implementation](https://github.com/apollographql/router/blob/baeb6d02f7999753e1170e70d0d682fcb1e6a06f/apollo-router/src/plugins/telemetry/config_new/instruments.rs#L1289-L1316) demonstrates that the _opposite_ is correct. This change modifies the wording to make it clearer that these instruments are set to `true` by default.

This PR updates wording and provides additional information to decrease ambiguity:
 * rewords the NOTE for `default_requirement_level`
 * includes a chart to indicate what each value of the property corresponds to for the standard instruments
 * updates the related example YAML to explicitly include `default_requirement_level` and show that the standard instuments can be set to `false` as desired
 * adds `none` to the list of "Valid values" in the definition of `default_requirement_level` as well as in the "Instrument configuration reference" table

---

Note: This commit is a squash of previous commits made to this file in the now-closed [PR#9423](https://github.com/apollographql/router/pull/9423):
 * 0bd18dbef - docs: clarify default setting for required instruments
 * a24add128 - docs: add chart to clarify how to configure standard otel instruments
 * e05b8be7c - docs: add missing info for `none` value of `default_requirement_level`


[ROUTER-1317]: https://apollographql.atlassian.net/browse/ROUTER-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ