### PR TITLE
fix(composition): only merge enum-value directives from subgraphs that define the value

### DIFF
--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -133,7 +133,17 @@ impl Merger {
             directives: Default::default(),
         });
         value_pos.insert(&mut self.merged, dest)?;
-        let pos_sources = map_sources(sources, |source| source.as_ref().map(|_| value_pos.clone()));
+        // Only treat a subgraph as a source for this value's description/directives if it actually
+        // *defines* the value. Mapping over every subgraph that merely declares the enum type would
+        // make subgraphs that omit this value look like they apply the value's directives with empty
+        // arguments, polluting mismatch hints (e.g. INCONSISTENT_NON_REPEATABLE_DIRECTIVE_ARGUMENTS
+        // listing subgraphs that don't define the value at all).
+        let pos_sources = map_sources(sources, |source| {
+            source
+                .as_ref()
+                .filter(|enum_type| enum_type.values.contains_key(&value_pos.value_name))
+                .map(|_| value_pos.clone())
+        });
         self.merge_description(&pos_sources, value_pos)?;
         self.record_applied_directives_to_merge(&pos_sources, value_pos)?;
         self.add_join_enum_value(&value_sources, value_pos)?;

--- a/apollo-federation/tests/composition/hints.rs
+++ b/apollo-federation/tests/composition/hints.rs
@@ -2190,3 +2190,67 @@ mod external_types {
         assert_no_hints(&composition_result);
     }
 }
+
+mod directive_argument_inconsistencies {
+    use super::*;
+
+    /// Regression: when an enum value is defined in only some subgraphs and carries inconsistent
+    /// `@deprecated` arguments, the INCONSISTENT_NON_REPEATABLE_DIRECTIVE_ARGUMENTS hint must only
+    /// reference subgraphs that actually *define the value*. Previously RS listed every subgraph
+    /// that merely declared the enum type (treating a missing value as "empty arguments").
+    #[test]
+    fn inconsistent_enum_value_directive_args_only_lists_defining_subgraphs() {
+        // Subgraph1/2 define V with @deprecated(reason: "use W") -> the chosen (most-used) value.
+        let s1 = ServiceDefinition {
+            name: "Subgraph1",
+            type_defs: r#"
+                type Query { a: E }
+                enum E { V @deprecated(reason: "use W") W }
+            "#,
+        };
+        let s2 = ServiceDefinition {
+            name: "Subgraph2",
+            type_defs: r#"
+                type Query { b: E }
+                enum E { V @deprecated(reason: "use W") W }
+            "#,
+        };
+        // Subgraph3 applies @deprecated with NO args -> a second, incompatible application that
+        // triggers the INCONSISTENT_NON_REPEATABLE_DIRECTIVE_ARGUMENTS hint.
+        let s3 = ServiceDefinition {
+            name: "Subgraph3",
+            type_defs: r#"
+                type Query { c: E }
+                enum E { V @deprecated W }
+            "#,
+        };
+        // Subgraph4 defines V but WITHOUT @deprecated -> the divergent "empty" group; it *does*
+        // define the value, so it is legitimately listed.
+        let s4 = ServiceDefinition {
+            name: "Subgraph4",
+            type_defs: r#"
+                type Query { d: E }
+                enum E { V W }
+            "#,
+        };
+        // Subgraph5 declares the enum but does NOT define V -> must NOT appear in the hint.
+        let s5 = ServiceDefinition {
+            name: "Subgraph5",
+            type_defs: r#"
+                type Query { e: E }
+                enum E { W }
+            "#,
+        };
+
+        let result =
+            compose_as_fed2_subgraphs(&[s1, s2, s3, s4, s5]).expect("should successfully compose");
+        assert_has_hint(
+            &result,
+            "INCONSISTENT_NON_REPEATABLE_DIRECTIVE_ARGUMENTS",
+            "Non-repeatable directive @deprecated is applied to \"E.V\" in multiple \
+            subgraphs but with incompatible arguments. The supergraph will use arguments {reason: \"use W\"} \
+            (from subgraphs \"Subgraph1\" and \"Subgraph2\"), but found no arguments in subgraph \"Subgraph3\" \
+            and  in subgraph \"Subgraph4\".",
+        );
+    }
+}


### PR DESCRIPTION
`merge_enum_value` built `pos_sources` by mapping over every subgraph that declared the enum *type*, rather than only the subgraphs that define the specific value. Those extra sources were then passed to `merge_description` and `record_applied_directives_to_merge`, making subgraphs that omit the value appear as if they applied the value's directives with empty arguments.

The visible symptom was a polluted INCONSISTENT_NON_REPEATABLE_DIRECTIVE_ARGUMENTS hint: for an inconsistent `@deprecated` application on an enum value, the message listed every subgraph that merely declares the enum (including ones that don't define the value) instead of only the subgraph(s) that actually define it. This diverged from the JS composer, which lists only the defining subgraph(s).

Gate `pos_sources` on `enum_type.values.contains_key(value_name)`, matching the existing `value_sources` gating a few lines above. Adds a regression test that composes an enum whose value is defined in only some subgraphs with inconsistent `@deprecated` arguments and asserts the hint omits the non-defining subgraph.