### PR TITLE
ci: allow gh api writes in claude-review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -50,3 +50,13 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }} --comment'
           show_full_output: true
+          settings: |
+            {
+              "permissions": {
+                "allow": [
+                  "Bash(gh api -X POST repos/apollographql/router/pulls/*/comments *)",
+                  "Bash(gh api -X POST repos/apollographql/router/pulls/*/reviews *)",
+                  "Write(.claude_comment*.md)"
+                ]
+              }
+            }


### PR DESCRIPTION
## Summary

- The \`code-review@claude-code-plugins\` plugin posts inline PR comments via \`gh api -X POST\` and stages them in temp files — both were blocked by Claude Code's default permission system
- This caused \`/claude-review\` runs to complete successfully but post no comments (the \`post-buffered-inline-comments.ts\` postprocessor found nothing because the direct \`gh api\` calls never executed)
- Adds the minimum necessary write permissions so the plugin can post comments without waiting for the upstream plugin to adopt the action's native \`PostInlineComment\` tool

## Permissions added

| Rule | Purpose |
|------|---------|
| \`Bash(gh api -X POST repos/*/pulls/*/comments *)\` | Inline review comments |
| \`Bash(gh api -X POST repos/*/pulls/*/reviews *)\` | PR-level review summary |
| \`Write(.claude_comment*.md)\` | Temp comment staging files |

All \`Bash\` rules are still bounded by the job's \`GITHUB_TOKEN\` (\`pull-requests: write\` + \`contents: read\`), so no additional blast radius beyond posting PR review content.

## Test plan

- [ ] Trigger \`/claude-review\` on a PR and confirm a review comment appears

🤖 Generated with [Claude Code](https://claude.ai/claude-code)