### PR TITLE
fix(composition): coerce applied directive arg values after merge

### DIFF
--- a/apollo-federation/src/compat.rs
+++ b/apollo-federation/src/compat.rs
@@ -267,35 +267,6 @@ fn coerce_arguments_default_values(
     }
 }
 
-/// Like [`coerce_arguments_default_values`] but preserves `= {}` defaults even when the
-/// input type has required fields. Used at subgraph-parse time to match graphql-js behavior:
-/// JS keeps `= {}` verbatim in the upgraded subgraph SDL regardless of required fields;
-/// the supergraph/API-schema path uses [`coerce_arguments_default_values`] directly, which
-/// still strips them there.
-fn coerce_arguments_default_values_keep_empty_object(
-    types: &IndexMap<Name, ExtendedType>,
-    arguments: &mut Vec<Node<InputValueDefinition>>,
-) {
-    for arg in arguments {
-        let arg = arg.make_mut();
-        let Some(default_value) = &mut arg.default_value else {
-            continue;
-        };
-        let is_empty_object =
-            matches!(default_value.as_ref(), Value::Object(fields) if fields.is_empty());
-        if coerce_value(types, default_value, &arg.ty, DefaultValueBehavior::Check).is_err() {
-            if is_empty_object {
-                // Restore `= {}` — coerce_value may have partially mutated the value before
-                // failing. Matches graphql-js parse-time behavior: keep `= {}` even when the
-                // input type has required fields with no defaults.
-                *default_value.make_mut() = Value::Object(Default::default());
-            } else {
-                arg.default_value = None;
-            }
-        }
-    }
-}
-
 /// Do graphql-js-style input coercion on default values. Invalid default values are silently
 /// removed from the schema.
 ///
@@ -371,7 +342,7 @@ pub(crate) fn coerce_schema_values(schema: &mut Schema) {
                 );
                 for field in object.fields.values_mut() {
                     let field = field.make_mut();
-                    coerce_arguments_default_values_keep_empty_object(&types, &mut field.arguments);
+                    coerce_arguments_default_values(&types, &mut field.arguments);
                     coerce_directive_application_values_ast(
                         &directive_definitions,
                         &types,
@@ -393,7 +364,7 @@ pub(crate) fn coerce_schema_values(schema: &mut Schema) {
                 );
                 for field in interface.fields.values_mut() {
                     let field = field.make_mut();
-                    coerce_arguments_default_values_keep_empty_object(&types, &mut field.arguments);
+                    coerce_arguments_default_values(&types, &mut field.arguments);
                     coerce_directive_application_values_ast(
                         &directive_definitions,
                         &types,

--- a/apollo-federation/src/compat.rs
+++ b/apollo-federation/src/compat.rs
@@ -273,58 +273,6 @@ fn coerce_arguments_default_values(
 /// This is not what we would want to do for coercion in a real execution scenario, but it matches
 /// a behaviour in graphql-js so we can compare API schema results between federation-next and JS
 /// federation. We can consider removing this when we no longer rely on JS federation.
-pub(crate) fn coerce_schema_default_values(schema: &mut Schema) {
-    // Keep a copy of the types in the schema so we can mutate the schema while walking it.
-    let types = schema.types.clone();
-
-    for ty in schema.types.values_mut() {
-        match ty {
-            ExtendedType::Object(object) => {
-                let object = object.make_mut();
-                for field in object.fields.values_mut() {
-                    let field = field.make_mut();
-                    coerce_arguments_default_values(&types, &mut field.arguments);
-                }
-            }
-            ExtendedType::Interface(interface) => {
-                let interface = interface.make_mut();
-                for field in interface.fields.values_mut() {
-                    let field = field.make_mut();
-                    coerce_arguments_default_values(&types, &mut field.arguments);
-                }
-            }
-            ExtendedType::InputObject(input_object) => {
-                let input_object = input_object.make_mut();
-                for field in input_object.fields.values_mut() {
-                    let field = field.make_mut();
-                    let Some(default_value) = &mut field.default_value else {
-                        continue;
-                    };
-
-                    if coerce_value(
-                        &types,
-                        default_value,
-                        &field.ty,
-                        DefaultValueBehavior::Check,
-                    )
-                    .is_err()
-                    {
-                        field.default_value = None;
-                    }
-                }
-            }
-            ExtendedType::Union(_) | ExtendedType::Scalar(_) | ExtendedType::Enum(_) => {
-                // Nothing to do
-            }
-        }
-    }
-
-    for directive in schema.directive_definitions.values_mut() {
-        let directive = directive.make_mut();
-        coerce_arguments_default_values(&types, &mut directive.arguments);
-    }
-}
-
 pub(crate) fn coerce_schema_values(schema: &mut Schema) {
     // Keep a copy of the types in the schema so we can mutate the schema while walking it.
     let types = schema.types.clone();
@@ -627,7 +575,7 @@ pub(crate) fn coerce_executable_values(schema: &Valid<Schema>, document: &mut Ex
 /// `printSchema(buildSchema()` in graphql-js.
 pub(crate) fn make_print_schema_compatible(schema: &mut Schema) {
     remove_non_semantic_directives(schema);
-    coerce_schema_default_values(schema);
+    coerce_schema_values(schema);
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -264,7 +264,7 @@ impl Merger {
         }
 
         if self.errors.is_empty() {
-            crate::compat::coerce_schema_default_values(&mut supergraph);
+            crate::compat::coerce_schema_values(&mut supergraph);
 
             // TODO: validate here and extend `MergeFailure` to propagate validation errors
             let supergraph = Valid::assume_valid(supergraph);

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -628,7 +628,7 @@ impl Merger {
         // Match graphql-js `printSchema(buildSchema(...))` behavior: argument and input-field
         // defaults that cannot be coerced to their types (for example `{}` when the input object
         // has required fields) are removed rather than left on the composed supergraph SDL.
-        crate::compat::coerce_schema_default_values(merged.schema_mut());
+        crate::compat::coerce_schema_values(merged.schema_mut());
 
         // TODO: Errors thrown by the `validate` below are likely to be confusing for users,
         // because they refer to a document they don't know about (the merged-but-not-returned

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -357,7 +357,7 @@ pub(crate) fn extract_subgraphs_from_supergraph(
 
     let mut valid_subgraphs = ValidFederationSubgraphs::new();
     for (_, mut subgraph) in subgraphs {
-        crate::compat::coerce_schema_default_values(subgraph.schema.schema_mut());
+        crate::compat::coerce_schema_values(subgraph.schema.schema_mut());
         let valid_subgraph_schema = if validate_extracted_subgraphs {
             match subgraph.schema.validate_or_return_self() {
                 Ok(schema) => schema,

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -1505,6 +1505,66 @@ mod inconsistent_definitions {
     }
 }
 
+mod string_to_enum_coercion {
+    use super::*;
+    use insta::assert_snapshot;
+
+    /// When one subgraph defines a composed directive with an enum argument type
+    /// and another defines it with a String argument type, both subgraphs are
+    /// internally valid.
+    /// After merging, whichever definition is picked, the applied directives from
+    /// the other subgraph should be coerced rather than rejected. A string value
+    /// like `"PUBLIC"` is a valid representation of enum value `PUBLIC`, and an
+    /// unquoted enum value `INTERNAL` is a valid representation of string `"INTERNAL"`.
+    #[test]
+    fn composes_directive_with_enum_arg_when_other_subgraph_uses_string() {
+        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+            extend schema @composeDirective(name: "@custom")
+              @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
+              @link(url: "https://custom.dev/custom/v1.0", import: ["@custom"])
+
+            enum CustomTag {
+              INTERNAL
+              PUBLIC
+            }
+
+            directive @custom(tag: CustomTag!) on FIELD_DEFINITION
+
+            type Query {
+              product(id: ID!): Product @custom(tag: PUBLIC)
+            }
+
+            type Product @key(fields: "id") {
+              id: ID!
+              name: String
+            }
+        "#).expect("valid first subgraph");
+
+        let subgraph_b = Subgraph::parse("subgraphB", "", r#"
+            extend schema @composeDirective(name: "@custom")
+              @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
+              @link(url: "https://custom.dev/custom/v1.0", import: ["@custom"])
+
+            directive @custom(tag: String!) on FIELD_DEFINITION
+
+            type Query {
+              user(id: ID!): User @custom(tag: "INTERNAL")
+            }
+
+            type User @key(fields: "id")  {
+              id: ID!
+              name: String
+            }
+        "#).expect("valid second subgraph");
+
+        // Regardless of subgraph ordering (which determines which definition is
+        // picked), composition must succeed. The applied directives that were
+        // valid in their source subgraph should not be rejected after merge.
+        let result = compose(vec![subgraph_a, subgraph_b]).expect("successfully composed");
+        assert_snapshot!(result.schema().schema());
+    }
+}
+
 fn generate_subgraph(
     name: &str,
     link_text: &str,

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -1506,8 +1506,9 @@ mod inconsistent_definitions {
 }
 
 mod string_to_enum_coercion {
-    use super::*;
     use insta::assert_snapshot;
+
+    use super::*;
 
     /// When one subgraph defines a composed directive with an enum argument type
     /// and another defines it with a String argument type, both subgraphs are

--- a/apollo-federation/tests/composition/compose_misc.rs
+++ b/apollo-federation/tests/composition/compose_misc.rs
@@ -24,9 +24,7 @@ fn misc_strips_invalid_empty_object_argument_defaults_on_supergraph() {
         }
 
         input InputWithRequired {
-          requiredA: String!
-          requiredB: String!
-          requiredC: String!
+          required: String!
         }
 
         input InputAllOptional {
@@ -36,16 +34,7 @@ fn misc_strips_invalid_empty_object_argument_defaults_on_supergraph() {
     };
 
     let supergraph = compose_as_fed2_subgraphs(&[subgraph]).expect("composition should succeed");
-    let sdl = print_sdl(supergraph.schema().schema());
-
-    assert!(
-        !sdl.contains("filter: InputWithRequired = {}"),
-        "supergraph should omit invalid empty-object default when input has required fields, got:\n{sdl}"
-    );
-    assert!(
-        sdl.contains("filter: InputAllOptional = {}"),
-        "supergraph should keep valid empty-object default when all input fields are optional, got:\n{sdl}"
-    );
+    assert_snapshot!(supergraph.schema().schema());
 }
 
 #[test]

--- a/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
@@ -4,44 +4,6 @@ use apollo_federation::subgraph::typestate::Subgraph;
 use insta::assert_snapshot;
 use test_log::test;
 
-// Subgraph parse must preserve `= {}` even when the input type has required fields.
-// graphql-js keeps the default in the upgraded subgraph SDL; RS was stripping it at parse time.
-#[test]
-fn parse_preserves_empty_object_argument_default_with_required_input_fields() {
-    let subgraph = Subgraph::parse(
-        "subgraph",
-        "http://subgraph",
-        r#"
-        extend schema
-          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
-
-        type Query {
-          field(filter: InputWithRequired = {}): String
-        }
-
-        input InputWithRequired {
-          requiredA: String!
-          requiredB: String!
-          requiredC: String!
-        }
-        "#,
-    )
-    .expect("parses schema")
-    .expand_links()
-    .expect("expands schema");
-
-    let [validated]: [Subgraph<_>; 1] = upgrade_subgraphs_if_necessary(vec![subgraph])
-        .expect("upgrades schema")
-        .try_into()
-        .expect("Expected 1 element");
-
-    let sdl = validated.validated_schema().schema().to_string();
-    assert!(
-        sdl.contains("filter: InputWithRequired = {}"),
-        "upgraded subgraph SDL should preserve `= {{}}` when input type has required fields\n\nGot:\n{sdl}"
-    );
-}
-
 // =============================================================================
 // Fed1 Schema Upgrade Tests
 // =============================================================================

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_directive__string_to_enum_coercion__composes_directive_with_enum_arg_when_other_subgraph_uses_string.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_directive__string_to_enum_coercion__composes_directive_with_enum_arg_when_other_subgraph_uses_string.snap
@@ -1,0 +1,64 @@
+---
+source: apollo-federation/tests/composition/compose_directive.rs
+assertion_line: 1565
+expression: result.schema().schema()
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://custom.dev/custom/v1.0", import: ["@custom"]) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @custom(tag: String!) on FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  SUBGRAPHA @join__graph(name: "subgraphA", url: "")
+  SUBGRAPHB @join__graph(name: "subgraphB", url: "")
+}
+
+scalar join__FieldSet
+
+enum CustomTag @join__type(graph: SUBGRAPHA) {
+  INTERNAL @join__enumValue(graph: SUBGRAPHA)
+  PUBLIC @join__enumValue(graph: SUBGRAPHA)
+}
+
+type Query @join__type(graph: SUBGRAPHA) @join__type(graph: SUBGRAPHB) {
+  product(id: ID!): Product @join__field(graph: SUBGRAPHA) @custom(tag: "PUBLIC")
+  user(id: ID!): User @join__field(graph: SUBGRAPHB) @custom(tag: "INTERNAL")
+}
+
+type Product @join__type(graph: SUBGRAPHA, key: "id") {
+  id: ID!
+  name: String
+}
+
+type User @join__type(graph: SUBGRAPHB, key: "id") {
+  id: ID!
+  name: String
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_misc__misc_strips_invalid_empty_object_argument_defaults_on_supergraph.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_misc__misc_strips_invalid_empty_object_argument_defaults_on_supergraph.snap
@@ -1,0 +1,67 @@
+---
+source: apollo-federation/tests/composition/compose_misc.rs
+assertion_line: 37
+expression: supergraph.schema().schema()
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  SUBGRAPH @join__graph(name: "subgraph", url: "http://subgraph")
+}
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+type Query @join__type(graph: SUBGRAPH) {
+  fieldA(filter: InputWithRequired): String
+  fieldB(filter: InputAllOptional = {}): String
+}
+
+input InputWithRequired @join__type(graph: SUBGRAPH) {
+  required: String!
+}
+
+input InputAllOptional @join__type(graph: SUBGRAPH) {
+  optionalField: String
+}


### PR DESCRIPTION
When subgraphs define the same composed directive with different argument types (e.g., one uses an enum, another uses String), both are internally valid. After merging picks one definition, applied directives from the other subgraph may have values that need coercion (string→enum or enum→string). Replace `coerce_schema_default_values` with `coerce_schema_values` so applied directive arguments are also coerced before supergraph validation.