### PR TITLE
fix(QP-execution): Replace`is_subtype` check with possible-types intersection

### DIFF
--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -816,30 +816,14 @@ impl Query {
                         continue;
                     }
 
-                    // NOTE: The subtype logic is strange. We are trying to determine if a fragment
-                    // should be applied, but we don't have the __typename of the selection set
-                    // (otherwise, we would be on a different branch). Consider the following query
-                    // for a union Thing = Foo | Bar:
-                    // { thing { ... on Foo { foo }, ... on Bar { bar } } }
-                    //
-                    // As we process the `... on Foo` fragment, `Foo` is `type_condition` and
-                    // `Thing` is `current_type`, we *could* reverse the order in calling
-                    // `is_subtype` and apply the fragment; however, the same is true for the `Bar`
-                    // fragment. Without the type info of the data we have in our response, we
-                    // can't know which to apply (or if both should apply in the case of
-                    // interfaces).
-                    //
-                    // Without that information, this is the best we can do without construction a
-                    // much more complicated reformatting heuristic.
-                    //
-                    // This formatter processes fragments sequentially rather than pre-merging them
-                    // via CollectFields (as the GraphQL spec prescribes) — root cause of several
-                    // correctness bugs, tracked in ROUTER-740.
-                    let is_apply = current_type.inner_named_type().as_str()
-                        == type_condition.as_str()
-                        || parameters
-                            .schema
-                            .is_subtype(type_condition, current_type.inner_named_type().as_str());
+                    // Fragments are still processed sequentially rather than
+                    // pre-merged via CollectFields (see ROUTER-740).
+                    let is_apply = does_fragment_type_apply(
+                        parameters.schema,
+                        current_type.inner_named_type().as_str(),
+                        type_condition.as_str(),
+                        input,
+                    );
 
                     if is_apply {
                         // if this is the filtered query, we must keep the __typename field because the original query must know the type
@@ -875,14 +859,12 @@ impl Query {
                         selection_set,
                     }) = self.fragments.get(name)
                     {
-                        // NOTE: This subtype logic is a bit strange. See the InlineFragment
-                        // branch for why its done this way.
-                        let is_apply = current_type.inner_named_type().as_str()
-                            == type_condition.as_str()
-                            || parameters.schema.is_subtype(
-                                type_condition,
-                                current_type.inner_named_type().as_str(),
-                            );
+                        let is_apply = does_fragment_type_apply(
+                            parameters.schema,
+                            current_type.inner_named_type().as_str(),
+                            type_condition.as_str(),
+                            input,
+                        );
 
                         if is_apply {
                             // if this is the filtered query, we must keep the __typename field because the original query must know the type
@@ -1240,6 +1222,76 @@ impl Query {
 
     pub(crate) fn is_deferred(&self, defer_conditions: BooleanValues) -> bool {
         self.defer_stats.has_unconditional_defer || defer_conditions.bits != 0
+    }
+}
+
+/// Decide whether a fragment with `type_condition` applies to a value of static field type
+/// `current_type`. Evaluated per-arm of the (current_kind × condition_kind) matrix:
+///
+/// **Concrete `current_type`** — `current_type` IS the runtime type. The static schema check is
+/// authoritative; `__typename` doesn't matter.
+///
+/// **Abstract `current_type` + concrete `type_condition`** — cheap static prune: reject when the
+/// Object is not in `current_type`'s possible types (no declared `implements` / not a union
+/// member). Otherwise the static check is inconclusive (the runtime value might be a different
+/// object also in `current_type`'s possible types) and we defer to the same `__typename` check
+/// as the abstract × abstract arm below.
+///
+/// **Abstract `current_type` + abstract `type_condition`** — Avoid the static intersection check
+/// that would cost an O(n_object_types) schema scan; defer entirely to `__typename`, with a cheap
+/// inclusion check of "runtime type (__typename value) is a subtype of type_condition".
+///
+/// TODO: We currently have false negative cases with shared-implementer subsets (e.g. an interface
+/// whose possible types are a subset of a union type condition.) A more accurate & optimized
+/// abstract-vs-abstract inclusion check is desirable without scanning the whole `possible_types`
+/// every time.
+///
+/// TODO: Currently, __typename can't be trusted entirely since query could alias it with something
+/// else like `{ __typename: foo }`. We plan to fix it with something like `__apollo_typename:
+/// __typename` private subgraph alias (so we always have a trustworthy concrete runtime type).
+fn does_fragment_type_apply(
+    schema: &ApiSchema,
+    current_type: &str,
+    type_condition: &str,
+    input: &Object,
+) -> bool {
+    use apollo_compiler::schema::ExtendedType::*;
+
+    if current_type == type_condition {
+        return true;
+    }
+
+    let Some(current_kind) = schema.types.get(current_type) else {
+        return false;
+    };
+    let Some(condition_kind) = schema.types.get(type_condition) else {
+        return false;
+    };
+
+    // Cheap (incomplete) inclusion check if runtime `__typename` is a subset of `type_condition`.
+    let runtime_type_apply = || match input.get(TYPENAME).and_then(|v| v.as_str()) {
+        Some(rt) => rt == type_condition || schema.is_subtype(type_condition, rt),
+        None => false,
+    };
+
+    match (current_kind, condition_kind) {
+        // Two distinct concrete Objects: disjoint possible-types (the identity case was already
+        // short-circuited above).
+        (Object(_), Object(_)) => false,
+
+        // Concrete current_type: current_type IS the runtime type. Static is authoritative.
+        (Object(_), Interface(_)) => schema.is_subtype(type_condition, current_type),
+        (Object(_), Union(union)) => union.members.contains(current_type),
+
+        // Abstract current_type, concrete type_condition: cheap static prune, then defer to
+        // runtime `__typename` check.
+        (Interface(_), Object(_)) => {
+            schema.is_subtype(current_type, type_condition) && runtime_type_apply()
+        }
+        (Union(union), Object(_)) => union.members.contains(type_condition) && runtime_type_apply(),
+
+        // Abstract × abstract: skip the costly static intersection. Defer entirely to runtime.
+        _ => runtime_type_apply(),
     }
 }
 

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -7726,3 +7726,175 @@ fn reformat_response_root_fragment_mixed_with_direct_fields() {
         }))
         .test();
 }
+
+// ---------------------------------------------------------------------------
+// `apply_selection_set` fragment type check (`does_fragment_type_apply` in
+// `spec/query.rs`) tests.
+//
+// We have three type variables to consider -- two static and one runtime.
+// - current_type: the parent type of fragment
+// - type_condition: the type condition of the fragment
+// - runtime_type: the __typename field value of the current response object
+//
+// When current_type is concrete, the type check can be done statically without
+// consulting __typename. Otherwise, we need to consult __typename value.
+// Here we test the cases where the runtime type is abstract or wrong outright.
+// ---------------------------------------------------------------------------
+
+// Abstract × abstract — positive: runtime `__typename` is an abstract type
+// that declaredly extends the fragment's type condition. The cheap inclusion
+// check (`is_subtype(type_condition, runtime_type)`) detects this via the
+// declared `interface X implements Y` edge.
+//
+//   interface Item                         { id }
+//   interface Likeable implements Item     { id, liked }     # declared extends
+//   type Photo implements Likeable         { id, liked, url }
+//
+//   query:    { item { id ... on Item { id } ... on Likeable { liked } } }
+//   response: { item: { __typename: "Likeable", id: "p1", liked: true } }
+//
+// At the `... on Likeable` fragment: `current_type = Item` (the field's
+// declared type), `type_condition = Likeable`. Both abstract → `runtime_type
+// = "Likeable"`, `is_subtype("Likeable", "Likeable")` matches via identity
+// (the runtime-includes path also catches strict declared subtypes).
+#[test]
+fn does_fragment_type_apply_abstract_runtime_typename_via_declared_extends() {
+    FormatTest::builder()
+        .fed2()
+        .schema(
+            "type Query { item: Item }
+             interface Item { id: ID! }
+             interface Likeable implements Item { id: ID!  liked: Boolean }
+             type Photo implements Likeable & Item { id: ID!  liked: Boolean  url: String }",
+        )
+        .query("{ item { id ... on Likeable { liked } } }")
+        .response(serde_json_bytes::json! {{
+            "item": { "__typename": "Likeable", "id": "p1", "liked": true }
+        }})
+        .expected(serde_json_bytes::json! {{
+            "item": { "id": "p1", "liked": true }
+        }})
+        .test();
+}
+
+// Abstract × abstract — TRUE negative: runtime `__typename` and the fragment
+// type condition are both abstract, and `possible_types(runtime)` is NOT a
+// subset of `possible_types(type_condition)`. The cheap `is_subtype` check
+// rejects and the rejection is semantically correct — the runtime value
+// might be an object outside the fragment's type, so applying the fragment
+// would leak fields that aren't valid for that object.
+//
+//   interface Item                     { id }
+//   interface Liked                    { liked }
+//   type Photo implements Item & Liked { id, url, liked }
+//   type Doc   implements Item         { id, content }
+//
+// possible_types:  Item = {Photo, Doc};  Liked = {Photo}
+//
+//   query:    { item { id ... on Liked { liked } } }
+//   response: { item: { __typename: "Item", id: "p1", liked: true } }
+//
+// `possible_types("Item") = {Photo, Doc}` is NOT `⊆ {Photo} = possible_types("Liked")` —
+// at runtime the value could be a `Doc`, which doesn't carry `liked`. Rejecting is
+// the correct conservative behavior; the cheap `is_subtype("Liked", "Item")` reject
+// also agrees with it.
+#[test]
+fn does_fragment_type_apply_abstract_true_negative_runtime_not_a_subset() {
+    FormatTest::builder()
+        .fed2()
+        .schema(
+            "type Query { item: Item }
+             interface Item  { id: ID! }
+             interface Liked { liked: Boolean }
+             type Photo implements Item & Liked { id: ID!  url: String  liked: Boolean }
+             type Doc   implements Item         { id: ID!  content: String }",
+        )
+        .query("{ item { id ... on Liked { liked } } }")
+        .response(serde_json_bytes::json! {{
+            "item": { "__typename": "Item", "id": "p1", "liked": true }
+        }})
+        .expected(serde_json_bytes::json! {{
+            "item": { "id": "p1" }
+        }})
+        .test();
+}
+
+// Abstract × abstract — FALSE negative: runtime `__typename` and the fragment
+// type condition are both abstract, and `possible_types(runtime)` IS a
+// subset of `possible_types(type_condition)` via shared implementers — but
+// with no declared `interface X implements Y` edge between them. The cheap
+// `is_subtype` check only inspects declared edges, misses the inclusion, and
+// rejects even though the fragment ought to apply. `itemDesc` is stripped.
+//
+//   interface Container                            { id }
+//   interface Item                                 { id, itemDesc }
+//   interface Liked                                { id, liked }     # sole impl: Photo
+//   type Photo implements Container & Item & Liked { id, itemDesc, liked, url }
+//   type Audio implements Container & Item         { id, itemDesc, source }
+//
+// possible_types:  Container = {Photo, Audio};  Item = {Photo, Audio};  Liked = {Photo}
+//
+//   query:    { container { id ... on Item { itemDesc } } }
+//   response: { container: { __typename: "Liked", id: "p1", itemDesc: "x" } }
+//
+// `possible_types("Liked") = {Photo}` IS `⊆ {Photo, Audio} = possible_types("Item")` —
+// every Liked value is a Photo, and every Photo is an Item, so the fragment SHOULD
+// apply. The cheap `is_subtype("Item", "Liked")` reject is wrong here. A tighter
+// inclusion check that walks `possible_types` directly would catch this — see the
+// TODO in `does_fragment_type_apply`.
+#[test]
+fn does_fragment_type_apply_abstract_false_negative_runtime_subset_via_shared_implementer() {
+    FormatTest::builder()
+        .fed2()
+        .schema(
+            "type Query { container: Container }
+             interface Container { id: ID! }
+             interface Item  { id: ID!  itemDesc: String }
+             interface Liked { id: ID!  liked: Boolean }
+             type Photo implements Container & Item & Liked
+                 { id: ID!  itemDesc: String  liked: Boolean  url: String }
+             type Audio implements Container & Item
+                 { id: ID!  itemDesc: String  source: String }",
+        )
+        .query("{ container { id ... on Item { itemDesc } } }")
+        .response(serde_json_bytes::json! {{
+            "container": { "__typename": "Liked", "id": "p1", "itemDesc": "the description" }
+        }})
+        .expected(serde_json_bytes::json! {{
+            "container": { "id": "p1" }
+        }})
+        .test();
+}
+
+// Concrete runtime `__typename` differs from the fragment's type condition. Both Object types
+// implement the field's declared interface, so the static intersection is non-empty — but the
+// runtime is `Doc`, not `Photo`, and `url` (a Photo-only field) must not leak through.
+//
+//   interface Item                 { id: ID! }
+//   type Photo implements Item     { id, url }
+//   type Doc   implements Item     { id, content }
+//
+//   query: { item { id ... on Photo { url } } }
+//   response: { item: { __typename: "Doc", id: "d1", url: "should-be-filtered" } }
+//
+// The subgraph's `url` value is intentionally included in the response to prove the router — not
+// the subgraph — is the one filtering.
+#[test]
+fn does_fragment_type_apply_excludes_when_runtime_typename_differs() {
+    FormatTest::builder()
+        .fed2()
+        .schema(
+            "type Query { item: Item }
+             interface Item { id: ID! }
+             type Photo implements Item { id: ID!  url: String }
+             type Doc   implements Item { id: ID!  content: String }",
+        )
+        .query("{ item { id ... on Photo { url } } }")
+        .response(serde_json_bytes::json! {{
+            "item": { "__typename": "Doc", "id": "d1", "url": "should-be-filtered" }
+        }})
+        .expected(serde_json_bytes::json! {{
+            "item": { "id": "d1" }
+        }})
+        .test();
+}


### PR DESCRIPTION
## Summary

Incremental fix of the apply_selection_set's type condition check:

- Fix the one-directional `is_subtype` check, which silently rejected fragments wherever `current_type` was abstract (due to`@interfaceObject`).
- Replace the legacy `is_subtype(type_condition, current_type)` fragment gate in `apply_selection_set` with a new `does_fragment_type_apply` helper.
- Add a (cheap-but-incomplete) runtime type inclusion check against the type condition.

<!-- start metadata -->

<!-- [ROUTER-1838] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary


[ROUTER-1838]: https://apollographql.atlassian.net/browse/ROUTER-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ