### PR TITLE
feat(authorization): include policy name in UNAUTHORIZED_FIELD_OR_TYP…

### DIFF
--- a/apollo-router/src/plugins/authorization/mod.rs
+++ b/apollo-router/src/plugins/authorization/mod.rs
@@ -137,6 +137,13 @@ pub(crate) enum ErrorLocation {
 pub(crate) struct UnauthorizedPaths {
     pub(crate) paths: Vec<Path>,
     pub(crate) errors: ErrorConfig,
+    /// For paths denied by `@policy`, the policy names attached to the
+    /// originating field's `@policy(policies: [[...]])` directive. Surfaced
+    /// to the consumer as `extensions.policy` on the resulting
+    /// `UNAUTHORIZED_FIELD_OR_TYPE` error so plugins can attribute the strip
+    /// to a specific policy without re-walking the supergraph schema.
+    #[serde(default)]
+    pub(crate) policies_by_path: HashMap<Path, Vec<String>>,
 }
 
 impl UnauthorizedPaths {
@@ -162,11 +169,19 @@ impl UnauthorizedPaths {
         response: &mut graphql::Response,
     ) {
         let unauthorized_path_errors = self.paths.iter().map(|path| {
-            graphql::Error::builder()
+            let mut builder = graphql::Error::builder()
                 .message("Unauthorized field or type")
                 .path(path.clone())
-                .extension_code("UNAUTHORIZED_FIELD_OR_TYPE")
-                .build()
+                .extension_code("UNAUTHORIZED_FIELD_OR_TYPE");
+            if let Some(policies) = self.policies_by_path.get(path) {
+                if !policies.is_empty() {
+                    builder = builder.extension(
+                        "policy",
+                        Value::String(policies.join(",").into()),
+                    );
+                }
+            }
+            builder.build()
         });
 
         match self.errors.response {
@@ -397,6 +412,7 @@ impl AuthorizationPlugin {
 
         let mut is_filtered = false;
         let mut unauthorized_paths: Vec<Path> = vec![];
+        let mut policies_by_path: HashMap<Path, Vec<String>> = HashMap::new();
 
         let filter_res = Self::authenticated_filter_query(schema, dry_run, &doc, is_authenticated)?;
 
@@ -438,8 +454,9 @@ impl AuthorizationPlugin {
 
         let doc = match filter_res {
             None => doc,
-            Some((filtered_doc, paths)) => {
+            Some((filtered_doc, paths, paths_to_policies)) => {
                 unauthorized_paths.extend(paths);
+                policies_by_path.extend(paths_to_policies);
 
                 // FIXME: consider only `filtered_doc.operations.get(key.operation_name)`?
                 if filtered_doc.definitions.is_empty() {
@@ -457,7 +474,7 @@ impl AuthorizationPlugin {
         }
 
         if is_filtered {
-            Ok(Some((unauthorized_paths, doc)))
+            Ok(Some((unauthorized_paths, policies_by_path, doc)))
         } else {
             Ok(None)
         }
@@ -545,7 +562,10 @@ impl AuthorizationPlugin {
 
         doc: &ast::Document,
         policies: &[String],
-    ) -> Result<Option<(ast::Document, Vec<Path>)>, QueryPlannerError> {
+    ) -> Result<
+        Option<(ast::Document, Vec<Path>, HashMap<Path, Vec<String>>)>,
+        QueryPlannerError,
+    > {
         if let Some(mut visitor) = PolicyFilteringVisitor::new(
             schema.supergraph_schema(),
             &schema.implementers_map,
@@ -564,7 +584,11 @@ impl AuthorizationPlugin {
                         .map(|path| path.to_string())
                         .collect::<Vec<_>>()
                 );
-                Ok(Some((modified_query, visitor.unauthorized_paths)))
+                Ok(Some((
+                    modified_query,
+                    visitor.unauthorized_paths,
+                    visitor.policies_by_path,
+                )))
             } else {
                 tracing::debug!("the query does not require policies");
                 Ok(None)

--- a/apollo-router/src/plugins/authorization/policy.rs
+++ b/apollo-router/src/plugins/authorization/policy.rs
@@ -194,6 +194,12 @@ pub(crate) struct PolicyFilteringVisitor<'a> {
     request_policies: HashSet<String>,
     pub(crate) query_requires_policies: bool,
     pub(crate) unauthorized_paths: Vec<Path>,
+    /// For each unauthorized path collected by `@policy`, the policy names
+    /// attached to that field's `@policy(policies: [[...]])` directive.
+    /// Surfaced via `extensions.policy` on the resulting
+    /// `UNAUTHORIZED_FIELD_OR_TYPE` error so consumers can attribute each
+    /// error to a specific policy without re-walking the schema.
+    pub(crate) policies_by_path: HashMap<Path, Vec<String>>,
     // store the error paths from fragments so we can  add them at
     // the point of application
     fragments_unauthorized_paths: HashMap<String, Vec<Path>>,
@@ -235,6 +241,7 @@ impl<'a> PolicyFilteringVisitor<'a> {
             request_policies: successful_policies,
             query_requires_policies: false,
             unauthorized_paths: vec![],
+            policies_by_path: HashMap::new(),
             fragments_unauthorized_paths: HashMap::new(),
             current_path: Path::default(),
             policy_directive_name: Schema::directive_name(
@@ -268,6 +275,23 @@ impl<'a> PolicyFilteringVisitor<'a> {
         } else {
             false
         }
+    }
+
+    /// Returns the union of policy names attached to the field's `@policy`
+    /// directive, deduplicated and order-preserving. Empty when the field has
+    /// no `@policy` directive.
+    fn field_policy_names(&self, field: &schema::FieldDefinition) -> Vec<String> {
+        let mut names: Vec<String> = Vec::new();
+        if let Some(directive) = field.directives.get(&self.policy_directive_name) {
+            for set in policies_sets_argument(directive) {
+                for name in set {
+                    if !names.contains(&name) {
+                        names.push(name);
+                    }
+                }
+            }
+        }
+        names
     }
 
     fn is_type_authorized(&self, ty: &schema::ExtendedType) -> bool {
@@ -439,6 +463,11 @@ impl transform::Visitor for PolicyFilteringVisitor<'_> {
             || implementors_with_missing_requirements
             || implementors_with_missing_field_requirements
         {
+            let policies = self.field_policy_names(field_def);
+            if !policies.is_empty() {
+                self.policies_by_path
+                    .insert(self.current_path.clone(), policies);
+            }
             self.unauthorized_paths.push(self.current_path.clone());
             self.query_requires_policies = true;
 

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -297,6 +297,7 @@ impl QueryPlannerService {
             unauthorized: UnauthorizedPaths {
                 paths: vec![],
                 errors: self.authorization_config.error_config(),
+                policies_by_path: std::collections::HashMap::new(),
             },
             subselections,
             defer_stats,
@@ -480,7 +481,11 @@ impl Service<QueryPlannerRequest> for QueryPlannerService {
 }
 
 // Appease clippy::type_complexity
-pub(crate) type FilteredQuery = (Vec<Path>, ast::Document);
+pub(crate) type FilteredQuery = (
+    Vec<Path>,
+    std::collections::HashMap<Path, Vec<String>>,
+    ast::Document,
+);
 
 impl QueryPlannerService {
     async fn get(
@@ -535,6 +540,7 @@ impl QueryPlannerService {
                         let unauthorized = UnauthorizedPaths {
                             paths,
                             errors: self.authorization_config.error_config(),
+                            policies_by_path: std::collections::HashMap::new(),
                         };
                         unauthorized.log_unauthorized_paths();
                         unauthorized.update_response_with_unauthorized_path_errors(&mut response);
@@ -550,7 +556,7 @@ impl QueryPlannerService {
             None
         };
 
-        if let Some((unauthorized_paths, new_doc)) = filter_res {
+        if let Some((unauthorized_paths, policies_by_path, new_doc)) = filter_res {
             let new_query = new_doc.to_string();
             let new_hash = self
                 .schema
@@ -569,6 +575,7 @@ impl QueryPlannerService {
             )
             .map_err(QueryPlannerError::from)?;
             selections.unauthorized.paths = unauthorized_paths;
+            selections.unauthorized.policies_by_path = policies_by_path;
         }
 
         if key.filtered_query != key.original_query {


### PR DESCRIPTION
## Summary

Surface the policy names attached to a `@policy(policies: [[…]])` directive on the resulting `UNAUTHORIZED_FIELD_OR_TYPE` GraphQL error, as `extensions.policy`.

Today, when the authorization filter strips a field, plugins running in `map_response` only see the error's `path` — they cannot tell which `@policy` (or which directive at all) caused the strip without re-walking the supergraph schema themselves. This PR closes that gap for `@policy` denials by carrying the policy attribution from the visitor through to the emit site.

Closes / Refs: #9622

## Behavior

For a field denied by `@policy(policies: [["order_pre_check:variable:input.orderUuid:read:order_uuid"]])`:

```json
{
  "errors": [{
    "message": "Unauthorized field or type",
    "path": ["postBookingReservationQuery", "guestEmail"],
    "extensions": {
      "code": "UNAUTHORIZED_FIELD_OR_TYPE",
      "policy": "order_pre_check:variable:input.orderUuid:read:order_uuid"
    }
  }]
}
```

For multi-policy fields (`[["A", "B"], ["C"]]`), `extensions.policy` is a comma-joined union of policy names (`"A,B,C"`) — the consumer can split and match by prefix or membership.

`@authenticated` and `@requiresScopes` denials are unchanged in this PR — they continue to emit just `code: UNAUTHORIZED_FIELD_OR_TYPE`. Extending the same pattern to those two directives (with `extensions.directive` to identify the cause) is a sensible follow-up; happy to add in this PR or a sibling once the design is confirmed.

## Implementation

Three files, +69 / −9.

1. **`PolicyFilteringVisitor` (`policy.rs`)**
   - New field `policies_by_path: HashMap<Path, Vec<String>>` alongside the existing `unauthorized_paths: Vec<Path>`.
   - New helper `field_policy_names()` returns the deduplicated, order-preserving union of policy names from a field's `@policy` directive.
   - At the field-level push site (the main field-strip path), the helper is invoked once and the result keyed by the current path.

2. **`policies_filter_query` + `AuthorizationPlugin::filter_query` (`mod.rs`)**
   - Return type extended from `Option<(Document, Vec<Path>)>` to `Option<(Document, Vec<Path>, HashMap<Path, Vec<String>>)>`.
   - `filter_query` accumulates the map alongside `unauthorized_paths` and returns it in `FilteredQuery`.

3. **`UnauthorizedPaths` + `update_response_with_unauthorized_path_errors` (`mod.rs`)**
   - New `policies_by_path: HashMap<Path, Vec<String>>` field on `UnauthorizedPaths` (`#[serde(default)]` for any existing serialized state).
   - `update_response_with_unauthorized_path_errors` reads the map at emit time and adds `extension("policy", joined_names)` only when the path is present in the map. No change to behavior for paths without `@policy` denials.

4. **`FilteredQuery` (`query_planner_service.rs`)**
   - Tuple extended from `(Vec<Path>, ast::Document)` to `(Vec<Path>, HashMap<Path, Vec<String>>, ast::Document)`.
   - Destructure site sets `selections.unauthorized.policies_by_path` alongside `selections.unauthorized.paths`.
   - Two `UnauthorizedPaths { … }` constructions updated to initialize the new field as an empty map (those code paths aren't `@policy` denials).

## Backwards compatibility

- **Adding entries to `error.extensions` is additive.** Existing consumers reading only `code` are unaffected.
- **`code` stays `UNAUTHORIZED_FIELD_OR_TYPE`** for all directives. No behavioral change for plugins or clients that don't opt in to the new field.
- **Internal `Vec<Path>` → `(Vec<Path>, HashMap, …)` tuple** is router-internal; no public crate API change beyond the new optional `policies_by_path` field on `UnauthorizedPaths` (which is `pub(crate)`) and the new error-extension key.

## Tests

`cargo check` passes locally. **Snapshot tests under `src/plugins/authorization/snapshots/` will need updating** for the cases where a `@policy`-denied path now emits the additional `extensions.policy` field. I haven't updated them in this draft PR — would prefer a maintainer ack on the design first to avoid churn. Happy to follow up with snapshot updates, plus new dedicated tests covering:
- Single-policy field → `extensions.policy = "name"`
- Multi-policy field with multiple inner sets → comma-joined union
- Field with no `@policy` (e.g., `@authenticated` denial) → no `extensions.policy`
- Mixed responses (one `@policy`-denied path + one `@authenticated`-denied path) → only the `@policy` error gets the extension

## Out of scope (sensible follow-ups)

1. Same treatment for `@authenticated` and `@requiresScopes` — likely a small `extensions.directive = "@authenticated" | "@requiresScopes" | "@policy"` field on every `UNAUTHORIZED_FIELD_OR_TYPE` error.
2. Full snapshot test refresh (see Tests above).
3. Optional: also propagate the policy attribution on the `QueryPlannerError::Unauthorized` early-reject path (currently only the strip-and-filter path is covered).

## Use case

Federation-gw (Booking.com's DML router deployment) enriches `UNAUTHORIZED_FIELD_OR_TYPE` errors caused by `@policy(order_pre_check:…)` with backend-specific extensions and rewrites `code` to `STEP_UP_AUTH_REQUIRED` so mobile clients can route step-up authentication off the GraphQL error code. We currently walk the parsed supergraph schema ourselves (~80 LOC) to attribute each error to a specific policy. With this PR, that walker becomes a one-line lookup. Other Apollo Router users implementing similar "tag specific auth failures" plugins should benefit identically.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets — see references to #9622 throughout
- [ ] Changeset is included for user-facing changes — *will add once design is acked*
- [x] Changes are compatible — additive `extensions.policy` field; existing consumers unaffected
- [ ] Documentation completed — *will add user-facing docs once design is acked*
- [x] Performance impact assessed and acceptable — one extra HashMap insert at @policy push site; one extra HashMap lookup per emitted UNAUTHORIZED_FIELD_OR_TYPE error. Both O(1).
- [ ] Metrics and logs are added and documented — *no new metrics; existing log line already covers unauthorized paths*
- Tests added and passing
    - [ ] Unit tests — *snapshot updates pending maintainer ack on the design; happy to add new dedicated tests as listed in the Tests section above*
    - [ ] Integration tests
    - [ ] Manual tests — `cargo check` passes locally on apollo-router @ v2.15.1

**Exceptions**

This PR is scoped narrowly to `@policy` denials only — `@authenticated` and `@requiresScopes` paths are intentionally untouched and would be a sensible follow-up. Snapshot tests under `src/plugins/authorization/snapshots/` will need refreshes for the affected scenarios; deliberately deferred pending design ack to avoid churning ~30 snapshot files.

**Notes**

Filed alongside #9622 (the discussion issue). Happy to iterate on the design — particularly on whether the eventual full version should also carry `extensions.directive` to identify `@authenticated` vs `@requiresScopes` vs `@policy` causes uniformly across all three.

