### PR TITLE
chore(ci): add weekly forward-port workflow for dev → dev-v3.x

### DIFF
--- a/.github/workflows/forward-port-dev-to-dev-v3.yml
+++ b/.github/workflows/forward-port-dev-to-dev-v3.yml
@@ -1,0 +1,78 @@
+name: Forward-port dev to dev-v3.x
+
+on:
+  schedule:
+    # Every Monday at 09:00 UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  forward-port:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.APOLLO_BOT2_GITHUB_PAT }}
+
+      - name: Configure git
+        run: |
+          git config user.name "apollo-bot2"
+          git config user.email "apollo-bot2@users.noreply.github.com"
+
+      - name: Create or update forward-port branch
+        id: merge
+        run: |
+          BRANCH="forward-port/dev-to-dev-v3.x"
+          git checkout -b "$BRANCH" origin/dev-v3.x
+
+          if git merge --no-edit origin/dev; then
+            echo "merge_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Merge conflict between dev and dev-v3.x — resolve manually."
+            exit 1
+          fi
+
+          if git diff --quiet origin/dev-v3.x..HEAD; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Push forward-port branch
+        if: steps.merge.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.APOLLO_BOT2_GITHUB_PAT }}
+        run: |
+          git push --force-with-lease origin "${{ steps.merge.outputs.branch }}"
+
+      - name: Open PR if none exists
+        if: steps.merge.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.APOLLO_BOT2_GITHUB_PAT }}
+        run: |
+          BRANCH="${{ steps.merge.outputs.branch }}"
+          EXISTING=$(gh pr list \
+            --head "$BRANCH" \
+            --base dev-v3.x \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+
+          if [[ -n "$EXISTING" ]]; then
+            echo "PR #$EXISTING already open — branch updated, no new PR needed."
+          else
+            gh pr create \
+              --base dev-v3.x \
+              --head "$BRANCH" \
+              --title "chore: forward-port dev into dev-v3.x" \
+              --body "Automated weekly forward-port of changes from \`dev\` into \`dev-v3.x\`.
+
+Merge this once CI passes and any conflicts have been resolved."
+          fi
+
+      - name: Nothing to forward-port
+        if: steps.merge.outputs.has_changes == 'false'
+        run: echo "dev-v3.x is already up to date with dev — nothing to do."

--- a/.github/workflows/forward-port-dev-to-dev-v3.yml
+++ b/.github/workflows/forward-port-dev-to-dev-v3.yml
@@ -27,10 +27,13 @@ jobs:
           git checkout -b "$BRANCH" origin/dev-v3.x
 
           if git merge --no-edit origin/dev; then
-            echo "merge_ok=true" >> "$GITHUB_OUTPUT"
+            echo "merge_conflicts=false" >> "$GITHUB_OUTPUT"
           else
-            echo "::error::Merge conflict between dev and dev-v3.x — resolve manually."
-            exit 1
+            # Stage conflicted files as-is (with conflict markers) so we can commit
+            # and create a PR that shows the diff needing manual resolution.
+            git diff --name-only --diff-filter=U | xargs git add
+            git commit -m "chore: forward-port dev into dev-v3.x"
+            echo "merge_conflicts=true" >> "$GITHUB_OUTPUT"
           fi
 
           if git diff --quiet origin/dev-v3.x..HEAD; then
@@ -43,8 +46,6 @@ jobs:
 
       - name: Push forward-port branch
         if: steps.merge.outputs.has_changes == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.APOLLO_BOT2_GITHUB_PAT }}
         run: |
           git push --force-with-lease origin "${{ steps.merge.outputs.branch }}"
 
@@ -64,13 +65,27 @@ jobs:
           if [[ -n "$EXISTING" ]]; then
             echo "PR #$EXISTING already open — branch updated, no new PR needed."
           else
+            if [[ "${{ steps.merge.outputs.merge_conflicts }}" == "true" ]]; then
+              {
+                echo '> [!CAUTION]'
+                echo '> This PR contains merge conflicts that must be resolved manually before merging.'
+                echo "> Check out the \`$BRANCH\` branch, resolve the conflict markers, commit, and push."
+                echo ''
+                echo 'Automated weekly forward-port of changes from `dev` into `dev-v3.x`.'
+              } > /tmp/pr-body.md
+            else
+              {
+                echo 'Automated weekly forward-port of changes from `dev` into `dev-v3.x`.'
+                echo ''
+                echo 'Merge this once CI passes.'
+              } > /tmp/pr-body.md
+            fi
+
             gh pr create \
               --base dev-v3.x \
               --head "$BRANCH" \
               --title "chore: forward-port dev into dev-v3.x" \
-              --body "Automated weekly forward-port of changes from \`dev\` into \`dev-v3.x\`.
-
-Merge this once CI passes and any conflicts have been resolved."
+              --body-file /tmp/pr-body.md
           fi
 
       - name: Nothing to forward-port


### PR DESCRIPTION
Adds a scheduled GitHub Actions workflow that merges `dev` into `dev-v3.x` every Monday and opens a PR with the result.

The workflow uses `APOLLO_BOT2_GITHUB_PAT` so CI runs on the created PR. If the merge has conflicts, it commits the conflicted files as-is and opens the PR with a `[!CAUTION]` alert at the top pointing the team to resolve the markers manually. If an open forward-port PR already exists, it updates the branch instead of opening a duplicate. If `dev-v3.x` is already up to date, it exits cleanly with no PR created.