### PR TITLE
chore(3.0): remove `Static(String)` telemetry selector variant

### DIFF
--- a/.changesets/breaking_caroline_router_1767_remove_static_string_selector.md
+++ b/.changesets/breaking_caroline_router_1767_remove_static_string_selector.md
@@ -13,4 +13,4 @@ attributes:
     static: "my-value"
 ```
 
-By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/XXXX
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9602

--- a/.changesets/breaking_caroline_router_1767_remove_static_string_selector.md
+++ b/.changesets/breaking_caroline_router_1767_remove_static_string_selector.md
@@ -1,0 +1,16 @@
+### Remove deprecated `Static(String)` telemetry selector variant
+
+The deprecated `Static(String)` variant has been removed from the `supergraph`, `router`, and `subgraph` telemetry selector enums. Use the `static` field instead:
+
+```yaml
+# Before (no longer supported)
+attributes:
+  my.attr: "my-value"
+
+# After
+attributes:
+  my.attr:
+    static: "my-value"
+```
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/XXXX

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -8956,10 +8956,6 @@ expression: "&schema"
           "type": "object"
         },
         {
-          "description": "Deprecated, should not be used anymore, use static field instead",
-          "type": "string"
-        },
-        {
           "additionalProperties": false,
           "properties": {
             "static": {
@@ -10852,10 +10848,6 @@ expression: "&schema"
           "type": "object"
         },
         {
-          "description": "Deprecated, should not be used anymore, use static field instead",
-          "type": "string"
-        },
-        {
           "additionalProperties": false,
           "properties": {
             "static": {
@@ -11933,10 +11925,6 @@ expression: "&schema"
             "env"
           ],
           "type": "object"
-        },
-        {
-          "description": "Deprecated, should not be used anymore, use static field instead",
-          "type": "string"
         },
         {
           "additionalProperties": false,

--- a/apollo-router/src/configuration/testdata/metrics/telemetry.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/telemetry.router.yaml
@@ -71,7 +71,8 @@ telemetry:
           unit: request
           description: "supergraph requests"
           attributes:
-            static: hello
+            static:
+              static: hello
             graphql_operation_kind:
               operation_kind: string
       subgraph:

--- a/apollo-router/src/plugins/telemetry/config_new/conditional.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/conditional.rs
@@ -359,16 +359,13 @@ where
                     value: Arc::new(Default::default()),
                 })
             }
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            fn visit_str<E>(self, _v: &str) -> Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(Conditional {
-                    selector: Att::deserialize(Value::String(v.to_string()))
-                        .map_err(|e| Error::custom(e.to_string()))?,
-                    condition: None,
-                    value: Arc::new(Default::default()),
-                })
+                Err(E::custom(
+                    "plain string selectors are not supported in Router 3.x; use '{ static: \"<value>\" }' instead",
+                ))
             }
         }
 
@@ -628,14 +625,17 @@ mod test {
     }
 
     #[test]
-    fn test_simple_value() {
+    fn test_simple_value_no_longer_supported() {
         let config = r#"
             "foo"
         "#;
 
-        let result = serde_yaml::from_str::<super::Conditional<RouterSelector>>(config)
-            .expect("should have parsed");
-        assert!(result.condition.is_none());
-        assert!(matches!(result.selector, RouterSelector::Static(_)));
+        let result = serde_yaml::from_str::<super::Conditional<RouterSelector>>(config);
+        assert!(
+            result
+                .expect_err("should have got error")
+                .to_string()
+                .contains("plain string selectors are not supported"),
+        )
     }
 }

--- a/apollo-router/src/plugins/telemetry/config_new/router/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/selectors.rs
@@ -184,8 +184,6 @@ pub(crate) enum RouterSelector {
         /// The mode for extracting active subgraph request information
         active_subgraph_requests: ActiveSubgraphRequests,
     },
-    /// Deprecated, should not be used anymore, use static field instead
-    Static(String),
     StaticField {
         /// A static value
         r#static: AttributeValue,
@@ -266,7 +264,6 @@ impl Selector for RouterSelector {
             RouterSelector::Baggage {
                 baggage, default, ..
             } => get_baggage(baggage).or_else(|| default.maybe_to_otel_value()),
-            RouterSelector::Static(val) => Some(val.clone().into()),
             RouterSelector::StaticField { r#static } => Some(r#static.clone().into()),
             RouterSelector::ResponseBody { response_body } if *response_body => {
                 insert_display_router_response(request);
@@ -411,7 +408,6 @@ impl Selector for RouterSelector {
                     .unwrap_or_default();
                 Some(opentelemetry::Value::Bool(contains_error))
             }
-            RouterSelector::Static(val) => Some(val.clone().into()),
             RouterSelector::StaticField { r#static } => Some(r#static.clone().into()),
             RouterSelector::StudioOperationId {
                 studio_operation_id,
@@ -431,7 +427,6 @@ impl Selector for RouterSelector {
     fn on_error(&self, error: &tower::BoxError, ctx: &Context) -> Option<opentelemetry::Value> {
         match self {
             RouterSelector::Error { .. } => Some(error.to_string().into()),
-            RouterSelector::Static(val) => Some(val.clone().into()),
             RouterSelector::StaticField { r#static } => Some(r#static.clone().into()),
             RouterSelector::ContextId { context_id } if *context_id => {
                 Some(opentelemetry::Value::from(ctx.id.clone()))
@@ -468,7 +463,6 @@ impl Selector for RouterSelector {
 
     fn on_drop(&self) -> Option<opentelemetry::Value> {
         match self {
-            RouterSelector::Static(val) => Some(val.clone().into()),
             RouterSelector::StaticField { r#static } => Some(r#static.clone().into()),
             _ => None,
         }
@@ -485,7 +479,6 @@ impl Selector for RouterSelector {
                         | RouterSelector::TraceId { .. }
                         | RouterSelector::StudioOperationId { .. }
                         | RouterSelector::Baggage { .. }
-                        | RouterSelector::Static(_)
                         | RouterSelector::Env { .. }
                         | RouterSelector::StaticField { .. }
                         | RouterSelector::ContextId { .. }
@@ -497,7 +490,6 @@ impl Selector for RouterSelector {
                     | RouterSelector::StudioOperationId { .. }
                     | RouterSelector::OperationName { .. }
                     | RouterSelector::Baggage { .. }
-                    | RouterSelector::Static(_)
                     | RouterSelector::Env { .. }
                     | RouterSelector::StaticField { .. }
                     | RouterSelector::ResponseHeader { .. }
@@ -517,17 +509,13 @@ impl Selector for RouterSelector {
                     | RouterSelector::StudioOperationId { .. }
                     | RouterSelector::OperationName { .. }
                     | RouterSelector::Baggage { .. }
-                    | RouterSelector::Static(_)
                     | RouterSelector::Env { .. }
                     | RouterSelector::StaticField { .. }
                     | RouterSelector::ResponseContext { .. }
                     | RouterSelector::Error { .. }
                     | RouterSelector::ContextId { .. }
             ),
-            Stage::Drop => matches!(
-                self,
-                RouterSelector::Static(_) | RouterSelector::StaticField { .. }
-            ),
+            Stage::Drop => matches!(self, RouterSelector::StaticField { .. }),
         }
     }
 }
@@ -563,22 +551,6 @@ mod test {
     use crate::query_planner::APOLLO_OPERATION_ID;
     use crate::services::RouterRequest;
     use crate::services::RouterResponse;
-
-    #[test]
-    fn router_static() {
-        let selector = RouterSelector::Static("test_static".to_string());
-        assert_eq!(
-            selector
-                .on_request(
-                    &crate::services::RouterRequest::fake_builder()
-                        .build()
-                        .unwrap()
-                )
-                .unwrap(),
-            "test_static".into()
-        );
-        assert_eq!(selector.on_drop().unwrap(), "test_static".into());
-    }
 
     #[test]
     fn router_static_field() {

--- a/apollo-router/src/plugins/telemetry/config_new/subgraph/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/subgraph/selectors.rs
@@ -262,8 +262,6 @@ pub(crate) enum SubgraphSelector {
         #[serde(skip)]
         mocked_env_var: Option<String>,
     },
-    /// Deprecated, should not be used anymore, use static field instead
-    Static(String),
     StaticField {
         /// A static value
         r#static: AttributeValue,
@@ -476,7 +474,6 @@ impl Selector for SubgraphSelector {
                     .or_else(|| default.clone())
                     .map(opentelemetry::Value::from)
             }
-            SubgraphSelector::Static(val) => Some(val.clone().into()),
             SubgraphSelector::StaticField { r#static } => Some(r#static.clone().into()),
             SubgraphSelector::ContextId { context_id } if *context_id => {
                 Some(opentelemetry::Value::from(request.context.id.clone()))
@@ -612,7 +609,6 @@ impl Selector for SubgraphSelector {
                     .map(|v| opentelemetry::Value::from(v as i64))
             }
             .or_else(|| default.maybe_to_otel_value()),
-            SubgraphSelector::Static(val) => Some(val.clone().into()),
             SubgraphSelector::StaticField { r#static } => Some(r#static.clone().into()),
             SubgraphSelector::Cache { cache, entity_type } => {
                 let cache_info: CacheSubgraph = response
@@ -801,7 +797,6 @@ impl Selector for SubgraphSelector {
                 .map(opentelemetry::Value::from)
             }
             SubgraphSelector::Error { .. } => Some(error.to_string().into()),
-            SubgraphSelector::Static(val) => Some(val.clone().into()),
             SubgraphSelector::StaticField { r#static } => Some(r#static.clone().into()),
             SubgraphSelector::ResponseContext {
                 response_context,
@@ -821,7 +816,6 @@ impl Selector for SubgraphSelector {
 
     fn on_drop(&self) -> Option<Value> {
         match self {
-            SubgraphSelector::Static(val) => Some(val.clone().into()),
             SubgraphSelector::StaticField { r#static } => Some(r#static.clone().into()),
             _ => None,
         }
@@ -845,7 +839,6 @@ impl Selector for SubgraphSelector {
                     | SubgraphSelector::RequestContext { .. }
                     | SubgraphSelector::Baggage { .. }
                     | SubgraphSelector::Env { .. }
-                    | SubgraphSelector::Static(_)
                     | SubgraphSelector::StaticField { .. }
                     | SubgraphSelector::ContextId { .. }
             ),
@@ -861,7 +854,6 @@ impl Selector for SubgraphSelector {
                     | SubgraphSelector::SubgraphResponseErrors { .. }
                     | SubgraphSelector::ResponseContext { .. }
                     | SubgraphSelector::OnGraphQLError { .. }
-                    | SubgraphSelector::Static(_)
                     | SubgraphSelector::StaticField { .. }
                     | SubgraphSelector::Cache { .. }
                     | SubgraphSelector::ResponseCache { .. }
@@ -876,15 +868,11 @@ impl Selector for SubgraphSelector {
                     | SubgraphSelector::SupergraphOperationKind { .. }
                     | SubgraphSelector::SupergraphOperationName { .. }
                     | SubgraphSelector::Error { .. }
-                    | SubgraphSelector::Static(_)
                     | SubgraphSelector::StaticField { .. }
                     | SubgraphSelector::ResponseContext { .. }
                     | SubgraphSelector::ContextId { .. }
             ),
-            Stage::Drop => matches!(
-                self,
-                SubgraphSelector::Static(_) | SubgraphSelector::StaticField { .. }
-            ),
+            Stage::Drop => matches!(self, SubgraphSelector::StaticField { .. }),
         }
     }
 }
@@ -942,26 +930,6 @@ mod test {
     use crate::services::SubgraphRequest;
     use crate::services::SubgraphResponse;
     use crate::services::subgraph::SubgraphRequestId;
-
-    #[test]
-    fn subgraph_static() {
-        let selector = SubgraphSelector::Static("test_static".to_string());
-        assert_eq!(
-            selector
-                .on_request(
-                    &crate::services::SubgraphRequest::fake_builder()
-                        .supergraph_request(Arc::new(
-                            http::Request::builder()
-                                .body(graphql::Request::builder().build())
-                                .unwrap()
-                        ))
-                        .build()
-                )
-                .unwrap(),
-            "test_static".into()
-        );
-        assert_eq!(selector.on_drop().unwrap(), "test_static".into());
-    }
 
     #[test]
     fn subgraph_static_field() {

--- a/apollo-router/src/plugins/telemetry/config_new/supergraph/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/supergraph/selectors.rs
@@ -187,8 +187,6 @@ pub(crate) enum SupergraphSelector {
         #[serde(skip)]
         mocked_env_var: Option<String>,
     },
-    /// Deprecated, should not be used anymore, use static field instead
-    Static(String),
     StaticField {
         /// A static value
         r#static: AttributeValue,
@@ -315,7 +313,6 @@ impl Selector for SupergraphSelector {
                     .or_else(|| default.clone())
                     .map(opentelemetry::Value::from)
             }
-            SupergraphSelector::Static(val) => Some(val.clone().into()),
             SupergraphSelector::StaticField { r#static } => Some(r#static.clone().into()),
             SupergraphSelector::ContextId { context_id } if *context_id => {
                 Some(opentelemetry::Value::from(request.context.id.clone()))
@@ -412,7 +409,6 @@ impl Selector for SupergraphSelector {
             SupergraphSelector::IsPrimaryResponse {
                 is_primary_response: is_primary,
             } if *is_primary => Some(true.into()),
-            SupergraphSelector::Static(val) => Some(val.clone().into()),
             SupergraphSelector::StaticField { r#static } => Some(r#static.clone().into()),
             SupergraphSelector::ContextId { context_id } if *context_id => {
                 Some(opentelemetry::Value::from(response.context.id.clone()))
@@ -517,7 +513,6 @@ impl Selector for SupergraphSelector {
                 .as_ref()
                 .and_then(|v| v.maybe_to_otel_value())
                 .or_else(|| default.maybe_to_otel_value()),
-            SupergraphSelector::Static(val) => Some(val.clone().into()),
             SupergraphSelector::StaticField { r#static } => Some(r#static.clone().into()),
             SupergraphSelector::ContextId { context_id } if *context_id => {
                 Some(opentelemetry::Value::from(ctx.id.clone()))
@@ -570,7 +565,6 @@ impl Selector for SupergraphSelector {
                 }
             }
             SupergraphSelector::Error { .. } => Some(error.to_string().into()),
-            SupergraphSelector::Static(val) => Some(val.clone().into()),
             SupergraphSelector::StaticField { r#static } => Some(r#static.clone().into()),
             SupergraphSelector::ResponseContext {
                 response_context,
@@ -596,7 +590,6 @@ impl Selector for SupergraphSelector {
 
     fn on_drop(&self) -> Option<Value> {
         match self {
-            SupergraphSelector::Static(val) => Some(val.clone().into()),
             SupergraphSelector::StaticField { r#static } => Some(r#static.clone().into()),
             _ => None,
         }
@@ -614,7 +607,6 @@ impl Selector for SupergraphSelector {
                     | SupergraphSelector::RequestContext { .. }
                     | SupergraphSelector::Baggage { .. }
                     | SupergraphSelector::Env { .. }
-                    | SupergraphSelector::Static(_)
                     | SupergraphSelector::StaticField { .. }
                     | SupergraphSelector::ContextId { .. }
             ),
@@ -628,7 +620,6 @@ impl Selector for SupergraphSelector {
                     | SupergraphSelector::OperationName { .. }
                     | SupergraphSelector::OperationKind { .. }
                     | SupergraphSelector::IsPrimaryResponse { .. }
-                    | SupergraphSelector::Static(_)
                     | SupergraphSelector::StaticField { .. }
                     | SupergraphSelector::ContextId { .. }
             ),
@@ -642,7 +633,6 @@ impl Selector for SupergraphSelector {
                     | SupergraphSelector::OperationKind { .. }
                     | SupergraphSelector::IsPrimaryResponse { .. }
                     | SupergraphSelector::ResponseContext { .. }
-                    | SupergraphSelector::Static(_)
                     | SupergraphSelector::StaticField { .. }
                     | SupergraphSelector::ContextId { .. }
             ),
@@ -653,16 +643,12 @@ impl Selector for SupergraphSelector {
                     | SupergraphSelector::OperationKind { .. }
                     | SupergraphSelector::Query { .. }
                     | SupergraphSelector::Error { .. }
-                    | SupergraphSelector::Static(_)
                     | SupergraphSelector::StaticField { .. }
                     | SupergraphSelector::ResponseContext { .. }
                     | SupergraphSelector::IsPrimaryResponse { .. }
                     | SupergraphSelector::ContextId { .. }
             ),
-            Stage::Drop => matches!(
-                self,
-                SupergraphSelector::Static(_) | SupergraphSelector::StaticField { .. }
-            ),
+            Stage::Drop => matches!(self, SupergraphSelector::StaticField { .. }),
         }
     }
 }
@@ -736,22 +722,6 @@ mod test {
             ),
             None
         );
-    }
-
-    #[test]
-    fn supergraph_static() {
-        let selector = SupergraphSelector::Static("test_static".to_string());
-        assert_eq!(
-            selector
-                .on_request(
-                    &crate::services::SupergraphRequest::fake_builder()
-                        .build()
-                        .unwrap()
-                )
-                .unwrap(),
-            "test_static".into()
-        );
-        assert_eq!(selector.on_drop().unwrap(), "test_static".into());
     }
 
     #[test]

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -1033,7 +1033,8 @@ subgraph:
     on: response
     attributes:
       subgraph.name: true
-      static: foo # This shows up twice without attribute deduplication
+      static:
+        static: foo # This shows up twice without attribute deduplication
         "#,
         )
         .unwrap();

--- a/apollo-router/src/plugins/telemetry/testdata/config.router.yaml
+++ b/apollo-router/src/plugins/telemetry/testdata/config.router.yaml
@@ -54,7 +54,9 @@ telemetry:
           unit: request
           description: "supergraph requests"
           attributes:
-            static: hello
+            static:
+              static: hello
+
             graphql_operation_kind:
               operation_kind: string
       subgraph:

--- a/apollo-router/src/plugins/telemetry/testdata/full_config_all_features_defaults.router.yaml
+++ b/apollo-router/src/plugins/telemetry/testdata/full_config_all_features_defaults.router.yaml
@@ -59,7 +59,9 @@ telemetry:
           unit: request
           description: "supergraph requests"
           attributes:
-            static: hello
+            static:
+              static: hello
+
             graphql_operation_kind:
               operation_kind: string
       subgraph:

--- a/apollo-router/src/plugins/telemetry/testdata/full_config_all_features_enabled.router.yaml
+++ b/apollo-router/src/plugins/telemetry/testdata/full_config_all_features_enabled.router.yaml
@@ -76,7 +76,9 @@ telemetry:
           unit: request
           description: "supergraph requests"
           attributes:
-            static: hello
+            static:
+              static: hello
+
             graphql_operation_kind:
               operation_kind: string
       subgraph:

--- a/apollo-router/src/plugins/telemetry/testdata/full_config_all_features_enabled_response_cache.router.yaml
+++ b/apollo-router/src/plugins/telemetry/testdata/full_config_all_features_enabled_response_cache.router.yaml
@@ -76,7 +76,9 @@ telemetry:
           unit: request
           description: "supergraph requests"
           attributes:
-            static: hello
+            static:
+              static: hello
+
             graphql_operation_kind:
               operation_kind: string
       subgraph:

--- a/apollo-router/src/plugins/telemetry/testdata/full_config_all_features_explicitly_disabled.router.yaml
+++ b/apollo-router/src/plugins/telemetry/testdata/full_config_all_features_explicitly_disabled.router.yaml
@@ -84,7 +84,9 @@ telemetry:
           unit: request
           description: "supergraph requests"
           attributes:
-            static: hello
+            static:
+              static: hello
+
             graphql_operation_kind:
               operation_kind: string
       subgraph:

--- a/apollo-router/src/plugins/telemetry/testdata/full_config_apq_disabled_partial_defaults.router.yaml
+++ b/apollo-router/src/plugins/telemetry/testdata/full_config_apq_disabled_partial_defaults.router.yaml
@@ -65,7 +65,9 @@ telemetry:
           unit: request
           description: "supergraph requests"
           attributes:
-            static: hello
+            static:
+              static: hello
+
             graphql_operation_kind:
               operation_kind: string
       subgraph:

--- a/apollo-router/src/plugins/telemetry/testdata/full_config_apq_enabled_partial_defaults.router.yaml
+++ b/apollo-router/src/plugins/telemetry/testdata/full_config_apq_enabled_partial_defaults.router.yaml
@@ -66,7 +66,9 @@ telemetry:
           unit: request
           description: "supergraph requests"
           attributes:
-            static: hello
+            static:
+              static: hello
+
             graphql_operation_kind:
               operation_kind: string
       subgraph:

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog_override_span_names.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog_override_span_names.router.yaml
@@ -19,6 +19,7 @@ telemetry:
       mode: spec_compliant
       router:
         attributes:
-          otel.name: overridden
+          otel.name:
+            static: overridden
 
 

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog_resource_mapping_override.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog_resource_mapping_override.router.yaml
@@ -26,7 +26,8 @@ telemetry:
             operation_name: string
       supergraph:
         attributes:
-          override.name: overridden
+          override.name:
+            static: overridden
 
 
 

--- a/apollo-router/tests/integration/telemetry/fixtures/json.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/json.router.yaml
@@ -75,7 +75,8 @@ telemetry:
           level: warn
           on: event_response
           attributes:
-            on_supergraph_response_event: on_supergraph_event
+            on_supergraph_response_event:
+              static: on_supergraph_event
       subgraph:
         # Standard events
         request: info

--- a/apollo-router/tests/integration/telemetry/fixtures/json.sampler_off.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/json.sampler_off.router.yaml
@@ -56,7 +56,8 @@ telemetry:
           level: warn
           on: event_response
           attributes:
-            on_supergraph_response_event: on_supergraph_event
+            on_supergraph_response_event:
+              static: on_supergraph_event
         my.request.event:
           message: "my event message"
           level: info

--- a/apollo-router/tests/integration/telemetry/fixtures/text.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/text.router.yaml
@@ -57,7 +57,8 @@ telemetry:
           level: warn
           on: event_response
           attributes:
-            on_supergraph_response_event: on_supergraph_event
+            on_supergraph_response_event:
+              static: on_supergraph_event
         my.request.event:
           message: "my event message"
           level: info

--- a/docs/source/routing/observability/router-telemetry-otel/apm-guides/datadog/router-instrumentation.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/apm-guides/datadog/router-instrumentation.mdx
@@ -21,15 +21,19 @@ telemetry:
 
       router:
         attributes:
-          otel.name: router
-          operation.name: "router"
+          otel.name:
+            static: router
+          operation.name:
+            static: "router"
           resource.name:
             request_method: true
 
       supergraph:
         attributes:
-          otel.name: supergraph
-          operation.name: "supergraph"
+          otel.name:
+            static: supergraph
+          operation.name:
+            static: "supergraph"
           resource.name:
             operation_name: string
           # Error tracking
@@ -44,8 +48,10 @@ telemetry:
 
       subgraph:
         attributes:
-          otel.name: subgraph
-          operation.name: "subgraph"
+          otel.name:
+            static: subgraph
+          operation.name:
+            static: "subgraph"
           resource.name:
             subgraph_operation_name: string
           otel.status_code:

--- a/docs/source/routing/observability/router-telemetry-otel/index.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/index.mdx
@@ -278,20 +278,26 @@ telemetry:
       mode: spec_compliant
       router:
         attributes:
-          otel.name: router
-          operation.name: "router"
+          otel.name:
+            static: router
+          operation.name:
+            static: "router"
           resource.name:
             request_method: true
       supergraph:
         attributes:
-          otel.name: supergraph
-          operation.name: "supergraph"
+          otel.name:
+            static: supergraph
+          operation.name:
+            static: "supergraph"
           resource.name:
             operation_name: string
       subgraph:
         attributes:
-          otel.name: subgraph
-          operation.name: "subgraph"
+          otel.name:
+            static: subgraph
+          operation.name:
+            static: "subgraph"
           resource.name:
             subgraph_operation_name: string
   exporters:


### PR DESCRIPTION
## Summary

Closes [ROUTER-1767](https://apollographql.atlassian.net/browse/ROUTER-1767).

Removes the deprecated `Static(String)` variant from the `supergraph`, `router`, and `subgraph` telemetry selector enums. The `StaticField { r#static: AttributeValue }` variant has been available since 2.x and covers the same use case with support for typed values (bool, i64, f64, string, arrays). The `graphql` and `connector` selectors were already `StaticField`-only and required no changes.

### What changed

- **`supergraph/selectors.rs`, `router/selectors.rs`, `subgraph/selectors.rs`**: Removed `Static(String)` enum variant, all match arms (`on_request`, `on_response`, `on_response_event`, `on_error`, `on_drop`, `is_active`), and the associated unit tests.
- **`conditional.rs`**: `visit_str` now returns an explicit error message pointing users to the new syntax rather than silently accepting a plain string as `Static(String)`.
- **YAML test fixtures, testdata, and docs**: Updated all instances of the old plain-string selector syntax (`attr: value`) to the new `StaticField` form (`attr:\n  static: value`).

### Config migration

```yaml
# Before (no longer supported)
attributes:
  my.attr: "my-value"

# After
attributes:
  my.attr:
    static: "my-value"
```

## Test plan

- [x] `cargo check -p apollo-router` — clean compile
- [x] `cargo test -p apollo-router --lib` — 2919 tests pass, 0 failures
- [x] `cargo fmt` and `cargo clippy` — no issues
- [x] Snapshot updated for schema generation (removes the `"type": "string"` branch from affected selector schemas)

[ROUTER-1767]: https://apollographql.atlassian.net/browse/ROUTER-1767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ