### PR TITLE
fix(composition): handle supergraph spec imports in subgraphs

### DIFF
--- a/apollo-federation/src/merger/merge_links.rs
+++ b/apollo-federation/src/merger/merge_links.rs
@@ -74,13 +74,20 @@ impl Merger {
                 let import = match linked_elem.import {
                     Some(import) => import,
                     None => {
-                        // If there is no explicit import, we create a synthetic import for merging
-                        let Some((_, directive_name_in_spec)) = directive.split_once("__") else {
-                            continue;
-                        };
-                        let Ok(element_name) = Name::new(directive_name_in_spec) else {
-                            continue;
-                        };
+                        // If there is no explicit import, we create a synthetic import for
+                        // merging. The directive name in the spec is either derived from the
+                        // "__" prefix (e.g., "join__field" -> "field") or, for directives
+                        // that match their spec's identity name (e.g., @requiresScopes from
+                        // the requiresScopes spec), from the linked element's name_in_spec.
+                        let element_name =
+                            if let Some((_, name_in_spec)) = directive.split_once("__") {
+                                let Ok(name) = Name::new(name_in_spec) else {
+                                    continue;
+                                };
+                                name
+                            } else {
+                                linked_elem.name_in_spec
+                            };
                         Arc::new(Import {
                             element: element_name,
                             is_directive: true,

--- a/apollo-federation/tests/composition/compose_misc.rs
+++ b/apollo-federation/tests/composition/compose_misc.rs
@@ -598,3 +598,198 @@ fn misc_conflicting_subgraph_names_sanitization() {
         "Expected MYSUBGRAPH_2 in schema"
     );
 }
+
+mod supergraph_spec_imports {
+    use apollo_federation::subgraph::typestate::Subgraph;
+    use insta::assert_snapshot;
+
+    use crate::composition::assert_composition_errors;
+    use crate::composition::compose;
+
+    #[test]
+    fn fed2_with_explicit_supergraph_spec_import_propagates_policy() {
+        let sdl = r#"
+            extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key"])
+                @link(url: "https://specs.apollo.dev/policy/v0.1", for: SECURITY)
+
+            type Query {
+                user(id: ID!): Account
+            }
+
+            type Account @key(fields: "id") {
+                id: ID!
+                rate: Float @policy(policies: [["view_rate"]])
+            }
+        "#;
+        let subgraph =
+            Subgraph::parse("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
+
+        let supergraph = compose(vec![subgraph]).expect("composition should succeed");
+        assert_snapshot!(supergraph.schema().schema());
+    }
+
+    #[test]
+    fn fed2_with_overlapping_inaccessible_import_errors() {
+        let sdl = r#"
+            extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key", "@inaccessible"])
+                @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
+
+            type Query {
+                product(id: ID!): Product
+            }
+
+            type Product @key(fields: "id") {
+                id: ID!
+                name: String!
+                internalCode: String @inaccessible
+            }
+        "#;
+        let subgraph = Subgraph::parse("products", "http://products/graphql", sdl)
+            .expect("successfully parsed");
+        let result = compose(vec![subgraph]);
+        assert_composition_errors(
+            &result,
+            &[(
+                "INVALID_LINK_DIRECTIVE_USAGE",
+                r#"[products] Invalid use of @link in schema: import for '@inaccessible' of https://specs.apollo.dev/federation/v2.5 conflicts with spec https://specs.apollo.dev/inaccessible/v0.2"#,
+            )],
+        );
+    }
+
+    #[test]
+    fn fed2_with_overlapping_policy_and_requires_scopes_imports_errors() {
+        let sdl = r#"
+            extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.6", import: ["@key", "@policy", "@requiresScopes"])
+                @link(url: "https://specs.apollo.dev/requiresScopes/v0.1", for: SECURITY)
+                @link(url: "https://specs.apollo.dev/policy/v0.1", for: SECURITY)
+
+            type Query {
+                account(id: ID!): Account
+            }
+
+            type Account @key(fields: "id") {
+                id: ID!
+                balance: Float! @requiresScopes(scopes: [["read:balance"]])
+                rate: Float @policy(policies: [["view_rate"]])
+            }
+        "#;
+        let subgraph =
+            Subgraph::parse("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
+        let result = compose(vec![subgraph]);
+        assert_composition_errors(
+            &result,
+            &[(
+                "INVALID_LINK_DIRECTIVE_USAGE",
+                r#"[accounts] Invalid use of @link in schema: import for '@policy' of https://specs.apollo.dev/federation/v2.6 conflicts with spec https://specs.apollo.dev/policy/v0.1"#,
+            )],
+        );
+    }
+
+    #[test]
+    fn fed1_with_link_bootstrap_and_supergraph_spec_import_propagates_policy() {
+        let sdl = r#"
+            schema
+                @link(url: "https://specs.apollo.dev/link/v1.0")
+                @link(url: "https://specs.apollo.dev/policy/v0.1", for: SECURITY)
+            {
+                query: Query
+            }
+
+            directive @key(fields: String!) repeatable on OBJECT | INTERFACE
+            directive @policy(policies: [[policy__Policy!]!]!) on
+              | FIELD_DEFINITION
+              | OBJECT
+              | INTERFACE
+              | SCALAR
+              | ENUM
+
+            scalar policy__Policy
+
+            type Query {
+                account(id: ID!): Account
+            }
+
+            type Account @key(fields: "id") {
+                id: ID!
+                rate: Float @policy(policies: [["view_rate"]])
+            }
+        "#;
+        let subgraph =
+            Subgraph::parse("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
+
+        let supergraph = compose(vec![subgraph]).expect("composition should succeed");
+        assert_snapshot!(supergraph.schema().schema());
+    }
+
+    #[test]
+    fn fed1_with_link_bootstrap_and_inaccessible_spec_import_errors_due_to_collision() {
+        let sdl = r#"
+            schema
+                @link(url: "https://specs.apollo.dev/link/v1.0")
+                @link(url: "https://specs.apollo.dev/inaccessible/v0.2")
+            {
+                query: Query
+            }
+
+            type Query {
+                product(id: ID!): Product
+            }
+
+            type Product {
+                id: ID!
+                name: String!
+                internalCode: String @inaccessible
+            }
+        "#;
+        let subgraph =
+            Subgraph::parse("products", "http://products/graphql", sdl).expect("valid subgraph");
+        let result = compose(vec![subgraph]);
+        assert_composition_errors(
+            &result,
+            &[(
+                "INVALID_LINK_DIRECTIVE_USAGE",
+                r#"[products] Invalid use of @link in schema: import for '@inaccessible' of https://specs.apollo.dev/federation/v2.4 conflicts with spec https://specs.apollo.dev/inaccessible/v0.2"#,
+            )],
+        );
+    }
+
+    #[test]
+    fn fed1_without_link_bootstrap_drops_supergraph_spec_import_of_policy() {
+        let sdl = r#"
+            extend schema
+                @link(url: "https://specs.apollo.dev/policy/v0.1", for: SECURITY)
+
+            directive @key(fields: String!) repeatable on OBJECT | INTERFACE
+            directive @policy(policies: [[policy__Policy!]!]!) on
+              | FIELD_DEFINITION
+              | OBJECT
+              | INTERFACE
+              | SCALAR
+              | ENUM
+
+            scalar policy__Policy
+
+            type Query {
+                account(id: ID!): Account
+            }
+
+            type Account @key(fields: "id") {
+                id: ID!
+                rate: Float @policy(policies: [["view_rate"]])
+            }
+        "#;
+        let subgraph =
+            Subgraph::parse("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
+
+        let supergraph = compose(vec![subgraph]).expect("composition should succeed");
+        let schema = supergraph.schema().schema();
+
+        assert!(
+            !schema.directive_definitions.contains_key("policy"),
+            "Supergraph should NOT contain @policy when @link is not bootstrapped"
+        );
+    }
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_misc__supergraph_spec_imports__fed1_with_link_bootstrap_and_supergraph_spec_import_propagates_policy.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_misc__supergraph_spec_imports__fed1_with_link_bootstrap_and_supergraph_spec_import_propagates_policy.snap
@@ -1,0 +1,54 @@
+---
+source: apollo-federation/tests/composition/compose_misc.rs
+assertion_line: 737
+expression: supergraph.schema().schema()
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://specs.apollo.dev/policy/v0.1", for: SECURITY) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @policy(policies: [[policy__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://accounts/graphql")
+}
+
+scalar join__FieldSet
+
+scalar policy__Policy @join__type(graph: ACCOUNTS)
+
+type Query @join__type(graph: ACCOUNTS) {
+  account(id: ID!): Account
+}
+
+type Account @join__type(graph: ACCOUNTS, key: "id") {
+  id: ID!
+  rate: Float @policy(policies: [["view_rate"]])
+}

--- a/apollo-federation/tests/composition/snapshots/main__composition__compose_misc__supergraph_spec_imports__fed2_with_explicit_supergraph_spec_import_propagates_policy.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__compose_misc__supergraph_spec_imports__fed2_with_explicit_supergraph_spec_import_propagates_policy.snap
@@ -1,0 +1,54 @@
+---
+source: apollo-federation/tests/composition/compose_misc.rs
+assertion_line: 641
+expression: supergraph.schema().schema()
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://specs.apollo.dev/policy/v0.1", for: SECURITY) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @policy(policies: [[policy__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://accounts/graphql")
+}
+
+scalar join__FieldSet
+
+scalar policy__Policy @join__type(graph: ACCOUNTS)
+
+type Query @join__type(graph: ACCOUNTS) {
+  user(id: ID!): Account
+}
+
+type Account @join__type(graph: ACCOUNTS, key: "id") {
+  id: ID!
+  rate: Float @policy(policies: [["view_rate"]])
+}


### PR DESCRIPTION
When directives like `@requiresScopes`, `@policy`, or `@inaccessible` were imported via their own spec URLs (e.g., `@link(url: ".../requiresScopes/v0.1")`) rather than through the federation `@link` import, RS composition silently dropped them from the supergraph. Whereas JS was propagating them to supergraph schema.

The "bug" was in `collect_core_directives_to_compose()` where directives without an explicit import and without a "__" prefix were skipped. The fix uses `linked_elem.name_in_spec` as fallback for the synthetic import element name.
