### PR TITLE
docs: deprecate `apollo.router.operations.jwt` metric

### DIFF
--- a/.changesets/docs_deprecate_operations_jwt_metric.md
+++ b/.changesets/docs_deprecate_operations_jwt_metric.md
@@ -1,0 +1,5 @@
+### Deprecate `apollo.router.operations.jwt` in favor of `apollo.router.operations.authentication.jwt`
+
+Updated the JWT authentication observability documentation to mark `apollo.router.operations.jwt` as deprecated. It is a misnamed metric that has been emitted in parallel with its replacement for over a year; operators should use `apollo.router.operations.authentication.jwt` with the `authentication.jwt.failed` attribute instead. The metric will continue to be emitted, but will be removed in a future release.
+
+By [@conwuegb](https://github.com/conwuegb) in https://github.com/apollographql/router/pull/XXXX

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -621,9 +621,9 @@ fn authenticate(
         // but has existed for two years with a buggy name. Keep it for now.
         u64_counter!(
             "apollo.router.operations.jwt",
-            "Number of requests with JWT successful authentication (deprecated, \
-                use `apollo.router.operations.authentication.jwt` \
-                with `authentication.jwt.failed = false` instead)",
+            "Number of requests with JWT successful authentication (**deprecated**, \
+                use `apollo.router.operations.authentication.jwt` with the \
+                attribute `authentication.jwt.failed = false` instead)",
             1
         );
         // Use the fixed name too:

--- a/docs/source/routing/security/jwt.mdx
+++ b/docs/source/routing/security/jwt.mdx
@@ -806,6 +806,12 @@ If your router enables [tracing](/router/configuration/telemetry/exporters/traci
 
 If your router [exports metrics](/graphos/routing/observability/telemetry/metrics-exporters/overview), the JWT authentication plugin exports the `apollo.router.operations.authentication.jwt` metric. You can use the metric's `authentication.jwt.failed` attribute to count failed authentications. If the `authentication.jwt.failed` attribute is absent or `false`, the authentication succeeded.
 
+<Note>
+
+`apollo.router.operations.jwt` is deprecated. Use `apollo.router.operations.authentication.jwt` with `authentication.jwt.failed = false` instead. `apollo.router.operations.jwt` will be removed in a future release.
+
+</Note>
+
 ## Additional resources
 
 You can use the Apollo Solutions [router JWKS generator](https://github.com/apollosolutions/router-jwks-generator) to create a router configuration file for use with the authentication plugin.


### PR DESCRIPTION
[jira/ROUTER-1763](https://apollographql.atlassian.net/browse/ROUTER-1762)

The `apollo.router.operations.jwt` metric is is a misnamed metric that is being replaced with the correctly named `apollo.router.operations.authentication.jwt`, which has been emitted in parallel since [PR#7258](https://github.com/apollographql/router/pull/7258).

There is an existing deprecation message being emitted alongside this metric, and this change updates its wording slightly. It also adds a note about this deprecation to the JWT telemetry documentation.


<!-- start metadata -->

<!-- [ROUTER-1762] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible

[ROUTER-1762]: https://apollographql.atlassian.net/browse/ROUTER-1762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ