### PR TITLE
fix(redis): eager connections for a fred-rs bug in how it round-robins conns to replicas

### DIFF
--- a/.changesets/fix_aaron_redis_eager_connections.md
+++ b/.changesets/fix_aaron_redis_eager_connections.md
@@ -1,0 +1,7 @@
+### Fix Redis replica routing failure caused by lazy connections with even replica counts ([Issue/PR #9589](https://github.com/apollographql/router/pull/9589))
+
+When a Redis cluster had an even number of replicas, the router's use of `lazy_connections = true` could trigger a bug in fred's round-robin replica selection logic. Fred increments its round-robin counter when searching for a routable replica, and increments it again when it can't find one before requeuing the command. With an even replica count this causes fred to consistently target replicas that have no established connection, leading to GET failures falling through to backends and Redis CPU spikes.
+
+Switched to `lazy_connections = false` (eager connections) so all replica connections are established upfront. The `RouteableReplicaFilter` that was the original motivation for lazy connections — preventing unroutable replicas from entering the routing table — continues to handle that responsibility, making the blast-radius isolation that lazy connections provided redundant.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9589

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -422,15 +422,18 @@ impl RedisCacheStorage {
                 // then recreate the client with a fresh view of the infrastructure
                 config.replica.ignore_reconnection_errors = false;
                 config.replica.primary_fallback = true;
-                // NOTE: lazy_connections must be true (fred's default). With eager connections,
-                // a replica connection failure during add_connection propagates via ? through
-                // sync_replicas and can trigger the reconnection policy pool-wide. With lazy
-                // connections, failures are deferred to per-command time and isolated. The
-                // RouteableReplicaFilter prevents ghost replicas from entering the routing
-                // table at topology sync time regardless, but lazy connections provide
-                // additional blast-radius isolation for replicas that pass the TCP probe but
-                // fail Redis protocol setup (AUTH, HELLO, etc).
-                config.replica.lazy_connections = true;
+                // NOTE: lazy_connections must be false! There's a bug in fred's round-robin logic
+                // for selecting replicas when in a cluster that has an even number of replicas.
+                // The details are roughly that when fred looks for a routeable replica, it
+                // increments its round-robin counter, and if it can't find one, it moves on to
+                // creating one but also increments the counter _again_ before requeuing the redis
+                // command to run. When there are, eg, 2 replicas, those requeues will make it so
+                // that fred always tries to route a command to a replica that has no connection.
+                // Redis CPU explodes, GETs fail and fallthrough to backends, and so on. Not great.
+                // Don't set this to true! We originally set it to true to have additional blast
+                // radius for sync failures but we now have a ReplicaFilter doing that work for us
+                // (by removing unrouteable replicas from what we try to route to)
+                config.replica.lazy_connections = false;
                 config.tcp = TcpConfig {
                     #[cfg(target_os = "linux")]
                     user_timeout: Some(self.redis_client_config.timeout),


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-1884] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1884]: https://apollographql.atlassian.net/browse/ROUTER-1884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ