### PR TITLE
ci: always post claude review decision as PR comment

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: '--model claude-opus-4-8'
+          claude_args: '--model claude-opus-4-8 --append-system-prompt "Always post a PR comment summarizing your decision, even if you decide to STOP without doing a full review."'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }} --comment'

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -50,3 +50,19 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }} --comment'
           show_full_output: true
+
+      - name: Post decision comment if agent did not
+        if: steps.team-check.outputs.is_member == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          RESULT=$(jq -r '.result // empty' /home/runner/work/_temp/claude-execution-output.json)
+          [ -z "$RESULT" ] && exit 0
+
+          EXISTING=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --comments --json comments \
+            | jq -r '[.comments[] | select(.body | contains("## Code review"))] | length')
+
+          if [ "$EXISTING" -eq 0 ]; then
+            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$RESULT"
+          fi

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -71,19 +71,3 @@ jobs:
           # forms between runs (-X POST vs --method POST, with/without a
           # leading slash, inline body vs heredoc via cat). The token scope is
           # the real security boundary here.
-
-      - name: Post decision comment if agent did not
-        if: steps.team-check.outputs.is_member == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          RESULT=$(jq -r '.result // empty' /home/runner/work/_temp/claude-execution-output.json)
-          [ -z "$RESULT" ] && exit 0
-
-          EXISTING=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --comments --json comments \
-            | jq -r '[.comments[] | select(.body | contains("## Code review"))] | length')
-
-          if [ "$EXISTING" -eq 0 ]; then
-            gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$RESULT"
-          fi

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -48,5 +48,5 @@ jobs:
           claude_args: '--model claude-opus-4-8'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }} --comment'
           show_full_output: true


### PR DESCRIPTION
## Summary

- When the review pre-check returns STOP (e.g. automated forward-port PRs like #9611), no comment was posted to the PR despite `--comment` being set
- Adds a follow-up step that reads the `result` field from Claude's output JSON and posts it as a PR comment if no `## Code review` comment already exists
- On a full review the comment is already there, so the step is a no-op

## Test plan

- [ ] Trigger `/claude-review` on an automated forward-port PR — should now see Claude's STOP reasoning posted as a comment
- [ ] Trigger `/claude-review` on a normal PR — step should be a no-op (comment already posted by the review itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)