### PR TITLE
fix(test): migrate 7 remaining get_trace_report callers to subgraph mock (ROUTER-1878)

### DIFF
--- a/apollo-router/.changesets/fix_aaron_otel_traces_subgraph_mock_completion.md
+++ b/apollo-router/.changesets/fix_aaron_otel_traces_subgraph_mock_completion.md
@@ -1,0 +1,13 @@
+### Fix `apollo_otel_traces` live-network flake for 7 remaining tests (ROUTER-1878)
+
+7 tests in `tests/apollo_otel_traces.rs` still called `get_trace_report`, which routes
+through `with_subgraph_network_requests()` to `https://*.demo.starstuff.dev/`. When
+those hosts reset the connection (Windows os error 10054, Linux ECONNRESET), the subgraph
+fetch fails and `apollo_private.ftv1` is stripped from the OTel span, breaking the
+snapshot assertion.
+
+Migrates all 7 remaining callers (`non_defer`, `test_condition_if`, `test_condition_else`,
+`test_trace_id`, `test_client_name`, `test_client_version`, `test_send_header`) to
+`get_trace_report_with_subgraph_mock`, which routes through the localhost wiremock
+introduced in ROUTER-1834. No snapshot re-bless needed: `assert_report!` redacts FTV1
+to `"[redacted]"` regardless of source.

--- a/apollo-router/tests/apollo_otel_traces.rs
+++ b/apollo-router/tests/apollo_otel_traces.rs
@@ -776,37 +776,10 @@ async fn traces_handler(
     Ok(Json(()))
 }
 
-async fn get_trace_report(
-    reports: Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
-    request: router::Request,
-    use_legacy_request_span: bool,
-) -> ExportTraceServiceRequest {
-    get_traces(
-        get_router_service,
-        reports,
-        use_legacy_request_span,
-        false,
-        request,
-        |r| {
-            !r.resource_spans
-                .first()
-                .expect("resource spans required")
-                .scope_spans
-                .first()
-                .expect("scope spans required")
-                .spans
-                .is_empty()
-        },
-    )
-    .await
-}
-
-/// Variant of `get_trace_report` that swaps the real
-/// `https://*.demo.starstuff.dev/` subgraph egress for a localhost
-/// wiremock. Used by `test_send_variable_value` to make the test
-/// hermetic on Linux CI runners where the public demo subgraphs
-/// occasionally reset the TLS connection. See `ROUTER-1814` for the
-/// failure that motivated this.
+/// Routes all subgraph traffic through a localhost wiremock instead of
+/// the public `https://*.demo.starstuff.dev/` hosts, making every caller
+/// hermetic against live-network flakes (ECONNRESET / os error 104/10054).
+/// See `start_demo_subgraphs_mock_server` and `ROUTER-1878`.
 async fn get_trace_report_with_subgraph_mock(
     reports: Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
     request: router::Request,
@@ -1189,18 +1162,6 @@ async fn test_batch_send_header() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_send_variable_value() {
-    // Uses the wiremock-backed `get_trace_report_with_subgraph_mock`
-    // rather than `get_trace_report`. The latter routes through
-    // `with_subgraph_network_requests()` against the live
-    // `https://*.demo.starstuff.dev/` subgraphs hardcoded in
-    // `fixtures/supergraph.graphql`; on Linux CI those hosts sporadically
-    // reset the TLS connection (`ECONNRESET` / `os error 104`), which
-    // turns the `apollo.subgraph.name=accounts` `http_request` span's
-    // status from OK to ERROR and the snapshot then drifts (see
-    // ROUTER-1814 for the CircleCI failure). The mock returns canned
-    // federation responses with valid FTV1 trace blobs captured from
-    // the live demo deployment so the resulting OTel trace shape still
-    // matches the existing snapshot.
     for use_legacy_request_span in [true, false] {
         let request = supergraph::Request::fake_builder()
         .query("query($sendValue:Boolean!, $dontSendValue: Boolean!){topProducts{name reviews @include(if: $sendValue) {author{name}} reviews @include(if: $dontSendValue){author{name}}}}")

--- a/apollo-router/tests/apollo_otel_traces.rs
+++ b/apollo-router/tests/apollo_otel_traces.rs
@@ -1045,7 +1045,7 @@ async fn non_defer() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report(reports, req, use_legacy_request_span).await;
+        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1061,7 +1061,7 @@ async fn test_condition_if() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report(reports, req, use_legacy_request_span).await;
+        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1077,7 +1077,7 @@ async fn test_condition_else() {
         .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report(reports, req, use_legacy_request_span).await;
+        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1091,7 +1091,7 @@ async fn test_trace_id() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report(reports, req, use_legacy_request_span).await;
+        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1124,7 +1124,7 @@ async fn test_client_name() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report(reports, req, use_legacy_request_span).await;
+        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1139,7 +1139,7 @@ async fn test_client_version() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report(reports, req, use_legacy_request_span).await;
+        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1155,7 +1155,7 @@ async fn test_send_header() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report(reports, req, use_legacy_request_span).await;
+        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }

--- a/apollo-router/tests/apollo_otel_traces.rs
+++ b/apollo-router/tests/apollo_otel_traces.rs
@@ -121,31 +121,6 @@ async fn config(
     (task, config)
 }
 
-async fn get_router_service(
-    reports: Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
-    use_legacy_request_span: bool,
-    mocked: bool,
-) -> (JoinHandle<()>, BoxCloneService) {
-    let (task, config) = config(use_legacy_request_span, false, reports).await;
-
-    let builder = TestHarness::builder()
-        .try_log_level("INFO")
-        .configuration_json(config)
-        .expect("test harness had config errors")
-        .schema(include_str!("fixtures/supergraph.graphql"));
-    let builder = if mocked {
-        builder.subgraph_hook(|subgraph, _service| tracing_common::subgraph_mocks(subgraph))
-    } else {
-        builder.with_subgraph_network_requests()
-    };
-    (
-        task,
-        builder
-            .build_router()
-            .await
-            .expect("could create router test harness"),
-    )
-}
 
 /// Spin up a localhost wiremock server that mimics the subset of the
 /// `https://jsonplaceholder.typicode.com/` REST surface that
@@ -314,12 +289,10 @@ async fn start_demo_subgraphs_mock_server() -> MockServer {
     server
 }
 
-/// Variant of `get_router_service` that points the three demo subgraph URLs
-/// at a localhost wiremock instead of the public
-/// `https://*.demo.starstuff.dev/` hosts. The wiremock returns canned
-/// federation responses (including valid FTV1 traces) captured from the
-/// live demo subgraphs so the resulting OTel trace shape matches what the
-/// existing snapshots expect, but without any off-box network egress.
+/// Routes the three demo subgraph URLs to a localhost wiremock instead of
+/// the public `https://*.demo.starstuff.dev/` hosts. Returns canned
+/// federation responses (including valid FTV1 traces) so the OTel trace
+/// shape matches existing snapshots without off-box network egress.
 ///
 /// Introduced to fix ROUTER-1814: `test_send_variable_value` flaked on
 /// Linux CI when the accounts demo subgraph reset the TLS connection

--- a/apollo-router/tests/apollo_otel_traces.rs
+++ b/apollo-router/tests/apollo_otel_traces.rs
@@ -1045,7 +1045,8 @@ async fn non_defer() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
+        let report =
+            get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1061,7 +1062,8 @@ async fn test_condition_if() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
+        let report =
+            get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1077,7 +1079,8 @@ async fn test_condition_else() {
         .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
+        let report =
+            get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1091,7 +1094,8 @@ async fn test_trace_id() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
+        let report =
+            get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1124,7 +1128,8 @@ async fn test_client_name() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
+        let report =
+            get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1139,7 +1144,8 @@ async fn test_client_version() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
+        let report =
+            get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }
@@ -1155,7 +1161,8 @@ async fn test_send_header() {
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
         let reports = Arc::new(Mutex::new(vec![]));
-        let report = get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
+        let report =
+            get_trace_report_with_subgraph_mock(reports, req, use_legacy_request_span).await;
         assert_report!(report);
     }
 }

--- a/apollo-router/tests/apollo_otel_traces.rs
+++ b/apollo-router/tests/apollo_otel_traces.rs
@@ -121,7 +121,6 @@ async fn config(
     (task, config)
 }
 
-
 /// Spin up a localhost wiremock server that mimics the subset of the
 /// `https://jsonplaceholder.typicode.com/` REST surface that
 /// `tests/fixtures/supergraph_connect.graphql` exercises:


### PR DESCRIPTION
## Summary

- 7 tests in `tests/apollo_otel_traces.rs` still called `get_trace_report`, routing through `with_subgraph_network_requests()` to the live `https://*.demo.starstuff.dev/` hosts
- When those hosts reset the connection (Windows os error 10054 / Linux ECONNRESET), `apollo_private.ftv1` is stripped from the OTel span, breaking the snapshot assertion
- Migrates all 7 to `get_trace_report_with_subgraph_mock` (localhost wiremock introduced by ROUTER-1834). No snapshot re-bless needed: `assert_report!` always redacts FTV1 to `"[redacted]"`

## Affected tests

`non_defer`, `test_condition_if`, `test_condition_else`, `test_trace_id`, `test_client_name`, `test_client_version`, `test_send_header`

## Evidence

Post-bundle #9497 sweep (June 5 2026): `non_defer`, `test_client_name`, `test_condition_else` all failed on `dk/intf_object_validation` Windows (CircleCI build 382388) with "An existing connection was forcibly closed by the remote host. (os error 10054)" from the `reviews` subgraph. The remaining 4 are latent — same class, same fix.

## Relationship to prior work

ROUTER-1834 introduced `get_trace_report_with_subgraph_mock` and migrated 1 caller (`test_send_variable_value`). This completes the family.

Fixes [ROUTER-1878](https://apollographql.atlassian.net/browse/ROUTER-1878) under epic [ROUTER-1722](https://apollographql.atlassian.net/browse/ROUTER-1722).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ROUTER-1878]: https://apollographql.atlassian.net/browse/ROUTER-1878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ