### PR TITLE
feat(federation): support variable arguments in @requires field sets

### DIFF
--- a/.changesets/feat_requires_field_argument_variables.md
+++ b/.changesets/feat_requires_field_argument_variables.md
@@ -1,0 +1,19 @@
+### Support variable arguments in `@requires` field sets
+
+A `@requires` field set may now bind the arguments of a required field to the annotated field's own arguments, instead of being limited to static literal values. The value a client passes to the annotated field's argument is threaded through to the subgraph that owns the required field at query-planning time.
+
+```graphql
+type Product @key(fields: "id") {
+  id: ID!
+  price(currency: Currency!): Money @external
+  localizedPrice(currency: Currency!): Money
+    @requires(fields: "price(currency: $currency)")
+}
+```
+
+Given the operation `{ product { localizedPrice(currency: $userCurrency) } }`, the router now fetches `price(currency: $userCurrency)` from the subgraph that owns `price`, forwarding the client-supplied value rather than a fixed one.
+
+- An omitted argument resolves to its schema default (or `null` for a nullable argument), following GraphQL argument coercion.
+- A variable bound to an argument whose type is incompatible with the required field's argument is rejected during composition.
+
+By [@jeffutter](https://github.com/jeffutter) in https://github.com/apollographql/router/pull/9604

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -138,6 +138,40 @@ fn sort_value(value: &mut executable::Value) {
     }
 }
 
+/// Returns a copy of `value` with every variable reference named in `substitutions` replaced by the
+/// corresponding value, recursing into list and object values. Variables not in `substitutions` and
+/// all other values are returned unchanged.
+fn substitute_variables_in_value(
+    value: &executable::Value,
+    substitutions: &IndexMap<Name, Node<executable::Value>>,
+) -> executable::Value {
+    use apollo_compiler::executable::Value;
+    match value {
+        Value::Variable(name) => substitutions
+            .get(name)
+            .map(|replacement| replacement.as_ref().clone())
+            .unwrap_or_else(|| value.clone()),
+        Value::List(items) => Value::List(
+            items
+                .iter()
+                .map(|item| Node::new(substitute_variables_in_value(item, substitutions)))
+                .collect(),
+        ),
+        Value::Object(fields) => Value::Object(
+            fields
+                .iter()
+                .map(|(name, item)| {
+                    (
+                        name.clone(),
+                        Node::new(substitute_variables_in_value(item, substitutions)),
+                    )
+                })
+                .collect(),
+        ),
+        _ => value.clone(),
+    }
+}
+
 /// Sort arguments, which means specifically sorting arguments by names and object values by keys
 /// (assuming no duplicates).
 ///
@@ -720,6 +754,13 @@ mod field_selection {
             }
         }
 
+        pub(crate) fn with_updated_arguments(&self, arguments: impl Into<ArgumentList>) -> Self {
+            Self {
+                arguments: arguments.into(),
+                ..self.clone()
+            }
+        }
+
         /// Turn this `Field` into a `FieldSelection` with the given sub-selection. If this is
         /// meant to be a leaf selection, use `None`.
         pub(crate) fn with_subselection(
@@ -1071,6 +1112,63 @@ impl SelectionSet {
         }
     }
 
+    /// Returns a copy of this selection set with every field-argument value that references a
+    /// variable named in `substitutions` replaced by the corresponding value. Other variable
+    /// references and values are left unchanged.
+    ///
+    /// This binds the variables in a `@requires` field set — which reference the annotated field's
+    /// own arguments (e.g. `price(currency: $currency)`) — to the values the operation being planned
+    /// supplies for those arguments, before the field set is resolved into a subgraph fetch. A
+    /// supplied literal is inlined; a supplied operation variable is forwarded as-is (its value is
+    /// resolved at execution time).
+    pub(crate) fn substitute_field_argument_variables(
+        &self,
+        substitutions: &IndexMap<Name, Node<executable::Value>>,
+    ) -> Result<SelectionSet, FederationError> {
+        let mut new_selections = Vec::with_capacity(self.selections.len());
+        for selection in self.selections.values() {
+            let new_selection_set = match selection.selection_set() {
+                Some(selection_set) => {
+                    Some(selection_set.substitute_field_argument_variables(substitutions)?)
+                }
+                None => None,
+            };
+            let new_selection = match selection {
+                Selection::Field(field_selection) => {
+                    let field = &field_selection.field;
+                    let arguments: ArgumentList = field
+                        .arguments
+                        .iter()
+                        .map(|argument| {
+                            Node::new(executable::Argument {
+                                name: argument.name.clone(),
+                                value: Node::new(substitute_variables_in_value(
+                                    &argument.value,
+                                    substitutions,
+                                )),
+                            })
+                        })
+                        .collect();
+                    Selection::from_field(
+                        field.with_updated_arguments(arguments),
+                        new_selection_set,
+                    )
+                }
+                // Inline fragments carry no field arguments; only the child selection set needs
+                // (recursively) substituting, which `new_selection_set` already holds.
+                Selection::InlineFragment(_) => {
+                    selection.with_updated_selection_set(new_selection_set)?
+                }
+            };
+            new_selections.push(new_selection);
+        }
+        Ok(SelectionSet::from_raw_selections(
+            self.schema.clone(),
+            self.type_position.clone(),
+            new_selections,
+        ))
+    }
+
     #[cfg(any(doc, test))]
     pub(crate) fn parse(
         schema: ValidFederationSchema,
@@ -1082,6 +1180,7 @@ impl SelectionSet {
             type_position.type_name().clone(),
             source_text,
             false,
+            &Default::default(),
         )?
         .0;
         let fragments = Default::default();

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -32,7 +32,9 @@ use crate::query_graph::QueryGraphNode;
 use crate::query_graph::QueryGraphNodeType;
 use crate::query_plan::query_planning_traversal::non_local_selections_estimation::precompute_non_local_selection_metadata;
 use crate::schema::ValidFederationSchema;
+use crate::schema::field_set::field_argument_names;
 use crate::schema::field_set::parse_field_set;
+use crate::schema::field_set::parse_field_set_allowing_field_argument_variables;
 use crate::schema::position::AbstractTypeDefinitionPosition;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::FieldDefinitionPosition;
@@ -1509,6 +1511,10 @@ impl FederatedQueryGraphBuilder {
             let schema = self.base.query_graph.schema_by_source(source)?;
             let subgraph_data = self.subgraphs.get(source)?;
             let field = field_definition_position.get(schema.schema())?;
+            // A `@requires` field set may reference the annotated field's own arguments as variables
+            // (e.g. `price(currency: $currency)`). Collect those argument names so the parser accepts
+            // them; they're stored symbolically on the edge and bound during query planning.
+            let allowed_variable_names = field_argument_names(field);
             let mut all_conditions = Vec::new();
             for directive in field
                 .directives
@@ -1518,11 +1524,11 @@ impl FederatedQueryGraphBuilder {
                     .federation_spec_definition
                     .requires_directive_arguments(directive)?;
                 // @requires field set is validated against the supergraph
-                let conditions = parse_field_set(
+                let conditions = parse_field_set_allowing_field_argument_variables(
                     &self.supergraph_schema,
                     field_definition_position.parent().type_name().clone(),
                     application.fields,
-                    true,
+                    &allowed_variable_names,
                 )?;
                 all_conditions.push(conditions);
             }

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -1132,6 +1132,11 @@ where
         context: &OpGraphPathContext,
         excluded_destinations: &ExcludedDestinations,
         excluded_conditions: &ExcludedConditions,
+        // When the edge's `@requires` condition references the annotated field's arguments as
+        // variables, this holds the condition with those variables already substituted for the
+        // values the operation supplies for those arguments. It overrides the edge's own conditions
+        // during resolution (and, because it is supplied, bypasses the condition-resolution cache).
+        extra_conditions: Option<&SelectionSet>,
     ) -> Result<ConditionResolution, FederationError> {
         let edge_weight = self.graph.edge_weight(edge)?;
         if edge_weight.conditions.is_none() && edge_weight.required_contexts.is_empty() {
@@ -1334,7 +1339,7 @@ where
             context,
             excluded_destinations,
             excluded_conditions,
-            None,
+            extra_conditions,
         )?;
         if matches!(resolution, ConditionResolution::Unsatisfied { .. }) {
             return Ok(ConditionResolution::Unsatisfied { reason: None });
@@ -1617,6 +1622,7 @@ where
                     context,
                     &excluded_destinations.add_excluded(&edge_tail_weight.source),
                     excluded_conditions,
+                    None,
                 )?;
 
                 let ConditionResolution::Satisfied {

--- a/apollo-federation/src/query_graph/graph_path/operation.rs
+++ b/apollo-federation/src/query_graph/graph_path/operation.rs
@@ -4,7 +4,10 @@ use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use apollo_compiler::Name;
+use apollo_compiler::Node;
 use apollo_compiler::ast::Value;
+use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use itertools::Itertools;
 use petgraph::graph::EdgeIndex;
@@ -32,6 +35,7 @@ use crate::operation::SelectionId;
 use crate::operation::SelectionKey;
 use crate::operation::SelectionSet;
 use crate::operation::SiblingTypename;
+use crate::operation::VariableCollector;
 use crate::query_graph::OverrideConditions;
 use crate::query_graph::QueryGraphEdgeTransition;
 use crate::query_graph::QueryGraphNodeType;
@@ -626,12 +630,15 @@ impl OpGraphPath {
         condition_resolver: &mut impl ConditionResolver,
         context: &OpGraphPathContext,
     ) -> Result<Option<OpGraphPath>, FederationError> {
+        let field_argument_substituted_conditions =
+            self.field_argument_substituted_conditions(edge, &operation_field)?;
         let condition_resolution = self.can_satisfy_conditions(
             edge,
             condition_resolver,
             context,
             &Default::default(),
             &Default::default(),
+            field_argument_substituted_conditions.as_ref(),
         )?;
         if matches!(condition_resolution, ConditionResolution::Satisfied { .. }) {
             self.add(
@@ -644,6 +651,61 @@ impl OpGraphPath {
         } else {
             Ok(None)
         }
+    }
+
+    /// If `edge`'s `@requires` condition references `operation_field`'s arguments as variables,
+    /// returns a copy of that condition with each variable substituted for the value
+    /// `operation_field` supplies for that argument (a literal, or a forwarded operation variable).
+    /// Returns `None` when there is nothing to substitute (the common case), so that condition
+    /// resolution proceeds normally and stays cacheable.
+    fn field_argument_substituted_conditions(
+        &self,
+        edge: EdgeIndex,
+        operation_field: &Field,
+    ) -> Result<Option<SelectionSet>, FederationError> {
+        let edge_weight = self.graph.edge_weight(edge)?;
+        let Some(conditions) = &edge_weight.conditions else {
+            return Ok(None);
+        };
+        // Collect referenced variables first so the common (no-variable) case returns before allocating.
+        let mut collector = VariableCollector::new();
+        collector.visit_selection_set(conditions);
+        let referenced_variables = collector.into_inner();
+        if referenced_variables.is_empty() {
+            return Ok(None);
+        }
+        // Bind each referenced variable that names one of the annotated field's arguments to that
+        // argument's effective value for this operation, following GraphQL argument coercion: the
+        // value the client supplied, else the argument's schema default, else null for a nullable
+        // argument the client omitted. (A non-null argument without a default is always supplied,
+        // per operation validation.)
+        let field_definition = operation_field
+            .field_position
+            .get(operation_field.schema.schema())?;
+        let mut substitutions: IndexMap<Name, Node<Value>> = IndexMap::default();
+        for argument_definition in field_definition.arguments.iter() {
+            if !referenced_variables.contains(&argument_definition.name) {
+                continue;
+            }
+            let value = if let Some(supplied) = operation_field
+                .arguments
+                .iter()
+                .find(|argument| argument.name == argument_definition.name)
+            {
+                supplied.value.clone()
+            } else if let Some(default_value) = &argument_definition.default_value {
+                default_value.clone()
+            } else {
+                Node::new(Value::Null)
+            };
+            substitutions.insert(argument_definition.name.clone(), value);
+        }
+        if substitutions.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(
+            conditions.substitute_field_argument_variables(&substitutions)?,
+        ))
     }
 
     pub(crate) fn subgraph_jumps(&self) -> Result<u32, FederationError> {
@@ -1690,6 +1752,7 @@ impl OpGraphPath {
                                     context,
                                     &Default::default(),
                                     &Default::default(),
+                                    None,
                                 )?;
                                 if matches!(
                                     condition_resolution,

--- a/apollo-federation/src/query_graph/graph_path/transition.rs
+++ b/apollo-federation/src/query_graph/graph_path/transition.rs
@@ -389,6 +389,7 @@ impl TransitionGraphPath {
                 &Default::default(),
                 &Default::default(),
                 &Default::default(),
+                None,
             )?;
             match condition_resolution {
                 ConditionResolution::Satisfied { .. } => {

--- a/apollo-federation/src/schema/field_set.rs
+++ b/apollo-federation/src/schema/field_set.rs
@@ -1,10 +1,17 @@
+use std::sync::LazyLock;
+
+use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::Schema;
+use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable;
 use apollo_compiler::executable::FieldSet;
 use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::schema::FieldDefinition;
 use apollo_compiler::schema::NamedType;
+use apollo_compiler::validation::DiagnosticList;
 use apollo_compiler::validation::Valid;
+use regex::Regex;
 
 use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
@@ -78,19 +85,108 @@ pub(crate) fn parse_field_set(
         )?)
     };
 
-    // A field set should not contain any named fragments.
+    finalize_field_set(&field_set.selection_set, schema, validate)
+}
+
+/// Converts a parsed field set into the normalized federation `SelectionSet`, rejecting named
+/// fragments (always) and aliases (when `check_aliases`), neither of which federation directives
+/// permit in a field set.
+fn finalize_field_set(
+    selection_set: &executable::SelectionSet,
+    schema: &ValidFederationSchema,
+    check_aliases: bool,
+) -> Result<SelectionSet, FederationError> {
     let fragments = Default::default();
     let selection_set =
-        SelectionSet::from_selection_set(&field_set.selection_set, &fragments, schema, &||
-            // never cancel
-            Ok(()))?;
-
-    // Validate that the field set has no aliases.
-    if validate {
+        SelectionSet::from_selection_set(selection_set, &fragments, schema, &||
+        // never cancel
+        Ok(()))?;
+    if check_aliases {
         check_absence_of_aliases(&selection_set)?;
     }
-
     Ok(selection_set)
+}
+
+/// The names of `field`'s arguments — the set of variable names a `@requires` field set on `field`
+/// may reference, since each bare `$argName` binds to the field's argument of that name.
+pub(crate) fn field_argument_names(field: &FieldDefinition) -> IndexSet<Name> {
+    field
+        .arguments
+        .iter()
+        .map(|argument| argument.name.clone())
+        .collect()
+}
+
+// This matches the error message for `DiagnosticData::UndefinedVariable` as defined in
+// https://github.com/apollographql/apollo-rs/blob/apollo-compiler%401.32.0/crates/apollo-compiler/src/validation/diagnostics.rs
+static APOLLO_COMPILER_UNDEFINED_VARIABLE_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"variable `\$((?-u:\w)+)` is not defined").unwrap());
+
+/// If `message` is an apollo-compiler "undefined variable" diagnostic (e.g.
+/// ``variable `$currency` is not defined``), returns the referenced variable name.
+pub(crate) fn undefined_variable_name(message: &str) -> Option<Name> {
+    APOLLO_COMPILER_UNDEFINED_VARIABLE_PATTERN
+        .captures(message)
+        .and_then(|captures| captures.get(1))
+        .and_then(|name| Name::new(name.as_str()).ok())
+}
+
+/// Collects every diagnostic in `diagnostics` into a `MultipleFederationErrors`, except tolerated
+/// `@requires` field-argument variable references — an "undefined variable" diagnostic whose name
+/// appears in `allowed_variable_names` (see [`parse_field_set_allowing_field_argument_variables`]).
+/// Shared by the two field-set entry points that allow such variables.
+fn collect_unexpected_field_set_diagnostics(
+    diagnostics: &DiagnosticList,
+    allowed_variable_names: &IndexSet<Name>,
+) -> MultipleFederationErrors {
+    let mut unexpected_errors = MultipleFederationErrors { errors: vec![] };
+    for diagnostic in diagnostics.iter() {
+        let message = diagnostic.to_string();
+        let is_tolerated_variable = undefined_variable_name(&message)
+            .is_some_and(|name| allowed_variable_names.contains(&name));
+        if is_tolerated_variable {
+            continue;
+        }
+        unexpected_errors
+            .errors
+            .push(SingleFederationError::InvalidGraphQL { message });
+    }
+    unexpected_errors
+}
+
+/// Like [`parse_field_set`] with `validate = true`, but tolerates references to GraphQL variables
+/// whose names appear in `allowed_variable_names`. This supports `@requires` field sets that
+/// reference the annotated field's own arguments (e.g. `price(currency: $currency)` where
+/// `currency` is an argument of the field carrying the `@requires`). Such variables remain in the
+/// returned selection set as placeholders, to be substituted at query-planning time with the
+/// values the operation supplies for those arguments (see
+/// `SelectionSet::substitute_field_argument_variables`).
+///
+/// Every other validation failure — including a reference to an undefined variable that is *not*
+/// one of the annotated field's arguments — remains a hard error.
+pub(crate) fn parse_field_set_allowing_field_argument_variables(
+    schema: &ValidFederationSchema,
+    parent_type_name: NamedType,
+    field_set: &str,
+    allowed_variable_names: &IndexSet<Name>,
+) -> Result<SelectionSet, FederationError> {
+    let field_set = match FieldSet::parse_and_validate(
+        schema.schema(),
+        parent_type_name,
+        field_set,
+        "field_set.graphql",
+    ) {
+        Ok(field_set) => field_set,
+        Err(with_errors) => {
+            collect_unexpected_field_set_diagnostics(&with_errors.errors, allowed_variable_names)
+                .into_result()?;
+            // The only diagnostics were tolerated field-argument variables; the field set is
+            // otherwise valid, so the fully-parsed `partial` result is safe to use.
+            Valid::assume_valid(with_errors.partial)
+        }
+    };
+
+    finalize_field_set(&field_set.selection_set, schema, true)
 }
 
 /// When we first see a field set in a GraphQL document, there are some constraints which can make
@@ -115,28 +211,39 @@ pub(crate) fn parse_field_set_without_normalization(
     parent_type_name: NamedType,
     field_set: &str,
     fix_string_enum_values: bool,
+    // Variables in the field set whose names appear here are tolerated rather than reported as
+    // undefined; see [`parse_field_set_allowing_field_argument_variables`]. Pass an empty set for
+    // field sets that cannot reference variables (e.g. `@provides`).
+    allowed_variable_names: &IndexSet<Name>,
 ) -> Result<(executable::SelectionSet, bool), FederationError> {
     // Note this parsing takes care of adding curly braces ("{" and "}") if they aren't in the
     // string.
-    let (field_set, is_modified) = if fix_string_enum_values {
-        let mut field_set = FieldSet::parse(
-            schema,
-            parent_type_name.clone(),
-            field_set,
-            "field_set.graphql",
-        )?;
-        let is_modified = fix_string_enum_values_in_field_set(schema, &mut field_set);
-        field_set.validate(schema)?;
-        // `FieldSet::validate()` strangely doesn't return `Valid<FieldSet>`, so we instead use
-        // `Valid::assume_valid()` here.
-        (Valid::assume_valid(field_set), is_modified)
+    let mut field_set = FieldSet::parse(schema, parent_type_name, field_set, "field_set.graphql")?;
+    let is_modified = if fix_string_enum_values {
+        fix_string_enum_values_in_field_set(schema, &mut field_set)
     } else {
-        (
-            FieldSet::parse_and_validate(schema, parent_type_name, field_set, "field_set.graphql")?,
-            false,
-        )
+        false
     };
-    Ok((field_set.into_inner().selection_set, is_modified))
+    validate_field_set_allowing_field_argument_variables(
+        &field_set,
+        schema,
+        allowed_variable_names,
+    )?;
+    Ok((field_set.selection_set, is_modified))
+}
+
+/// Runs [`FieldSet::validate`], tolerating "undefined variable" diagnostics whose variable name
+/// appears in `allowed_variable_names` (i.e. references to the annotated field's own arguments in a
+/// `@requires` field set). Any other diagnostic is returned as an error.
+fn validate_field_set_allowing_field_argument_variables(
+    field_set: &FieldSet,
+    schema: &Valid<Schema>,
+    allowed_variable_names: &IndexSet<Name>,
+) -> Result<(), FederationError> {
+    let Err(diagnostics) = field_set.validate(schema) else {
+        return Ok(());
+    };
+    collect_unexpected_field_set_diagnostics(&diagnostics, allowed_variable_names).into_result()
 }
 
 /// In the past, arguments in field sets may have mistakenly provided strings when they meant to
@@ -256,7 +363,7 @@ fn fix_string_enum_values_in_input_value(
             let ExtendedType::Enum(type_definition) = type_definition else {
                 return is_modified;
             };
-            let Ok(enum_value) = executable::Name::new(string_value) else {
+            let Ok(enum_value) = Name::new(string_value) else {
                 return is_modified;
             };
             if !type_definition.values.contains_key(&enum_value) {

--- a/apollo-federation/src/schema/validators/merged.rs
+++ b/apollo-federation/src/schema/validators/merged.rs
@@ -1,10 +1,12 @@
 use std::sync::LazyLock;
 
 use apollo_compiler::Name;
+use apollo_compiler::executable;
 use apollo_compiler::executable::FieldSet;
 use apollo_compiler::schema::Directive;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::schema::FieldDefinition;
+use apollo_compiler::schema::Type;
 use apollo_compiler::validation::Valid;
 use itertools::Itertools;
 use regex::Regex;
@@ -17,6 +19,8 @@ use crate::error::HasLocations;
 use crate::error::Locations;
 use crate::error::SingleFederationError;
 use crate::schema::FederationSchema;
+use crate::schema::field_set::field_argument_names;
+use crate::schema::field_set::undefined_variable_name;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectFieldDefinitionPosition;
@@ -155,6 +159,12 @@ pub(crate) fn validate_merged_schema(
                 .get_type(&parent_field_pos.type_name)?
                 .try_into()?;
 
+            // Collect the annotated field's argument names; a `@requires` field set may reference
+            // them as variables (e.g. `price(currency: $currency)`), so their "undefined variable"
+            // diagnostics are expected and tolerated below.
+            let parent_field_definition = parent_field_pos.get(subgraph.schema().schema())?;
+            let requires_field_argument_names = field_argument_names(parent_field_definition);
+
             let Err(error) = FieldSet::parse_and_validate(
                 Valid::assume_valid_ref(supergraph_schema.schema()),
                 parent_type_pos_in_supergraph.type_name().clone(),
@@ -163,6 +173,11 @@ pub(crate) fn validate_merged_schema(
             ) else {
                 continue;
             };
+            // Keep the parsed field set so we can additionally check, below, that any
+            // field-argument variables are used at positions whose type is compatible with the
+            // annotated field's argument they are bound to. (`error.partial` is otherwise discarded
+            // by `FederationError::from`, so we move it out rather than clone.)
+            let parsed_field_set = error.partial.selection_set;
             // Providing a useful error message to the user here is tricky in the general case
             // because what we checked is that a given subgraph @requires application is invalid "on
             // the supergraph", but the user seeing the error will not have the supergraph, so we
@@ -206,7 +221,7 @@ pub(crate) fn validate_merged_schema(
             // having error codes and variants for all the GraphQL validations. The apollo-compiler
             // crate has this already, but it's crate-private and potentially unstable, so we can't
             // use that for now.
-            for error in FederationError::from(error).into_errors() {
+            for error in FederationError::from(error.errors).into_errors() {
                 let SingleFederationError::InvalidGraphQL { message } = error else {
                     errors.push(CompositionError::SubgraphError {
                         subgraph: subgraph.name.to_string(),
@@ -215,6 +230,25 @@ pub(crate) fn validate_merged_schema(
                     });
                     continue;
                 };
+                // A variable must name one of the annotated field's arguments; those are tolerated
+                // here. Any other variable cannot be bound and is reported as an invalid field set.
+                if let Some(variable_name) = undefined_variable_name(&message) {
+                    if requires_field_argument_names.contains(&variable_name) {
+                        continue;
+                    }
+                    errors.push(CompositionError::SubgraphError {
+                        subgraph: subgraph.name.to_string(),
+                        error: SingleFederationError::RequiresInvalidFields {
+                            coordinate: parent_field_pos.to_string(),
+                            application: requires_directive.to_string(),
+                            message: format!(
+                                "variable \"${variable_name}\" is not defined; a variable in a @requires field set must reference an argument of \"{parent_field_pos}\"",
+                            ),
+                        },
+                        locations: requires_directive.locations(subgraph),
+                    });
+                    continue;
+                }
                 if let Some(captures) =
                     APOLLO_COMPILER_UNDEFINED_ARGUMENT_PATTERN.captures(&message)
                 {
@@ -289,9 +323,101 @@ pub(crate) fn validate_merged_schema(
                     message,
                 );
             }
+
+            // Validate that each field-argument variable in the field set is used at a position
+            // whose type is compatible with the annotated field's argument it is bound to.
+            let mut variable_type_errors = Vec::new();
+            collect_requires_variable_type_errors(
+                &parsed_field_set,
+                parent_field_definition,
+                &mut variable_type_errors,
+            );
+            for message in variable_type_errors {
+                errors.push(CompositionError::SubgraphError {
+                    subgraph: subgraph.name.to_string(),
+                    error: SingleFederationError::RequiresInvalidFields {
+                        coordinate: parent_field_pos.to_string(),
+                        application: requires_directive.to_string(),
+                        message,
+                    },
+                    locations: requires_directive.locations(subgraph),
+                });
+            }
         }
     }
     Ok(())
+}
+
+/// Walks a parsed `@requires` field set and, for every field argument whose value is a variable
+/// that names an argument of `annotated_field`, checks that the annotated field's argument type is
+/// compatible with the type expected at that position. Incompatibilities are pushed to `errors` as
+/// formatted messages.
+fn collect_requires_variable_type_errors(
+    selection_set: &executable::SelectionSet,
+    annotated_field: &FieldDefinition,
+    errors: &mut Vec<String>,
+) {
+    for selection in &selection_set.selections {
+        match selection {
+            executable::Selection::Field(field) => {
+                for argument in &field.arguments {
+                    let executable::Value::Variable(variable_name) = argument.value.as_ref() else {
+                        continue;
+                    };
+                    let Some(bound_argument) = annotated_field.argument_by_name(variable_name)
+                    else {
+                        continue;
+                    };
+                    let Some(location_argument) = field.definition.argument_by_name(&argument.name)
+                    else {
+                        continue;
+                    };
+                    if !argument_types_compatible(&bound_argument.ty, &location_argument.ty) {
+                        errors.push(format!(
+                            "variable \"${variable_name}\" cannot be used for argument \"{}\" of field \"{}\": it is bound to argument \"{}\" of type \"{}\", which is not compatible with the expected type \"{}\"",
+                            argument.name,
+                            field.name,
+                            variable_name,
+                            bound_argument.ty,
+                            location_argument.ty,
+                        ));
+                    }
+                }
+                collect_requires_variable_type_errors(
+                    &field.selection_set,
+                    annotated_field,
+                    errors,
+                );
+            }
+            executable::Selection::InlineFragment(inline_fragment) => {
+                collect_requires_variable_type_errors(
+                    &inline_fragment.selection_set,
+                    annotated_field,
+                    errors,
+                )
+            }
+            executable::Selection::FragmentSpread(_) => {}
+        }
+    }
+}
+
+/// Conservative input-type compatibility for a `@requires` field-argument variable: the variable's
+/// bound type and the location type must share the same inner named type and the same list nesting.
+/// Nullability differences are intentionally not rejected here — a nullable value flowing into a
+/// non-null position surfaces at runtime via argument coercion (an omitted/`null` value), not as a
+/// type error — so this only flags clear mismatches (e.g. `String` bound into an `Int` argument).
+fn argument_types_compatible(variable_type: &Type, location_type: &Type) -> bool {
+    match (variable_type, location_type) {
+        (
+            Type::Named(left) | Type::NonNullNamed(left),
+            Type::Named(right) | Type::NonNullNamed(right),
+        ) => left == right,
+        (
+            Type::List(left) | Type::NonNullList(left),
+            Type::List(right) | Type::NonNullList(right),
+        ) => argument_types_compatible(left, right),
+        _ => false,
+    }
 }
 
 // This matches the error message for `DiagnosticData::UndefinedArgument` as defined in

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -62,6 +62,7 @@ use crate::link::spec::Version;
 use crate::link::spec_definition::SpecDefinition;
 use crate::schema::FederationSchema;
 use crate::schema::ValidFederationSchema;
+use crate::schema::field_set::field_argument_names;
 use crate::schema::field_set::parse_field_set_without_normalization;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::DirectiveDefinitionPosition;
@@ -2080,6 +2081,13 @@ fn remove_inactive_applications(
 ) -> Result<(), FederationError> {
     let mut replacement_directives = Vec::new();
     let field = object_or_interface_field_definition_position.get(schema.schema())?;
+    // A `@requires` field set may reference the annotated field's own arguments as variables
+    // (e.g. `price(currency: $currency)`); tolerate those when parsing here. `@provides` field
+    // sets cannot reference variables.
+    let allowed_variable_names = match directive_kind {
+        FieldSetDirectiveKind::Requires => field_argument_names(field),
+        FieldSetDirectiveKind::Provides => Default::default(),
+    };
     for directive in field.directives.get_all(name_in_schema) {
         let (fields, parent_type_pos, target_schema) = match directive_kind {
             FieldSetDirectiveKind::Provides => {
@@ -2126,6 +2134,7 @@ fn remove_inactive_applications(
             parent_type_pos.type_name().clone(),
             fields,
             true,
+            &allowed_variable_names,
         )?;
 
         if remove_non_external_leaf_fields(schema, &mut fields)? {

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -347,6 +347,381 @@ fn merge_validations_errors_if_subgraph_required_with_arg_not_in_supergraph() {
     );
 }
 
+// Tests for `@requires` referencing a field that takes arguments.
+//
+// Federation supports static literal argument values in a `@requires` field set. This group also
+// covers binding the argument value to a GraphQL variable that names one of the annotated field's
+// own arguments (e.g. an end user's currency or locale): at planning time the value the operation
+// supplies for that argument is threaded through to the subgraph that owns the required field —
+// inlined when it is a literal, or forwarded as a variable resolved at execution time. See:
+// https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/entities/contribute-fields#using-requires-with-fields-that-take-arguments
+
+#[test]
+fn requires_with_static_argument_value_composes() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y: Int @requires(fields: "x(arg: 42)")
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, requires_variable_subgraph_b()]);
+    assert_composition_succeeds(&result, "a static @requires argument value");
+}
+
+/// `subgraphB` shared by the `@requires`-argument tests: it owns the external `x(arg:)` field.
+fn requires_variable_subgraph_b() -> ServiceDefinition<'static> {
+    ServiceDefinition {
+        name: "subgraphB",
+        type_defs: REQUIRES_VARIABLE_SUBGRAPH_B,
+    }
+}
+
+/// Asserts composition succeeded, rendering the composition errors with their codes otherwise.
+fn assert_composition_succeeds<T>(
+    result: &Result<T, apollo_federation::composition::CompositionFailure>,
+    context: &str,
+) {
+    if let Err(failure) = result {
+        let errors: Vec<_> = failure
+            .errors
+            .iter()
+            .map(|error| format!("[{}] {}", error.code().definition().code(), error))
+            .collect();
+        panic!("composition with {context} should succeed, got: {errors:?}");
+    }
+}
+
+#[test]
+fn requires_with_variable_argument_value_composes() {
+    // Sibling of `requires_with_static_argument_value_composes`, but the required field's
+    // argument value is a variable bound to the annotated field's own argument (`y(arg:)`) rather
+    // than a literal. This test only asserts that such a schema composes; the
+    // `..._threads_into_subgraph_fetch` test below proves the value is actually threaded through.
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y(arg: Int): Int @requires(fields: "x(arg: $arg)")
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, requires_variable_subgraph_b()]);
+    assert_composition_succeeds(&result, "a variable @requires argument value");
+}
+
+#[test]
+fn requires_with_unbound_variable_argument_value_is_rejected() {
+    // `$arg` is not an argument of the annotated field `y`, so it cannot be bound to anything and
+    // must be rejected with a clear field-set error (not an internal error).
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y: Int @requires(fields: "x(arg: $arg)")
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, requires_variable_subgraph_b()]);
+    assert_composition_errors(
+        &result,
+        &[(
+            "REQUIRES_INVALID_FIELDS",
+            r#"[subgraphA] On field "T.y", for @requires(fields: "x(arg: $arg)"): variable "$arg" is not defined; a variable in a @requires field set must reference an argument of "T.y""#,
+        )],
+    );
+}
+
+/// Composes the two given subgraphs (named `subgraphA`/`subgraphB`) with the Rust composer, builds
+/// a query planner from the result, plans `operation`, and returns the rendered query plan.
+///
+/// This drives the query planner directly from a Rust-composed supergraph because the rover-backed
+/// `planner!` macro can't be used for `@requires` argument variables (JS composition does not
+/// accept this syntax).
+fn requires_variable_query_plan(
+    subgraph_a_type_defs: &str,
+    subgraph_b_type_defs: &str,
+    operation: &str,
+) -> String {
+    use apollo_compiler::ExecutableDocument;
+    use apollo_federation::Supergraph;
+    use apollo_federation::query_plan::query_planner::QueryPlanner;
+
+    let supergraph = compose_as_fed2_subgraphs(&[
+        ServiceDefinition {
+            name: "subgraphA",
+            type_defs: subgraph_a_type_defs,
+        },
+        ServiceDefinition {
+            name: "subgraphB",
+            type_defs: subgraph_b_type_defs,
+        },
+    ])
+    .expect("composition should succeed");
+    let supergraph_sdl = supergraph.schema().schema().to_string();
+    let supergraph =
+        Supergraph::new_with_router_specs(&supergraph_sdl).expect("valid supergraph schema");
+    let planner = QueryPlanner::new(&supergraph, Default::default()).expect("query planner builds");
+    let document = ExecutableDocument::parse_and_validate(
+        planner.api_schema().schema(),
+        operation,
+        "op.graphql",
+    )
+    .expect("valid operation");
+    planner
+        .build_query_plan(&document, None, Default::default())
+        .expect("query plan is generated")
+        .to_string()
+}
+
+const REQUIRES_VARIABLE_SUBGRAPH_B: &str = r#"
+    type T @key(fields: "id") {
+      id: ID!
+      x(arg: Int): Int
+    }
+"#;
+
+// End-to-end query planning: the value the client passes to `t.y(arg:)` is threaded into the
+// `x(arg:)` fetch on the subgraph that owns `x` — as a forwarded variable, and (in the literal
+// case) inlined.
+#[test]
+fn requires_with_variable_argument_value_threads_into_subgraph_fetch() {
+    let subgraph_a = r#"
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y(arg: Int): Int @requires(fields: "x(arg: $arg)")
+        }
+        "#;
+
+    let plan = requires_variable_query_plan(
+        subgraph_a,
+        REQUIRES_VARIABLE_SUBGRAPH_B,
+        "query($v: Int) { t { y(arg: $v) } }",
+    );
+    assert!(
+        plan.contains("x(arg: $v)"),
+        "expected the subgraph fetch to request `x(arg: $v)` with the client variable threaded through, but got plan:\n{plan}"
+    );
+
+    let literal_plan = requires_variable_query_plan(
+        subgraph_a,
+        REQUIRES_VARIABLE_SUBGRAPH_B,
+        "{ t { y(arg: 7) } }",
+    );
+    assert!(
+        literal_plan.contains("x(arg: 7)"),
+        "expected the subgraph fetch to request `x(arg: 7)` with the literal inlined, but got plan:\n{literal_plan}"
+    );
+}
+
+// When the client omits a nullable argument the variable is bound to, it resolves to `null` per
+// GraphQL argument coercion, and `null` is what gets threaded into the required field's fetch.
+#[test]
+fn requires_with_omitted_nullable_argument_substitutes_null() {
+    let subgraph_a = r#"
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y(arg: Int): Int @requires(fields: "x(arg: $arg)")
+        }
+        "#;
+
+    let plan =
+        requires_variable_query_plan(subgraph_a, REQUIRES_VARIABLE_SUBGRAPH_B, "{ t { y } }");
+    assert!(
+        plan.contains("x(arg: null)"),
+        "expected the omitted nullable argument to resolve to null in the fetch, but got plan:\n{plan}"
+    );
+}
+
+// When the client omits an argument that has a schema default, the default is what gets threaded
+// into the required field's fetch.
+#[test]
+fn requires_with_omitted_defaulted_argument_substitutes_default() {
+    let subgraph_a = r#"
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y(arg: Int = 5): Int @requires(fields: "x(arg: $arg)")
+        }
+        "#;
+
+    let plan =
+        requires_variable_query_plan(subgraph_a, REQUIRES_VARIABLE_SUBGRAPH_B, "{ t { y } }");
+    assert!(
+        plan.contains("x(arg: 5)"),
+        "expected the argument's schema default (5) to be threaded into the fetch, but got plan:\n{plan}"
+    );
+}
+
+// The variable can appear nested inside a list-valued argument; substitution recurses into it.
+#[test]
+fn requires_with_variable_in_list_argument_threads_through() {
+    let subgraph_a = r#"
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(args: [Int]): Int @external
+          y(arg: Int): Int @requires(fields: "x(args: [$arg])")
+        }
+        "#;
+    let subgraph_b = r#"
+        type T @key(fields: "id") {
+          id: ID!
+          x(args: [Int]): Int
+        }
+        "#;
+
+    let plan = requires_variable_query_plan(
+        subgraph_a,
+        subgraph_b,
+        "query($v: Int) { t { y(arg: $v) } }",
+    );
+    assert!(
+        plan.contains("x(args: [$v])"),
+        "expected the variable to be threaded into the list-valued argument, but got plan:\n{plan}"
+    );
+}
+
+// A field set may require multiple fields, each binding a distinct field argument.
+#[test]
+fn requires_with_multiple_variable_arguments_threads_each() {
+    let subgraph_a = r#"
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          z(arg: Int): Int @external
+          y(a: Int, b: Int): Int @requires(fields: "x(arg: $a) z(arg: $b)")
+        }
+        "#;
+    let subgraph_b = r#"
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int
+          z(arg: Int): Int
+        }
+        "#;
+
+    let plan = requires_variable_query_plan(
+        subgraph_a,
+        subgraph_b,
+        "query($v1: Int, $v2: Int) { t { y(a: $v1, b: $v2) } }",
+    );
+    assert!(
+        plan.contains("x(arg: $v1)") && plan.contains("z(arg: $v2)"),
+        "expected both variables threaded into their respective fetches, but got plan:\n{plan}"
+    );
+}
+
+// A variable whose bound argument type is incompatible with the required field's argument type is
+// rejected at composition.
+#[test]
+fn requires_with_incompatible_variable_type_is_rejected() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+          y(arg: String): Int @requires(fields: "x(arg: $arg)")
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, requires_variable_subgraph_b()]);
+    assert_composition_errors(
+        &result,
+        &[(
+            "REQUIRES_INVALID_FIELDS",
+            r#"[subgraphA] On field "T.y", for @requires(fields: "x(arg: $arg)"): variable "$arg" cannot be used for argument "arg" of field "x": it is bound to argument "arg" of type "String", which is not compatible with the expected type "Int""#,
+        )],
+    );
+}
+
+// `@provides` field sets cannot reference variables; such a reference must fail composition.
+#[test]
+fn provides_with_variable_argument_is_rejected() {
+    let subgraph_a = ServiceDefinition {
+        name: "subgraphA",
+        type_defs: r#"
+        type Query {
+          t: T
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          u(arg: Int): U @provides(fields: "x(arg: $arg)")
+        }
+
+        type U @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int @external
+        }
+        "#,
+    };
+    let subgraph_b = ServiceDefinition {
+        name: "subgraphB",
+        type_defs: r#"
+        type U @key(fields: "id") {
+          id: ID!
+          x(arg: Int): Int
+        }
+        "#,
+    };
+
+    let result = compose_as_fed2_subgraphs(&[subgraph_a, subgraph_b]);
+    assert!(
+        result.is_err(),
+        "expected composition to reject a @provides field set referencing a variable"
+    );
+}
+
 // =============================================================================
 // POST-MERGE VALIDATIONS - Tests for validation after the merge phase
 // =============================================================================

--- a/apollo-router/tests/requires_field_arguments.rs
+++ b/apollo-router/tests/requires_field_arguments.rs
@@ -1,0 +1,157 @@
+//! Execution-level coverage for `@requires` field sets whose required field's argument is bound to
+//! a variable naming the annotated field's own argument (e.g. `price(currency: $currency)`).
+//!
+//! The supergraph is composed in-test with the Rust composer (the rover-backed fixtures can't be
+//! used because JS composition does not accept this syntax yet), then driven through the router
+//! with subgraph services replaced by a capturing stub, to confirm the client-supplied value is
+//! actually forwarded to the subgraph that owns the required field.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use apollo_federation::composition::CompositionOptions;
+use apollo_federation::composition::compose;
+use apollo_federation::subgraph::typestate::Subgraph;
+use apollo_router::TestHarness;
+use apollo_router::services::subgraph;
+use apollo_router::services::supergraph;
+use serde_json::json;
+use tower::ServiceExt;
+
+const SUBGRAPH_A: &str = r#"
+    type Query {
+      t: T
+    }
+
+    type T @key(fields: "id") {
+      id: ID!
+      x(arg: Int): Int @external
+      y(arg: Int): Int @requires(fields: "x(arg: $arg)")
+    }
+"#;
+
+const SUBGRAPH_B: &str = r#"
+    type T @key(fields: "id") {
+      id: ID!
+      x(arg: Int): Int
+    }
+"#;
+
+fn compose_supergraph() -> String {
+    let subgraph_a = Subgraph::parse("subgraphA", "http://subgraphA", SUBGRAPH_A)
+        .unwrap()
+        .into_fed2_test_subgraph(true)
+        .unwrap();
+    let subgraph_b = Subgraph::parse("subgraphB", "http://subgraphB", SUBGRAPH_B)
+        .unwrap()
+        .into_fed2_test_subgraph(true)
+        .unwrap();
+    let supergraph = compose(vec![subgraph_a, subgraph_b], CompositionOptions::default())
+        .expect("composition should succeed");
+    supergraph.schema().schema().to_string()
+}
+
+/// A captured subgraph request: (subgraph name, operation string, variables).
+type CapturedRequest = (String, String, serde_json_bytes::Value);
+
+/// Plans and executes `operation` against the composed supergraph with every subgraph replaced by a
+/// stub that records the request it receives and returns canned data so execution can proceed.
+/// Returns the request received by `subgraphB` (the owner of the external `x` field).
+async fn captured_subgraph_b_request(operation: &str, variable: Option<i32>) -> CapturedRequest {
+    let schema = compose_supergraph();
+    let captured: Arc<Mutex<Vec<CapturedRequest>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured_for_hook = captured.clone();
+
+    let harness = TestHarness::builder()
+        .configuration_json(json!({"include_subgraph_errors": {"all": true}}))
+        .unwrap()
+        .schema(&schema)
+        .subgraph_hook(move |name, _default| {
+            let captured = captured_for_hook.clone();
+            let name = name.to_string();
+            tower::service_fn(move |request: subgraph::Request| {
+                let captured = captured.clone();
+                let name = name.clone();
+                async move {
+                    let body = request.subgraph_request.body();
+                    let query = body.query.clone().unwrap_or_default();
+                    let variables = serde_json_bytes::Value::Object(body.variables.clone());
+                    captured
+                        .lock()
+                        .unwrap()
+                        .push((name.clone(), query.clone(), variables));
+
+                    // Return just enough data for each fetch so execution proceeds to the next.
+                    let data = if name == "subgraphA" && !query.contains("_entities") {
+                        serde_json_bytes::json!({ "t": { "__typename": "T", "id": "1" } })
+                    } else if name == "subgraphB" {
+                        serde_json_bytes::json!({ "_entities": [ { "x": 100 } ] })
+                    } else {
+                        serde_json_bytes::json!({ "_entities": [ { "y": 200 } ] })
+                    };
+
+                    Ok::<_, tower::BoxError>(
+                        subgraph::Response::fake_builder()
+                            .data(data)
+                            .context(request.context.clone())
+                            .subgraph_name(name)
+                            .build(),
+                    )
+                }
+            })
+            .boxed()
+        })
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let mut request = supergraph::Request::fake_builder().query(operation);
+    if let Some(value) = variable {
+        request = request.variable("v", value);
+    }
+    let response = harness
+        .oneshot(request.build().unwrap())
+        .await
+        .unwrap()
+        .next_response()
+        .await
+        .unwrap();
+    assert!(
+        response.errors.is_empty(),
+        "unexpected execution errors: {:?}",
+        response.errors
+    );
+
+    let captured = captured.lock().unwrap();
+    captured
+        .iter()
+        .find(|(name, _, _)| name == "subgraphB")
+        .cloned()
+        .expect("subgraphB should have been queried to resolve the required `x` field")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn forwards_client_variable_to_owning_subgraph() {
+    let (_, operation, variables) =
+        captured_subgraph_b_request("query($v: Int) { t { y(arg: $v) } }", Some(7)).await;
+
+    assert!(
+        operation.replace(' ', "").contains("x(arg:$v)"),
+        "subgraphB operation should request `x` with the threaded variable, got: {operation}"
+    );
+    assert_eq!(
+        variables.as_object().and_then(|object| object.get("v")),
+        Some(&serde_json_bytes::Value::from(7)),
+        "subgraphB should have received the client-supplied value for the threaded variable; variables were {variables}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn inlines_literal_argument_for_owning_subgraph() {
+    let (_, operation, _) = captured_subgraph_b_request("{ t { y(arg: 7) } }", None).await;
+
+    assert!(
+        operation.replace(' ', "").contains("x(arg:7)"),
+        "subgraphB operation should request `x` with the literal argument inlined, got: {operation}"
+    );
+}


### PR DESCRIPTION
`@requires(fields: "...")` previously only accepted static literal argument values for required fields that take arguments — there was no way to pass a per-request value (e.g. an end user's currency) through to the subgraph that owns the required field. This adds support for referencing the annotated field's own arguments as bare `$arg` variables, e.g.:

```graphql
price(currency: Currency!) @external
localizedPrice(currency: Currency!): Money @requires(fields: "price(currency: $currency)")
```

At query-planning time the variable is bound to the operation's concrete value for that argument (a client variable or a literal) and threaded into the fetch for the external field on its owning subgraph.

Composition: the field-set parser/validators tolerate `$arg` references that name one of the annotated field's arguments across all three validation sites (query-graph build, post-merge validation, and subgraph extraction); a variable that does not name a field argument is rejected with a REQUIRES_INVALID_FIELDS error rather than an internal error.

Query planning: `add_field_edge` substitutes the placeholder with the operation's concrete argument value and resolves the condition through the existing `extra_conditions` channel (as `@context` does), which bypasses the condition-resolution cache and so keeps per-operation bindings correct. No new subgraph variable is minted; existing variable collection and forwarding carry the value to the subgraph.

It is my understanding that the [federation](https://github.com/apollographql/federation) JS implementations need to be maintained with feature parity, so I have a similar PR over there: https://github.com/apollographql/federation/pull/3448

Fixes: #9583

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [x] Manual tests, as necessary

**Notes**

👋 Hi folks. I've done my best here to make sure these changes are accurate and reasonable. I'm obviously not an expert in this codebase - I've tried to adopt the style of surrounding code and consider maintainability in my implementation. That said I'm sure folks closer to the codebase will have opinions here. I'm glad to make any updates you see fit, even if it's heading back to the drawing board to approach this from a different angle.

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

