### PR TITLE
fix(test): register subscription IDs in callback mock subgraph (ROUTER-1885)

### DIFF
--- a/apollo-router/tests/integration/subscriptions/callback.rs
+++ b/apollo-router/tests/integration/subscriptions/callback.rs
@@ -22,8 +22,13 @@ async fn test_subscription_callback() -> Result<(), BoxError> {
     let callback_url = format!("http://{callback_addr}/callback");
 
     // Start mock subgraph server that will send callbacks
-    let subgraph_server =
-        start_callback_subgraph_server(nb_events, interval_ms, callback_url.clone()).await;
+    let subgraph_server = start_callback_subgraph_server(
+        nb_events,
+        interval_ms,
+        callback_url.clone(),
+        callback_state.subscription_ids.clone(),
+    )
+    .await;
 
     // Create router with port reservations
     let mut router = IntegrationTest::builder()
@@ -393,6 +398,7 @@ async fn test_subscription_callback_error_payload() -> Result<(), BoxError> {
         custom_payloads.clone(),
         interval_ms,
         callback_url.clone(),
+        callback_state.subscription_ids.clone(),
     )
     .await;
 
@@ -515,6 +521,7 @@ async fn test_subscription_callback_pure_error_payload() -> Result<(), BoxError>
         custom_payloads.clone(),
         interval_ms,
         callback_url.clone(),
+        callback_state.subscription_ids.clone(),
     )
     .await;
 

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -858,9 +858,7 @@ pub async fn start_callback_subgraph_server_with_payloads(
                         // the correct 200/202 (not 404) for subsequent next/complete
                         // callbacks. Without this the mock returns NOT_FOUND, which
                         // is what a real subgraph would treat as "subscription gone".
-                        subscription_ids
-                            .lock()
-                            .push(subscription_id.to_string());
+                        subscription_ids.lock().push(subscription_id.to_string());
 
                         tokio::spawn(send_callback_events_with_payloads(
                             callback_url.to_string(),

--- a/apollo-router/tests/integration/subscriptions/mod.rs
+++ b/apollo-router/tests/integration/subscriptions/mod.rs
@@ -808,11 +808,13 @@ pub async fn start_callback_subgraph_server(
     nb_events: usize,
     interval_ms: u64,
     callback_url: String,
+    subscription_ids: Arc<Mutex<Vec<String>>>,
 ) -> wiremock::MockServer {
     start_callback_subgraph_server_with_payloads(
         generate_default_payloads(nb_events),
         interval_ms,
         callback_url,
+        subscription_ids,
     )
     .await
 }
@@ -821,6 +823,7 @@ pub async fn start_callback_subgraph_server_with_payloads(
     payloads: Vec<serde_json::Value>,
     interval_ms: u64,
     callback_url: String,
+    subscription_ids: Arc<Mutex<Vec<String>>>,
 ) -> wiremock::MockServer {
     let server = wiremock::MockServer::start().await;
 
@@ -850,6 +853,14 @@ pub async fn start_callback_subgraph_server_with_payloads(
                             callback_url
                         );
                         info!("Subscription ID: {}", subscription_id);
+
+                        // Register the subscription ID so handle_callback returns
+                        // the correct 200/202 (not 404) for subsequent next/complete
+                        // callbacks. Without this the mock returns NOT_FOUND, which
+                        // is what a real subgraph would treat as "subscription gone".
+                        subscription_ids
+                            .lock()
+                            .push(subscription_id.to_string());
 
                         tokio::spawn(send_callback_events_with_payloads(
                             callback_url.to_string(),


### PR DESCRIPTION
## Summary

- `start_callback_subgraph_server` and `start_callback_subgraph_server_with_payloads` now accept `subscription_ids: Arc<Mutex<Vec<String>>>` and register the router-generated subscription ID before spawning the callback-sending task
- Fixes `test_subscription_callback_pure_error_payload` (and the related tests) which were flaky because `handle_callback` always returned 404 — `subscription_ids` was never populated, so the callback server treated every callback as an unknown subscription

## Root cause

The mock subgraph extracted the `subscriptionId` from the subscription extension but had no reference to `CallbackTestState`, so it could never register the ID. `handle_callback` returned `NOT_FOUND` for every `next`/`complete` action. Real subgraphs stop sending on 404; the mock happened to ignore it. The test still passed most of the time but was vulnerable to ordering races.

## Test plan

- [x] All four callback integration tests pass locally (`test_subscription_callback`, `test_subscription_callback_error_payload`, `test_subscription_callback_pure_error_payload`, `test_subscription_callback_error_scenarios`)
- [x] No changeset needed (test-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)