### PR TITLE
fix(connectors): credit fields under list-shaped method sub-selections

### DIFF
--- a/.changesets/fix_connect_v04_entries_subselection_unresolved_fields.md
+++ b/.changesets/fix_connect_v04_entries_subselection_unresolved_fields.md
@@ -1,0 +1,13 @@
+### Connectors: credit fields selected beneath list-shaped methods like `->entries` (connect v0.4) ([PR #9619](https://github.com/apollographql/router/pull/9619))
+
+Composition with connect v0.4 reported spurious `CONNECTORS_UNRESOLVED_FIELD` errors for fields selected
+beneath an `->entries` sub-selection — e.g. `attributes: attributes->entries { key value }` against
+`attributes: [AttributesEntry]` left `AttributesEntry.key` and `AttributesEntry.value` "unresolved", even
+though the selection plainly resolves them. The identical schema composed cleanly under connect v0.3.
+
+Cause: v0.4's shape-based selection validator only collected seen fields for object-shaped selections;
+list-valued shapes — produced by methods with statically known list outputs, like `->entries` — fell
+through a catch-all and contributed no seen fields. The validator now walks `Array` shapes by validating
+each item shape against the field's (already list-unwrapped) inner named type.
+
+By [@fernando-apollo](https://github.com/fernando-apollo) in [PR #9619](https://github.com/apollographql/router/pull/9619)

--- a/apollo-federation/src/connectors/validation/connect/selection.rs
+++ b/apollo-federation/src/connectors/validation/connect/selection.rs
@@ -725,6 +725,23 @@ impl<'schema> SelectionValidator<'schema> {
                     })
                 }
             }
+            ShapeCase::Array { prefix, tail } => {
+                // A list-valued shape — e.g. produced by methods with statically known
+                // list outputs like `->entries` — validates each item shape against the
+                // same type: the caller already unwrapped GraphQL list types to their
+                // inner named type via `inner_named_type()`. Without this arm, fields
+                // selected beneath such methods were never marked as seen, producing
+                // spurious CONNECTORS_UNRESOLVED_FIELD errors (e.g. `->entries { key value }`
+                // against `[FooEntry]` left `FooEntry.key`/`FooEntry.value` unresolved).
+                let mut all_seen_fields = Vec::new();
+                for item_shape in prefix {
+                    all_seen_fields.extend(self.walk_selection_with_shape(type_ref, item_shape)?);
+                }
+                if !tail.is_none() {
+                    all_seen_fields.extend(self.walk_selection_with_shape(type_ref, tail)?);
+                }
+                Ok(all_seen_fields)
+            }
             _ => Ok(Vec::new()), // Handle other shape cases
         }
     }

--- a/apollo-federation/src/connectors/validation/connect/selection.rs
+++ b/apollo-federation/src/connectors/validation/connect/selection.rs
@@ -742,7 +742,40 @@ impl<'schema> SelectionValidator<'schema> {
                 }
                 Ok(all_seen_fields)
             }
-            _ => Ok(Vec::new()), // Handle other shape cases
+            ShapeCase::All(shapes) => {
+                // An intersection shape (e.g. `IntfA & IntfB`, or merged records):
+                // the value simultaneously satisfies every member, so the selected
+                // fields are the union across members and each must validate against
+                // `type_ref`. Walk every member and accumulate, propagating errors —
+                // unlike `One` (a union of alternatives), an intersection member that
+                // fails to validate is a genuine error, not a discarded branch.
+                let mut all_seen_fields = Vec::new();
+                for member_shape in shapes.iter() {
+                    all_seen_fields.extend(self.walk_selection_with_shape(type_ref, member_shape)?);
+                }
+                Ok(all_seen_fields)
+            }
+            // Structureless shapes expose no selectable GraphQL fields, so they
+            // contribute nothing to `seen_fields`. These are listed explicitly,
+            // rather than behind a `_` catch-all, so that introducing a new
+            // `ShapeCase` variant becomes a compile error here — forcing a
+            // deliberate decision instead of silently dropping fields (the root
+            // cause of the `->entries` bug the `Array` arm above fixes).
+            ShapeCase::Bool(_)
+            | ShapeCase::String(_)
+            | ShapeCase::Int(_)
+            | ShapeCase::Float
+            | ShapeCase::Null
+            | ShapeCase::None => Ok(Vec::new()),
+            // Opaque / deferred shapes whose structure is not statically known
+            // here. We preserve the existing behavior of contributing nothing;
+            // crucially we do NOT treat them as resolving every field, which could
+            // mask genuine `CONNECTORS_UNRESOLVED_FIELD` errors. A structure-aware
+            // policy for these is left to a follow-up.
+            ShapeCase::Name(_, _) | ShapeCase::Unknown => Ok(Vec::new()),
+            // A shape-processing failure is surfaced through other diagnostics;
+            // there is nothing to credit as seen here.
+            ShapeCase::Error(_) => Ok(Vec::new()),
         }
     }
 }

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@entries_subselection_v0_4.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@entries_subselection_v0_4.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/connectors/validation/mod.rs
+expression: result.errors
+input_file: apollo-federation/src/connectors/validation/test_data/entries_subselection_v0_4.graphql
+---
+[]

--- a/apollo-federation/src/connectors/validation/test_data/entries_subselection_v0_4.graphql
+++ b/apollo-federation/src/connectors/validation/test_data/entries_subselection_v0_4.graphql
@@ -1,0 +1,38 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.4"
+    import: ["@connect", "@source"]
+)
+@source(name: "api", http: { baseURL: "https://api.example.com" })
+
+# Fields selected beneath an ->entries sub-selection must be credited to the
+# declared entry type. ->entries has a statically known list shape, so the
+# shape-based validator (v0.4+) must walk Array shapes; previously it dropped
+# them, leaving AttributesEntry.key / AttributesEntry.value spuriously
+# unresolved (CONNECTORS_UNRESOLVED_FIELD). v0.1-v0.3 are unaffected (legacy
+# AST-visitor validator).
+
+type Thing {
+    name: String
+    attributes: [AttributesEntry]
+}
+
+type AttributesEntry {
+    key: String
+    value: String
+}
+
+type Query {
+    thing: Thing
+    @connect(
+        source: "api"
+        http: { GET: "/thing" }
+        selection: """
+        name
+        attributes: attributes->entries {
+            key
+            value
+        }
+        """
+    )
+}


### PR DESCRIPTION
## Summary

Composition with **connect v0.4** reported spurious `CONNECTORS_UNRESOLVED_FIELD` errors for
fields selected beneath an `->entries` sub-selection — e.g. `attributes: attributes->entries { key value }`
against `attributes: [AttributesEntry]` left `AttributesEntry.key` and `AttributesEntry.value`
"unresolved", even though the selection plainly resolves them. The identical schema composed
cleanly under connect v0.3.

## Cause

v0.4's shape-based selection validator only collected seen fields for **object-shaped**
selections. List-valued shapes — produced by methods with statically known list outputs, like
`->entries` — fell through a catch-all and contributed no seen fields, so the entry type's
fields were reported as unresolved.

## Fix

The validator now walks `Array` shapes by validating each item shape against the field's
(already list-unwrapped) inner named type. v0.1–v0.3 use the legacy AST validator and are
unaffected.

## Tests

Adds an `entries_subselection_v0_4.graphql` validation fixture + snapshot covering
`->entries { key value }`. `cargo test -p apollo-federation --lib -- connectors::validation`
passes.
