### PR TITLE
fix typos in config migrations README

### DIFF
--- a/apollo-router/src/configuration/migrations/README.md
+++ b/apollo-router/src/configuration/migrations/README.md
@@ -1,12 +1,12 @@
 # Configuration migrations
-This directory contains configuration migrations that can be applied to a router to a router config to bring it up to date with current config format.
+This directory contains configuration migrations that can be applied to a router config to bring it up to date with current config format.
 
 It uses [proteus](https://github.com/rust-playground/proteus) under the hood, which handles the complexities of merging Json.
 
 A migration has the following format:
 
 The filename should begin with a 4 digit numerical prefix. This allows us to apply migrations in a deterministic order.
-`Filename: 0001-name.yaml`. It must start with the current major version of the router. For example for router 2.x it should start with `2001-name.yaml`. If it doesn'start with the right version then it would be considered as a real breaking change and won't be automatically migrated when the router starts.
+`Filename: 0001-name.yaml`. It must start with the current major version of the router. For example for router 2.x it should start with `2001-name.yaml`. If it doesn't start with the right version then it would be considered as a real breaking change and won't be automatically migrated when the router starts.
 
 The yaml consists of a description and a number of actions:
 ```yaml


### PR DESCRIPTION
Fixes minor typos in the "Configuration migrations" README page