### PR TITLE
fix(test): skip instead of panic when graph_os_enabled() is false (ROUTER-1854)

### DIFF
--- a/apollo-router/.changesets/fix_aaron_otlp_tracing_skip_not_panic.md
+++ b/apollo-router/.changesets/fix_aaron_otlp_tracing_skip_not_panic.md
@@ -1,0 +1,11 @@
+### Fix `otlp::tracing` test family panic when GraphOS credentials are absent (ROUTER-1854)
+
+10 tests in `tests/integration/telemetry/otlp/tracing.rs` used `panic!` instead of
+`return Ok(())` when `graph_os_enabled()` returned false. `graph_os_enabled()` checks
+for `TEST_APOLLO_KEY` / `TEST_APOLLO_GRAPH_REF`, which are only present in dev-branch
+CI — not in PR-branch CI. The panic caused the entire `integration::telemetry::otlp::tracing::*`
+family to fail deterministically on any PR that didn't have those env vars, even when
+the PR's diff was completely unrelated to OTLP tracing.
+
+Five other tests in the same file already used `return Ok(())` correctly; this aligns
+the remaining ten.

--- a/apollo-router/tests/integration/telemetry/otlp/tracing.rs
+++ b/apollo-router/tests/integration/telemetry/otlp/tracing.rs
@@ -45,7 +45,7 @@ async fn test_trace_error() -> Result<(), BoxError> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basic() -> Result<(), BoxError> {
     if !graph_os_enabled() {
-        panic!("Error: test skipped because GraphOS is not enabled");
+        return Ok(());
     }
     let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp.router.yaml")
@@ -99,7 +99,7 @@ async fn test_basic() -> Result<(), BoxError> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_resources() -> Result<(), BoxError> {
     if !graph_os_enabled() {
-        panic!("Error: test skipped because GraphOS is not enabled");
+        return Ok(());
     }
     let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp.router.yaml")
@@ -130,7 +130,7 @@ async fn test_resources() -> Result<(), BoxError> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_otlp_tracing_reload() -> Result<(), BoxError> {
     if !graph_os_enabled() {
-        panic!("Error: test skipped because GraphOS is not enabled");
+        return Ok(());
     }
     let mock_server = mock_otlp_server(0..).await;
     let config_initial = include_str!("../fixtures/otlp_tracing.router.yaml")
@@ -190,7 +190,7 @@ async fn test_otlp_tracing_reload() -> Result<(), BoxError> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_otlp_request_with_datadog_propagator() -> Result<(), BoxError> {
     if !graph_os_enabled() {
-        panic!("Error: test skipped because GraphOS is not enabled");
+        return Ok(());
     }
     let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_propagation.router.yaml")
@@ -221,7 +221,7 @@ async fn test_otlp_request_with_datadog_propagator() -> Result<(), BoxError> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_otlp_request_with_datadog_propagator_no_agent() -> Result<(), BoxError> {
     if !graph_os_enabled() {
-        panic!("Error: test skipped because GraphOS is not enabled");
+        return Ok(());
     }
     let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_propagation_no_agent.router.yaml")
@@ -255,7 +255,7 @@ async fn test_otlp_request_with_datadog_propagator_no_agent() -> Result<(), BoxE
 async fn test_otlp_request_with_zipkin_trace_context_propagator_with_datadog()
 -> Result<(), BoxError> {
     if !graph_os_enabled() {
-        panic!("Error: test skipped because GraphOS is not enabled");
+        return Ok(());
     }
     let mock_server = mock_otlp_server(1..).await;
     let config =
@@ -376,7 +376,7 @@ async fn test_otlp_request_with_zipkin_trace_context_propagator_with_datadog()
 #[tokio::test(flavor = "multi_thread")]
 async fn test_untraced_request_no_sample_datadog_agent() -> Result<(), BoxError> {
     if !graph_os_enabled() {
-        panic!("Error: test skipped because GraphOS is not enabled");
+        return Ok(());
     }
     let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_agent_no_sample.router.yaml")
@@ -411,7 +411,7 @@ async fn test_untraced_request_no_sample_datadog_agent() -> Result<(), BoxError>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_untraced_request_sample_datadog_agent() -> Result<(), BoxError> {
     if !graph_os_enabled() {
-        panic!("Error: test skipped because GraphOS is not enabled");
+        return Ok(());
     }
     let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_agent_sample.router.yaml")
@@ -446,7 +446,7 @@ async fn test_untraced_request_sample_datadog_agent() -> Result<(), BoxError> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_untraced_request_sample_datadog_agent_unsampled() -> Result<(), BoxError> {
     if !graph_os_enabled() {
-        panic!("Error: test skipped because GraphOS is not enabled");
+        return Ok(());
     }
     let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_agent_sample_no_sample.router.yaml")
@@ -481,7 +481,7 @@ async fn test_untraced_request_sample_datadog_agent_unsampled() -> Result<(), Bo
 #[tokio::test(flavor = "multi_thread")]
 async fn test_priority_sampling_propagated() -> Result<(), BoxError> {
     if !graph_os_enabled() {
-        panic!("Error: test skipped because GraphOS is not enabled");
+        return Ok(());
     }
     let mock_server = mock_otlp_server(1..).await;
     let config = include_str!("../fixtures/otlp_datadog_propagation.router.yaml")


### PR DESCRIPTION
## Summary

- 10 tests in `tests/integration/telemetry/otlp/tracing.rs` used `panic!("Error: test skipped because GraphOS is not enabled")` instead of `return Ok(())` when `graph_os_enabled()` returned false
- `graph_os_enabled()` checks `TEST_APOLLO_KEY` / `TEST_APOLLO_GRAPH_REF`, which are only present in dev-branch CI — not in PR-branch CI
- The panic caused the entire `integration::telemetry::otlp::tracing::*` family to fail deterministically on any PR that lacked those env vars, regardless of what the PR actually changed

## Evidence

Cross-branch sweep (June 1–4 2026, post-bundle #9497) via CircleCI v1.1 failed-builds API:
- Same ~10 tests failed on `pull/9531` and `pull/9543` (both `ebylund` response_cache PRs — diffs completely unrelated to OTLP tracing): CircleCI builds 381321, 381324, 381635

5 other tests in the same file (`test_priority_sampling_no_parent_propagated`, `test_attributes`, `test_plugin_overridden_client_name_is_included_in_telemetry`, `test_otlp_ipv6`, `test_priority_sampling_parent_sampler_very_small_no_parent_no_agent_sampling`) already used `return Ok(())` correctly. This aligns the remaining 10.

## Test plan

- [ ] Confirm all 10 affected tests show as skipped (pass) on a CI run without `TEST_APOLLO_KEY`/`TEST_APOLLO_GRAPH_REF`
- [ ] Confirm they still run and pass on dev-branch CI where those env vars are present

Fixes [ROUTER-1854](https://apollographql.atlassian.net/browse/ROUTER-1854) under epic [ROUTER-1722](https://apollographql.atlassian.net/browse/ROUTER-1722).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ROUTER-1854]: https://apollographql.atlassian.net/browse/ROUTER-1854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ