### PR TITLE
fix(composition): validate multiple intf object types in same subgraph

### DIFF
--- a/apollo-federation/src/merger/merge_interface.rs
+++ b/apollo-federation/src/merger/merge_interface.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use apollo_compiler::Name;
-use apollo_compiler::collections::HashMap;
+use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use tracing::trace;
 
@@ -146,10 +146,10 @@ impl Merger {
             }
 
             // collect all @interfaceObject types in this subgraph and their implementations
-            let mut impls_to_intf_objects: HashMap<
+            let mut impls_to_intf_objects: IndexMap<
                 ObjectTypeDefinitionPosition,
                 IndexSet<InterfaceTypeDefinitionPosition>,
-            > = HashMap::default();
+            > = IndexMap::default();
             for intf_object in subgraph.metadata().interface_object_types() {
                 let itf_pos = InterfaceTypeDefinitionPosition {
                     type_name: intf_object.clone(),
@@ -168,7 +168,7 @@ impl Merger {
 
             impls_to_intf_objects.iter()
                 .filter(|(_, intf_objects)| intf_objects.len() > 1)
-                .fold(HashMap::<BTreeSet<Name>, IndexSet<Name>>::default(), |mut acc, (impl_, intf_objects)| {
+                .fold(IndexMap::<BTreeSet<Name>, IndexSet<Name>>::default(), |mut acc, (impl_, intf_objects)| {
                     let key: BTreeSet<Name> = BTreeSet::from_iter(intf_objects.iter().map(|i| i.type_name.clone()));
                     acc.entry(key)
                         .or_default()

--- a/apollo-federation/src/merger/merge_interface.rs
+++ b/apollo-federation/src/merger/merge_interface.rs
@@ -1,4 +1,8 @@
-use indexmap::IndexSet;
+use std::collections::BTreeSet;
+
+use apollo_compiler::Name;
+use apollo_compiler::collections::HashMap;
+use apollo_compiler::collections::IndexSet;
 use tracing::trace;
 
 use crate::error::CompositionError;
@@ -126,6 +130,66 @@ impl Merger {
                     ),
                 });
             }
+        }
+        Ok(())
+    }
+
+    /// Validates that `@interfaceObject` types within the same subgraph are pairwise
+    /// disjoint in their implementing types. Query planning assumes that when jumping
+    /// to a type in a subgraph via `@key`, there's only one version of that type.
+    /// Multiple `@interfaceObject` types sharing an implementation type would violate
+    /// this assumption.
+    pub(crate) fn validate_interface_object_disjointness(&mut self) -> Result<(), FederationError> {
+        for subgraph in self.subgraphs.iter() {
+            if subgraph.metadata().interface_object_types().is_empty() {
+                continue;
+            }
+
+            // collect all @interfaceObject types in this subgraph and their implementations
+            let mut impls_to_intf_objects: HashMap<
+                ObjectTypeDefinitionPosition,
+                IndexSet<InterfaceTypeDefinitionPosition>,
+            > = HashMap::default();
+            for intf_object in subgraph.metadata().interface_object_types() {
+                let itf_pos = InterfaceTypeDefinitionPosition {
+                    type_name: intf_object.clone(),
+                };
+                if let Ok(runtime_types) =
+                    self.merged.possible_runtime_types(itf_pos.clone().into())
+                {
+                    runtime_types.iter().for_each(|t| {
+                        impls_to_intf_objects
+                            .entry(t.clone())
+                            .or_default()
+                            .insert(itf_pos.clone());
+                    });
+                }
+            }
+
+            impls_to_intf_objects.iter()
+                .filter(|(_, intf_objects)| intf_objects.len() > 1)
+                .fold(HashMap::<BTreeSet<Name>, IndexSet<Name>>::default(),
+                      |mut acc, (impl_, intf_objects)| {
+                          let key: BTreeSet<Name> = BTreeSet::from_iter(intf_objects.iter().map(|i| i.type_name.clone()));
+                    acc.entry(key)
+                        .or_default()
+                        .insert(impl_.type_name.clone());
+                    acc
+                })
+                .iter()
+                .for_each(|(intf_objects, impls)|
+                  self.error_reporter.add_error(
+                      CompositionError::InterfaceObjectUsageError {
+                          message: format!(
+                              "[{}] @interfaceObject {} in subgraph \"{}\" share implementation type(s) {}. Each @interfaceObject type in a subgraph must have a disjoint set of implementations.",
+                              subgraph.name,
+                              human_readable_types(intf_objects.iter()),
+                              subgraph.name,
+                              human_readable_types(impls.iter()),
+                          ),
+                      },
+                  )
+                );
         }
         Ok(())
     }

--- a/apollo-federation/src/merger/merge_interface.rs
+++ b/apollo-federation/src/merger/merge_interface.rs
@@ -168,9 +168,8 @@ impl Merger {
 
             impls_to_intf_objects.iter()
                 .filter(|(_, intf_objects)| intf_objects.len() > 1)
-                .fold(HashMap::<BTreeSet<Name>, IndexSet<Name>>::default(),
-                      |mut acc, (impl_, intf_objects)| {
-                          let key: BTreeSet<Name> = BTreeSet::from_iter(intf_objects.iter().map(|i| i.type_name.clone()));
+                .fold(HashMap::<BTreeSet<Name>, IndexSet<Name>>::default(), |mut acc, (impl_, intf_objects)| {
+                    let key: BTreeSet<Name> = BTreeSet::from_iter(intf_objects.iter().map(|i| i.type_name.clone()));
                     acc.entry(key)
                         .or_default()
                         .insert(impl_.type_name.clone());

--- a/apollo-federation/src/merger/merge_interface.rs
+++ b/apollo-federation/src/merger/merge_interface.rs
@@ -180,7 +180,7 @@ impl Merger {
                   self.error_reporter.add_error(
                       CompositionError::InterfaceObjectUsageError {
                           message: format!(
-                              "[{}] @interfaceObject {} in subgraph \"{}\" share implementation type(s) {}. Each @interfaceObject type in a subgraph must have a disjoint set of implementations.",
+                              "[{}] @interfaceObject {} in subgraph \"{}\" share implementation {}. Each @interfaceObject type in a subgraph must have a disjoint set of implementations.",
                               subgraph.name,
                               human_readable_types(intf_objects.iter()),
                               subgraph.name,

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -517,6 +517,9 @@ impl Merger {
             self.merge_implements(interface_type)?;
         }
 
+        trace!("Validating interface object disjointness");
+        self.validate_interface_object_disjointness()?;
+
         // Merge union types
         trace!("Merging union types");
         for union_type in &union_types {

--- a/apollo-federation/tests/composition/compose_interface_object.rs
+++ b/apollo-federation/tests/composition/compose_interface_object.rs
@@ -1033,7 +1033,7 @@ fn validate_multiple_overlapping_interface_object_types_in_same_subgraph() {
         &result,
         &[(
             "INTERFACE_OBJECT_USAGE_ERROR",
-            r#"[subgraphB] @interfaceObject types "I1" and "I2" in subgraph "subgraphB" share implementation type(s) type "T". Each @interfaceObject type in a subgraph must have a disjoint set of implementations."#,
+            r#"[subgraphB] @interfaceObject types "I1" and "I2" in subgraph "subgraphB" share implementation type "T". Each @interfaceObject type in a subgraph must have a disjoint set of implementations."#,
         )],
     );
 }

--- a/apollo-federation/tests/composition/compose_interface_object.rs
+++ b/apollo-federation/tests/composition/compose_interface_object.rs
@@ -990,3 +990,50 @@ fn interface_object_type_kind_mismatch_labels_correctly_when_object_processed_fi
         )],
     );
 }
+
+#[test]
+fn validate_multiple_overlapping_interface_object_types_in_same_subgraph() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+            type Query { t: T }
+            interface I1 { id: ID! }
+            interface I2 { id: ID! }
+            type T implements I1 & I2 @key(fields: "id") {
+              id: ID!
+            }
+        "#,
+    };
+
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+            type I1 @key(fields: "id") @interfaceObject {
+              id: ID!
+              a: String!
+            }
+            type I2 @key(fields: "id") @interfaceObject {
+              id: ID!
+              b: String!
+            }
+        "#,
+    };
+
+    let subgraph_c = ServiceDefinition {
+        name: "subgraphC",
+        type_defs: r#"
+            interface I1 @key(fields: "id") { id: ID! }
+            interface I2 @key(fields: "id") { id: ID! }
+            type T implements I1 & I2 @key(fields: "id") { id: ID!, t: String }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b, subgraph_c]);
+    assert_composition_errors(
+        &result,
+        &[(
+            "INTERFACE_OBJECT_USAGE_ERROR",
+            r#"[subgraphB] @interfaceObject types "I1" and "I2" in subgraph "subgraphB" share implementation type(s) type "T". Each @interfaceObject type in a subgraph must have a disjoint set of implementations."#,
+        )],
+    );
+}


### PR DESCRIPTION
Validates that `@interfaceObject` types within the same subgraph are pairwise disjoint in their implementing types. Query planning assumes that when jumping to a type in a subgraph via `@key`, there's only one version of that type. Multiple `@interfaceObject` types sharing an implementation type would violate this assumption leading to unexpected runtime behavior in QP.
