### PR TITLE
chore: deprecate `apollo_router::otel_compat`

### DIFF
--- a/.changesets/maint_caroline_router_1779_deprecate_otel_compat.md
+++ b/.changesets/maint_caroline_router_1779_deprecate_otel_compat.md
@@ -1,0 +1,7 @@
+### Deprecate `apollo_router::otel_compat`
+
+`otel_compat::HeaderExtractor` and `otel_compat::HeaderInjector` are now deprecated. The `opentelemetry_http` crate (v0.31+) already ships identical types that work with `http` 1.x.
+
+Use `opentelemetry_http::HeaderExtractor` and `opentelemetry_http::HeaderInjector` directly. These types will be removed in a future major version.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9573

--- a/apollo-router/src/axum_factory/utils.rs
+++ b/apollo-router/src/axum_factory/utils.rs
@@ -27,7 +27,7 @@ impl<B> MakeSpan<B> for PropagatingMakeSpan {
 
         // Before we make the span we need to attach span info that may have come in from the request.
         let context = global::get_text_map_propagator(|propagator| {
-            propagator.extract(&crate::otel_compat::HeaderExtractor(request.headers()))
+            propagator.extract(&opentelemetry_http::HeaderExtractor(request.headers()))
         });
         let use_legacy_request_span = matches!(self.span_mode, SpanMode::Deprecated);
 

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -82,6 +82,10 @@ mod uplink;
 
 pub(crate) mod allocator;
 #[doc(hidden)]
+#[deprecated(
+    since = "2.16.0",
+    note = "Will be removed in 3.0. Use opentelemetry_http::HeaderExtractor / opentelemetry_http::HeaderInjector directly."
+)]
 pub mod otel_compat;
 mod registry;
 

--- a/apollo-router/src/otel_compat.rs
+++ b/apollo-router/src/otel_compat.rs
@@ -1,9 +1,14 @@
 //! Facilities for using our old version of opentelemetry with our new version of http/hyper.
+#![allow(deprecated)]
 
 /// A header extractor that works on http 1.x types.
 ///
 /// The implementation is a straight copy from [opentelemetry_http::HeaderExtractor].
 /// This can be removed after we update otel.
+#[deprecated(
+    since = "2.16.0",
+    note = "Will be removed in 3.0. Use opentelemetry_http::HeaderExtractor directly."
+)]
 pub struct HeaderExtractor<'a>(pub &'a http::HeaderMap);
 impl opentelemetry::propagation::Extractor for HeaderExtractor<'_> {
     /// Get a value for a key from the HeaderMap.  If the value is not valid ASCII, returns None.
@@ -24,6 +29,10 @@ impl opentelemetry::propagation::Extractor for HeaderExtractor<'_> {
 ///
 /// The implementation is a straight copy from [opentelemetry_http::HeaderInjector].
 /// This can be removed after we update otel.
+#[deprecated(
+    since = "2.16.0",
+    note = "Will be removed in 3.0. Use opentelemetry_http::HeaderInjector directly."
+)]
 pub struct HeaderInjector<'a>(pub &'a mut http::HeaderMap);
 
 impl opentelemetry::propagation::Injector for HeaderInjector<'_> {

--- a/apollo-router/src/plugins/subscription/subgraph.rs
+++ b/apollo-router/src/plugins/subscription/subgraph.rs
@@ -472,7 +472,7 @@ fn get_websocket_request(
     opentelemetry::global::get_text_map_propagator(|propagator| {
         propagator.inject_context(
             &prepare_context(tracing::Span::current().context()),
-            &mut crate::otel_compat::HeaderInjector(request.headers_mut()),
+            &mut opentelemetry_http::HeaderInjector(request.headers_mut()),
         );
     });
 

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -324,7 +324,7 @@ where
         get_text_map_propagator(|propagator| {
             propagator.inject_context(
                 &prepare_context(http_req_span.context()),
-                &mut crate::otel_compat::HeaderInjector(http_request.headers_mut()),
+                &mut opentelemetry_http::HeaderInjector(http_request.headers_mut()),
             );
         });
 

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -532,7 +532,7 @@ impl tower::Service<HttpRequest> for HttpClientService {
         get_text_map_propagator(|propagator| {
             propagator.inject_context(
                 &prepare_context(http_req_span.context()),
-                &mut crate::otel_compat::HeaderInjector(http_request.headers_mut()),
+                &mut opentelemetry_http::HeaderInjector(http_request.headers_mut()),
             );
         });
 

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -676,7 +676,7 @@ impl Telemetry {
                 let propagator = opentelemetry_datadog::DatadogPropagator::new();
                 propagator.inject_context(
                     &ctx,
-                    &mut apollo_router::otel_compat::HeaderInjector(request.headers_mut()),
+                    &mut opentelemetry_http::HeaderInjector(request.headers_mut()),
                 );
 
                 if let Some(psr) = psr {
@@ -689,14 +689,14 @@ impl Telemetry {
                 let propagator = opentelemetry_sdk::propagation::TraceContextPropagator::default();
                 propagator.inject_context(
                     &ctx,
-                    &mut apollo_router::otel_compat::HeaderInjector(request.headers_mut()),
+                    &mut opentelemetry_http::HeaderInjector(request.headers_mut()),
                 )
             }
             Telemetry::Zipkin => {
                 let propagator = opentelemetry_zipkin::Propagator::new();
                 propagator.inject_context(
                     &ctx,
-                    &mut apollo_router::otel_compat::HeaderInjector(request.headers_mut()),
+                    &mut opentelemetry_http::HeaderInjector(request.headers_mut()),
                 )
             }
             _ => {}
@@ -1454,7 +1454,7 @@ impl IntegrationTest {
                 global::get_text_map_propagator(|propagator| {
                     propagator.inject_context(
                         &tracing::span::Span::current().context(),
-                        &mut apollo_router::otel_compat::HeaderInjector(request.headers_mut()),
+                        &mut opentelemetry_http::HeaderInjector(request.headers_mut()),
                     );
                 });
                 request.headers_mut().remove(ACCEPT);
@@ -1495,7 +1495,7 @@ impl IntegrationTest {
         global::get_text_map_propagator(|propagator| {
             propagator.inject_context(
                 &span.context(),
-                &mut apollo_router::otel_compat::HeaderInjector(request.headers_mut()),
+                &mut opentelemetry_http::HeaderInjector(request.headers_mut()),
             );
         });
 


### PR DESCRIPTION
## What

- Add `#[deprecated(since = "2.16.0", ...)]` to `HeaderExtractor` and `HeaderInjector` in `apollo-router/src/otel_compat.rs`, directing users to `opentelemetry_http::HeaderExtractor` / `opentelemetry_http::HeaderInjector`
- Add `#[deprecated]` to the `pub mod otel_compat` declaration in `lib.rs`
- Add `#![allow(deprecated)]` at the module level in `otel_compat.rs` to suppress self-referential lint errors within the impl blocks
- Migrate all internal router call sites (`axum_factory/utils.rs`, `plugins/subscription/subgraph.rs`, `services/external.rs`, `services/http/service.rs`, `tests/common.rs`) to use `opentelemetry_http::HeaderExtractor` / `opentelemetry_http::HeaderInjector` directly
- Add changeset

## Notes

Hard removal is tracked in the 3.x series: [#9572](https://github.com/apollographql/router/pull/9572).

## Verified
- `cargo fmt --check` passed
- `cargo clippy -- -D warnings` passed
- CHANGELOG.md not modified
- Changeset title contains no conventional-commit prefix