### PR TITLE
fix: clamp license timers to a safe limit

### DIFF
--- a/.changesets/fix_license_check_max_timer_duration.md
+++ b/.changesets/fix_license_check_max_timer_duration.md
@@ -1,7 +1,5 @@
-### fix: clamp license timers to a safe limit ([PR #9561](https://github.com/apollographql/router/pull/9561))
+### Clamp license timers to a safe limit ([PR #9561](https://github.com/apollographql/router/pull/9561))
 
-Routers with licenses whose `halt_at` date is more than approximately two years in the future would panic on startup with `invalid deadline; err=Invalid`.
-
-The fix clamps `halt_at` and `warn_at` deadlines to a maximum derived from the documented offline license validity window (one year plus grace) plus headroom, kept below Tokio's timer wheel limit, before registering them with the timer queue. In practice this has no observable effect: license checks are refreshed continuously from Uplink, so the clamped timer is always replaced well before it would fire.
+A router started with a license whose expiry date falls more than roughly two years in the future crashed on startup with invalid deadline; err=Invalid. It now starts and serves traffic normally with such licenses.
 
 By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9561

--- a/.changesets/fix_license_check_max_timer_duration.md
+++ b/.changesets/fix_license_check_max_timer_duration.md
@@ -1,0 +1,7 @@
+### fix: clamp license timers to a safe limit ([PR #9561](https://github.com/apollographql/router/pull/9561))
+
+Routers with licenses whose `halt_at` date is more than approximately two years in the future would panic on startup with `invalid deadline; err=Invalid`.
+
+The fix clamps `halt_at` and `warn_at` deadlines to a maximum derived from the documented offline license validity window (one year plus grace) plus headroom, kept below Tokio's timer wheel limit, before registering them with the timer queue. In practice this has no observable effect: license checks are refreshed continuously from Uplink, so the clamped timer is always replaced well before it would fire.
+
+By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9561

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
+use std::time::Duration;
 use std::time::SystemTime;
 
 use futures::Stream;
@@ -39,6 +40,10 @@ use crate::uplink::license_stream::license_query::FetchErrorCode;
 use crate::uplink::license_stream::license_query::LicenseQueryRouterEntitlements;
 
 const APOLLO_ROUTER_LICENSE_OFFLINE_UNSUPPORTED: &str = "APOLLO_ROUTER_LICENSE_OFFLINE_UNSUPPORTED";
+
+/// Tokio's timer wheel supports at most `(1 << 36) - 1` ms (~2 years 64 days).
+/// We clamp scheduled deadlines to half that to stay safely within range.
+const MAX_TIMER_DURATION: Duration = Duration::from_millis(1 << 35);
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -272,8 +277,11 @@ fn to_positive_instant(system_time: SystemTime) -> Instant {
 
     // system_time is likely to be a time in the future, but may be in the past.
     match system_time.duration_since(now_system_time) {
-        // system_time was in the future.
-        Ok(duration) => now_instant + duration,
+        // system_time was in the future — clamp to MAX_TIMER_DURATION so that
+        // `DelayQueue::insert_at` cannot overflow tokio's timer wheel.
+        // License refreshes from Uplink happen far more frequently than this
+        // cap, so in practice the clamped timer is always replaced before it fires.
+        Ok(duration) => now_instant + duration.min(MAX_TIMER_DURATION),
 
         // system_time was in the past.
         Err(_) => now_instant,
@@ -406,6 +414,55 @@ mod test {
         let past_instant = to_positive_instant(past_system_time);
         assert!(past_instant > now_instant);
         assert!(past_instant < Instant::now());
+    }
+
+    #[test]
+    fn test_to_instant_far_future_is_clamped() {
+        let now_instant = Instant::now();
+        let three_years = Duration::from_secs(3 * 365 * 24 * 3600);
+        let far_future = SystemTime::now() + three_years;
+
+        let result = to_positive_instant(far_future);
+
+        assert!(
+            result < now_instant + three_years,
+            "far-future instant must be clamped below the original duration"
+        );
+        assert!(
+            result <= now_instant + super::MAX_TIMER_DURATION + Duration::from_secs(1),
+            "clamped instant must not exceed MAX_TIMER_DURATION"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn license_expander_far_future_does_not_panic() {
+        let three_years_secs: u64 = 3 * 365 * 24 * 3600;
+        let now = SystemTime::now();
+        let license = License {
+            claims: Some(Claims {
+                iss: "".to_string(),
+                sub: "".to_string(),
+                aud: OneOrMany::One(Audience::SelfHosted),
+                warn_at: now + Duration::from_secs(three_years_secs - 1000),
+                halt_at: now + Duration::from_secs(three_years_secs),
+                tps: Default::default(),
+                allowed_features: Default::default(),
+            }),
+        };
+
+        // Before the clamp fix this would panic with "invalid deadline; err=Invalid"
+        // because the deadline exceeded tokio's timer wheel maximum of ~2^36 ms.
+        let events_stream = futures::stream::iter(vec![license])
+            .expand_licenses()
+            .map(SimpleEvent::from);
+
+        let events = events_stream.collect::<Vec<_>>().await;
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0], SimpleEvent::UpdateLicense);
+        // Both warn_at and halt_at are clamped to the same MAX_TIMER_DURATION, so their
+        // relative order depends on DelayQueue tie-breaking (insertion order).
+        assert!(events.contains(&SimpleEvent::WarnLicense));
+        assert!(events.contains(&SimpleEvent::HaltLicense));
     }
 
     #[tokio::test]

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -43,6 +43,11 @@ const APOLLO_ROUTER_LICENSE_OFFLINE_UNSUPPORTED: &str = "APOLLO_ROUTER_LICENSE_O
 
 /// Tokio's timer wheel supports at most `(1 << 36) - 1` ms (~2 years 64 days).
 /// We clamp scheduled deadlines to half that to stay safely within range.
+///
+/// When both `warn_at` and `halt_at` exceed the cap they collapse to the same
+/// instant, so the usual soft-then-hard grace period is not preserved and both
+/// fire together (DelayQueue insertion order). That is an acceptable trade-off
+/// for otherwise-unschedulable deadlines; Uplink refresh replaces them first.
 const MAX_TIMER_DURATION: Duration = Duration::from_millis(1 << 35);
 
 #[derive(GraphQLQuery)]
@@ -218,6 +223,8 @@ fn reset_checks_for_licenses(
 
     let halt_at = to_positive_instant(claims.halt_at);
     let warn_at = to_positive_instant(claims.warn_at);
+    // If both were clamped to MAX_TIMER_DURATION, warn and halt share one deadline
+    // instead of the staged soft-then-hard window (see MAX_TIMER_DURATION).
     let now = Instant::now();
     // Insert the new checks. If any of the boundaries are in the past then just return the immediate result
     if halt_at > now {
@@ -459,8 +466,7 @@ mod test {
         let events = events_stream.collect::<Vec<_>>().await;
         assert_eq!(events.len(), 3);
         assert_eq!(events[0], SimpleEvent::UpdateLicense);
-        // Both warn_at and halt_at are clamped to the same MAX_TIMER_DURATION, so their
-        // relative order depends on DelayQueue tie-breaking (insertion order).
+        // Clamped warn/halt share one deadline; event order is not staged (see MAX_TIMER_DURATION).
         assert!(events.contains(&SimpleEvent::WarnLicense));
         assert!(events.contains(&SimpleEvent::HaltLicense));
     }

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -456,19 +456,8 @@ mod test {
 
     #[tokio::test(start_paused = true)]
     async fn license_expander_far_future_does_not_panic() {
-        let three_years_secs: u64 = 3 * 365 * 24 * 3600;
-        let now = SystemTime::now();
-        let license = License {
-            claims: Some(Claims {
-                iss: "".to_string(),
-                sub: "".to_string(),
-                aud: OneOrMany::One(Audience::SelfHosted),
-                warn_at: now + Duration::from_secs(three_years_secs - 1000),
-                halt_at: now + Duration::from_secs(three_years_secs),
-                tps: Default::default(),
-                allowed_features: Default::default(),
-            }),
-        };
+        let three_years_ms: u64 = 3 * 365 * 24 * 3600 * 1000;
+        let license = license_with_claim(three_years_ms - 1_000_000, three_years_ms);
 
         // Before the clamp fix this would panic with "invalid deadline; err=Invalid"
         // because the deadline exceeded tokio's timer wheel maximum of ~2^36 ms.

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -430,6 +430,20 @@ mod test {
         assert!(future_instant < now_instant + Duration::from_secs(1025));
         assert!(future_instant > now_instant + Duration::from_secs(1023));
 
+        // One day below the scheduling cap: a realistic license halt window must not be clamped.
+        let one_day_before_cap =
+            super::MAX_TIMER_DURATION - Duration::from_secs(super::SECS_PER_DAY);
+        let near_cap_system_time = now_system_time + one_day_before_cap;
+        let near_cap_instant = to_positive_instant(near_cap_system_time);
+        assert!(
+            near_cap_instant > now_instant + one_day_before_cap - Duration::from_secs(1),
+            "deadline one day below MAX_TIMER_DURATION must not be clamped"
+        );
+        assert!(
+            near_cap_instant < now_instant + one_day_before_cap + Duration::from_secs(1),
+            "deadline one day below MAX_TIMER_DURATION must not be clamped"
+        );
+
         // An instant in the past will return something greater than the original now_instant, but less than a new instant.
         let past_system_time = now_system_time - Duration::from_secs(1024);
         let past_instant = to_positive_instant(past_system_time);

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -241,8 +241,6 @@ fn reset_checks_for_licenses(
 
     let halt_at = to_positive_instant(claims.halt_at);
     let warn_at = to_positive_instant(claims.warn_at);
-    // If both were clamped to MAX_TIMER_DURATION, warn and halt share one deadline
-    // instead of the staged soft-then-hard window (see MAX_TIMER_DURATION).
     let now = Instant::now();
     // Insert the new checks. If any of the boundaries are in the past then just return the immediate result
     if halt_at > now {

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -251,23 +251,21 @@ fn reset_checks_for_licenses(
     let halt_at = to_positive_instant(claims.halt_at);
     let now_system = SystemTime::now();
 
-    // If both deadlines exceed MAX_TIMER_DURATION they would collapse to the same
-    // clamped instant, losing the soft-then-hard grace window. Detect this and
-    // anchor warn_at 28 days before the clamped halt_at to restore staged ordering.
+    // If halt_at was clamped, ensure warn_at is anchored at least WARN_BEFORE_HALT_GRACE
+    // before it. This covers two cases: (1) both deadlines exceed the cap (warn_at_raw and
+    // halt_at collapse to the same clamped instant), and (2) only halt_at is clamped but
+    // warn_at is close enough to MAX_TIMER_DURATION that the remaining gap is shorter than
+    // the documented grace window.
     let halt_exceeds_cap = claims
         .halt_at
         .duration_since(now_system)
         .map(|d| d > MAX_TIMER_DURATION)
         .unwrap_or(false);
-    let warn_exceeds_cap = claims
-        .warn_at
-        .duration_since(now_system)
-        .map(|d| d > MAX_TIMER_DURATION)
-        .unwrap_or(false);
-    let warn_at = if halt_exceeds_cap && warn_exceeds_cap {
+    let warn_at_raw = to_positive_instant(claims.warn_at);
+    let warn_at = if halt_exceeds_cap && warn_at_raw + WARN_BEFORE_HALT_GRACE > halt_at {
         halt_at - WARN_BEFORE_HALT_GRACE
     } else {
-        to_positive_instant(claims.warn_at)
+        warn_at_raw
     };
 
     // Capture `now` after all to_positive_instant calls so that a past warn_at
@@ -515,6 +513,33 @@ mod test {
         // When both deadlines exceed MAX_TIMER_DURATION, warn_at is anchored
         // WARN_BEFORE_HALT_GRACE before the clamped halt_at, so staged ordering
         // is preserved even for far-future licenses.
+        assert_eq!(
+            events,
+            &[
+                SimpleEvent::UpdateLicense,
+                SimpleEvent::WarnLicense,
+                SimpleEvent::HaltLicense,
+            ]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn license_expander_halt_clamped_warn_close_to_cap() {
+        // warn_at is 14 days before MAX_TIMER_DURATION — under the cap on its own, but
+        // within WARN_BEFORE_HALT_GRACE (28 days) of the clamped halt_at. The old code
+        // only adjusted warn_at when both deadlines exceeded the cap, leaving a < 28-day
+        // gap here. The new code anchors warn_at to halt_at - WARN_BEFORE_HALT_GRACE.
+        let half_grace_ms = (super::HALT_GRACE_PERIOD_DAYS / 2) * super::SECS_PER_DAY * 1000;
+        let warn_delta_ms = super::MAX_TIMER_DURATION_SECS * 1000 - half_grace_ms;
+        let three_years_ms: u64 = 3 * 365 * 24 * 3600 * 1000;
+
+        let license = license_with_claim(warn_delta_ms, three_years_ms);
+
+        let events_stream = futures::stream::iter(vec![license])
+            .expand_licenses()
+            .map(SimpleEvent::from);
+
+        let events = events_stream.collect::<Vec<_>>().await;
         assert_eq!(
             events,
             &[

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -41,14 +41,32 @@ use crate::uplink::license_stream::license_query::LicenseQueryRouterEntitlements
 
 const APOLLO_ROUTER_LICENSE_OFFLINE_UNSUPPORTED: &str = "APOLLO_ROUTER_LICENSE_OFFLINE_UNSUPPORTED";
 
-/// Tokio's timer wheel supports at most `(1 << 36) - 1` ms (~2 years 64 days).
-/// We clamp scheduled deadlines to half that to stay safely within range.
+/// Maximum span from "now" to `halt_at` for offline licenses in
+/// `docs/source/routing/license.mdx`: at most one year of validity plus a
+/// 28-day grace period (~393 days).
+const DOCUMENTED_MAX_HALT_OFFSET_DAYS: u64 = 365 + 28;
+
+/// Slack above the documented span so legitimate `warn_at` / `halt_at` values are
+/// not truncated if validity or grace windows change.
+const LICENSE_SCHEDULE_HEADROOM_DAYS: u64 = 90;
+
+const SECS_PER_DAY: u64 = 24 * 60 * 60;
+
+/// Tokio's timer wheel rejects deadlines beyond `(1 << 36) - 1` ms (~795 days).
+const TOKIO_TIMER_WHEEL_MAX_MILLIS: u64 = (1 << 36) - 1;
+
+const MAX_TIMER_DURATION_SECS: u64 =
+    (DOCUMENTED_MAX_HALT_OFFSET_DAYS + LICENSE_SCHEDULE_HEADROOM_DAYS) * SECS_PER_DAY;
+
+const _: () = assert!(MAX_TIMER_DURATION_SECS * 1000 < TOKIO_TIMER_WHEEL_MAX_MILLIS);
+
+/// Upper bound for scheduling `warn_at` / `halt_at` in `DelayQueue`.
 ///
-/// When both `warn_at` and `halt_at` exceed the cap they collapse to the same
-/// instant, so the usual soft-then-hard grace period is not preserved and both
-/// fire together (DelayQueue insertion order). That is an acceptable trade-off
-/// for otherwise-unschedulable deadlines; Uplink refresh replaces them first.
-const MAX_TIMER_DURATION: Duration = Duration::from_millis(1 << 35);
+/// Derived from the documented license timeline plus headroom, and kept below
+/// Tokio's timer wheel maximum so `insert_at` cannot panic. When both deadlines
+/// exceed this cap they collapse to the same instant, so the usual soft-then-hard
+/// grace period is not preserved and both fire together.
+const MAX_TIMER_DURATION: Duration = Duration::from_secs(MAX_TIMER_DURATION_SECS);
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -423,21 +441,18 @@ mod test {
         assert!(past_instant < Instant::now());
     }
 
-    #[test]
-    fn test_to_instant_far_future_is_clamped() {
+    #[tokio::test(start_paused = true)]
+    async fn test_to_instant_far_future_is_clamped() {
         let now_instant = Instant::now();
         let three_years = Duration::from_secs(3 * 365 * 24 * 3600);
         let far_future = SystemTime::now() + three_years;
 
         let result = to_positive_instant(far_future);
 
-        assert!(
-            result < now_instant + three_years,
-            "far-future instant must be clamped below the original duration"
-        );
-        assert!(
-            result <= now_instant + super::MAX_TIMER_DURATION + Duration::from_secs(1),
-            "clamped instant must not exceed MAX_TIMER_DURATION"
+        assert_eq!(
+            result,
+            now_instant + super::MAX_TIMER_DURATION,
+            "far-future SystemTime must clamp to MAX_TIMER_DURATION from the current Instant"
         );
     }
 

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -284,31 +284,29 @@ fn reset_checks_for_licenses(
     ))))
 }
 
-/// This function exists to generate an approximate Instant from a `SystemTime`. We have externally generated unix timestamps that need to be scheduled, but anything time related to scheduling must be an `Instant`.
-/// The generated instant is only approximate.
-/// Subtracting from instants is not supported on all platforms, so if the calculated instant was in the past we just return now as we don't care about how long ago the instant was, just that it happened already.
+/// Converts an externally generated `SystemTime` (e.g. JWT `warn_at` / `halt_at`) into a
+/// `tokio::time::Instant` for scheduling license state transitions in a `DelayQueue`.
 ///
-/// Returns a `tokio::time::Instant` (rather than `std::time::Instant`) so that scheduling
-/// respects `tokio::time::pause()` / `tokio::time::advance()` in tests. The downstream
-/// `DelayQueue` reads `tokio::time::Instant::now()` to decide when entries fire; using a
-/// `tokio::time::Instant` here keeps the "now" reference consistent with the queue's clock,
-/// which is required for deterministic virtual-time tests.
+/// The result is approximate: there is no exact conversion between `SystemTime` and
+/// `Instant`. If `system_time` is in the past, returns `Instant::now()` — we only need to
+/// know the event already happened, not how far in the past. (Subtracting from instants is
+/// not supported on all platforms, which motivates treating past times as "now".)
+///
+/// Uses `tokio::time::Instant` (not `std::time::Instant`) so scheduling respects
+/// `tokio::time::pause()` / `tokio::time::advance()` in tests and stays consistent with the
+/// queue's clock.
+///
+/// Future times are clamped to [`MAX_TIMER_DURATION`] so `DelayQueue::insert_at` cannot
+/// overflow Tokio's timer wheel. Uplink license refreshes occur far more frequently than
+/// this cap, so the clamped deadline is replaced before it fires in practice. When both
+/// `warn_at` and `halt_at` exceed the cap they schedule at the same instant and the usual
+/// soft-then-hard grace ordering is not preserved.
 fn to_positive_instant(system_time: SystemTime) -> Instant {
-    // This is approximate as there is no real conversion between SystemTime and Instant.
-    // We use `tokio::time::Instant::now()` so the returned instant is anchored to the same
-    // clock as `DelayQueue`'s scheduler (this clock is virtualized under `tokio::time::pause()`).
     let now_instant = Instant::now();
     let now_system_time = SystemTime::now();
 
-    // system_time is likely to be a time in the future, but may be in the past.
     match system_time.duration_since(now_system_time) {
-        // system_time was in the future — clamp to MAX_TIMER_DURATION so that
-        // `DelayQueue::insert_at` cannot overflow tokio's timer wheel.
-        // License refreshes from Uplink happen far more frequently than this
-        // cap, so in practice the clamped timer is always replaced before it fires.
         Ok(duration) => now_instant + duration.min(MAX_TIMER_DURATION),
-
-        // system_time was in the past.
         Err(_) => now_instant,
     }
 }

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -471,6 +471,28 @@ mod test {
         assert!(events.contains(&SimpleEvent::HaltLicense));
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn license_expander_far_future_halt_only_clamped() {
+        let three_years_ms: u64 = 3 * 365 * 24 * 3600 * 1000;
+        // warn_at stays under the cap; only halt_at is clamped. This is the more likely
+        // real-world shape and must preserve warn-before-halt ordering.
+        let license = license_with_claim(15_000, three_years_ms);
+
+        let events_stream = futures::stream::iter(vec![license])
+            .expand_licenses()
+            .map(SimpleEvent::from);
+
+        let events = events_stream.collect::<Vec<_>>().await;
+        assert_eq!(
+            events,
+            &[
+                SimpleEvent::UpdateLicense,
+                SimpleEvent::WarnLicense,
+                SimpleEvent::HaltLicense,
+            ]
+        );
+    }
+
     #[tokio::test]
     async fn license_expander() {
         let events_stream = futures::stream::iter(vec![license_with_claim(15, 30)])

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -41,10 +41,15 @@ use crate::uplink::license_stream::license_query::LicenseQueryRouterEntitlements
 
 const APOLLO_ROUTER_LICENSE_OFFLINE_UNSUPPORTED: &str = "APOLLO_ROUTER_LICENSE_OFFLINE_UNSUPPORTED";
 
+/// The documented grace window between `warn_at` and `halt_at` (days).
+/// Used both to define the maximum documented halt offset and to restore
+/// the grace window when both deadlines are clamped.
+const HALT_GRACE_PERIOD_DAYS: u64 = 28;
+
 /// Maximum span from "now" to `halt_at` for offline licenses in
 /// `docs/source/routing/license.mdx`: at most one year of validity plus a
 /// 28-day grace period (~393 days).
-const DOCUMENTED_MAX_HALT_OFFSET_DAYS: u64 = 365 + 28;
+const DOCUMENTED_MAX_HALT_OFFSET_DAYS: u64 = 365 + HALT_GRACE_PERIOD_DAYS;
 
 /// Slack above the documented span so legitimate `warn_at` / `halt_at` values are
 /// not truncated if validity or grace windows change.
@@ -64,9 +69,13 @@ const _: () = assert!(MAX_TIMER_DURATION_SECS * 1000 < TOKIO_TIMER_WHEEL_MAX_MIL
 ///
 /// Derived from the documented license timeline plus headroom, and kept below
 /// Tokio's timer wheel maximum so `insert_at` cannot panic. When both deadlines
-/// exceed this cap they collapse to the same instant, so the usual soft-then-hard
-/// grace period is not preserved and both fire together.
+/// exceed this cap, `warn_at` is anchored `WARN_BEFORE_HALT_GRACE` before the
+/// clamped `halt_at` so the soft-then-hard grace ordering is preserved.
 const MAX_TIMER_DURATION: Duration = Duration::from_secs(MAX_TIMER_DURATION_SECS);
+
+/// How far before the clamped `halt_at` to schedule `warn_at` when both deadlines
+/// exceed [`MAX_TIMER_DURATION`]. Matches the documented [`HALT_GRACE_PERIOD_DAYS`]-day grace window.
+const WARN_BEFORE_HALT_GRACE: Duration = Duration::from_secs(HALT_GRACE_PERIOD_DAYS * SECS_PER_DAY);
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -240,7 +249,29 @@ fn reset_checks_for_licenses(
     };
 
     let halt_at = to_positive_instant(claims.halt_at);
-    let warn_at = to_positive_instant(claims.warn_at);
+    let now_system = SystemTime::now();
+
+    // If both deadlines exceed MAX_TIMER_DURATION they would collapse to the same
+    // clamped instant, losing the soft-then-hard grace window. Detect this and
+    // anchor warn_at 28 days before the clamped halt_at to restore staged ordering.
+    let halt_exceeds_cap = claims
+        .halt_at
+        .duration_since(now_system)
+        .map(|d| d > MAX_TIMER_DURATION)
+        .unwrap_or(false);
+    let warn_exceeds_cap = claims
+        .warn_at
+        .duration_since(now_system)
+        .map(|d| d > MAX_TIMER_DURATION)
+        .unwrap_or(false);
+    let warn_at = if halt_exceeds_cap && warn_exceeds_cap {
+        halt_at - WARN_BEFORE_HALT_GRACE
+    } else {
+        to_positive_instant(claims.warn_at)
+    };
+
+    // Capture `now` after all to_positive_instant calls so that a past warn_at
+    // (returned as Instant::now() inside that function) correctly compares as <= now.
     let now = Instant::now();
     // Insert the new checks. If any of the boundaries are in the past then just return the immediate result
     if halt_at > now {
@@ -295,10 +326,9 @@ fn reset_checks_for_licenses(
 /// queue's clock.
 ///
 /// Future times are clamped to [`MAX_TIMER_DURATION`] so `DelayQueue::insert_at` cannot
-/// overflow Tokio's timer wheel. Uplink license refreshes occur far more frequently than
-/// this cap, so the clamped deadline is replaced before it fires in practice. When both
-/// `warn_at` and `halt_at` exceed the cap they schedule at the same instant and the usual
-/// soft-then-hard grace ordering is not preserved.
+/// overflow Tokio's timer wheel. When both `warn_at` and `halt_at` exceed the cap,
+/// `reset_checks_for_licenses` anchors `warn_at` to [`WARN_BEFORE_HALT_GRACE`] before the
+/// clamped `halt_at` so the soft-then-hard grace ordering is preserved.
 fn to_positive_instant(system_time: SystemTime) -> Instant {
     let now_instant = Instant::now();
     let now_system_time = SystemTime::now();
@@ -482,11 +512,17 @@ mod test {
             .map(SimpleEvent::from);
 
         let events = events_stream.collect::<Vec<_>>().await;
-        assert_eq!(events.len(), 3);
-        assert_eq!(events[0], SimpleEvent::UpdateLicense);
-        // Clamped warn/halt share one deadline; event order is not staged (see MAX_TIMER_DURATION).
-        assert!(events.contains(&SimpleEvent::WarnLicense));
-        assert!(events.contains(&SimpleEvent::HaltLicense));
+        // When both deadlines exceed MAX_TIMER_DURATION, warn_at is anchored
+        // WARN_BEFORE_HALT_GRACE before the clamped halt_at, so staged ordering
+        // is preserved even for far-future licenses.
+        assert_eq!(
+            events,
+            &[
+                SimpleEvent::UpdateLicense,
+                SimpleEvent::WarnLicense,
+                SimpleEvent::HaltLicense,
+            ]
+        );
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
The `DelayQueue` in tokio-utils can panic when `insert_at` is called with a value too far in the future.

<!-- start metadata -->

<!-- [ROUTER-1842] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1842]: https://apollographql.atlassian.net/browse/ROUTER-1842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ