### PR TITLE
fix(logging): drop empty-string message field emitted by otel_error! in JSON formatter (ROUTER-1736)

### DIFF
--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -536,7 +536,11 @@ connector:
         let fmt_layer = FmtLayer::new(format, buff.clone()).boxed();
 
         ::tracing::subscriber::with_default(fmt::Subscriber::new().with(fmt_layer), || {
-            error!(name = "export_failure", message = "explicit error message", "");
+            error!(
+                name = "export_failure",
+                message = "explicit error message",
+                ""
+            );
         });
 
         let raw = buff.to_string();
@@ -544,8 +548,7 @@ connector:
         let parsed: serde_json::Value =
             serde_json::from_str(raw).expect("output should be valid JSON");
         assert_eq!(
-            parsed["message"],
-            "explicit error message",
+            parsed["message"], "explicit error message",
             "explicit message should be present"
         );
         assert!(

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -519,6 +519,42 @@ connector:
     }
 
     #[tokio::test]
+    async fn test_json_logging_no_duplicate_empty_message() {
+        // otel_error!(name: "op", message = "explicit") expands to:
+        //   error!(name = "op", message = "explicit", "")
+        // The trailing "" sets message = "" while the kv field sets message = "explicit",
+        // producing duplicate JSON keys. Verify the formatter drops the empty-string one.
+        let buff = LogBuffer::default();
+        let json_format = JsonFormat {
+            display_timestamp: false,
+            display_span_list: false,
+            display_current_span: false,
+            display_resource: false,
+            ..Default::default()
+        };
+        let format = Json::new(Resource::builder_empty().build(), json_format);
+        let fmt_layer = FmtLayer::new(format, buff.clone()).boxed();
+
+        ::tracing::subscriber::with_default(fmt::Subscriber::new().with(fmt_layer), || {
+            error!(name = "export_failure", message = "explicit error message", "");
+        });
+
+        let raw = buff.to_string();
+        let raw = raw.trim();
+        let parsed: serde_json::Value =
+            serde_json::from_str(raw).expect("output should be valid JSON");
+        assert_eq!(
+            parsed["message"],
+            "explicit error message",
+            "explicit message should be present"
+        );
+        assert!(
+            !raw.contains(r#""message":"""#) && !raw.contains(r#""message": """#),
+            "empty-string message should be dropped; got: {raw}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_json_logging_attributes() {
         let buff = LogBuffer::default();
         let format = Json::default();

--- a/apollo-router/src/plugins/telemetry/formatters/json.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/json.rs
@@ -12,7 +12,9 @@ use serde::ser::SerializeMap;
 use serde::ser::Serializer as _;
 use serde_json::Serializer;
 use tracing_core::Event;
+use tracing_core::Field;
 use tracing_core::Subscriber;
+use tracing_core::field;
 use tracing_serde::AsSerde;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::LookupSpan;
@@ -261,6 +263,72 @@ where
     }
 }
 
+/// Collects tracing event fields into an ordered buffer so we can filter before serializing.
+///
+/// Needed because `otel_error!` (and similar OTel macros) append a trailing `""` format-string
+/// arg after explicit kv fields, which causes tracing to record both `message = ""` (from the
+/// empty format string) and an explicit `message = kv` field — producing duplicate JSON keys.
+/// By collecting first we can drop the empty-string `message` when a real one is present.
+struct EventFieldCollector {
+    fields: Vec<(String, serde_json::Value)>,
+}
+
+impl EventFieldCollector {
+    fn new() -> Self {
+        Self { fields: Vec::new() }
+    }
+
+    fn serialize_into<M: SerializeMap>(self, map: &mut M) -> Result<(), M::Error> {
+        let has_real_message = self.fields.iter().any(|(k, v)| {
+            k == "message" && !matches!(v, serde_json::Value::String(s) if s.is_empty())
+        });
+        for (key, value) in self.fields {
+            if key == "message"
+                && has_real_message
+                && matches!(&value, serde_json::Value::String(s) if s.is_empty())
+            {
+                continue;
+            }
+            map.serialize_entry(key.as_str(), &value)?;
+        }
+        Ok(())
+    }
+}
+
+impl field::Visit for EventFieldCollector {
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.fields
+            .push((field.name().to_owned(), serde_json::Value::from(value)));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .push((field.name().to_owned(), serde_json::Value::from(value)));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .push((field.name().to_owned(), serde_json::Value::from(value)));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .push((field.name().to_owned(), serde_json::Value::from(value)));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .push((field.name().to_owned(), serde_json::Value::from(value)));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let name = field.name();
+        let name = name.strip_prefix("r#").unwrap_or(name);
+        self.fields
+            .push((name.to_owned(), serde_json::Value::from(format!("{value:?}"))));
+    }
+}
+
 impl<S> EventFormatter<S> for Json
 where
     S: Subscriber + for<'lookup> LookupSpan<'lookup>,
@@ -380,10 +448,11 @@ where
                 }
             }
 
-            let mut visitor = tracing_serde::SerdeMapVisitor::new(serializer);
-            event.record(&mut visitor);
-
-            serializer = visitor.take_serializer()?;
+            let mut collector = EventFieldCollector::new();
+            event.record(&mut collector);
+            collector
+                .serialize_into(&mut serializer)
+                .map_err(|e| serde::ser::Error::custom(e))?;
 
             if self.config.display_target {
                 serializer.serialize_entry("target", meta.target())?;

--- a/apollo-router/src/plugins/telemetry/formatters/json.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/json.rs
@@ -324,8 +324,10 @@ impl field::Visit for EventFieldCollector {
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
         let name = field.name();
         let name = name.strip_prefix("r#").unwrap_or(name);
-        self.fields
-            .push((name.to_owned(), serde_json::Value::from(format!("{value:?}"))));
+        self.fields.push((
+            name.to_owned(),
+            serde_json::Value::from(format!("{value:?}")),
+        ));
     }
 }
 
@@ -452,7 +454,7 @@ where
             event.record(&mut collector);
             collector
                 .serialize_into(&mut serializer)
-                .map_err(|e| serde::ser::Error::custom(e))?;
+                .map_err(serde::ser::Error::custom)?;
 
             if self.config.display_target {
                 serializer.serialize_entry("target", meta.target())?;


### PR DESCRIPTION
## Summary

- `otel_error!(name: "op", message = "explicit")` expands to `tracing::error!(... message = "explicit", "")` — the trailing `""` produces an implicit `message = ""` alongside the explicit `message = kv` field
- `tracing_serde::SerdeMapVisitor` serialized both directly, emitting duplicate `"message"` keys in JSON log output (invalid JSON, confusing in log aggregators)
- Replaces `SerdeMapVisitor` in the JSON formatter with `EventFieldCollector`, a collect-then-filter visitor that drops empty-string `message` fields when a non-empty `message` is also present
- All other fields and non-empty messages are unaffected

## Test plan

- [ ] New test `test_json_logging_no_duplicate_empty_message` in `fmt_layer.rs` directly simulates the `otel_error!` expansion and asserts the empty-string message is dropped and the explicit message is preserved
- [ ] All existing `fmt_layer` and `formatters::json` tests pass unchanged

Fixes ROUTER-1736

🤖 Generated with [Claude Code](https://claude.com/claude-code)