### PR TITLE
config(router): change `early_cancel` to be the default behavior of the router

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -756,7 +756,7 @@ pub(crate) struct Supergraph {
     pub(crate) query_planning: QueryPlanning,
 
     /// abort request handling when the client drops the connection.
-    /// Default: false.
+    /// Default: true.
     /// When set to true, some parts of the request pipeline like telemetry will not work properly,
     /// but request handling will stop immediately when the client connection is closed.
     pub(crate) early_cancel: bool,
@@ -814,7 +814,7 @@ impl Supergraph {
             query_planning: query_planning.unwrap_or_default(),
             generate_query_fragments: generate_query_fragments
                 .unwrap_or_else(default_generate_query_fragments),
-            early_cancel: early_cancel.unwrap_or_default(),
+            early_cancel: early_cancel.unwrap_or(true),
             experimental_log_on_broken_pipe: experimental_log_on_broken_pipe.unwrap_or_default(),
             enable_result_coercion_errors: insert_result_coercion_errors.unwrap_or_default(),
             strict_variable_validation: strict_variable_validation
@@ -852,7 +852,7 @@ impl Supergraph {
             query_planning: query_planning.unwrap_or_default(),
             generate_query_fragments: generate_query_fragments
                 .unwrap_or_else(default_generate_query_fragments),
-            early_cancel: early_cancel.unwrap_or_default(),
+            early_cancel: early_cancel.unwrap_or(true),
             experimental_log_on_broken_pipe: experimental_log_on_broken_pipe.unwrap_or_default(),
             enable_result_coercion_errors: insert_result_coercion_errors.unwrap_or_default(),
             strict_variable_validation: strict_variable_validation

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -11547,8 +11547,8 @@ expression: "&schema"
           "type": "boolean"
         },
         "early_cancel": {
-          "default": false,
-          "description": "abort request handling when the client drops the connection.\nDefault: false.\nWhen set to true, some parts of the request pipeline like telemetry will not work properly,\nbut request handling will stop immediately when the client connection is closed.",
+          "default": true,
+          "description": "abort request handling when the client drops the connection.\nDefault: true.\nWhen set to true, some parts of the request pipeline like telemetry will not work properly,\nbut request handling will stop immediately when the client connection is closed.",
           "type": "boolean"
         },
         "enable_result_coercion_errors": {
@@ -13206,7 +13206,7 @@ expression: "&schema"
           "secs": 60
         },
         "defer_support": true,
-        "early_cancel": false,
+        "early_cancel": true,
         "enable_result_coercion_errors": false,
         "experimental_log_on_broken_pipe": false,
         "generate_query_fragments": true,

--- a/docs/shared/config/supergraph.mdx
+++ b/docs/shared/config/supergraph.mdx
@@ -5,7 +5,7 @@
 ```yaml title="supergraph"
 supergraph:
   defer_support: true
-  early_cancel: false
+  early_cancel: true
   experimental_log_on_broken_pipe: false
   generate_query_fragments: true
   introspection: false

--- a/docs/shared/router-config-properties-table.mdx
+++ b/docs/shared/router-config-properties-table.mdx
@@ -722,7 +722,7 @@ Configuration options pertaining to the supergraph server component.
 ```yaml title="supergraph"
 supergraph:
   defer_support: true
-  early_cancel: false
+  early_cancel: true
   experimental_log_on_broken_pipe: false
   generate_query_fragments: true
   introspection: false

--- a/docs/shared/router-yaml-complete.mdx
+++ b/docs/shared/router-yaml-complete.mdx
@@ -332,7 +332,7 @@ subscription:
   queue_capacity: null
 supergraph:
   defer_support: true
-  early_cancel: false
+  early_cancel: true
   experimental_log_on_broken_pipe: false
   generate_query_fragments: true
   introspection: false

--- a/docs/source/routing/configuration/yaml.mdx
+++ b/docs/source/routing/configuration/yaml.mdx
@@ -543,13 +543,15 @@ Enabling this option will make debugging more difficult, as clients won't receiv
 
 #### Early cancel
 
-Up until [Apollo Router Core v1.43.1](https://github.com/apollographql/router/releases/tag/v1.43.1), when the client closed the connection without waiting for the response, the entire request was cancelled and did not go through the entire pipeline. Since this causes issues with request monitoring, the router introduced a new behavior in 1.43.1. Now, the entire pipeline is executed if the request is detected as cancelled, but subgraph requests are not actually done. The response will be reported with the `499` status code, but not actually sent to the client.
+When early cancel is enabled, which is done by setting `supergraph.early_cancel: true`, if the client closes the connection without waiting for the response, the entire request will be canceled and not proceed through the pipeline. Early cancel is **enabled by default**. 
 
-To go back to the previous behavior of immediately cancelling the request, the following configuration can be used for `supergraph.early_cancel`:
+Since this causes issues with request monitoring, the router introduced a new behavior in [Apollo Router Core v1.43.1](https://github.com/apollographql/router/releases/tag/v1.43.1). Instead, the entire pipeline is executed if the request is detected as cancelled, but subgraph requests are not actually done. The response will be reported with the `499` status code, but not actually sent to the client.
+
+To get this newer behavior of executing the entire pipeline despite a dropped connection, the following configuration can be used for `supergraph.early_cancel`:
 
 ```yaml
 supergraph:
-  early_cancel: true
+  early_cancel: false
 ```
 
 Additionally, since v1.43.1, the router can show a log when it detects that the client canceled the request. This log can be activated with:


### PR DESCRIPTION
[jira/ROUTER-1656](https://apollographql.atlassian.net/browse/ROUTER-1656)

<!-- [ROUTER-1656] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1656]: https://apollographql.atlassian.net/browse/ROUTER-1656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ