### PR TITLE
chore(telemetry): deprecate Static(String) selector variant with startup warning

### DIFF
--- a/.changesets/maint_deprecate_static_string_selector.md
+++ b/.changesets/maint_deprecate_static_string_selector.md
@@ -1,0 +1,10 @@
+### Emit startup warning when deprecated `Static(String)` telemetry selector is used ([Issue #1766](https://github.com/apollographql/router/issues/1766))
+
+The string shorthand form for static telemetry attribute selectors (e.g. `my_attribute: "value"`) is now deprecated and will log a warning at startup. Use the object form instead:
+
+```yaml
+my_attribute:
+  static: "value"
+```
+
+The object form additionally supports typed values (bool, int, float, array), making it strictly more capable than the string shorthand.

--- a/apollo-router/src/configuration/migrations/2048-static-string-selector-deprecated.yaml
+++ b/apollo-router/src/configuration/migrations/2048-static-string-selector-deprecated.yaml
@@ -1,0 +1,47 @@
+description: log deprecation warning for the Static(String) telemetry attribute selector variant
+actions:
+  - type: log
+    condition: is_string
+    level: warn
+    path: telemetry.instrumentation.spans.router.attributes.*
+    log: "The string shorthand form of the static telemetry attribute selector (e.g. `my_attribute: \"value\"`) is deprecated. Use the object form instead: `my_attribute: {static: \"value\"}`, which additionally supports typed values (bool, int, float, array). See https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors"
+  - type: log
+    condition: is_string
+    level: warn
+    path: telemetry.instrumentation.spans.supergraph.attributes.*
+    log: "The string shorthand form of the static telemetry attribute selector (e.g. `my_attribute: \"value\"`) is deprecated. Use the object form instead: `my_attribute: {static: \"value\"}`, which additionally supports typed values (bool, int, float, array). See https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors"
+  - type: log
+    condition: is_string
+    level: warn
+    path: telemetry.instrumentation.spans.subgraph.attributes.*
+    log: "The string shorthand form of the static telemetry attribute selector (e.g. `my_attribute: \"value\"`) is deprecated. Use the object form instead: `my_attribute: {static: \"value\"}`, which additionally supports typed values (bool, int, float, array). See https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors"
+  - type: log
+    condition: is_string
+    level: warn
+    path: telemetry.instrumentation.events.router.*.attributes.*
+    log: "The string shorthand form of the static telemetry attribute selector (e.g. `my_attribute: \"value\"`) is deprecated. Use the object form instead: `my_attribute: {static: \"value\"}`, which additionally supports typed values (bool, int, float, array). See https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors"
+  - type: log
+    condition: is_string
+    level: warn
+    path: telemetry.instrumentation.events.supergraph.*.attributes.*
+    log: "The string shorthand form of the static telemetry attribute selector (e.g. `my_attribute: \"value\"`) is deprecated. Use the object form instead: `my_attribute: {static: \"value\"}`, which additionally supports typed values (bool, int, float, array). See https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors"
+  - type: log
+    condition: is_string
+    level: warn
+    path: telemetry.instrumentation.events.subgraph.*.attributes.*
+    log: "The string shorthand form of the static telemetry attribute selector (e.g. `my_attribute: \"value\"`) is deprecated. Use the object form instead: `my_attribute: {static: \"value\"}`, which additionally supports typed values (bool, int, float, array). See https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors"
+  - type: log
+    condition: is_string
+    level: warn
+    path: telemetry.instrumentation.instruments.router.*.attributes.*
+    log: "The string shorthand form of the static telemetry attribute selector (e.g. `my_attribute: \"value\"`) is deprecated. Use the object form instead: `my_attribute: {static: \"value\"}`, which additionally supports typed values (bool, int, float, array). See https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors"
+  - type: log
+    condition: is_string
+    level: warn
+    path: telemetry.instrumentation.instruments.supergraph.*.attributes.*
+    log: "The string shorthand form of the static telemetry attribute selector (e.g. `my_attribute: \"value\"`) is deprecated. Use the object form instead: `my_attribute: {static: \"value\"}`, which additionally supports typed values (bool, int, float, array). See https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors"
+  - type: log
+    condition: is_string
+    level: warn
+    path: telemetry.instrumentation.instruments.subgraph.*.attributes.*
+    log: "The string shorthand form of the static telemetry attribute selector (e.g. `my_attribute: \"value\"`) is deprecated. Use the object form instead: `my_attribute: {static: \"value\"}`, which additionally supports typed values (bool, int, float, array). See https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@static-string-selector-deprecated.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@static-string-selector-deprecated.yaml.snap
@@ -1,0 +1,11 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+telemetry:
+  instrumentation:
+    spans:
+      router:
+        attributes:
+          my.static.attribute: deprecated static string value

--- a/apollo-router/src/configuration/testdata/migrations/static-string-selector-deprecated.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/static-string-selector-deprecated.yaml
@@ -1,0 +1,6 @@
+telemetry:
+  instrumentation:
+    spans:
+      router:
+        attributes:
+          my.static.attribute: "deprecated static string value"

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -51,7 +51,21 @@ enum Action {
         path: String,
         level: String,
         log: String,
+        #[serde(default)]
+        condition: LogCondition,
     },
+}
+
+/// Filter applied to values selected by the JSONPath in a `Log` action.
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+enum LogCondition {
+    /// Log when the path returns any results (default).
+    #[default]
+    NonEmpty,
+    /// Only log when at least one matched value is a plain string.
+    /// Used to detect deprecated untagged-string selector variants (e.g. `Static(String)`).
+    IsString,
 }
 
 const REMOVAL_VALUE: &str = "__PLEASE_DELETE_ME";
@@ -176,13 +190,20 @@ fn apply_migration(config: &Value, migration: &Migration) -> Result<Value, Confi
                         .add_action(Parser::parse(&format!(r#"const({to})"#), path)?);
                 }
             }
-            Action::Log { path, level, log } => {
+            Action::Log {
+                path,
+                level,
+                log,
+                condition,
+            } => {
                 let level = Level::from_str(level).map_err(migration_failure_error)?;
 
-                if !jsonpath_lib::select(config, &format!("$.{path}"))
-                    .unwrap_or_default()
-                    .is_empty()
-                {
+                let values = jsonpath_lib::select(config, &format!("$.{path}")).unwrap_or_default();
+                let should_log = match condition {
+                    LogCondition::NonEmpty => !values.is_empty(),
+                    LogCondition::IsString => values.iter().any(|v| v.is_string()),
+                };
+                if should_log {
                     match level {
                         Level::INFO => tracing::info!("{log}"),
                         Level::ERROR => tracing::error!("{log}"),


### PR DESCRIPTION
## Summary

Closes [ROUTER-1766](https://apollographql.atlassian.net/browse/ROUTER-1766).

The `Static(String)` telemetry attribute selector variant (bare string shorthand, e.g. `my_attribute: "value"`) has been marked deprecated in code for some time but emitted no user-visible warning. This PR wires up a startup warning via the config migration system.

### What changed

- **`upgrade.rs`**: Extended the `Log` migration action with an optional `condition` field (`LogCondition` enum). The default variant `NonEmpty` preserves existing behavior (fire when the JSONPath returns any results). The new `IsString` variant fires only when at least one matched value is a plain string — which is how `Static(String)` manifests in JSON (all other selector variants are objects with named fields).

- **`2048-static-string-selector-deprecated.yaml`**: New migration with `condition: is_string` log actions covering all attribute selector positions across spans, events, and instruments for `router`, `supergraph`, and `subgraph`.

- **Test config + snapshot**: Exercises the migration and confirms the config passes through unchanged (log-only migration).

- **Changeset**: `maint_` entry describing the deprecation.

### Migration YAML shape

```yaml
- type: log
  condition: is_string
  level: warn
  path: telemetry.instrumentation.spans.router.attributes.*
  log: "The string shorthand form of the static telemetry attribute selector..."
```

### Reviewer notes

- `condition` defaults to `NonEmpty` via `#[derive(Default)]` + `#[default]` on the variant, so all existing migrations that omit `condition` continue to work without change.
- `graphql` and `connector` selectors don't have a `Static(String)` variant so are not covered.

[ROUTER-1766]: https://apollographql.atlassian.net/browse/ROUTER-1766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ