### PR TITLE
breaking: switch `supergraph.early_cancel` default to true

### DIFF
--- a/.changesets/breaking_early_cancel_default_true.md
+++ b/.changesets/breaking_early_cancel_default_true.md
@@ -1,0 +1,9 @@
+### Default `supergraph.early_cancel` to `true` ([PR #XXXX](https://github.com/apollographql/router/pull/XXXX))
+
+The `supergraph.early_cancel` configuration option now defaults to `true`. When a client disconnects, the router will immediately cancel the in-flight request and release its buffer permit, which is consistent with the behavior of most other web services.
+
+Previously the default was `false`, which caused requests to run to completion in a background task even after the client disconnected, holding buffer permits unnecessarily.
+
+To restore the previous behavior (e.g. to preserve telemetry for canceled requests), set `early_cancel: false` in your router config.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/XXXX

--- a/.changesets/breaking_early_cancel_default_true.md
+++ b/.changesets/breaking_early_cancel_default_true.md
@@ -1,9 +1,9 @@
-### Default `supergraph.early_cancel` to `true` ([PR #XXXX](https://github.com/apollographql/router/pull/XXXX))
+### Default `supergraph.early_cancel` to `true` ([PR #9594](https://github.com/apollographql/router/pull/9594))
 
-The `supergraph.early_cancel` configuration option now defaults to `true`. When a client disconnects, the router will immediately cancel the in-flight request and release its buffer permit, which is consistent with the behavior of most other web services.
+The `supergraph.early_cancel` configuration option now defaults to `true`. When a client disconnects, the router will immediately cancel the in-flight request, consistent with the behavior of most other web services.
 
-Previously the default was `false`, which caused requests to run to completion in a background task even after the client disconnected, holding buffer permits unnecessarily.
+Previously the default was `false`, which caused requests to continue running in a background task even after the client disconnected.
 
 To restore the previous behavior (e.g. to preserve telemetry for canceled requests), set `early_cancel: false` in your router config.
 
-By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/XXXX
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9594

--- a/apollo-router/src/axum_factory/testdata/log_on_broken_pipe.router.yaml
+++ b/apollo-router/src/axum_factory/testdata/log_on_broken_pipe.router.yaml
@@ -1,2 +1,3 @@
 supergraph:
+  early_cancel: false
   experimental_log_on_broken_pipe: true

--- a/apollo-router/src/axum_factory/testdata/no_log_on_broken_pipe.router.yaml
+++ b/apollo-router/src/axum_factory/testdata/no_log_on_broken_pipe.router.yaml
@@ -1,2 +1,3 @@
 supergraph:
+  early_cancel: false
   experimental_log_on_broken_pipe: false

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -758,8 +758,7 @@ pub(crate) struct Supergraph {
     /// Abort request handling when the client drops the connection.
     /// Default: true.
     /// When set to false, telemetry will be recorded for canceled requests, but request
-    /// handling will continue running (holding buffer permits) until completion even after
-    /// the client disconnects.
+    /// handling will continue running until completion even after the client disconnects.
     pub(crate) early_cancel: bool,
 
     /// Enable errors generated during response reformatting and result coercion to be returned in

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -755,10 +755,11 @@ pub(crate) struct Supergraph {
     /// Query planning options
     pub(crate) query_planning: QueryPlanning,
 
-    /// abort request handling when the client drops the connection.
-    /// Default: false.
-    /// When set to true, some parts of the request pipeline like telemetry will not work properly,
-    /// but request handling will stop immediately when the client connection is closed.
+    /// Abort request handling when the client drops the connection.
+    /// Default: true.
+    /// When set to false, telemetry will be recorded for canceled requests, but request
+    /// handling will continue running (holding buffer permits) until completion even after
+    /// the client disconnects.
     pub(crate) early_cancel: bool,
 
     /// Enable errors generated during response reformatting and result coercion to be returned in
@@ -780,6 +781,10 @@ pub(crate) struct Supergraph {
 }
 
 const fn default_generate_query_fragments() -> bool {
+    true
+}
+
+const fn default_early_cancel() -> bool {
     true
 }
 
@@ -814,7 +819,7 @@ impl Supergraph {
             query_planning: query_planning.unwrap_or_default(),
             generate_query_fragments: generate_query_fragments
                 .unwrap_or_else(default_generate_query_fragments),
-            early_cancel: early_cancel.unwrap_or_default(),
+            early_cancel: early_cancel.unwrap_or_else(default_early_cancel),
             experimental_log_on_broken_pipe: experimental_log_on_broken_pipe.unwrap_or_default(),
             enable_result_coercion_errors: insert_result_coercion_errors.unwrap_or_default(),
             strict_variable_validation: strict_variable_validation
@@ -852,7 +857,7 @@ impl Supergraph {
             query_planning: query_planning.unwrap_or_default(),
             generate_query_fragments: generate_query_fragments
                 .unwrap_or_else(default_generate_query_fragments),
-            early_cancel: early_cancel.unwrap_or_default(),
+            early_cancel: early_cancel.unwrap_or_else(default_early_cancel),
             experimental_log_on_broken_pipe: experimental_log_on_broken_pipe.unwrap_or_default(),
             enable_result_coercion_errors: insert_result_coercion_errors.unwrap_or_default(),
             strict_variable_validation: strict_variable_validation

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -11459,8 +11459,8 @@ expression: "&schema"
           "type": "boolean"
         },
         "early_cancel": {
-          "default": false,
-          "description": "abort request handling when the client drops the connection.\nDefault: false.\nWhen set to true, some parts of the request pipeline like telemetry will not work properly,\nbut request handling will stop immediately when the client connection is closed.",
+          "default": true,
+          "description": "Abort request handling when the client drops the connection.\nDefault: true.\nWhen set to false, telemetry will be recorded for canceled requests, but request\nhandling will continue running (holding buffer permits) until completion even after\nthe client disconnects.",
           "type": "boolean"
         },
         "enable_result_coercion_errors": {
@@ -13118,7 +13118,7 @@ expression: "&schema"
           "secs": 60
         },
         "defer_support": true,
-        "early_cancel": false,
+        "early_cancel": true,
         "enable_result_coercion_errors": false,
         "experimental_log_on_broken_pipe": false,
         "generate_query_fragments": true,

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -11460,7 +11460,7 @@ expression: "&schema"
         },
         "early_cancel": {
           "default": true,
-          "description": "Abort request handling when the client drops the connection.\nDefault: true.\nWhen set to false, telemetry will be recorded for canceled requests, but request\nhandling will continue running (holding buffer permits) until completion even after\nthe client disconnects.",
+          "description": "Abort request handling when the client drops the connection.\nDefault: true.\nWhen set to false, telemetry will be recorded for canceled requests, but request\nhandling will continue running until completion even after the client disconnects.",
           "type": "boolean"
         },
         "enable_result_coercion_errors": {


### PR DESCRIPTION
## What

- Changed the default value of `supergraph.early_cancel` from `false` to `true`
- Added `default_early_cancel()` const fn to drive both the builder default and serde deserialization default
- Updated the doc comment on the field to reflect the new default and describe the trade-off of opting back to `false`
- Regenerated the `schema_generation` snapshot to reflect `"default": true`
- Added a `breaking_` changeset

## Verified
- `cargo fmt --check` passed
- `cargo clippy -- -D warnings` passed
- CHANGELOG.md not modified
- Changeset title contains no conventional-commit prefix

## Notes

Users who need full telemetry for canceled requests (the previous behavior) can restore it with `early_cancel: false` in their router config. The `false` path (spawned task + `CancelHandler`) is unchanged.