### PR TITLE
fix(test): widen wait_for_router_ready budget in callback tests (ROUTER-1881)

### DIFF
--- a/apollo-router/.changesets/fix_aaron_callback_wait_for_router_ready_arm.md
+++ b/apollo-router/.changesets/fix_aaron_callback_wait_for_router_ready_arm.md
@@ -1,0 +1,9 @@
+### Widen `wait_for_router_ready` budget in callback subscription tests (ROUTER-1881)
+
+`wait_for_router_ready` polled with a 1-second per-request `reqwest` timeout, yielding
+only ~59 attempts within the 60-second outer deadline. On ARM Linux CI under heavy
+scheduling pressure the router can take ~61 seconds to start accepting HTTP connections
+after logging "GraphQL endpoint exposed", causing a spurious panic.
+
+Reduces the per-request timeout to 200ms (~270 attempts per 60s) and widens the outer
+deadline at both call sites from 60s to 90s, giving ~400 attempts across 90s.

--- a/apollo-router/tests/integration/subscriptions/callback.rs
+++ b/apollo-router/tests/integration/subscriptions/callback.rs
@@ -157,7 +157,7 @@ async fn wait_for_callbacks(
 async fn wait_for_router_ready(url: &str, deadline: tokio::time::Duration) {
     let start = tokio::time::Instant::now();
     let client = reqwest::Client::builder()
-        .timeout(tokio::time::Duration::from_secs(1))
+        .timeout(tokio::time::Duration::from_millis(200))
         .build()
         .expect("build reqwest client");
     while start.elapsed() < deadline {
@@ -422,7 +422,7 @@ async fn test_subscription_callback_error_payload() -> Result<(), BoxError> {
     // scheduling pressure (the failure surface previously observed
     // on `test-amd_linux_test`).
     let router_url = format!("http://{}/", router.bind_address());
-    wait_for_router_ready(&router_url, tokio::time::Duration::from_secs(60)).await;
+    wait_for_router_ready(&router_url, tokio::time::Duration::from_secs(90)).await;
 
     let subscription_query = r#"subscription { userWasCreated(intervalMs: 100, nbEvents: 2) { name reviews { body } } }"#;
 
@@ -542,7 +542,7 @@ async fn test_subscription_callback_pure_error_payload() -> Result<(), BoxError>
     // surface that crashed this test on CircleCI build 378842,
     // `test-amd_linux_test`).
     let router_url = format!("http://{}/", router.bind_address());
-    wait_for_router_ready(&router_url, tokio::time::Duration::from_secs(60)).await;
+    wait_for_router_ready(&router_url, tokio::time::Duration::from_secs(90)).await;
 
     let subscription_query = r#"subscription { userWasCreated(intervalMs: 100, nbEvents: 2) { name reviews { body } } }"#;
 


### PR DESCRIPTION
## Summary

- `wait_for_router_ready` in the callback subscription tests polled with a 1-second per-request `reqwest` timeout, yielding only ~59 attempts in the 60-second window
- On ARM Linux CI under heavy scheduling pressure the router can take ~61 seconds to accept HTTP connections after logging "GraphQL endpoint exposed", causing a panic
- Fix: reduce per-request timeout 1s → 200ms (~270 attempts/60s) and widen both call-site deadlines 60s → 90s (~400 attempts total)

## Evidence

`test_subscription_callback_error_payload` failed on PR #9579 ARM Linux (CircleCI build 382474): test took 61.49s, panic at `callback.rs:169`. AMD Linux, macOS, Windows all passed. The ROUTER-1821 fix (bundle #9497) introduced this probe to replace the previous formula sleep — the probe is correct but the budget was too tight for the ARM runner.

## Test plan

- [ ] ARM Linux test passes without hitting the deadline

Fixes [ROUTER-1881](https://apollographql.atlassian.net/browse/ROUTER-1881) under epic [ROUTER-1722](https://apollographql.atlassian.net/browse/ROUTER-1722).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ROUTER-1881]: https://apollographql.atlassian.net/browse/ROUTER-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROUTER-1722]: https://apollographql.atlassian.net/browse/ROUTER-1722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ