### PR TITLE
chore: replace unnecessary macro by generic function

### DIFF
--- a/apollo-router/src/axum_factory/listeners.rs
+++ b/apollo-router/src/axum_factory/listeners.rs
@@ -17,6 +17,7 @@ use hyper_util::rt::TokioIo;
 use hyper_util::rt::TokioTimer;
 use hyper_util::server::conn::auto::Builder;
 use hyper_util::server::conn::auto::Http1Builder;
+use hyper_util::server::graceful::GracefulConnection;
 use multimap::MultiMap;
 #[cfg(unix)]
 use tokio::net::UnixListener;
@@ -200,47 +201,48 @@ pub(super) async fn get_extra_listeners(
     Ok(listeners_and_routers)
 }
 
-// This macro unifies the logic tht deals with connections.
-// Ideally this would be a function, but the generics proved too difficult to figure out.
-macro_rules! handle_connection {
-    ($connection:expr, $connection_handle:expr, $connection_shutdown:expr, $connection_shutdown_timeout:expr, $received_first_request:expr) => {
-        let connection = $connection;
-        let mut connection_handle = $connection_handle;
-        let connection_shutdown = $connection_shutdown;
-        let connection_shutdown_timeout = $connection_shutdown_timeout;
-        let received_first_request = $received_first_request;
-        tokio::pin!(connection);
-        tokio::select! {
-            // the connection finished first
-            _res = &mut connection => {
-            }
-            // the shutdown receiver was triggered first,
-            // so we tell the connection to do a graceful shutdown
-            // on the next request, then we wait for it to finish
-            _ = connection_shutdown.cancelled() => {
-                connection_handle.shutdown();
-                connection.as_mut().graceful_shutdown();
-                // Only wait for the connection to close gracfully if we recieved a request.
-                // On hyper 0.x awaiting the connection would potentially hang forever if no request was recieved.
-                if received_first_request.load(Ordering::Relaxed) {
-                    // The connection may still not shutdown so we apply a timeout from the configuration
-                    // Connections stuck terminating will keep the pipeline and everything related to that pipeline
-                    // in memory.
+// Drive a connection until graceful shutdown.
+async fn handle_connection<C, E>(
+    connection: C,
+    mut connection_handle: ConnectionHandle,
+    connection_shutdown: CancellationToken,
+    connection_shutdown_timeout: Duration,
+    received_first_request: Arc<AtomicBool>,
+) where
+    C: Future<Output = Result<(), E>>,
+    C: GracefulConnection<Error = E>,
+{
+    tokio::pin!(connection);
+    tokio::select! {
+        // the connection finished first
+        _res = &mut connection => {
+        }
+        // the shutdown receiver was triggered first,
+        // so we tell the connection to do a graceful shutdown
+        // on the next request, then we wait for it to finish
+        _ = connection_shutdown.cancelled() => {
+            connection_handle.shutdown();
+            connection.as_mut().graceful_shutdown();
+            // Only wait for the connection to close gracfully if we recieved a request.
+            // On hyper 0.x awaiting the connection would potentially hang forever if no request was recieved.
+            if received_first_request.load(Ordering::Relaxed) {
+                // The connection may still not shutdown so we apply a timeout from the configuration
+                // Connections stuck terminating will keep the pipeline and everything related to that pipeline
+                // in memory.
 
-                    if let Err(_) = connection.timeout(connection_shutdown_timeout).await {
-                        tracing::warn!(
-                            timeout = connection_shutdown_timeout.as_secs(),
-                            server.address = connection_handle.address.to_string(),
-                            schema.id = connection_handle.pipeline_ref.schema_id,
-                            config.hash = connection_handle.pipeline_ref.config_hash,
-                            launch.id = connection_handle.pipeline_ref.launch_id,
-                            "connection shutdown exceeded, forcing close",
-                        );
-                    }
+                if connection.timeout(connection_shutdown_timeout).await.is_err() {
+                    tracing::warn!(
+                        timeout = connection_shutdown_timeout.as_secs(),
+                        server.address = connection_handle.address.to_string(),
+                        schema.id = connection_handle.pipeline_ref.schema_id,
+                        config.hash = connection_handle.pipeline_ref.config_hash,
+                        launch.id = connection_handle.pipeline_ref.launch_id,
+                        "connection shutdown exceeded, forcing close",
+                    );
                 }
             }
         }
-    };
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -399,7 +401,7 @@ pub(super) fn serve_router_on_listen_addr(
                                         let mut builder = Builder::new(TokioExecutor::new());
                                         let config = configure_connection(&mut builder, header_read_timeout, opt_max_http1_headers, opt_max_http1_buf_size, opt_max_http2_headers_list_bytes);
                                         let connection = config.serve_connection_with_upgrades(tokio_stream, hyper_service);
-                                        handle_connection!(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request);
+                                        handle_connection(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request).await;
                                     }
                                     #[cfg(unix)]
                                     NetworkStream::Unix(stream) => {
@@ -412,7 +414,7 @@ pub(super) fn serve_router_on_listen_addr(
                                         let mut builder = Builder::new(TokioExecutor::new());
                                         let config = configure_connection(&mut builder, header_read_timeout, opt_max_http1_headers, opt_max_http1_buf_size, opt_max_http2_headers_list_bytes);
                                         let connection = config.serve_connection_with_upgrades(tokio_stream, hyper_service);
-                                        handle_connection!(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request);
+                                        handle_connection(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request).await;
                                     },
                                     NetworkStream::Tls { stream, acceptor } => {
                                         // Perform TLS handshake with a timeout to prevent DoS attacks.
@@ -456,7 +458,7 @@ pub(super) fn serve_router_on_listen_addr(
                                         let connection = config
                                             .serve_connection_with_upgrades(tokio_stream, hyper_service);
 
-                                        handle_connection!(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request);
+                                        handle_connection(connection, connection_handle, connection_shutdown, connection_shutdown_timeout, received_first_request).await;
                                     }
                                 }
                             });


### PR DESCRIPTION
While scanning our connection handling code for our tower audit (ticket ROUTER-1849 for Apollo employees), the `handle_connection!` macro jumped out.

The comment on the macro said it's to avoid complicated generics, but it turns out the generics are now pretty simple.

Proposing this early as a drive-by fix separate of any more principled work that might come up later.

Suggest landing on 2.x and 3.x, but we could also land it only on 3.x if the GraphOS team prefers.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

Purely internal refactor, no need for changesets or new tests on top of the ones that already exist.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
