### PR TITLE
feat(composition): Port new `@link` validations 

### DIFF
--- a/apollo-federation/src/connectors/expand/carryover.rs
+++ b/apollo-federation/src/connectors/expand/carryover.rs
@@ -112,7 +112,7 @@ pub(super) fn carryover_directives(
         if !referencers.is_empty()
             && to
                 .metadata()
-                .and_then(|m| m.by_identity.get(&Identity::inaccessible_identity()))
+                .and_then(|m| m.for_identity(&Identity::inaccessible_identity()))
                 .is_none()
         {
             SchemaDefinitionPosition
@@ -206,15 +206,23 @@ pub(super) fn carryover_directives(
     // compose directive
 
     metadata
-        .directives_by_imported_name
+        .by_import_element_name_in_schema()
         .iter()
-        .filter(|(_name, (link, _import))| !is_known_link(link))
-        .try_for_each(|(name, (link, import))| {
+        .filter_map(|(name_in_schema, (link, name_in_spec))| {
+            if is_known_link(link) {
+                return None;
+            }
+            if !name_in_schema.is_directive {
+                return None;
+            }
+            Some((&name_in_schema.name, (link, &name_in_spec.name)))
+        })
+        .try_for_each(|(name_in_schema, (link, name_in_spec))| {
             // This is a strange thing — someone is importing @defer, but it's not a type system directive so we don't need to carry it over
-            if name == "defer" {
+            if name_in_schema == "defer" {
                 return Ok(());
             }
-            let directive_name = link.directive_name_in_schema(&import.element);
+            let directive_name = link.directive_name_in_schema(name_in_spec);
             let referencers = from.referencers().get_directive(&directive_name);
             if !referencers.is_empty() {
                 if !SchemaDefinitionPosition
@@ -380,6 +388,10 @@ pub(super) fn carryover_directives(
 }
 
 fn is_known_link(link: &Link) -> bool {
+    let Some(name) = link.url.identity.name.clone().try_into().ok() else {
+        return false;
+    };
+
     link.url.identity.domain == APOLLO_SPEC_DOMAIN
         && [
             name!(link),
@@ -391,7 +403,7 @@ fn is_known_link(link: &Link) -> bool {
             name!(policy),
             name!(context),
         ]
-        .contains(&link.url.identity.name)
+        .contains(&name)
 }
 
 fn copy_directive_definition(

--- a/apollo-federation/src/connectors/spec/mod.rs
+++ b/apollo-federation/src/connectors/spec/mod.rs
@@ -142,7 +142,7 @@ impl ConnectSpec {
     pub(crate) fn identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: CONNECT_IDENTITY_NAME,
+            name: CONNECT_IDENTITY_NAME.into(),
         }
     }
 
@@ -211,7 +211,9 @@ impl ConnectSpecDefinition {
         };
 
         let url: Url = url.parse()?;
-        if url.identity.domain != APOLLO_SPEC_DOMAIN || url.identity.name != CONNECT_IDENTITY_NAME {
+        if url.identity.domain != APOLLO_SPEC_DOMAIN
+            || url.identity.name.as_ref() != CONNECT_IDENTITY_NAME.as_str()
+        {
             return Ok(None);
         }
 

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -185,7 +185,7 @@ pub(crate) fn validate_supergraph(
         }
         .into());
     };
-    let link_spec_definition = metadata.link_spec_definition()?;
+    let link_spec_definition = metadata.link_spec_definition();
     let Some(join_link) = metadata.for_identity(&Identity::join_identity()) else {
         return Err(SingleFederationError::InvalidFederationSupergraph {
             message: "Invalid supergraph: must use the join spec".to_owned(),
@@ -349,12 +349,9 @@ fn check_spec_support(
         bail!("Schema must have metadata");
     };
     let mut errors = MultipleFederationErrors::new();
-    let link_spec = metadata.link_spec_definition()?;
+    let link_spec = metadata.link_spec_definition();
     if is_core_version_zero_dot_one(link_spec.url()) {
-        let has_link_with_purpose = metadata
-            .all_links()
-            .iter()
-            .any(|link| link.purpose.is_some());
+        let has_link_with_purpose = metadata.all_links().any(|link| link.purpose.is_some());
         if has_link_with_purpose {
             // PORT_NOTE: This is unreachable since the schema is validated before this check in
             //            Rust and a apollo-compiler error will have been raised already. This is
@@ -372,7 +369,7 @@ fn check_spec_support(
 
     let supported_specs: HashSet<_> = supported_specs.iter().collect();
     errors
-        .and_try(metadata.all_links().iter().try_for_all(|link| {
+        .and_try(metadata.all_links().try_for_all(|link| {
             let Some(purpose) = link.purpose else {
                 return Ok(());
             };

--- a/apollo-federation/src/link/link_spec_definition.rs
+++ b/apollo-federation/src/link/link_spec_definition.rs
@@ -187,18 +187,10 @@ impl TryFrom<&Value> for Import {
 
 impl From<&Import> for Value {
     fn from(value: &Import) -> Self {
-        let element_string = if value.is_directive {
-            format!("@{}", value.element)
-        } else {
-            value.element.to_string()
-        };
+        let element_string = value.element_name_in_spec().to_string();
 
-        if let Some(alias) = &value.alias {
-            let alias_string = if value.is_directive {
-                format!("@{}", alias)
-            } else {
-                alias.to_string()
-            };
+        if value.alias.is_some() {
+            let alias_string = value.element_name_in_schema().to_string();
             Value::Object(vec![
                 (
                     IMPORT_TYPE_NAME_FIELD_NAME,
@@ -215,151 +207,39 @@ impl From<&Import> for Value {
     }
 }
 
-/// Note that the generated [Link] won't contain `line_column_range` data, as that requires the
-/// schema the directive originated from along with the `Node` wrapping the `Directive`. Use
-/// [Link::from_directive_application] to also populate that data.
-impl TryFrom<&Directive> for Link {
-    type Error = FederationError;
-
-    fn try_from(value: &Directive) -> Result<Self, Self::Error> {
-        let (url, is_link) = if let Some(value) = value.specified_argument_by_name("url") {
-            (value, true)
-        } else if let Some(value) = value.specified_argument_by_name("feature") {
-            // XXX(@goto-bus-stop): @core compatibility is primarily to support old tests--should be
-            // removed when those are updated.
-            (value, false)
-        } else {
-            return Err(SingleFederationError::InvalidLinkDirectiveUsage {
-                message: format!(
-                    r#"`{}` missing required argument "url""#,
-                    value.serialize().no_indent()
-                ),
-            }
-            .into());
-        };
-
-        let (directive_name, arg_name) = if is_link {
-            ("link", "url")
-        } else {
-            ("core", "feature")
-        };
-
-        let url = url
-            .as_str()
-            .ok_or_else(|| SingleFederationError::InvalidLinkDirectiveUsage {
-                message: format!(
-                    r#"@{directive_name}({arg_name}:) argument `{}` must be a string"#,
-                    url.serialize().no_indent()
-                ),
-            })?;
-        let url: Url = url.parse::<Url>()?;
-
-        let spec_alias = value
-            .specified_argument_by_name("as")
-            .take_if(|arg| !arg.is_null())
-            .map(|arg| {
-                arg.as_str()
-                    .ok_or_else(|| SingleFederationError::InvalidLinkDirectiveUsage {
-                        message: format!(
-                            r#"@{directive_name}(as:) argument `{}` must be a string or null"#,
-                            arg.serialize().no_indent()
-                        ),
-                    })
-            })
-            .transpose()?
-            .map(Name::new)
-            .transpose()?;
-        let purpose = value
-            .specified_argument_by_name("for")
-            .take_if(|arg| !arg.is_null())
-            .map(|arg| Purpose::try_from(arg.as_ref()))
-            .transpose()?;
-
-        let imports = if is_link {
-            value
-                .specified_argument_by_name("import")
-                .take_if(|arg| !arg.is_null())
-                .map(|arg| {
-                    // Note that list input coercion rules mandate that when the value is not
-                    // a list and not null then it is wrapped into a list of size one.
-                    if let Value::List(value) = arg.as_ref() {
-                        value
-                    } else {
-                        std::slice::from_ref(arg)
-                    }
-                })
-                .unwrap_or(&[])
-                .iter()
-                .map(|value| Ok(Arc::new(Import::try_from(value.as_ref())?)))
-                .collect::<Result<Vec<Arc<Import>>, FederationError>>()?
-        } else {
-            Default::default()
-        };
-
-        Ok(Link {
-            url,
-            spec_alias,
-            imports,
-            purpose,
-            line_column_range: None,
-        })
-    }
-}
-
-/// Note that the generated directive assumes the default directive name of @link.
-impl From<&Link> for Directive {
-    fn from(value: &Link) -> Self {
-        let mut arguments = Vec::new();
-        arguments.push(Node::new(Argument {
-            name: LINK_DIRECTIVE_URL_ARGUMENT_NAME.clone(),
-            value: Node::new(Value::String(value.url.to_string())),
-        }));
-        if let Some(spec_alias) = &value.spec_alias {
-            arguments.push(Node::new(Argument {
-                name: LINK_DIRECTIVE_AS_ARGUMENT_NAME.clone(),
-                value: Node::new(Value::String(spec_alias.to_string())),
-            }));
-        }
-        if !value.imports.is_empty() {
-            arguments.push(Node::new(Argument {
-                name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME.clone(),
-                value: Node::new(Value::List(
-                    value
-                        .imports
-                        .iter()
-                        .map(|import| Node::new(Value::from(import.as_ref())))
-                        .collect(),
-                )),
-            }));
-        }
-        if let Some(purpose) = &value.purpose {
-            arguments.push(Node::new(Argument {
-                name: LINK_DIRECTIVE_FOR_ARGUMENT_NAME.clone(),
-                value: Node::new(Value::from(purpose)),
-            }));
-        }
-        Directive {
-            name: Identity::link_identity().name.clone(),
-            arguments,
-        }
-    }
-}
-
+#[derive(Debug)]
 pub(crate) struct LinkSpecDefinition {
     url: Url,
+    name: Name,
     minimum_federation_version: Version,
 }
 
 impl LinkSpecDefinition {
     pub(crate) fn new(
         version: Version,
-        identity: Identity,
         minimum_federation_version: Version,
+        is_link: bool,
     ) -> Self {
         Self {
-            url: Url { identity, version },
+            url: Url {
+                identity: if is_link {
+                    Identity::link_identity()
+                } else {
+                    Identity::core_identity()
+                },
+                version,
+            },
+            name: if is_link {
+                Identity::LINK_NAME
+            } else {
+                Identity::CORE_NAME
+            },
             minimum_federation_version,
         }
+    }
+
+    pub(crate) fn name(&self) -> &Name {
+        &self.name
     }
 
     fn create_definition_argument_specifications(&self) -> Vec<DirectiveArgumentSpecification> {
@@ -429,10 +309,134 @@ impl LinkSpecDefinition {
     }
 
     pub(crate) fn url_arg_name(&self) -> Name {
-        if self.url.identity.name == Identity::core_identity().name {
+        if self.name == Identity::CORE_NAME {
             LINK_DIRECTIVE_FEATURE_ARGUMENT_NAME
         } else {
             LINK_DIRECTIVE_URL_ARGUMENT_NAME
+        }
+    }
+
+    pub(crate) fn link_from_directive(
+        &self,
+        directive: &Node<Directive>,
+        schema: &Schema,
+    ) -> Result<Link, FederationError> {
+        let url = if let Some(value) = directive.specified_argument_by_name(&self.url_arg_name()) {
+            value
+        } else {
+            return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                message: format!(
+                    r#"`{}` missing required argument "{}""#,
+                    directive.serialize().no_indent(),
+                    self.url_arg_name(),
+                ),
+            }
+            .into());
+        };
+
+        let url = url
+            .as_str()
+            .ok_or_else(|| SingleFederationError::InvalidLinkDirectiveUsage {
+                message: format!(
+                    r#"@{}({}:) argument `{}` must be a string"#,
+                    self.name,
+                    self.url_arg_name(),
+                    url.serialize().no_indent()
+                ),
+            })?;
+        let url: Url = url.parse::<Url>()?;
+
+        let spec_alias = directive
+            .specified_argument_by_name("as")
+            .take_if(|arg| !arg.is_null())
+            .map(|arg| {
+                arg.as_str()
+                    .ok_or_else(|| SingleFederationError::InvalidLinkDirectiveUsage {
+                        message: format!(
+                            r#"@{}(as:) argument `{}` must be a string or null"#,
+                            self.name,
+                            arg.serialize().no_indent()
+                        ),
+                    })
+            })
+            .transpose()?
+            .map(Name::new)
+            .transpose()?;
+
+        let purpose = if self.supports_purpose() {
+            directive
+                .specified_argument_by_name("for")
+                .take_if(|arg| !arg.is_null())
+                .map(|arg| Purpose::try_from(arg.as_ref()))
+                .transpose()?
+        } else {
+            None
+        };
+
+        let imports = if self.supports_import() {
+            directive
+                .specified_argument_by_name("import")
+                .take_if(|arg| !arg.is_null())
+                .map(|arg| {
+                    // Note that list input coercion rules mandate that when the value is not
+                    // a list and not null then it is wrapped into a list of size one.
+                    if let Value::List(value) = arg.as_ref() {
+                        value
+                    } else {
+                        std::slice::from_ref(arg)
+                    }
+                })
+                .unwrap_or(&[])
+                .iter()
+                .map(|value| Ok(Arc::new(Import::try_from(value.as_ref())?)))
+                .collect::<Result<Vec<Arc<Import>>, FederationError>>()?
+        } else {
+            Default::default()
+        };
+
+        Ok(Link {
+            url,
+            spec_alias,
+            imports,
+            purpose,
+            line_column_range: directive.line_column_range(&schema.sources),
+        })
+    }
+
+    pub(crate) fn directive_from_link(&self, link: &Link) -> Directive {
+        let mut arguments = Vec::new();
+        arguments.push(Node::new(Argument {
+            name: self.url_arg_name().clone(),
+            value: Node::new(Value::String(link.url.to_string())),
+        }));
+        if let Some(spec_alias) = &link.spec_alias {
+            arguments.push(Node::new(Argument {
+                name: LINK_DIRECTIVE_AS_ARGUMENT_NAME.clone(),
+                value: Node::new(Value::String(spec_alias.to_string())),
+            }));
+        }
+        if self.supports_import() && !link.imports.is_empty() {
+            arguments.push(Node::new(Argument {
+                name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME.clone(),
+                value: Node::new(Value::List(
+                    link.imports
+                        .iter()
+                        .map(|import| Node::new(Value::from(import.as_ref())))
+                        .collect(),
+                )),
+            }));
+        }
+        if self.supports_purpose()
+            && let Some(purpose) = &link.purpose
+        {
+            arguments.push(Node::new(Argument {
+                name: LINK_DIRECTIVE_FOR_ARGUMENT_NAME.clone(),
+                value: Node::new(Value::from(purpose)),
+            }));
+        }
+        Directive {
+            name: self.name.clone(),
+            arguments,
         }
     }
 
@@ -570,7 +574,7 @@ impl LinkSpecDefinition {
         // Side-note: this test must be done _before_ we call `insert_directive`, otherwise it
         // would take it into account.
 
-        let name = alias.as_ref().unwrap_or(&self.url.identity.name).clone();
+        let name = alias.as_ref().unwrap_or(&self.name).clone();
         let mut arguments = vec![Node::new(Argument {
             name: self.url_arg_name(),
             value: self.url.to_string().into(),
@@ -630,7 +634,7 @@ impl LinkSpecDefinition {
         imports: Vec<Arc<Import>>,
     ) -> Result<(), FederationError> {
         if let Some(metadata) = schema.metadata() {
-            let link_spec_def = metadata.link_spec_definition()?;
+            let link_spec_def = metadata.link_spec_definition();
             if link_spec_def.url.identity == *self.identity() {
                 // Already exists with the same version, let it be.
                 return Ok(());
@@ -676,8 +680,19 @@ impl LinkSpecDefinition {
         alias: Option<Name>,
         purpose: Option<Purpose>,
         imports: Option<Vec<Import>>,
+        mut on_apply_error: impl FnMut(FederationError) -> Result<(), FederationError>,
     ) -> Result<(), FederationError> {
-        let mut directive = Directive::new(self.url.identity.name.clone());
+        let Some(metadata) = schema.metadata() else {
+            bail!("Schema unexpectedly not a link schema (add @link first)");
+        };
+        if metadata.link_itself().url != self.url {
+            bail!(
+                "Cannot use this version of @link ({}), the schema uses version {}",
+                self.url,
+                metadata.link_itself().url,
+            );
+        }
+        let mut directive = Directive::new(metadata.link_itself().spec_name_in_schema());
         directive.arguments.push(Node::new(Argument {
             name: self.url_arg_name(),
             value: Node::new(feature.to_string().into()),
@@ -725,7 +740,11 @@ impl LinkSpecDefinition {
             }
         }
 
-        SchemaDefinitionPosition.insert_directive(schema, Component::new(directive))?;
+        if let Err(error) =
+            SchemaDefinitionPosition.insert_directive(schema, Component::new(directive))
+        {
+            on_apply_error(error)?;
+        };
         feature.add_elements_to_schema(schema)?;
 
         Ok(())
@@ -754,7 +773,7 @@ impl SpecDefinition for LinkSpecDefinition {
 
     fn directive_specs(&self) -> Vec<Box<dyn TypeAndDirectiveSpecification>> {
         vec![Box::new(DirectiveSpecification::new(
-            self.url().identity.name.clone(),
+            self.name().clone(),
             &self.create_definition_argument_specifications(),
             true,
             &[DirectiveLocation::Schema],
@@ -823,13 +842,13 @@ pub(crate) static CORE_VERSIONS: LazyLock<SpecDefinitions<LinkSpecDefinition>> =
         let mut definitions = SpecDefinitions::new(Identity::core_identity());
         definitions.add(LinkSpecDefinition::new(
             Version { major: 0, minor: 1 },
-            Identity::core_identity(),
             Version { major: 1, minor: 0 },
+            false,
         ));
         definitions.add(LinkSpecDefinition::new(
             Version { major: 0, minor: 2 },
-            Identity::core_identity(),
             Version { major: 2, minor: 0 },
+            false,
         ));
         definitions
     });
@@ -838,8 +857,8 @@ pub(crate) static LINK_VERSIONS: LazyLock<SpecDefinitions<LinkSpecDefinition>> =
         let mut definitions = SpecDefinitions::new(Identity::link_identity());
         definitions.add(LinkSpecDefinition::new(
             Version { major: 1, minor: 0 },
-            Identity::link_identity(),
             Version { major: 2, minor: 0 },
+            true,
         ));
         definitions
     });

--- a/apollo-federation/src/link/metadata.rs
+++ b/apollo-federation/src/link/metadata.rs
@@ -1,50 +1,90 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::LazyLock;
 
 use apollo_compiler::Name;
 use apollo_compiler::Schema;
-use apollo_compiler::collections::HashSet;
+use apollo_compiler::collections::HashMap;
 use apollo_compiler::collections::IndexMap;
+use apollo_compiler::collections::IndexSet;
+use indexmap::map::Entry;
 
+use crate::bail;
 use crate::error::FederationError;
+use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
+use crate::error::suggestion::did_you_mean;
+use crate::error::suggestion::suggestion_list;
+use crate::link::ElementName;
 use crate::link::Import;
 use crate::link::Link;
-use crate::link::federation_spec_definition::FED_1;
-use crate::link::federation_spec_definition::FEDERATION_VERSIONS;
-use crate::link::federation_spec_definition::FederationSpecDefinition;
 use crate::link::link_spec_definition::CORE_VERSIONS;
 use crate::link::link_spec_definition::LINK_VERSIONS;
 use crate::link::link_spec_definition::LinkSpecDefinition;
 use crate::link::spec::Identity;
 use crate::link::spec::Url;
-use crate::link::spec::Version;
-use crate::link::spec_definition::SpecDefinition;
+use crate::link::spec_registry::SPEC_REGISTRY;
+use crate::schema::FederationSchema;
+use crate::schema::position::TypeDefinitionPosition;
 
+/// Metadata about a type/directive belonging to an @link application.
 #[derive(Clone, Debug)]
 pub struct LinkedElement {
+    /// Metadata about the @link application the type/directive belongs to.
     pub link: Arc<Link>,
-    pub import: Option<Arc<Import>>,
-    pub name: Name,
-    pub name_in_spec: Name,
+    /// The name-in-spec of the type/directive. Note that if the type/directive uses a default name
+    /// but its name-in-spec was imported already under a different name (a.k.a. a shadowing
+    /// import) or its name-in-spec is an invalid name, this method will still consider it to belong
+    /// to that @link application, but its name-in-spec will be `None`.
+    pub name_in_spec: Option<Name>,
 }
 
-#[derive(Clone, Eq, PartialEq, Debug)]
+/// Metadata about all the applications of @link in a schema.
+// PORT_NOTE: Named `CoreFeatures` in the JS codebase, but "core" is outdated terminology. Note that
+//            while the JS version allowed adding/removing @link applications, this version does not
+//            and instead computes all metadata from the whole schema at construction. This is less
+//            efficient, but slightly less bug-prone; if this becomes a hot function in the future,
+//            we should consider splitting this up to similarly allow @link addition/removal. A
+//            result of this change is that `conflictsByAlias` from the JS codebase doesn't need to
+//            be tracked here.
+#[derive(Clone, Debug)]
 pub struct LinksMetadata {
-    pub(crate) links: Vec<Arc<Link>>,
-    pub(crate) by_identity: IndexMap<Identity, Arc<Link>>,
-    pub(crate) by_name_in_schema: IndexMap<Name, Arc<Link>>,
-    pub(crate) types_by_imported_name: IndexMap<Name, (Arc<Link>, Arc<Import>)>,
-    pub(crate) directives_by_imported_name: IndexMap<Name, (Arc<Link>, Arc<Import>)>,
+    /// The [Link] for the link spec (or core spec) for the schema.
+    link_itself: Arc<Link>,
+    /// The [LinkSpecDefinition] for the link spec (or core spec) for the schema.
+    link_spec_definition: &'static LinkSpecDefinition,
+    /// For specs, a map from their names-in-schema to their [Link]s.
+    // PORT_NOTE: Named `byAlias` in the JS codebase, but this was confusing terminology.
+    by_spec_name_in_schema: IndexMap<Arc<str>, Arc<Link>>,
+    /// For specs, a map from their identities to their [Link]s plus another map from imported
+    /// type/directive names-in-spec to names-in-schema.
+    by_identity: IndexMap<Identity, (Arc<Link>, IndexMap<ElementName, ElementName>)>,
+    /// For imported types/directives, this is a map from their names-in-schema to their [Link]s
+    /// plus names-in-spec.
+    // PORT_NOTE: Named `byImportName` in the JS codebase, but this was confusing terminology.
+    by_import_element_name_in_schema: IndexMap<ElementName, (Arc<Link>, ElementName)>,
 }
 
 impl LinksMetadata {
-    /// Create @link metadata from a schema.
+    /// Create @link metadata from a schema. Specifically it:
+    /// 1. Finds the bootstrapping @link directive and definition (and ensures there's only one).
+    /// 2. Runs link spec validations against @link applications.
+    /// 3. Checks if imports are for known elements for @link applications with known specs.
+    /// 4. Collects metadata about @link applications.
+    ///
+    /// It does not:
+    /// 1. Expand definitions for any linked specs (including the link spec itself).
+    /// 2. Require definitions to be expanded, other than for the bootstrapping @link directive.
+    /// 3. Run non-link spec validations against @link applications with known specs.
+    /// 4. Run validations to ensure no used shadowing imports (this must be done separately, after
+    ///    definitions have been expanded and referencers collected).
+    // PORT_NOTE: As noted in the comment on `LinksMetadata`, this method constructs metadata all at
+    //            once instead of through individual @link adding removing. Unlike the JS codebase,
+    //            this method doesn't expand definitions for known versions of the federation spec.
     pub fn from_schema(schema: &Schema) -> Result<Option<LinksMetadata>, FederationError> {
-        // This finds "bootstrap" uses of @link / @core regardless of order. By spec,
-        // the bootstrap directive application must be the first application of @link / @core, but
-        // this was not enforced by the JS implementation, so we match it for backward compatibility.
+        // This finds "bootstrap" uses of @link/@core regardless of order. By spec, the bootstrap
+        // directive application must be the first application of @link/@core, but this was not
+        // enforced by the JS implementation, so we match it for backward compatibility.
         let mut bootstrap_directives = schema
             .schema_definition
             .directives
@@ -57,287 +97,1249 @@ impl LinksMetadata {
         if let Some(extraneous_directive) = bootstrap_directives.next() {
             return Err(SingleFederationError::InvalidLinkDirectiveUsage {
                 message: format!(
-                    "Invalid use of @link in schema: the @link for the link specification itself (\"{}\") is applied multiple times",
-                    extraneous_directive
-                        .specified_argument_by_name("url")
-                        // XXX(@goto-bus-stop): @core compatibility is primarily to support old tests in other projects,
-                        // and should be removed when those are updated.
-                        .or(extraneous_directive.specified_argument_by_name("feature"))
-                        .and_then(|value| value.as_str().map(Cow::Borrowed))
-                        .unwrap_or_else(|| Cow::Owned(Identity::link_identity().to_string()))
+                    "Cannot link the link/core feature itself in `{}` since it has already been linked in `{}`",
+                    extraneous_directive.serialize().no_indent(),
+                    bootstrap_directive.serialize().no_indent()
                 )
             }.into());
         }
-
-        // At this point, we know this schema uses "our" @link. So we now "just" want to validate
-        // all of the @link usages (starting with the bootstrapping one) and extract their metadata.
-        let link_name_in_schema = &bootstrap_directive.name;
-        let mut links = Vec::new();
-        let mut by_identity = IndexMap::default();
-        let mut by_name_in_schema = IndexMap::default();
-        let mut types_by_imported_name = IndexMap::default();
-        let mut directives_by_imported_name = IndexMap::default();
-        let link_applications = schema
-            .schema_definition
-            .directives
-            .iter()
-            .filter(|d| d.name == *link_name_in_schema);
-        for application in link_applications {
-            let link = Arc::new(Link::from_directive_application(application, schema)?);
-            links.push(Arc::clone(&link));
-            if by_identity
-                .insert(link.url.identity.clone(), Arc::clone(&link))
-                .is_some()
-            {
-                // XXX(Sylvain): We may want to loosen this limitation at some point. Including the same feature for 2 different major versions should be ok.
-                return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+        // Attempt to parse the bootstrap directive while not knowing the link spec version, but
+        // only keep the URL (which tells us the link spec version).
+        let url =
+            Link::from_directive_application_when_link_spec_unknown(bootstrap_directive, schema)?
+                .url;
+        let link_spec_definition = if url.identity == Identity::link_identity() {
+            LINK_VERSIONS.find(&url.version).ok_or_else(|| {
+                SingleFederationError::UnknownLinkVersion {
                     message: format!(
-                        "Invalid use of @link in schema: duplicate @link inclusion of specification \"{}\"",
-                        link.url.identity
-                    )
-                }.into());
-            }
-            let name_in_schema = link.spec_name_in_schema();
-            if let Some(other) = by_name_in_schema.insert(name_in_schema.clone(), Arc::clone(&link))
-            {
-                return Err(SingleFederationError::InvalidLinkDirectiveUsage {
-                    message: format!(
-                        "Invalid use of @link in schema: name conflict: {} and {} are imported under the same name (consider using the `@link(as:)` argument to disambiguate)",
-                        other.url, link.url,
-                    )
-                }.into());
-            }
-        }
-
-        // We do a 2nd pass to collect and validate all the imports (it's a separate path so we
-        // know all the names of the spec linked in the schema).
-        for link in &links {
-            if link.url.identity == Identity::federation_identity() {
-                Self::validate_federation_imports(link)?;
-            }
-
-            for import in &link.imports {
-                let imported_name = import.imported_name();
-                let element_map = if import.is_directive {
-                    // The name of each spec (in the schema) acts as an implicit import for a
-                    // directive of the same name. So one cannot import a directive with the
-                    // same name than a linked spec (unless that implicit import is explicitly
-                    // renamed).
-                    if let Some(other) = by_name_in_schema.get(imported_name)
-                        && !Arc::ptr_eq(other, link)
-                        && !other.renames(imported_name)
-                    {
-                        return Err(SingleFederationError::InvalidLinkDirectiveUsage {
-                            message: format!(
-                                "Invalid use of @link in schema: import for '{}' of {} conflicts with spec {}",
-                                import.imported_display_name(),
-                                link.url,
-                                other.url
-                            )
-                        }.into());
-                    }
-                    &mut directives_by_imported_name
-                } else {
-                    &mut types_by_imported_name
-                };
-                // Conflicting imports are not allowed, except for duplicate imports within the same
-                // @link application. Although it's odd, JS composition allows it.
-                if let Some((other_link, _)) = element_map.insert(
-                    imported_name.clone(),
-                    (Arc::clone(link), Arc::clone(import)),
-                ) && !Arc::ptr_eq(&other_link, link)
-                {
-                    return Err(SingleFederationError::InvalidLinkDirectiveUsage {
-                        message: format!(
-                            "Invalid use of @link in schema: name conflict: both {} and {} import {}",
-                            link.url,
-                            other_link.url,
-                            import.imported_display_name()
-                        )
-                    }.into());
+                        r#"Schema uses unknown version {} of the {} spec"#,
+                        url.version,
+                        Identity::LINK_NAME,
+                    ),
                 }
+            })
+        } else if url.identity == Identity::core_identity() {
+            CORE_VERSIONS.find(&url.version).ok_or_else(|| {
+                SingleFederationError::UnknownLinkVersion {
+                    message: format!(
+                        r#"Schema uses unknown version {} of the {} spec"#,
+                        url.version,
+                        Identity::CORE_NAME,
+                    ),
+                }
+            })
+        } else {
+            bail!("Unexpectedly found non-link/core URL for bootstrap directive");
+        }?;
+
+        // Now that we know the @link/@core directive's name-in-schema and the `LinkSpecDefinition`,
+        // we can properly parse each @link/@core directive application.
+        let link_directive_name_in_schema = &bootstrap_directive.name;
+        let mut link_itself: Option<_> = None;
+        let mut by_spec_name_in_schema = Default::default();
+        let mut by_identity = Default::default();
+        let mut by_import_element_name_in_schema = Default::default();
+        // For composed elements, merge will generally keep the names-in-schema of spec elements in
+        // subgraphs as a way to minimize conflicts while keeping element names predictable for
+        // user-defined downstream code. However, merge will also sometimes change the spec of
+        // certain spec elements (e.g. of a federation spec directive). The result of this is that
+        // sometimes elements using a default name of one spec may be imported using another spec,
+        // so we need to permit e.g. the cost spec to import "@cost" as "@federation__cost" in the
+        // supergraph schema. This kind of thing is generally fine, provided the old spec's
+        // name-in-schema is no longer in use in the supergraph schema.
+        //
+        // So whenever an import occurs with an element name-in-schema that uses a prefix but
+        // there's no spec in the schema whose name-in-schema is that prefix, we store an entry here
+        // from the yet-unused prefix to the element name-in-schema. This lets us easily lookup
+        // those elements in `self.by_element_name_in_schema` if a later spec's name-in-schema ends
+        // up equaling that prefix later and we need to generate an error message.
+        //
+        // PORT_NOTE: Unlike the JS code, we don't support @link addition/removal, so we only need
+        // to remember the first such conflict (if we supported removals, we'd need to remember all
+        // such conflicts).
+        let mut first_conflict_by_spec_name_in_schema: IndexMap<Arc<str>, ElementName> =
+            Default::default();
+        for directive in schema.schema_definition.directives.iter() {
+            // Ignore non-@link/@core directives.
+            if &directive.name != link_directive_name_in_schema {
+                continue;
             }
+            // Properly parse the @link/@core directive application into a `Link`.
+            let link = Arc::new(link_spec_definition.link_from_directive(directive, schema)?);
+            // If this is for the bootstrapped link/core spec, record it.
+            if link.url == url && link_itself.replace(link.clone()).is_some() {
+                bail!("Unexpectedly multiple @link applications for the link/core feature");
+            }
+            Self::add_link(
+                link,
+                &mut by_spec_name_in_schema,
+                &mut by_identity,
+                &mut by_import_element_name_in_schema,
+                &mut first_conflict_by_spec_name_in_schema,
+            )?;
         }
+        let Some(link_itself) = link_itself else {
+            bail!("Unexpectedly no @link applications for the link/core feature");
+        };
 
         Ok(Some(LinksMetadata {
-            links,
+            link_itself,
+            link_spec_definition,
+            by_spec_name_in_schema,
             by_identity,
-            by_name_in_schema,
-            types_by_imported_name,
-            directives_by_imported_name,
+            by_import_element_name_in_schema,
         }))
     }
 
-    fn find_federation_spec_for_version<'a>(
-        version: &Version,
-    ) -> Option<&'a FederationSpecDefinition> {
-        if *version == (Version { major: 1, minor: 0 }) {
-            Some(&FED_1)
-        } else {
-            FEDERATION_VERSIONS.find(version)
-        }
-    }
-
-    fn validate_federation_imports(link: &Link) -> Result<(), FederationError> {
-        let Some(federation_spec) = Self::find_federation_spec_for_version(&link.url.version)
-        else {
+    fn add_link(
+        link: Arc<Link>,
+        by_spec_name_in_schema: &mut IndexMap<Arc<str>, Arc<Link>>,
+        by_identity: &mut IndexMap<Identity, (Arc<Link>, IndexMap<ElementName, ElementName>)>,
+        by_import_element_name_in_schema: &mut IndexMap<ElementName, (Arc<Link>, ElementName)>,
+        first_conflict_by_spec_name_in_schema: &mut IndexMap<Arc<str>, ElementName>,
+    ) -> Result<(), FederationError> {
+        let identity = &link.url.identity;
+        // The identity can't already be mapped to another @link/`Link`. (Even when they're
+        // different major versions, they're usually describing the same capabilities but in
+        // incompatible ways, so we don't want to allow the same schema to try to use multiple of
+        // them.)
+        if by_identity.contains_key(identity) {
             return Err(SingleFederationError::InvalidLinkDirectiveUsage {
                 message: format!(
-                    "Unknown import: Unexpected federation version: {}",
-                    link.url.version
+                    r#"Cannot link feature "{}" since it has already been linked in the schema."#,
+                    identity,
                 ),
             }
             .into());
-        };
-        let federation_directives: HashSet<_> = federation_spec
-            .directive_specs()
-            .iter()
-            .map(|spec| spec.name().clone())
-            .collect();
-        let federation_types: HashSet<_> = federation_spec
-            .type_specs()
-            .iter()
-            .map(|spec| spec.name().clone())
-            .collect();
+        }
 
-        for imp in &link.imports {
-            if imp.is_directive && !federation_directives.contains(&imp.element) {
+        let spec_name_in_schema = link.spec_name_in_schema();
+        // Normally we'd always forbid "__" in spec names-in-schema. However, there are some older
+        // supergraph schemas that link the "tag" and "inaccessible" specs to the names-in-schema
+        // "federation__tag" and "federation__inaccessible". This is due to bugs in older versions
+        // of composition, but is technically fine since these specs have no types and directives
+        // other than the default directive, so they never prefix anything with "__". So we make a
+        // very specific exception here for that case. We may remove this exception in the future,
+        // once support has been dropped for those bugged composition versions.
+        if !(identity == &Identity::tag_identity()
+            && spec_name_in_schema == "federation__tag"
+            && link.imports.is_empty()
+            || identity == &Identity::inaccessible_identity()
+                && spec_name_in_schema == "federation__inaccessible"
+                && link.imports.is_empty())
+        {
+            // Don't allow spec names-in-schema to have "__" in them, as namespace splitting splits
+            // on the earliest "__" (so a namespaced name with a spec name-in-schema containing "__"
+            // would be erroneously split mid-spec-name-in-schema).
+            if spec_name_in_schema.contains("__") {
                 return Err(SingleFederationError::InvalidLinkDirectiveUsage {
                     message: format!(
-                        "Unknown import: Cannot import unknown federation directive \"@{}\".",
-                        imp.element,
+                        r#"Cannot link feature "{}" as "{}" since it contains "__". Please rename to a compliant name via "as"."#,
+                        identity,
+                        spec_name_in_schema,
                     ),
-                }
-                .into());
-            } else if !imp.is_directive && !federation_types.contains(&imp.element) {
-                return Err(SingleFederationError::InvalidLinkDirectiveUsage {
-                    message: format!(
-                        "Unknown import: Cannot import unknown federation element \"{}\".",
-                        imp.element,
-                    ),
-                }
-                .into());
+                }.into());
             }
         }
+        // Don't allow spec names-in-schema to end in "_", as namespace splitting splits on the
+        // earliest "__" (so a namespaced name with a spec name-in-schema ending with "_" would end
+        // up with "___", and be split before the ending "_" instead of after).
+        if spec_name_in_schema.ends_with("_") {
+            return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                message: format!(
+                    r#"Cannot link feature "{}" as "{}" since it ends in "_". Please rename to a compliant name via "as"."#,
+                    identity,
+                    spec_name_in_schema,
+                ),
+            }.into());
+        }
+        // Ideally here, we wouldn't allow spec names-in-schema to not be valid GraphQL names.
+        // However, enough supergraph schemas use "." and "-" after the first character that we
+        // can't impose that validation now. So instead, we match using a slightly relaxed regex
+        // that allows "." and "-" after the first character. For schemas that have "." or "-", they
+        // won't be able to use namespaced names for their spec schema elements due to GraphQL
+        // validation, but imports will still work. This is why there's a `Name::new_unchecked()`
+        // call in `Link::spec_name_in_schema()`.
+        //
+        // Note the error message below purposely says "not a valid GraphQL name" because we want to
+        // encourage users to actually use GraphQL names and avoid creating more exceptional cases.
+        if !SPEC_NAME_IN_SCHEMA_REGEX.is_match(&spec_name_in_schema) {
+            return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                message: format!(
+                    r#"Cannot link feature "{}" as "{}" since it is not a valid GraphQL name. Please rename to a compliant name via "as"."#,
+                    identity,
+                    spec_name_in_schema,
+                ),
+            }.into());
+        }
+        // Don't allow spec names-in-schema to conflict with previous imports that use "__" with a
+        // prefix equal to that spec name-in-schema.
+        if let Some(conflict_import_element_name_in_schema) =
+            first_conflict_by_spec_name_in_schema.get(spec_name_in_schema.as_str())
+        {
+            let Some((conflict_link, conflict_import_element_name_in_spec)) =
+                by_import_element_name_in_schema.get(conflict_import_element_name_in_schema)
+            else {
+                bail!("Unexpectedly cannot find link for import");
+            };
+            let conflict_identity = &conflict_link.url.identity;
+            Self::check_tag_inaccessible_conflict(conflict_identity, identity)?;
+            let import_error_message = if conflict_import_element_name_in_spec
+                == conflict_import_element_name_in_schema
+            {
+                format!(r#""{}""#, conflict_import_element_name_in_spec)
+            } else {
+                format!(
+                    r#""{}" as "{}""#,
+                    conflict_import_element_name_in_spec, conflict_import_element_name_in_schema
+                )
+            };
+            return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                message: format!(
+                    r#"Cannot import {} from feature "{}" since it can be confused with a namespaced name from another linked feature "{}". Please rename the import or feature to avoid conflicts via "as"."#,
+                    import_error_message,
+                    conflict_identity,
+                    identity,
+                ),
+            }.into());
+        }
+        // Don't allow spec names-in-schema to have default directive names that conflict with
+        // previous imports.
+        let conflict_import_element_name_in_schema = ElementName {
+            name: spec_name_in_schema.clone(),
+            is_directive: true,
+        };
+        if let Some((conflict_link, conflict_import_element_name_in_spec)) =
+            by_import_element_name_in_schema.get(&conflict_import_element_name_in_schema)
+        {
+            let conflict_identity = &conflict_link.url.identity;
+            Self::check_tag_inaccessible_conflict(conflict_identity, identity)?;
+            let import_error_message = if conflict_import_element_name_in_spec
+                == &conflict_import_element_name_in_schema
+            {
+                format!(r#""{}""#, conflict_import_element_name_in_spec)
+            } else {
+                format!(
+                    r#""{}" as "{}""#,
+                    conflict_import_element_name_in_spec, conflict_import_element_name_in_schema
+                )
+            };
+            return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                message: format!(
+                    r#"Cannot import {} from feature "{}" since it can be confused with a namespaced name from another linked feature "{}". Please rename the import or feature to avoid conflicts via "as"."#,
+                    import_error_message,
+                    conflict_identity,
+                    identity
+                ),
+            }.into());
+        }
+        // The spec name-in-schema can't be already mapped to another @link/`Link`.
+        if let Some(existing_link) = by_spec_name_in_schema.get(spec_name_in_schema.as_str()) {
+            let existing_identity = &existing_link.url.identity;
+            Self::check_tag_inaccessible_conflict(existing_identity, identity)?;
+            return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                message: format!(
+                    r#"Cannot link feature {} as "{}" since another feature "{}" already uses that alias. Please rename the feature to avoid conflicts via "as"."#,
+                    identity,
+                    spec_name_in_schema,
+                    existing_identity
+                ),
+            }.into());
+        }
+
+        let mut by_identity_imports: IndexMap<ElementName, ElementName> = Default::default();
+        let known_element_names_in_spec: Option<IndexSet<ElementName>> = SPEC_REGISTRY
+            .get_definition(&link.url)
+            .map(|spec_definition| spec_definition.all_element_names().collect());
+        for import in &link.imports {
+            let import_element_name_in_spec = import.element_name_in_spec();
+            let import_element_name_in_schema = import.element_name_in_schema();
+            let import_error_message =
+                if import_element_name_in_spec == import_element_name_in_schema {
+                    format!(r#""{}""#, import_element_name_in_spec)
+                } else {
+                    format!(
+                        r#""{}" as "{}""#,
+                        import_element_name_in_spec, import_element_name_in_schema
+                    )
+                };
+
+            // If the spec is known, the name-in-spec must be known.
+            Self::validate_known_element_name_in_spec(
+                &import_element_name_in_spec,
+                &known_element_names_in_spec,
+            )?;
+            // Only allow mapping to a name with "__" if it's a no-op import or if the prefix isn't
+            // equal to some existing spec's name-in-schema.
+            if let Some((split_spec_name_in_schema, split_name_in_spec)) =
+                Self::split_prefixed_name(&import_element_name_in_schema.name)
+            {
+                if split_spec_name_in_schema == spec_name_in_schema.as_str() {
+                    if split_name_in_spec != import_element_name_in_spec.name.as_str() {
+                        let split_element_name_in_spec = ElementName {
+                            // Only used for error messages, so should be fine.
+                            name: Name::new_unchecked(split_name_in_spec),
+                            is_directive: import.is_directive,
+                        };
+                        return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                            message: format!(
+                                r#"Cannot import {} from feature "{}" since it can be confused with the namespaced name for "{}". Please rename the import to avoid conflicts via "as"."#,
+                                import_error_message,
+                                identity,
+                                split_element_name_in_spec
+                            ),
+                        }.into());
+                    }
+                } else {
+                    if let Some(conflict_link) =
+                        by_spec_name_in_schema.get(split_spec_name_in_schema)
+                    {
+                        let conflict_identity = &conflict_link.url.identity;
+                        Self::check_tag_inaccessible_conflict(conflict_identity, identity)?;
+                        return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                            message: format!(
+                                r#"Cannot import {} from feature "{}" since it can be confused with a namespaced name from another linked feature "{}". Please rename the import or feature to avoid conflicts via "as"."#,
+                                import_error_message,
+                                identity,
+                                conflict_identity
+                            ),
+                        }.into());
+                    } else {
+                        // As mentioned in the comment for `first_conflict_by_spec_name_in_schema`
+                        // in the caller, we have to record the import in case a link gets added
+                        // with the spec name-in-schema later.
+                        first_conflict_by_spec_name_in_schema.insert(
+                            split_spec_name_in_schema.into(),
+                            import_element_name_in_schema.clone(),
+                        );
+                    }
+                }
+            }
+            // For default directives, only allow mapping to a spec name-in-schema if it's a no-op
+            // import.
+            if import.is_directive {
+                if import_element_name_in_schema.name == spec_name_in_schema {
+                    if import_element_name_in_spec.name.as_str() != link.url.identity.name.as_ref()
+                    {
+                        return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                            message: format!(
+                                r#"Cannot import {} from feature "{}" since it can be confused with the namespaced name for "@{}". Please rename the import to avoid conflicts via "as"."#,
+                                import_error_message,
+                                identity,
+                                link.url.identity.name
+                            ),
+                        }.into());
+                    }
+                } else {
+                    if let Some(conflict_link) =
+                        by_spec_name_in_schema.get(import_element_name_in_schema.name.as_str())
+                    {
+                        let conflict_identity = &conflict_link.url.identity;
+                        Self::check_tag_inaccessible_conflict(conflict_identity, identity)?;
+                        return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                            message: format!(
+                                r#"Cannot import {} from feature "{}" since it can be confused with a namespaced name from another linked feature "{}". Please rename the import or feature to avoid conflicts via "as"."#,
+                                import_error_message,
+                                identity,
+                                conflict_identity
+                            ),
+                        }.into());
+                    }
+                }
+            }
+            // The name-in-spec can't be already mapped to a different name-in-schema.
+            match by_identity_imports.entry(import_element_name_in_spec.clone()) {
+                Entry::Occupied(entry) => {
+                    let existing_element_name_in_schema = entry.get();
+                    if existing_element_name_in_schema != &import_element_name_in_schema {
+                        return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                            message: format!(
+                                r#"Cannot import {} from feature "{}" since it was previously imported as "{}". Please remove one of these imports."#,
+                                import_error_message,
+                                identity,
+                                existing_element_name_in_schema
+                            ),
+                        }.into());
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(import_element_name_in_schema.clone());
+                }
+            }
+            // The name-in-schema can't already be mapped to a different name-in-spec.
+            match by_import_element_name_in_schema.entry(import_element_name_in_schema) {
+                Entry::Occupied(entry) => {
+                    let (existing_link, existing_element_name_in_spec) = entry.get();
+                    let existing_identity = &existing_link.url.identity;
+                    if existing_identity != identity {
+                        Self::check_tag_inaccessible_conflict(existing_identity, identity)?;
+                        return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                            message: format!(
+                                r#"Cannot import {} from feature "{}" since it was previously imported from feature "{}". Please rename the import to avoid conflicts via "as"."#,
+                                import_error_message,
+                                identity,
+                                existing_identity
+                            ),
+                        }.into());
+                    }
+                    if existing_element_name_in_spec != &import_element_name_in_spec {
+                        return Err(SingleFederationError::InvalidLinkDirectiveUsage {
+                            message: format!(
+                                r#"Cannot import {} from feature "{}" since it was previously imported for "{}". Please rename the import to avoid conflicts via "as"."#,
+                                import_error_message,
+                                identity,
+                                existing_element_name_in_spec
+                            ),
+                        }.into());
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert((link.clone(), import_element_name_in_spec));
+                }
+            }
+        }
+        by_spec_name_in_schema.insert(spec_name_in_schema.into(), link.clone());
+        by_identity.insert(identity.clone(), (link, by_identity_imports));
         Ok(())
     }
 
-    // PORT_NOTE: Call this as a replacement for `CoreFeatures.coreItself` from JS.
-    pub(crate) fn link_spec_definition(
+    /// Returns whether a spec's name-in-schema would pass the checks in `add_link()`, except import
+    /// conflicts are taken from the given map, which should be computed via
+    /// `[Self::compute_spec_name_in_schema_conflicts].
+    pub(crate) fn is_spec_name_in_schema_valid(
         &self,
-    ) -> Result<&'static LinkSpecDefinition, FederationError> {
-        if let Some(link_link) = self.for_identity(&Identity::link_identity()) {
-            LINK_VERSIONS.find(&link_link.url.version).ok_or_else(|| {
-                SingleFederationError::Internal {
-                    message: format!("Unexpected link spec version {}", link_link.url.version),
+        spec_name_in_schema: &str,
+        identity: &Identity,
+        import_conflicts_by_identity: &ImportConflictsByIdentity,
+    ) -> bool {
+        // Don't allow spec names-in-schema to have "__" in them. Note that this method is only used
+        // in merging to detect whether we need to rename the spec, so we don't need the exception
+        // for "federation__tag" and "federation__inaccessible" here.
+        if spec_name_in_schema.contains("__") {
+            return false;
+        }
+        // Don't allow spec names-in-schema to end in "_".
+        if spec_name_in_schema.ends_with("_") {
+            return false;
+        }
+        // Don't allow spec names-in-schema to not be valid GraphQL names. Note that unlike
+        // `add_link()`, we consider "." and "-" to not be valid here, but since this method is only
+        // used in merging to detect whether we need to rename the spec, this has the effect of
+        // ensuring that supergraph schemas don't use "." and "-" in their spec names-in-schema
+        // (which will help later if we want to fully forbid "." and "-" in spec names-in-schema).
+        if !GRAPHQL_NAME_REGEX.is_match(spec_name_in_schema) {
+            return false;
+        }
+        for (conflict_identity, import_conflicts) in import_conflicts_by_identity {
+            if identity == conflict_identity {
+                // For import names namespaced using this spec name-in-schema, only allow them if
+                // they're no-op imports.
+                if import_conflicts.self_.contains(spec_name_in_schema) {
+                    return false;
                 }
-                .into()
-            })
-        } else if let Some(core_link) = self.for_identity(&Identity::core_identity()) {
-            CORE_VERSIONS.find(&core_link.url.version).ok_or_else(|| {
-                SingleFederationError::Internal {
-                    message: format!("Unexpected core spec version {}", core_link.url.version),
+            } else {
+                // Don't allow imports of other specs that are namespaced by this spec
+                // name-in-schema.
+                if import_conflicts.other.contains(spec_name_in_schema) {
+                    return false;
                 }
-                .into()
-            })
-        } else {
-            Err(SingleFederationError::Internal {
-                message: "Unexpectedly could not find core/link spec".to_owned(),
             }
-            .into())
+        }
+        // The spec name-in-schema can't be already mapped to another @link/`Link`.
+        if self
+            .by_spec_name_in_schema
+            .contains_key(spec_name_in_schema)
+        {
+            return false;
+        }
+        true
+    }
+
+    /// This is a method that helps us handle the case where:
+    /// 1. directives of some spec are being composed into the supergraph (due to them being Apollo
+    ///    specs or via `@composeDirective`),
+    /// 2. those directives don't actually have any conflicts, and
+    /// 3. the spec itself has spec name-in-schema conflicts when linked with the spec's name.
+    ///
+    /// For the `@composeDirective` case at least, you might think we could just use the
+    /// `@link(as:)` rename from the subgraph, but when we established `@composeDirective` we never
+    /// mandated that the spec names-in-schema be the same (just their composed directive
+    /// names-in-schema). The reason we focused on directives was that downstream consumers were
+    /// expecting certain directive names, so it makes sense to force agreement on a single name per
+    /// directive across subgraphs. As part of that, we explicitly generate imports for all those
+    /// directives, so the spec name-in-schema is never used for namespaced names via "__", and
+    /// consumers consequently don't deal or care about those spec names-in-schema much. We could
+    /// make a breaking change to force alignment on a spec name-in-schema to use in the supergraph,
+    /// but spec name-in-schema agreement likely isn't valuable enough for a breakage. More
+    /// importantly, it also doesn't really solve the case for conflicts linking Apollo specs.
+    ///
+    /// So instead, when we detect a conflict, we generate a unique spec name-in-schema. This method
+    /// does two things:
+    /// 1. Outputs data that can be used to efficiently detect import conflicts.
+    /// 2. Outputs a closure that can be used to generate unique spec names-in-schema.
+    ///
+    /// For unique spec name-in-schema computation, we compute a non-conflicting prefix by using a
+    /// trie to determine a GraphQL name that isn't a prefix of any existing names (this prefix also
+    /// doesn't use "_" outside the first character, so it should be safe for spec names-in-schema).
+    /// We then add an incrementing index to it, to account for @links that have the same spec name.
+    /// Finally, we add the spec name but without any non-letter characters.
+    pub(crate) fn compute_spec_name_in_schema_conflicts<'a>(
+        spec_conflict_infos: impl IntoIterator<Item = SpecConflictInfo<'a>>,
+        all_element_names: impl IntoIterator<Item = Name>,
+    ) -> (ImportConflictsByIdentity, UniqueSpecNameInSchema) {
+        // Generate `import_conflicts_by_identity` and track names for the trie.
+        let mut trie_names: IndexSet<Arc<str>> = all_element_names
+            .into_iter()
+            .map(|n| n.clone().into())
+            .collect();
+        let mut import_conflicts_by_identity: ImportConflictsByIdentity = Default::default();
+        for SpecConflictInfo {
+            spec_name_in_schema,
+            url,
+            imports,
+        } in spec_conflict_infos
+        {
+            trie_names.insert(spec_name_in_schema.clone());
+            let mut self_: IndexSet<_> = Default::default();
+            let mut other: IndexSet<_> = Default::default();
+            for import in imports {
+                let import_name_in_spec = &import.element;
+                let import_name_in_schema = import.name_in_schema();
+                trie_names.insert(import_name_in_schema.clone().into());
+                if let Some((split_spec_name_in_schema, split_name_in_spec)) =
+                    Self::split_prefixed_name(import_name_in_schema)
+                {
+                    if split_name_in_spec != import_name_in_spec.as_str() {
+                        // Spec name-in-schema being `split_spec_name_in_schema` would generate a
+                        // conflict due to the import not being a no-op import for a namespaced
+                        // name.
+                        self_.insert(split_spec_name_in_schema.into());
+                    }
+                    // Spec name-in-schema being `split_spec_name_in_schema` would generate a
+                    // conflict due to this import from some other identity being namespaced to it.
+                    other.insert(split_spec_name_in_schema.into());
+                }
+                if import.is_directive {
+                    if import_name_in_spec.as_str() != url.identity.name.as_ref() {
+                        // Spec name-in-schema being 'import_name_in_schema' would generate a
+                        // conflict due to the import not being a no-op import for the default
+                        // directive.
+                        self_.insert(import_name_in_schema.clone().into());
+                    }
+                    // Spec name-in-schema being `import_name_in_schema` would generate a conflict
+                    // due to this import from some other identity being the default directive for
+                    // it.
+                    other.insert(import_name_in_schema.clone().into());
+                }
+            }
+            import_conflicts_by_identity
+                .insert(url.identity.clone(), ImportConflict { self_, other });
+        }
+        // Create the closure for computing unique spec names-in-schema via a trie.
+        let mut prefix: Option<String> = None;
+        let mut index: usize = 0;
+        let compute_unique_spec_name_in_schema = move |spec_name: &str| {
+            let prefix = prefix.get_or_insert_with(|| {
+                let mut root: TrieNode = Default::default();
+                // Populate the trie.
+                for name in &trie_names {
+                    let mut node = &mut root;
+                    for char in name.chars() {
+                        node = node.children.entry(char).or_default();
+                    }
+                }
+                // This arena keeps track of nodes we've already traversed in the BFS, in addition
+                // to nodes we've queued but yet to traverse (starting at `head`). It's bounded by
+                // the number of nodes in the trie, and each traversal entry is constant size.
+                let mut nodes = vec![TrieTraversal {
+                    node: &root,
+                    // A sentinel value to indicate the root.
+                    parent: usize::MAX,
+                    char_: '\0',
+                }];
+                let mut head: usize = 0;
+                loop {
+                    let possible_chars = if head == 0 {
+                        TRIE_SPEC_NAME_IN_SCHEMA_START
+                    } else {
+                        TRIE_SPEC_NAME_IN_SCHEMA_CONTINUE
+                    };
+                    let node = nodes[head].clone();
+                    for char in possible_chars.chars() {
+                        if let Some(child) = node.node.children.get(&char) {
+                            nodes.push(TrieTraversal {
+                                node: child,
+                                parent: head,
+                                char_: char,
+                            })
+                        } else {
+                            let mut chars = vec![char];
+                            let mut cur = &node;
+                            while cur.parent != usize::MAX {
+                                chars.push(cur.char_);
+                                cur = &nodes[cur.parent];
+                            }
+                            return chars.into_iter().rev().collect();
+                        }
+                    }
+                    head += 1;
+                }
+            });
+            let suffix: String = spec_name
+                .chars()
+                .filter(|c| c.is_ascii_alphabetic())
+                .collect();
+            let unique_spec_name_in_schema = format!("{prefix}{index}{suffix}");
+            index += 1;
+            Name::new_unchecked(&unique_spec_name_in_schema)
+        };
+        (
+            import_conflicts_by_identity,
+            Box::new(compute_unique_spec_name_in_schema),
+        )
+    }
+
+    /// There's a particular pattern in Fed 1 subgraphs, where they would try to link the "tag" or
+    /// "inaccessible" specs directly instead of importing the directives from the "federation"
+    /// spec, and this can cause a conflict. This function gives a more helpful error message in
+    /// that case.
+    fn check_tag_inaccessible_conflict(
+        identity1: &Identity,
+        identity2: &Identity,
+    ) -> Result<(), FederationError> {
+        let identities: IndexSet<_> = [identity1, identity2].into_iter().collect();
+        if !identities.contains(&Identity::federation_identity()) {
+            return Ok(());
+        }
+        let (directive, identity) = if identities.contains(&Identity::tag_identity()) {
+            (Identity::TAG_NAME, Identity::tag_identity())
+        } else if identities.contains(&Identity::inaccessible_identity()) {
+            (
+                Identity::INACCESSIBLE_NAME,
+                Identity::inaccessible_identity(),
+            )
+        } else {
+            return Ok(());
+        };
+        Err(SingleFederationError::InvalidLinkDirectiveUsage {
+            message: format!(
+                r#"Please import "@{}" from the feature "{}" instead of using "{}" to avoid potential unexpected behavior in the future."#,
+                directive,
+                Identity::federation_identity(),
+                identity,
+            ),
+        }.into())
+    }
+
+    fn validate_known_element_name_in_spec(
+        element_name_in_spec: &ElementName,
+        known_element_names_in_spec: &Option<IndexSet<ElementName>>,
+    ) -> Result<(), FederationError> {
+        let Some(known_element_names_in_spec) = known_element_names_in_spec else {
+            return Ok(());
+        };
+        if known_element_names_in_spec.contains(element_name_in_spec) {
+            return Ok(());
+        };
+        let mut message_parts = vec![format!(
+            r#"Cannot import unknown element "{}"."#,
+            element_name_in_spec
+        )];
+        if !element_name_in_spec.is_directive
+            && let known_element_name_in_spec = (ElementName {
+                name: element_name_in_spec.name.clone(),
+                is_directive: true,
+            })
+            && known_element_names_in_spec.contains(&known_element_name_in_spec)
+        {
+            message_parts.push(format!(
+                r#" Did you mean directive "{}"?"#,
+                known_element_name_in_spec
+            ));
+        } else if let suggestions = suggestion_list(
+            &element_name_in_spec.to_string(),
+            known_element_names_in_spec.iter().map(ToString::to_string),
+        ) && !suggestions.is_empty()
+        {
+            // Note that the message returned by `did_you_mean()` has a leading space.
+            message_parts.push(did_you_mean(suggestions))
+        }
+        Err(SingleFederationError::InvalidLinkDirectiveUsage {
+            message: message_parts.join(""),
+        }
+        .into())
+    }
+
+    /// Assuming the [LinksMetadata] is for the given [FederationSchema], returns an error for each
+    /// used schema element with a shadowing import. A "shadowing import" occurs when an element
+    /// would normally belong to an @link application due to having a default name for its spec, but
+    /// the name-in-spec has been imported already under a different name. Note that for
+    /// backwards-compatibility reasons, we ignore shadowed types if they're only used by other
+    /// shadowed elements.
+    ///
+    /// We enforce this validation because downstream code almost always assumes there's exactly one
+    /// name for a spec element, and allowing multiple elements with the same @link application and
+    /// name-in-spec will thus result in some of those elements being erroneously ignored. (This is
+    /// similar to the validation that forbids importing the same name-in-spec with different
+    /// names-in-schema, but that can't be easily done when recomputing [LinksMetadata] due to a
+    /// change in @link applications since it depends on what elements are actually in the schema,
+    /// and that doesn't get finalized until later in the schema-building process.)
+    pub(crate) fn validate_no_shadowing_imports(
+        &self,
+        schema: &FederationSchema,
+    ) -> Result<(), FederationError> {
+        let mut used_shadowing_imports: Vec<(ShadowingImport, String)> = Vec::new();
+        for type_pos in schema.get_types() {
+            let element_name_in_schema = ElementName {
+                name: type_pos.type_name().clone(),
+                is_directive: false,
+            };
+            let Some(shadowing_import) = self.get_shadowing_import(&element_name_in_schema) else {
+                continue;
+            };
+            if self.has_non_shadowed_referencing_root_elements(schema, &type_pos) {
+                used_shadowing_imports.push((shadowing_import, type_pos.to_string()));
+            }
+        }
+        for directive_pos in schema.get_directive_definitions() {
+            let element_name_in_schema = ElementName {
+                name: directive_pos.directive_name.clone(),
+                is_directive: true,
+            };
+            let Some(shadowing_import) = self.get_shadowing_import(&element_name_in_schema) else {
+                continue;
+            };
+            if !schema
+                .referencers()
+                .get_directive(&directive_pos.directive_name)
+                .is_empty()
+            {
+                used_shadowing_imports.push((shadowing_import, directive_pos.to_string()));
+            };
+        }
+        if used_shadowing_imports.is_empty() {
+            return Ok(());
+        }
+        Err(FederationError::MultipleFederationErrors(MultipleFederationErrors {
+            errors: used_shadowing_imports.iter().map(|(shadowing_import, coordinate)| {
+                let import_error_message = if shadowing_import.import_element_name_in_spec ==
+                    shadowing_import.import_element_name_in_schema
+                {
+                    format!(r#""{}""#, shadowing_import.import_element_name_in_spec)
+                } else {
+                    format!(
+                        r#""{}" as "{}""#,
+                        shadowing_import.import_element_name_in_spec,
+                        shadowing_import.import_element_name_in_schema
+                    )
+                };
+                SingleFederationError::InvalidLinkDirectiveUsage {
+                    message: format!(
+                        r#"Cannot import {} from feature "{}" since there's a used definition for the namespaced name "{}". Please switch usages of the namespaced name to the import name and remove the definition."#,
+                        import_error_message,
+                        shadowing_import.link.url.identity,
+                        coordinate,
+                    )
+                }
+            }).collect(),
+        }))
+    }
+
+    fn has_non_shadowed_referencing_root_elements(
+        &self,
+        schema: &FederationSchema,
+        type_definition_position: &TypeDefinitionPosition,
+    ) -> bool {
+        match type_definition_position {
+            TypeDefinitionPosition::Scalar(type_pos) => {
+                let Some(referencers) = schema.referencers().scalar_types.get(&type_pos.type_name)
+                else {
+                    return false;
+                };
+                referencers
+                    .object_fields
+                    .iter()
+                    .map(|field_pos| ElementName {
+                        name: field_pos.type_name.clone(),
+                        is_directive: false,
+                    })
+                    .chain(
+                        referencers
+                            .object_field_arguments
+                            .iter()
+                            .map(|arg_pos| ElementName {
+                                name: arg_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .chain(
+                        referencers
+                            .interface_fields
+                            .iter()
+                            .map(|field_pos| ElementName {
+                                name: field_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .chain(referencers.interface_field_arguments.iter().map(|arg_pos| {
+                        ElementName {
+                            name: arg_pos.type_name.clone(),
+                            is_directive: false,
+                        }
+                    }))
+                    .chain(
+                        referencers
+                            .union_fields
+                            .iter()
+                            .map(|field_pos| ElementName {
+                                name: field_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .chain(
+                        referencers
+                            .input_object_fields
+                            .iter()
+                            .map(|field_pos| ElementName {
+                                name: field_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .chain(
+                        referencers
+                            .directive_arguments
+                            .iter()
+                            .map(|arg_pos| ElementName {
+                                name: arg_pos.directive_name.clone(),
+                                is_directive: true,
+                            }),
+                    )
+                    .any(|element_name_in_schema| {
+                        self.get_shadowing_import(&element_name_in_schema).is_none()
+                    })
+            }
+            TypeDefinitionPosition::Object(type_pos) => {
+                let Some(referencers) = schema.referencers().object_types.get(&type_pos.type_name)
+                else {
+                    return false;
+                };
+                if !referencers.schema_roots.is_empty() {
+                    return true;
+                }
+                referencers
+                    .object_fields
+                    .iter()
+                    .map(|field_pos| ElementName {
+                        name: field_pos.type_name.clone(),
+                        is_directive: false,
+                    })
+                    .chain(
+                        referencers
+                            .interface_fields
+                            .iter()
+                            .map(|field_pos| ElementName {
+                                name: field_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .chain(referencers.union_types.iter().map(|type_pos| ElementName {
+                        name: type_pos.type_name.clone(),
+                        is_directive: false,
+                    }))
+                    .any(|element_name_in_schema| {
+                        self.get_shadowing_import(&element_name_in_schema).is_none()
+                    })
+            }
+            TypeDefinitionPosition::Interface(type_pos) => {
+                let Some(referencers) = schema
+                    .referencers()
+                    .interface_types
+                    .get(&type_pos.type_name)
+                else {
+                    return false;
+                };
+                referencers
+                    .object_types
+                    .iter()
+                    .map(|type_pos| ElementName {
+                        name: type_pos.type_name.clone(),
+                        is_directive: false,
+                    })
+                    .chain(
+                        referencers
+                            .object_fields
+                            .iter()
+                            .map(|field_pos| ElementName {
+                                name: field_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .chain(
+                        referencers
+                            .interface_types
+                            .iter()
+                            .map(|type_pos| ElementName {
+                                name: type_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .chain(
+                        referencers
+                            .interface_fields
+                            .iter()
+                            .map(|field_pos| ElementName {
+                                name: field_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .any(|element_name_in_schema| {
+                        self.get_shadowing_import(&element_name_in_schema).is_none()
+                    })
+            }
+            TypeDefinitionPosition::Union(type_pos) => {
+                let Some(referencers) = schema.referencers().union_types.get(&type_pos.type_name)
+                else {
+                    return false;
+                };
+                referencers
+                    .object_fields
+                    .iter()
+                    .map(|field_pos| ElementName {
+                        name: field_pos.type_name.clone(),
+                        is_directive: false,
+                    })
+                    .chain(
+                        referencers
+                            .interface_fields
+                            .iter()
+                            .map(|field_pos| ElementName {
+                                name: field_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .any(|element_name_in_schema| {
+                        self.get_shadowing_import(&element_name_in_schema).is_none()
+                    })
+            }
+            TypeDefinitionPosition::Enum(type_pos) => {
+                let Some(referencers) = schema.referencers().enum_types.get(&type_pos.type_name)
+                else {
+                    return false;
+                };
+                referencers
+                    .object_fields
+                    .iter()
+                    .map(|field_pos| ElementName {
+                        name: field_pos.type_name.clone(),
+                        is_directive: false,
+                    })
+                    .chain(
+                        referencers
+                            .object_field_arguments
+                            .iter()
+                            .map(|arg_pos| ElementName {
+                                name: arg_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .chain(
+                        referencers
+                            .interface_fields
+                            .iter()
+                            .map(|field_pos| ElementName {
+                                name: field_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .chain(referencers.interface_field_arguments.iter().map(|arg_pos| {
+                        ElementName {
+                            name: arg_pos.type_name.clone(),
+                            is_directive: false,
+                        }
+                    }))
+                    .chain(
+                        referencers
+                            .input_object_fields
+                            .iter()
+                            .map(|field_pos| ElementName {
+                                name: field_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .chain(
+                        referencers
+                            .directive_arguments
+                            .iter()
+                            .map(|arg_pos| ElementName {
+                                name: arg_pos.directive_name.clone(),
+                                is_directive: true,
+                            }),
+                    )
+                    .any(|element_name_in_schema| {
+                        self.get_shadowing_import(&element_name_in_schema).is_none()
+                    })
+            }
+            TypeDefinitionPosition::InputObject(type_pos) => {
+                let Some(referencers) = schema
+                    .referencers()
+                    .input_object_types
+                    .get(&type_pos.type_name)
+                else {
+                    return false;
+                };
+                referencers
+                    .object_field_arguments
+                    .iter()
+                    .map(|arg_pos| ElementName {
+                        name: arg_pos.type_name.clone(),
+                        is_directive: false,
+                    })
+                    .chain(referencers.interface_field_arguments.iter().map(|arg_pos| {
+                        ElementName {
+                            name: arg_pos.type_name.clone(),
+                            is_directive: false,
+                        }
+                    }))
+                    .chain(
+                        referencers
+                            .input_object_fields
+                            .iter()
+                            .map(|field_pos| ElementName {
+                                name: field_pos.type_name.clone(),
+                                is_directive: false,
+                            }),
+                    )
+                    .chain(
+                        referencers
+                            .directive_arguments
+                            .iter()
+                            .map(|arg_pos| ElementName {
+                                name: arg_pos.directive_name.clone(),
+                                is_directive: true,
+                            }),
+                    )
+                    .any(|element_name_in_schema| {
+                        self.get_shadowing_import(&element_name_in_schema).is_none()
+                    })
+            }
         }
     }
 
-    pub fn all_links(&self) -> &[Arc<Link>] {
-        self.links.as_ref()
+    fn get_shadowing_import(
+        &self,
+        element_name_in_schema: &ElementName,
+    ) -> Option<ShadowingImport<'_>> {
+        let (link, element_name_in_spec) = self.source_default_name(element_name_in_schema)?;
+        // An invalid name-in-spec can't be imported, and thus can't be shadowed.
+        let element_name_in_spec = element_name_in_spec?;
+        let import_element_name_in_schema =
+            self.get_import_element_name_in_schema(link, &element_name_in_spec)?;
+        // If the import is a no-op import (i.e. it imports an element to its default name), then
+        // we don't consider it to shadow usages of the default name.
+        if import_element_name_in_schema == element_name_in_schema {
+            return None;
+        }
+        Some(ShadowingImport {
+            link,
+            import_element_name_in_spec: element_name_in_spec,
+            import_element_name_in_schema: import_element_name_in_schema.clone(),
+        })
+    }
+
+    // PORT_NOTE: Named `coreItself` in the JS codebase, but "core" is outdated terminology.
+    pub(crate) fn link_itself(&self) -> &Arc<Link> {
+        &self.link_itself
+    }
+
+    pub(crate) fn link_spec_definition(&self) -> &'static LinkSpecDefinition {
+        self.link_spec_definition
+    }
+
+    pub(crate) fn by_import_element_name_in_schema(
+        &self,
+    ) -> &IndexMap<ElementName, (Arc<Link>, ElementName)> {
+        &self.by_import_element_name_in_schema
+    }
+
+    // PORT_NOTE: Named `allFeatures` in the JS codebase, but "feature" is outdated terminology.
+    pub fn all_links(&self) -> impl ExactSizeIterator<Item = &Arc<Link>> {
+        self.by_identity.values().map(|(link, _)| link)
     }
 
     pub fn for_identity(&self, identity: &Identity) -> Option<Arc<Link>> {
-        self.by_identity.get(identity).cloned()
+        self.by_identity.get(identity).map(|(link, _)| link.clone())
     }
 
     pub fn source_link_of_type(&self, type_name: &Name) -> Option<LinkedElement> {
-        // For types, it's either an imported name or it must be fully qualified
-        if let Some((link, import)) = self.types_by_imported_name.get(type_name) {
-            return Some(LinkedElement {
-                link: Arc::clone(link),
-                import: Some(Arc::clone(import)),
-                name: type_name.clone(),
-                name_in_spec: import.element.clone(),
-            });
-        }
-
-        type_name
-            .split_once("__")
-            .and_then(|(spec_name, name_in_spec)| {
-                let Ok(name_in_spec) = Name::new(name_in_spec) else {
-                    return None;
-                };
-                self.by_name_in_schema
-                    .get(spec_name)
-                    .map(|link| LinkedElement {
-                        link: Arc::clone(link),
-                        import: None,
-                        name: type_name.clone(),
-                        name_in_spec,
-                    })
-            })
+        let element_name_in_schema = ElementName {
+            name: type_name.clone(),
+            is_directive: false,
+        };
+        self.source_link(&element_name_in_schema)
     }
 
     pub fn source_link_of_directive(&self, directive_name: &Name) -> Option<LinkedElement> {
-        // For directives, it can be either:
-        //   1. be an imported name,
-        //   2. be the "imported" name of a linked spec (special case of a directive named like the
-        //      spec),
-        //   3. or it must be fully qualified.
-        if let Some((link, import)) = self.directives_by_imported_name.get(directive_name) {
-            return Some(LinkedElement {
-                link: Arc::clone(link),
-                import: Some(Arc::clone(import)),
-                name: directive_name.clone(),
-                name_in_spec: import.element.clone(),
-            });
-        }
-
-        if let Some(link) = self.by_name_in_schema.get(directive_name) {
-            return Some(LinkedElement {
-                link: Arc::clone(link),
-                import: None,
-                name: directive_name.clone(),
-                name_in_spec: link.url.identity.name.clone(),
-            });
-        }
-
-        directive_name
-            .split_once("__")
-            .and_then(|(spec_name, name_in_spec)| {
-                let Ok(name_in_spec) = Name::new(name_in_spec) else {
-                    return None;
-                };
-                self.by_name_in_schema
-                    .get(spec_name)
-                    .map(|link| LinkedElement {
-                        link: Arc::clone(link),
-                        import: None,
-                        name: directive_name.clone(),
-                        name_in_spec,
-                    })
-            })
+        let element_name_in_schema = ElementName {
+            name: directive_name.clone(),
+            is_directive: true,
+        };
+        self.source_link(&element_name_in_schema)
     }
 
-    pub(crate) fn import_to_feature_url_map(&self) -> HashMap<String, Url> {
-        let directive_entries = self
-            .directives_by_imported_name
-            .iter()
-            .map(|(name, (link, _))| (name.to_string(), link.url.clone()));
-        let type_entries = self
-            .types_by_imported_name
-            .iter()
-            .map(|(name, (link, _))| (name.to_string(), link.url.clone()));
+    // PORT_NOTE: Named `sourceFeature` in the JS codebase, but "feature" is outdated terminology.
+    fn source_link(&self, element_name_in_schema: &ElementName) -> Option<LinkedElement> {
+        // Validations guarantee that names-in-schema don't collide with the default names of
+        // different spec schema elements, so it doesn't technically matter which order we check
+        // first. But we do have to some extra work for shadowing imports if we don't check imports
+        // first, so we do that first.
+        if let Some((link, import_element_name_in_spec)) = self
+            .by_import_element_name_in_schema
+            .get(element_name_in_schema)
+        {
+            return Some(LinkedElement {
+                link: link.clone(),
+                name_in_spec: Some(import_element_name_in_spec.name.clone()),
+            });
+        }
+        // If it's not an import, check whether it's a default name for some existing spec.
+        let (link, element_name_in_spec) = self.source_default_name(element_name_in_schema)?;
+        Some(LinkedElement {
+            link: link.clone(),
+            name_in_spec: element_name_in_spec.and_then(|element_name_in_spec| {
+                // Note that if an import's name-in-schema is the same as its default name, it's not
+                // a shadowing import, and we should return a `Some` for `name_in_spec`. But if that
+                // were true, we would have found an entry in `self.by_element_name_in_schema` above
+                // when checking for imports. So we don't need to handle that case specially here.
+                if self
+                    .get_import_element_name_in_schema(link, &element_name_in_spec)
+                    .is_none()
+                {
+                    Some(element_name_in_spec.name)
+                } else {
+                    None
+                }
+            }),
+        })
+    }
 
-        directive_entries.chain(type_entries).collect()
+    /// Returns the name-in-schema of an imported type/directive for the given link and
+    /// name-in-spec.
+    // PORT_NOTE: Named `getImportName` in the JS codebase, but this was vague.
+    fn get_import_element_name_in_schema(
+        &self,
+        link: &Arc<Link>,
+        element_name_in_spec: &ElementName,
+    ) -> Option<&ElementName> {
+        self.by_identity
+            .get(&link.url.identity)
+            .and_then(|(_, by_name_in_spec)| by_name_in_spec.get(element_name_in_spec))
+    }
+
+    /// If the given element name is a default name (i.e. it's prefixed with an existing spec
+    /// name-in-schema, or is a directive name for an existing spec name-in-schema), then return the
+    /// [Link] for that spec along with the name-in-spec for the element (if valid).
+    fn source_default_name(
+        &self,
+        element_name_in_schema: &ElementName,
+    ) -> Option<(&Arc<Link>, Option<ElementName>)> {
+        // Handle the prefixed case first.
+        if let Some((spec_name_in_schema, name_in_spec)) =
+            Self::split_prefixed_name(&element_name_in_schema.name)
+        {
+            // Note that we explicitly do not return `None` here if `link` isn't found, and instead
+            // fall-through to the default directive name logic below. Normally that default
+            // directive name logic would also return `None`, since validations above guarantee "__"
+            // isn't in spec names-in-schema. But as noted above, we make an exception for the "tag"
+            // and "inaccessible" specs for backwards-compatibility reasons, so we fall-through to
+            // allow those exceptions to be found in `self.by_spec_name_in_schema`.
+            if let Some(link) = self.by_spec_name_in_schema.get(spec_name_in_schema) {
+                return Some((
+                    link,
+                    Name::new(name_in_spec).ok().map(|name| ElementName {
+                        name,
+                        is_directive: element_name_in_schema.is_directive,
+                    }),
+                ));
+            }
+        }
+        // If not prefixed, then check whether it's the default directive name for a spec.
+        if !element_name_in_schema.is_directive {
+            return None;
+        }
+        let link = self
+            .by_spec_name_in_schema
+            .get(element_name_in_schema.name.as_str())?;
+        let name_in_spec = link.url.identity.name.clone().try_into().ok();
+        Some((
+            link,
+            name_in_spec.map(|name| ElementName {
+                name,
+                is_directive: true,
+            }),
+        ))
+    }
+
+    /// For type/directive names-in-schema that are prefixed to indicate they belong to a spec,
+    /// return their spec name-in-schema and their type/directive name-in-spec (which may not be
+    /// a valid GraphQL name).
+    fn split_prefixed_name(name_in_schema: &Name) -> Option<(&str, &str)> {
+        name_in_schema.split_once("__")
     }
 }
+
+pub(crate) type ImportConflictsByIdentity = IndexMap<Identity, ImportConflict>;
+
+pub(crate) struct ImportConflict {
+    /// Spec names-in-schema that would conflict with this identity.
+    self_: IndexSet<Arc<str>>,
+    /// Spec names-in-schema that would conflict with other identities than this one.
+    other: IndexSet<Arc<str>>,
+}
+
+pub(crate) struct SpecConflictInfo<'a> {
+    pub(crate) spec_name_in_schema: &'a Arc<str>,
+    pub(crate) url: &'a Url,
+    pub(crate) imports: Box<dyn Iterator<Item = Cow<'a, Import>> + 'a>,
+}
+
+pub(crate) type UniqueSpecNameInSchema = Box<dyn FnMut(&str) -> Name>;
+
+/// Information about a shadowing import found for an element.
+struct ShadowingImport<'a> {
+    link: &'a Arc<Link>,
+    import_element_name_in_spec: ElementName,
+    import_element_name_in_schema: ElementName,
+}
+
+#[derive(Default)]
+struct TrieNode {
+    children: HashMap<char, TrieNode>,
+}
+
+#[derive(Clone)]
+struct TrieTraversal<'a> {
+    node: &'a TrieNode,
+    parent: usize,
+    char_: char,
+}
+
+static SPEC_NAME_IN_SCHEMA_REGEX: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r#"^[_A-Za-z][_0-9A-Za-z.\-]*$"#).unwrap());
+
+static GRAPHQL_NAME_REGEX: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r#"^[_A-Za-z][_0-9A-Za-z]*$"#).unwrap());
+
+static TRIE_SPEC_NAME_IN_SCHEMA_START: &str = concat!(
+    "_",
+    "abcdefghijklmnopqrstuvwxyz",
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+);
+
+static TRIE_SPEC_NAME_IN_SCHEMA_CONTINUE: &str = concat!(
+    "abcdefghijklmnopqrstuvwxyz",
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "0123456789"
+);
 
 #[cfg(test)]
 mod tests {
@@ -521,7 +1523,6 @@ mod tests {
             .unwrap();
         let names_in_schema = meta
             .all_links()
-            .iter()
             .map(|l| l.spec_name_in_schema())
             .collect::<Vec<_>>();
         assert_eq!(names_in_schema.len(), 4);
@@ -566,39 +1567,32 @@ mod tests {
         let auth_spec = meta
             .for_identity(&Identity {
                 domain: "https://megacorp.com".to_string(),
-                name: name!("auth"),
+                name: name!("auth").into(),
             })
             .unwrap();
         assert_eq!(auth_spec.purpose, Some(Purpose::SECURITY));
 
         let import_source = meta.source_link_of_type(&name!("Import")).unwrap();
-        assert_eq!(import_source.link.url.identity.name, "link");
-        assert!(!import_source.import.as_ref().unwrap().is_directive);
-        assert_eq!(import_source.import.as_ref().unwrap().alias, None);
+        assert_eq!(import_source.link.url.identity.name.as_ref(), "link");
+        assert_eq!(import_source.name_in_spec, Some(name!("Import")));
 
         // Purpose is not imported, so it should only be accessible in fql form
         assert!(meta.source_link_of_type(&name!("Purpose")).is_none());
 
         let purpose_source = meta.source_link_of_type(&name!("link__Purpose")).unwrap();
-        assert_eq!(purpose_source.link.url.identity.name, "link");
-        assert_eq!(purpose_source.import, None);
+        assert_eq!(purpose_source.link.url.identity.name.as_ref(), "link");
+        assert_eq!(purpose_source.name_in_spec, Some(name!("Purpose")));
 
         let key_source = meta.source_link_of_directive(&name!("key")).unwrap();
-        assert_eq!(key_source.link.url.identity.name, "federation");
-        assert!(key_source.import.as_ref().unwrap().is_directive);
-        assert_eq!(key_source.import.as_ref().unwrap().alias, None);
+        assert_eq!(key_source.link.url.identity.name.as_ref(), "federation");
+        assert_eq!(key_source.name_in_spec, Some(name!("key")));
 
         // tag is imported under an alias, so "tag" itself should not match
         assert!(meta.source_link_of_directive(&name!("tag")).is_none());
 
         let tag_source = meta.source_link_of_directive(&name!("myTag")).unwrap();
-        assert_eq!(tag_source.link.url.identity.name, "federation");
-        assert_eq!(tag_source.import.as_ref().unwrap().element, "tag");
-        assert!(tag_source.import.as_ref().unwrap().is_directive);
-        assert_eq!(
-            tag_source.import.as_ref().unwrap().alias,
-            Some(name!("myTag"))
-        );
+        assert_eq!(tag_source.link.url.identity.name.as_ref(), "federation");
+        assert_eq!(tag_source.name_in_spec, Some(name!("tag")));
     }
 
     mod link_import {
@@ -675,7 +1669,7 @@ mod tests {
 
             let schema = Schema::parse(schema, "testSchema").unwrap();
             let errors = LinksMetadata::from_schema(&schema).expect_err("should error");
-            insta::assert_snapshot!(errors, @"Unknown import: Cannot import unknown federation directive \"@foo\".");
+            insta::assert_snapshot!(errors, @r###"Cannot import unknown element "@foo"."###);
 
             // TODO Support multiple errors, in the meantime we'll just clone the code and run again
             let schema = r#"
@@ -694,7 +1688,7 @@ mod tests {
 
             let schema = Schema::parse(schema, "testSchema").unwrap();
             let errors = LinksMetadata::from_schema(&schema).expect_err("should error");
-            insta::assert_snapshot!(errors, @"Unknown import: Cannot import unknown federation element \"key\".");
+            insta::assert_snapshot!(errors, @r###"Cannot import unknown element "key". Did you mean directive "@key"?"###);
 
             let schema = r#"
                 extend schema @link(url: "https://specs.apollo.dev/link/v1.0")
@@ -712,7 +1706,7 @@ mod tests {
 
             let schema = Schema::parse(schema, "testSchema").unwrap();
             let errors = LinksMetadata::from_schema(&schema).expect_err("should error");
-            insta::assert_snapshot!(errors, @"Unknown import: Cannot import unknown federation directive \"@sharable\".");
+            insta::assert_snapshot!(errors, @r###"Cannot import unknown element "@sharable". Did you mean "@shareable"?"###);
         }
     }
 

--- a/apollo-federation/src/link/metadata.rs
+++ b/apollo-federation/src/link/metadata.rs
@@ -1343,12 +1343,31 @@ static TRIE_SPEC_NAME_IN_SCHEMA_CONTINUE: &str = concat!(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use apollo_compiler::name;
 
     use super::*;
     use crate::link::Import;
     use crate::link::Purpose;
     use crate::link::spec::Version;
+    use crate::subgraph::typestate::Subgraph;
+
+    fn errors(schema: &str) -> Vec<String> {
+        // Note: we use `expand_links()` because currently it takes care of automatically adding
+        // directive definitions, and we don't want to bother with adding the @link definition
+        // to every example.
+        let actual_errors: BTreeSet<_> =
+            match Subgraph::parse("A", "", schema).and_then(|subgraph| subgraph.expand_links()) {
+                Ok(_) => Default::default(),
+                Err(error) => error
+                    .errors
+                    .into_iter()
+                    .map(|e| e.error.to_string())
+                    .collect(),
+            };
+        actual_errors.into_iter().collect()
+    }
 
     #[test]
     fn explicit_root_directive_import() -> Result<(), FederationError> {
@@ -1595,118 +1614,893 @@ mod tests {
         assert_eq!(tag_source.name_in_spec, Some(name!("tag")));
     }
 
+    /// TODO: In the JS codebase, malformed imports can generate multiple errors, we should mirror
+    ///       that behavior eventually.
     mod link_import {
         use super::*;
 
         #[test]
         fn errors_on_malformed_values() {
-            let schema = r#"
-                extend schema @link(url: "https://specs.apollo.dev/link/v1.0")
-                extend schema @link(
-                  url: "https://specs.apollo.dev/federation/v2.0",
-                  import: [
-                    2,
-                    { foo: "bar" },
-                    { name: "@key", badName: "foo"},
-                    { name: 42 },
-                    { as: "bar" },
-                   ]
-                )
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [2]
+              )
 
-                type Query {
-                  q: Int
-                }
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "`2` in @link(import:) argument must either be a string `\"<importedElement>\"` or an object `{ name: \"<importedElement>\", as: \"<alias>\" }`",
+            ]
+            "###);
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [{ foo: "bar" }]
+              )
 
-                directive @link(url: String, as: String, import: [Import], for: link__Purpose) repeatable on SCHEMA
-            "#;
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "For `{foo: \"bar\"}` in @link(import:) argument, field \"foo\" is not a known field",
+            ]
+            "###);
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [{ name: "@key", badName: "foo" }]
+              )
 
-            let schema = Schema::parse(schema, "testSchema").unwrap();
-            let errors = LinksMetadata::from_schema(&schema).expect_err("should error");
-            // TODO Multiple errors
-            insta::assert_snapshot!(errors, @r###"`2` in @link(import:) argument must either be a string `"<importedElement>"` or an object `{ name: "<importedElement>", as: "<alias>" }`"###);
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "For `{name: \"@key\", badName: \"foo\"}` in @link(import:) argument, field \"badName\" is not a known field",
+            ]
+            "###);
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [{ name: 42 }]
+              )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "For `{name: 42}` in @link(import:) argument, value for field \"name\" must be a string",
+            ]
+            "###);
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [{ name: "42" }]
+              )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "For `{name: \"42\"}` in @link(import:) argument, value for field \"name\" is not a valid GraphQL name",
+            ]
+            "###);
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [{ name: "" }]
+              )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "For `{name: \"\"}` in @link(import:) argument, value for field \"name\" is not a valid GraphQL name",
+            ]
+            "###);
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [{ name: "@bar", as: "@" }]
+              )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "For `{name: \"@bar\", as: \"@\"}` in @link(import:) argument, value for field \"as\" is not a valid GraphQL name",
+            ]
+            "###);
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [{ as: "bar" }]
+              )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "For `{as: \"bar\"}` in @link(import:) argument, missing required field \"name\"",
+            ]
+            "###);
         }
 
         #[test]
         fn errors_on_mismatch_between_name_and_alias() {
-            let schema = r#"
-                extend schema @link(url: "https://specs.apollo.dev/link/v1.0")
-                extend schema @link(
-                  url: "https://specs.apollo.dev/federation/v2.0",
-                  import: [
-                    { name: "@key", as: "myKey" },
-                    { name: "FieldSet", as: "@fieldSet" },
-                  ]
-                )
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [{ name: "@key", as: "myKey" }]
+              )
 
-                type Query {
-                  q: Int
-                }
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "For `{name: \"@key\", as: \"myKey\"}` in @link(import:) argument, value for field \"as\" must start with \"@\" since value for field \"name\" does (\"@\" indicates a directive import)",
+            ]
+            "###);
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [{ name: "FieldSet", as: "@fieldSet" }]
+              )
 
-                directive @link(url: String, as: String, import: [Import], for: link__Purpose) repeatable on SCHEMA
-            "#;
-
-            let schema = Schema::parse(schema, "testSchema").unwrap();
-            let errors = LinksMetadata::from_schema(&schema).expect_err("should error");
-            // TODO Multiple errors
-            insta::assert_snapshot!(errors, @r###"For `{name: "@key", as: "myKey"}` in @link(import:) argument, value for field "as" must start with "@" since value for field "name" does ("@" indicates a directive import)"###);
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "For `{name: \"FieldSet\", as: \"@fieldSet\"}` in @link(import:) argument, value for field \"as\" must not start with \"@\" since value for field \"name\" does not (\"@\" indicates a directive import)",
+            ]
+            "###);
         }
 
         #[test]
         fn errors_on_importing_unknown_elements_for_known_features() {
-            let schema = r#"
-                extend schema @link(url: "https://specs.apollo.dev/link/v1.0")
-                extend schema @link(
-                  url: "https://specs.apollo.dev/federation/v2.0",
-                  import: [ "@foo", "key", { name: "@sharable" } ]
-                )
-
-                type Query {
-                  q: Int
-                }
-
-                directive @link(url: String, as: String, import: [Import], for: link__Purpose) repeatable on SCHEMA
-            "#;
-
-            let schema = Schema::parse(schema, "testSchema").unwrap();
-            let errors = LinksMetadata::from_schema(&schema).expect_err("should error");
-            insta::assert_snapshot!(errors, @r###"Cannot import unknown element "@foo"."###);
-
-            // TODO Support multiple errors, in the meantime we'll just clone the code and run again
-            let schema = r#"
-                extend schema @link(url: "https://specs.apollo.dev/link/v1.0")
-                extend schema @link(
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
                 url: "https://specs.apollo.dev/federation/v2.0",
-                import: [ "key", { name: "@sharable" } ]
-                )
+                import: ["@foo"]
+              )
 
-                type Query {
+              type Query {
                 q: Int
-                }
-
-                directive @link(url: String, as: String, import: [Import], for: link__Purpose) repeatable on SCHEMA
-            "#;
-
-            let schema = Schema::parse(schema, "testSchema").unwrap();
-            let errors = LinksMetadata::from_schema(&schema).expect_err("should error");
-            insta::assert_snapshot!(errors, @r###"Cannot import unknown element "key". Did you mean directive "@key"?"###);
-
-            let schema = r#"
-                extend schema @link(url: "https://specs.apollo.dev/link/v1.0")
-                extend schema @link(
+              }
+            "#), @r###"
+            [
+                "Cannot import unknown element \"@foo\".",
+            ]
+            "###);
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
                 url: "https://specs.apollo.dev/federation/v2.0",
-                import: [ { name: "@sharable" } ]
+                import: ["key"]
+              )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot import unknown element \"key\". Did you mean directive \"@key\"?",
+            ]
+            "###);
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [{ name: "@sharable" }]
+              )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot import unknown element \"@sharable\". Did you mean \"@shareable\"?",
+            ]
+            "###);
+        }
+    }
+
+    mod link_alias_and_import_conflicts {
+        use super::*;
+
+        #[test]
+        fn errors_for_same_identity_imported_twice() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot link feature \"https://specs.apollo.dev/federation\" since it has already been linked in the schema.",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn errors_for_spec_name_in_schema_containing_double_underscore() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(url: "https://custom.dev/f__oo/v1.0")
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot link feature \"https://custom.dev/f__oo\" as \"f__oo\" since it contains \"__\". Please rename to a compliant name via \"as\".",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_renaming_spec_name_containing_double_underscore() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(url: "https://custom.dev/f__oo/v1.0", as: "foo")
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        // See the relevant code in `LinksMetadata.add_link()` for why we have this exception. That
+        // exception and this test may be removed in the future once we have dropped support for the
+        // bugged compositions that necessitate the exception.
+        #[test]
+        fn allows_exception_in_double_underscore_validation_for_federation_namespaced_tag_and_inaccessible()
+         {
+            insta::assert_debug_snapshot!(errors(r#"
+              schema
+                @link(url: "https://specs.apollo.dev/link/v1.0")
+                @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+                @link(
+                  url: "https://specs.apollo.dev/inaccessible/v0.2"
+                  as: "federation__inaccessible"
+                  for: SECURITY
+                )
+                @link(url: "https://specs.apollo.dev/tag/v0.3", as: "federation__tag") {
+                query: Query
+              }
+
+              directive @federation__tag(
+                name: String!
+              ) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+              directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+              directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+              directive @join__field(
+                graph: join__Graph
+                requires: join__FieldSet
+                provides: join__FieldSet
+                type: String
+                external: Boolean
+                override: String
+                usedOverridden: Boolean
+              ) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+              directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+              directive @join__implements(
+                graph: join__Graph!
+                interface: String!
+              ) repeatable on OBJECT | INTERFACE
+
+              directive @join__type(
+                graph: join__Graph!
+                key: join__FieldSet
+                extension: Boolean! = false
+                resolvable: Boolean! = true
+                isInterfaceObject: Boolean! = false
+              ) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+              directive @join__unionMember(
+                graph: join__Graph!
+                member: String!
+              ) repeatable on UNION
+
+              directive @link(
+                url: String
+                as: String
+                for: link__Purpose
+                import: [link__Import]
+              ) repeatable on SCHEMA
+
+              scalar join__FieldSet
+
+              enum join__Graph {
+                S @join__graph(name: "s", url: "")
+              }
+
+              scalar link__Import
+
+              enum link__Purpose {
+                SECURITY
+                EXECUTION
+              }
+
+              type Query @join__type(graph: S) {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_spec_name_in_schema_ending_in_underscore() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(url: "https://custom.dev/foo_/v1.0")
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot link feature \"https://custom.dev/foo_\" as \"foo_\" since it ends in \"_\". Please rename to a compliant name via \"as\".",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_renaming_spec_name_ending_in_underscore() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(url: "https://custom.dev/foo_/v1.0", as: "foo")
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_spec_name_in_schema_that_is_not_a_valid_graphql_name() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(url: "https://custom.dev/0foo/v1.0")
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot link feature \"https://custom.dev/0foo\" as \"0foo\" since it is not a valid GraphQL name. Please rename to a compliant name via \"as\".",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_renaming_spec_name_that_is_not_a_valid_graphql_name() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(url: "https://custom.dev/0foo/v1.0", as: "foo")
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        // See the relevant code in `LinksMetadata.add_link()` for why we have this exception. That
+        // exception and this test may be removed in the future during a major version bump.
+        #[test]
+        fn allows_exception_in_graphql_name_validation_for_period_and_hyphen() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(url: "https://custom.dev/f-o.o/v1.0")
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_spec_name_in_schema_that_conflicts_with_past_namespaced_directive() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: [{ name: "@key", as: "@foo__key" }]
+                )
+                @link(url: "https://custom.dev/foo/v1.0")
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot import \"@key\" as \"@foo__key\" from feature \"https://specs.apollo.dev/federation\" since it can be confused with a namespaced name from another linked feature \"https://custom.dev/foo\". Please rename the import or feature to avoid conflicts via \"as\".",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_renaming_spec_name_that_conflicts_with_past_namespaced_directive() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: [{ name: "@key", as: "@foo__key" }]
+                )
+                @link(url: "https://custom.dev/foo/v1.0", as: "bar")
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_spec_name_in_schema_that_conflicts_with_future_namespaced_directive() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(
+                  url: "https://custom.dev/foo/v1.0"
+                  import: [{ name: "Foo", as: "federation__Foo" }]
                 )
 
-                type Query {
+              type Query {
                 q: Int
-                }
+              }
+            "#), @r###"
+            [
+                "Cannot import \"Foo\" as \"federation__Foo\" from feature \"https://custom.dev/foo\" since it can be confused with a namespaced name from another linked feature \"https://specs.apollo.dev/federation\". Please rename the import or feature to avoid conflicts via \"as\".",
+            ]
+            "###);
+        }
 
-                directive @link(url: String, as: String, import: [Import], for: link__Purpose) repeatable on SCHEMA
-            "#;
+        #[test]
+        fn succeeds_renaming_spec_name_that_conflicts_with_future_namespaced_directive() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", as: "bar")
+                @link(
+                  url: "https://custom.dev/foo/v1.0"
+                  import: [{ name: "Foo", as: "federation__Foo" }]
+                )
 
-            let schema = Schema::parse(schema, "testSchema").unwrap();
-            let errors = LinksMetadata::from_schema(&schema).expect_err("should error");
-            insta::assert_snapshot!(errors, @r###"Cannot import unknown element "@sharable". Did you mean "@shareable"?"###);
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_spec_name_in_schema_that_conflicts_with_past_default_directive() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+                @link(url: "https://custom.dev/key/v1.0")
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot import \"@key\" from feature \"https://specs.apollo.dev/federation\" since it can be confused with a namespaced name from another linked feature \"https://custom.dev/key\". Please rename the import or feature to avoid conflicts via \"as\".",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_renaming_spec_name_that_conflicts_with_past_default_directive() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+                @link(url: "https://custom.dev/key/v1.0", as: "foo")
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_spec_name_in_schema_that_conflicts_with_future_default_directive() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(
+                  url: "https://custom.dev/foo/v1.0"
+                  import: [{ name: "@foo", as: "@federation" }]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot import \"@foo\" as \"@federation\" from feature \"https://custom.dev/foo\" since it can be confused with a namespaced name from another linked feature \"https://specs.apollo.dev/federation\". Please rename the import or feature to avoid conflicts via \"as\".",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_renaming_spec_name_that_conflicts_with_future_default_directive() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", as: "bar")
+                @link(
+                  url: "https://custom.dev/foo/v1.0"
+                  import: [{ name: "@foo", as: "@federation" }]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_spec_name_in_schema_that_conflicts_with_another_spec_name_in_schema() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(url: "https://custom.dev/federation/v1.0")
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot link feature https://custom.dev/federation as \"federation\" since another feature \"https://specs.apollo.dev/federation\" already uses that alias. Please rename the feature to avoid conflicts via \"as\".",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_renaming_spec_name_that_conflicts_with_another_spec_name_in_schema() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(url: "https://custom.dev/federation/v1.0", as: "foo")
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_namespaced_import_that_is_not_a_no_op_import() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: [{ name: "@key", as: "@federation__requires" }]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot import \"@key\" as \"@federation__requires\" from feature \"https://specs.apollo.dev/federation\" since it can be confused with the namespaced name for \"@requires\". Please rename the import to avoid conflicts via \"as\".",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_for_namespaced_import_that_is_a_no_op_import() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: [{ name: "@key", as: "@federation__key" }]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_default_directive_import_that_is_not_a_no_op_import() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(
+                  url: "https://custom.dev/foo/v1.0"
+                  as: "bar"
+                  import: [{ name: "@baz", as: "@bar" }]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot import \"@baz\" as \"@bar\" from feature \"https://custom.dev/foo\" since it can be confused with the namespaced name for \"@foo\". Please rename the import to avoid conflicts via \"as\".",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_for_default_directive_import_that_is_a_no_op_import() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0")
+                @link(
+                  url: "https://custom.dev/foo/v1.0"
+                  as: "bar"
+                  import: [{ name: "@foo", as: "@bar" }]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_imports_of_one_element_to_different_names() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: ["@key", { name: "@key", as: "@foo" }]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot import \"@key\" as \"@foo\" from feature \"https://specs.apollo.dev/federation\" since it was previously imported as \"@key\". Please remove one of these imports.",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_for_imports_of_one_element_to_same_name() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: [
+                    { name: "@key", as: "@foo" }
+                    "@requires"
+                    { name: "@key", as: "@foo" }
+                  ]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_import_name_in_schema_that_already_exists_in_different_spec() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+                @link(
+                  url: "https://custom.dev/foo/v1.0"
+                  import: [{ name: "@foo", as: "@key" }]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot import \"@foo\" as \"@key\" from feature \"https://custom.dev/foo\" since it was previously imported from feature \"https://specs.apollo.dev/federation\". Please rename the import to avoid conflicts via \"as\".",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_renaming_import_name_that_already_exists_in_different_spec() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: [{ name: "@key", as: "@bar" }]
+                )
+                @link(
+                  url: "https://custom.dev/foo/v1.0"
+                  import: [{ name: "@foo", as: "@key" }]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_import_name_in_schema_that_already_exists_in_same_spec() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: ["@key", { name: "@requires", as: "@key" }]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @r###"
+            [
+                "Cannot import \"@requires\" as \"@key\" from feature \"https://specs.apollo.dev/federation\" since it was previously imported for \"@key\". Please rename the import to avoid conflicts via \"as\".",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_renaming_import_name_that_already_exists_in_same_spec() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: [
+                    { name: "@key", as: "@requires" }
+                    { name: "@requires", as: "@key" }
+                  ]
+                )
+
+              type Query {
+                q: Int
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_used_shadowed_directive_import() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+              directive @federation__key(
+                fields: federation__FieldSet!
+                resolvable: Boolean = true
+              ) repeatable on OBJECT | INTERFACE
+
+              scalar federation__FieldSet
+
+              type Query {
+                users: [User!]!
+              }
+
+              type User @federation__key(fields: "id") {
+                id: ID!
+                name: String!
+              }
+            "#), @r###"
+            [
+                "Cannot import \"@key\" from feature \"https://specs.apollo.dev/federation\" since there's a used definition for the namespaced name \"@federation__key\". Please switch usages of the namespaced name to the import name and remove the definition.",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_for_unused_shadowed_directive_import() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+              directive @federation__key(
+                fields: federation__FieldSet!
+                resolvable: Boolean = true
+              ) repeatable on OBJECT | INTERFACE
+
+              scalar federation__FieldSet
+
+              type Query {
+                users: [User!]!
+              }
+
+              type User @key(fields: "id") {
+                id: ID!
+                name: String!
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn errors_for_used_shadowed_type_import() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: ["FieldSet"]
+                )
+
+              scalar federation__FieldSet
+
+              type Query {
+                users: [User!]!
+              }
+
+              type User {
+                id: ID!
+                fieldSet: federation__FieldSet!
+              }
+            "#), @r###"
+            [
+                "Cannot import \"FieldSet\" from feature \"https://specs.apollo.dev/federation\" since there's a used definition for the namespaced name \"federation__FieldSet\". Please switch usages of the namespaced name to the import name and remove the definition.",
+            ]
+            "###);
+        }
+
+        #[test]
+        fn succeeds_for_unused_shadowed_type_import() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: ["FieldSet"]
+                )
+
+              scalar federation__FieldSet
+
+              type Query {
+                users: [User!]!
+              }
+
+              type User {
+                id: ID!
+                fieldSet: String!
+              }
+            "#), @"[]");
+        }
+
+        #[test]
+        fn succeeds_for_shadowed_type_import_used_in_shadowed_import() {
+            insta::assert_debug_snapshot!(errors(r#"
+              extend schema
+                @link(
+                  url: "https://specs.apollo.dev/federation/v2.0"
+                  import: ["@key", "FieldSet"]
+                )
+
+              directive @federation__key(
+                fields: federation__FieldSet!
+                resolvable: Boolean = true
+              ) repeatable on OBJECT | INTERFACE
+
+              scalar federation__FieldSet
+
+              type Query {
+                users: [User!]!
+              }
+
+              type User {
+                id: ID!
+                fieldSet: String!
+              }
+            "#), @"[]");
         }
     }
 

--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 use std::ops::Range;
-use std::str;
 use std::sync::Arc;
 
 use apollo_compiler::Name;
@@ -12,6 +11,8 @@ use apollo_compiler::parser::LineColumn;
 use apollo_compiler::schema::Component;
 
 use crate::error::FederationError;
+use crate::link::link_spec_definition::CORE_VERSIONS;
+use crate::link::link_spec_definition::LINK_VERSIONS;
 use crate::link::spec::Identity;
 use crate::link::spec::Url;
 
@@ -45,7 +46,7 @@ impl fmt::Display for Purpose {
     }
 }
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Import {
     /// The name of the element that is being imported.
     ///
@@ -61,37 +62,39 @@ pub struct Import {
 }
 
 impl Import {
-    pub fn imported_name(&self) -> &Name {
+    pub fn name_in_schema(&self) -> &Name {
         self.alias.as_ref().unwrap_or(&self.element)
     }
 
-    pub fn element_display_name(&self) -> impl fmt::Display {
-        DisplayName {
-            name: &self.element,
+    pub fn element_name_in_spec(&self) -> ElementName {
+        ElementName {
+            name: self.element.clone(),
             is_directive: self.is_directive,
         }
     }
 
-    pub fn imported_display_name(&self) -> impl fmt::Display {
-        DisplayName {
-            name: self.imported_name(),
+    pub fn element_name_in_schema(&self) -> ElementName {
+        ElementName {
+            name: self.name_in_schema().clone(),
             is_directive: self.is_directive,
         }
     }
 }
 
-/// A [`fmt::Display`]able wrapper for name strings that adds an `@` in front for directive names.
-struct DisplayName<'s> {
-    name: &'s str,
-    is_directive: bool,
+/// The name of a type or directive, regardless of whether it's a name-in-spec or a name-in-schema.
+/// Note that this is cheap to clone since [Name] is cheap to clone.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ElementName {
+    pub name: Name,
+    pub is_directive: bool,
 }
 
-impl fmt::Display for DisplayName<'_> {
+impl fmt::Display for ElementName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_directive {
             f.write_str("@")?;
         }
-        f.write_str(self.name)
+        f.write_str(&self.name)
     }
 }
 
@@ -101,6 +104,8 @@ impl fmt::Display for Import {
     }
 }
 
+/// Metadata about a single application of @link in a schema.
+// PORT_NOTE: Named `CoreFeature` in the JS codebase, but "core" is outdated terminology.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Link {
     pub url: Url,
@@ -111,17 +116,42 @@ pub struct Link {
 }
 
 impl Link {
-    pub fn from_directive_application(
+    /// Use [super::LinkSpecDefinition::link_from_directive] instead of this method where possible,
+    /// since this method guesses the version of the link/core spec.
+    pub(crate) fn from_directive_application_when_link_spec_unknown(
         directive: &Node<Directive>,
         schema: &Schema,
     ) -> Result<Link, FederationError> {
-        let mut link = Link::try_from(directive.as_ref())?;
-        link.line_column_range = directive.line_column_range(&schema.sources);
-        Ok(link)
+        LINK_VERSIONS
+            .latest()
+            .link_from_directive(directive, schema)
+            .or_else(|error| {
+                // If the directive couldn't be parsed as a @link application, try parsing it as @core
+                // one, though if that also errors then prefer the original @link-parsing errors.
+                CORE_VERSIONS
+                    .latest()
+                    .link_from_directive(directive, schema)
+                    .or(Err(error))
+            })
     }
 
-    pub fn spec_name_in_schema(&self) -> &Name {
-        self.spec_alias.as_ref().unwrap_or(&self.url.identity.name)
+    pub fn spec_name_in_schema(&self) -> Name {
+        if let Some(spec_alias) = &self.spec_alias {
+            return spec_alias.clone();
+        }
+        let name = &self.url.identity.name;
+        name.clone().try_into().unwrap_or_else(|_| {
+            // TODO: While @link does allow for specs with invalid names as long as they have valid
+            // aliases, for backwards compatibility, we need to support @link applications that have
+            // an invalid name and no alias. These have historically been fine because such schemas
+            // do not use the default names for types/directives from the spec being linked. So
+            // ideally, we would return a `Result::Err` in `directive_name_in_schema()` and
+            // `type_name_in_schema()` when someone tries to compute an element name-in-schema that
+            // would be an invalid name. However, that would cause many upstream callers to also
+            // have to return `Result`. For now, we're leaving that step to the future. (We wouldn't
+            // do that in this method because it's used in `LinksMetadata::add_link()`.)
+            Name::new_unchecked(name)
+        })
     }
 
     pub fn directive_name_in_schema(&self, name: &Name) -> Name {
@@ -131,7 +161,7 @@ impl Link {
         // whose name match the one of the spec: those don't get qualified.
         if let Some(import) = self.imports.iter().find(|i| i.element == *name) {
             import.alias.clone().unwrap_or_else(|| name.clone())
-        } else if name == self.url.identity.name.as_str() {
+        } else if name.as_str() == self.url.identity.name.as_ref() {
             self.spec_name_in_schema().clone()
         } else {
             // Both sides are `Name`s and we just add valid characters in between.
@@ -149,8 +179,8 @@ impl Link {
             .iter()
             .find(|i| i.element == *directive_name_in_spec)
         {
-            element_import.imported_name().clone()
-        } else if spec_url.identity.name == *directive_name_in_spec {
+            element_import.name_in_schema().clone()
+        } else if spec_url.identity.name.as_ref() == directive_name_in_spec.as_str() {
             spec_name_in_schema.clone()
         } else {
             Name::new_unchecked(format!("{spec_name_in_schema}__{directive_name_in_spec}").as_str())
@@ -168,7 +198,7 @@ impl Link {
         }
     }
 
-    pub fn for_identity<'schema>(
+    pub(crate) fn for_identity<'schema>(
         schema: &'schema Schema,
         identity: &Identity,
     ) -> Option<(Self, &'schema Component<Directive>)> {
@@ -177,7 +207,9 @@ impl Link {
             .directives
             .iter()
             .find_map(|directive| {
-                let link = Link::from_directive_application(directive, schema).ok()?;
+                let link =
+                    Link::from_directive_application_when_link_spec_unknown(directive, schema)
+                        .ok()?;
                 if link.url.identity == *identity {
                     Some((link, directive))
                 } else {
@@ -185,18 +217,10 @@ impl Link {
                 }
             })
     }
-
-    /// Returns true if this link has an import assigning an alias to the given element.
-    pub(crate) fn renames(&self, element: &Name) -> bool {
-        self.imports
-            .iter()
-            .find(|import| &import.element == element)
-            .is_some_and(|import| *import.imported_name() != *element)
-    }
 }
 
 impl fmt::Display for Link {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Directive::from(self).fmt(f)
+        LINK_VERSIONS.latest().directive_from_link(self).fmt(f)
     }
 }

--- a/apollo-federation/src/link/spec.rs
+++ b/apollo-federation/src/link/spec.rs
@@ -1,8 +1,7 @@
 //! Representation of spec identities, versions, and URLs.
 use std::fmt;
 use std::str;
-
-use apollo_compiler::Name;
+use std::sync::Arc;
 
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
@@ -10,13 +9,13 @@ use crate::error::SingleFederationError;
 /// Represents the identity of a `@link` specification, which uniquely identify a specification.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Identity {
-    /// The "domain" of which the specification this identifies is part of.
-    /// For instance, `"https://specs.apollo.dev"`.
+    /// The "domain" of which the specification this identifies is part of. For instance,
+    /// `"https://specs.apollo.dev"`.
     pub domain: String,
 
-    /// The name of the specification this identifies.
-    /// For instance, "federation".
-    pub name: Name,
+    /// The name of the specification this identifies. For instance, "federation". This isn't
+    /// guaranteed to a valid GraphQL name.
+    pub name: Arc<str>,
 }
 
 impl fmt::Display for Identity {
@@ -25,7 +24,7 @@ impl fmt::Display for Identity {
     ///     # use apollo_federation::link::spec::Identity;
     ///     use apollo_compiler::name;
     ///     assert_eq!(
-    ///         Identity { domain: "https://specs.apollo.dev".to_string(), name: name!("federation") }.to_string(),
+    ///         Identity { domain: "https://specs.apollo.dev".to_string(), name: name!("federation").into() }.to_string(),
     ///         "https://specs.apollo.dev/federation"
     ///     )
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -140,7 +139,7 @@ impl fmt::Display for Url {
     ///     use apollo_compiler::name;
     ///     assert_eq!(
     ///         Url {
-    ///           identity: Identity { domain: "https://specs.apollo.dev".to_string(), name: name!("federation") },
+    ///           identity: Identity { domain: "https://specs.apollo.dev".to_string(), name: name!("federation").into() },
     ///           version: Version { major: 2, minor: 3 }
     ///         }.to_string(),
     ///         "https://specs.apollo.dev/federation/v2.3"
@@ -184,12 +183,7 @@ impl str::FromStr for Url {
                             r#"@link(url:) argument `"{s}"` missing specification name"#
                         ),
                     })
-                    // Note this is SUPER wrong, but the JS federation implementation didn't check
-                    // if the name was valid, and customers are actively using URLs with for example dashes.
-                    // So we pretend that it's fine. You can't reference an imported element by the
-                    // namespaced name because it's not valid GraphQL to do so--but you can
-                    // explicitly import elements from a spec with an invalid name.
-                    .map(Name::new_unchecked)?;
+                    .map(Arc::from)?;
                 if !url.scheme().starts_with("http") {
                     return Err(SingleFederationError::InvalidLinkIdentifier {
                         message: format!(
@@ -294,7 +288,7 @@ mod tests {
             Url {
                 identity: Identity {
                     domain: "https://specs.apollo.dev".to_string(),
-                    name: name!("federation")
+                    name: name!("federation").into(),
                 },
                 version: Version { major: 2, minor: 3 }
             }
@@ -307,7 +301,7 @@ mod tests {
             Url {
                 identity: Identity {
                     domain: "http://something.com/more/path".to_string(),
-                    name: name!("my_spec_name")
+                    name: name!("my_spec_name").into(),
                 },
                 version: Version { major: 0, minor: 1 }
             }
@@ -319,7 +313,7 @@ mod tests {
             Url {
                 identity: Identity {
                     domain: "http://localhost:8080".to_string(),
-                    name: name!("foo")
+                    name: name!("foo").into(),
                 },
                 version: Version { major: 1, minor: 0 }
             }
@@ -333,7 +327,7 @@ mod tests {
             Url {
                 identity: Identity {
                     domain: "http://localhost:8080/extra".to_string(),
-                    name: name!("foo")
+                    name: name!("foo").into(),
                 },
                 version: Version { major: 1, minor: 0 }
             }
@@ -347,7 +341,7 @@ mod tests {
             Url {
                 identity: Identity {
                     domain: "https://specs.apollo.dev".to_string(),
-                    name: name!("federation")
+                    name: name!("federation").into(),
                 },
                 version: Version { major: 2, minor: 3 }
             }

--- a/apollo-federation/src/link/spec_definition.rs
+++ b/apollo-federation/src/link/spec_definition.rs
@@ -13,6 +13,7 @@ use crate::ensure;
 use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
+use crate::link::ElementName;
 use crate::link::Link;
 use crate::link::Purpose;
 use crate::link::spec::Identity;
@@ -179,6 +180,21 @@ pub(crate) trait SpecDefinition {
             [error] => Err(FederationError::SingleFederationError(error.clone())),
             _ => Err(FederationError::MultipleFederationErrors(errors)),
         }
+    }
+
+    fn all_element_names(&self) -> Box<dyn Iterator<Item = ElementName>> {
+        Box::new(
+            self.type_specs()
+                .into_iter()
+                .map(|spec| ElementName {
+                    name: spec.name().clone(),
+                    is_directive: false,
+                })
+                .chain(self.directive_specs().into_iter().map(|spec| ElementName {
+                    name: spec.name().clone(),
+                    is_directive: true,
+                })),
+        )
     }
 }
 

--- a/apollo-federation/src/link/spec_registry.rs
+++ b/apollo-federation/src/link/spec_registry.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use std::str;
 use std::sync::LazyLock;
 
+use apollo_compiler::Name;
 use apollo_compiler::name;
 
 use crate::connectors::spec::CONNECT_VERSIONS;
-use crate::link::Import;
 use crate::link::Link;
 use crate::link::authenticated_spec_definition::AUTHENTICATED_VERSIONS;
 use crate::link::cache_tag_spec_definition::CACHE_TAG_VERSIONS;
@@ -29,101 +29,115 @@ use crate::schema::type_and_directive_specification::DirectiveSpecification;
 pub(crate) const APOLLO_SPEC_DOMAIN: &str = "https://specs.apollo.dev";
 
 impl Identity {
+    pub const AUTHENTICATED_NAME: Name = name!("authenticated");
     pub fn authenticated_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("authenticated"),
+            name: Self::AUTHENTICATED_NAME.into(),
         }
     }
 
+    pub const CACHE_TAG_NAME: Name = name!("cacheTag");
     pub fn cache_tag_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("cacheTag"),
+            name: Self::CACHE_TAG_NAME.into(),
         }
     }
 
+    pub const CONNECT_NAME: Name = name!("connect");
     pub fn connect_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("connect"),
+            name: Self::CONNECT_NAME.into(),
         }
     }
 
+    pub const CONTEXT_NAME: Name = name!("context");
     pub fn context_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("context"),
+            name: Self::CONTEXT_NAME.into(),
         }
     }
 
+    pub const CORE_NAME: Name = name!("core");
     pub fn core_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("core"),
+            name: Self::CORE_NAME.into(),
         }
     }
 
+    pub const COST_NAME: Name = name!("cost");
     pub fn cost_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("cost"),
+            name: Self::COST_NAME.into(),
         }
     }
 
+    pub const FEDERATION_NAME: Name = name!("federation");
     pub fn federation_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("federation"),
+            name: Self::FEDERATION_NAME.into(),
         }
     }
 
+    pub const INACCESSIBLE_NAME: Name = name!("inaccessible");
     pub fn inaccessible_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("inaccessible"),
+            name: Self::INACCESSIBLE_NAME.into(),
         }
     }
 
+    pub const JOIN_NAME: Name = name!("join");
     pub fn join_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("join"),
+            name: Self::JOIN_NAME.into(),
         }
     }
 
+    pub const LINK_NAME: Name = name!("link");
     pub fn link_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("link"),
+            name: Self::LINK_NAME.into(),
         }
     }
 
+    pub const POLICY_NAME: Name = name!("policy");
     pub fn policy_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("policy"),
+            name: Self::POLICY_NAME.into(),
         }
     }
 
+    pub const REQUIRES_SCOPES_NAME: Name = name!("requiresScopes");
     pub fn requires_scopes_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("requiresScopes"),
+            name: Self::REQUIRES_SCOPES_NAME.into(),
         }
     }
 
+    pub const SOURCE_NAME: Name = name!("source");
     pub fn source_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("source"),
+            name: Self::SOURCE_NAME.into(),
         }
     }
 
+    pub const TAG_NAME: Name = name!("tag");
     pub fn tag_identity() -> Identity {
         Identity {
             domain: APOLLO_SPEC_DOMAIN.to_string(),
-            name: name!("tag"),
+            name: Self::TAG_NAME.into(),
         }
     }
 }
@@ -183,12 +197,10 @@ impl SpecRegistry {
     pub(crate) fn get_composition_spec(
         &self,
         source: &Link,
-        directive_import: &Import,
+        directive_name_in_spec: &Name,
     ) -> Option<DirectiveCompositionSpecification> {
         let specs = self.get_definition(&source.url)?.directive_specs();
-        let spec = specs
-            .iter()
-            .find(|s| *s.name() == directive_import.element)?;
+        let spec = specs.iter().find(|s| s.name() == directive_name_in_spec)?;
         let directive_spec: DirectiveSpecification = spec.as_any().downcast_ref().cloned()?;
         directive_spec.composition
     }

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -927,7 +927,8 @@ struct DirectiveNames {
 impl DirectiveNames {
     fn for_metadata(metadata: &Option<&LinksMetadata>) -> Self {
         let federation_identity =
-            metadata.and_then(|m| m.by_identity.get(&Identity::federation_identity()));
+            metadata.and_then(|m| m.for_identity(&Identity::federation_identity()));
+        let federation_identity = federation_identity.as_ref();
 
         let key = federation_identity
             .map(|link| link.directive_name_in_schema(&FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC))

--- a/apollo-federation/src/merger/compose_directive_manager.rs
+++ b/apollo-federation/src/merger/compose_directive_manager.rs
@@ -65,28 +65,38 @@ pub(crate) struct ComposeDirectiveManager {
 pub(crate) struct MergeDirectiveItem {
     subgraph_name: String,
     pub(crate) definition: DirectiveDefinition,
-    link: LinkedElement,
+    link: Arc<Link>,
+    name_in_spec: Name,
+    name_in_schema: Name,
 }
 
 impl MergeDirectiveItem {
-    fn new(subgraph_name: String, definition: DirectiveDefinition, link: LinkedElement) -> Self {
+    fn new(
+        subgraph_name: String,
+        definition: DirectiveDefinition,
+        link: Arc<Link>,
+        name_in_spec: Name,
+        name_in_schema: Name,
+    ) -> Self {
         Self {
             subgraph_name,
             definition,
             link,
+            name_in_spec,
+            name_in_schema,
         }
     }
 
     fn identity(&self) -> &Identity {
-        &self.link.link.url.identity
+        &self.link.url.identity
     }
 
     fn directive_name_in_spec(&self) -> &Name {
-        &self.link.name_in_spec
+        &self.name_in_spec
     }
 
     fn directive_name(&self) -> &Name {
-        &self.link.name
+        &self.name_in_schema
     }
 
     fn directive_has_different_name_in_subgraph<T: HasMetadata>(
@@ -96,7 +106,7 @@ impl MergeDirectiveItem {
         let Some(metadata) = subgraph.schema().metadata() else {
             return false;
         };
-        let Some(link) = metadata.for_identity(&self.link.link.url.identity) else {
+        let Some(link) = metadata.for_identity(&self.link.url.identity) else {
             return false;
         };
         let Some(imp) = link
@@ -296,12 +306,20 @@ impl ComposeDirectiveManager {
                         // one when merging. Otherwise, it doesn't make much sense to force users to
                         // write a dummy URL, especially when we error/warn when used with any
                         // Federation directives.
-                        let Some(feature) = subgraph
+                        let Some(LinkedElement { link, name_in_spec }) = subgraph
                             .schema()
                             .metadata()
                             .and_then(|links| links.source_link_of_directive(&directive.name))
                         else {
                             error_reporter.add_compose_directive_error_for_unrecognized_feature(
+                                compose_directive.arguments.name,
+                                subgraph.name.as_str(),
+                            );
+                            continue;
+                        };
+
+                        let Some(name_in_spec) = name_in_spec else {
+                            error_reporter.add_compose_directive_error_for_invalid_name_in_spec(
                                 compose_directive.arguments.name,
                                 subgraph.name.as_str(),
                             );
@@ -314,15 +332,15 @@ impl ComposeDirectiveManager {
                         // Note that we check for conflicts across subgraphs to make sure that we
                         // don't compose a custom `@tag` directive with the federation one, if it
                         // hasn't been properly renamed in another subgraph.
-                        if feature.link.url.identity.domain == APOLLO_SPEC_DOMAIN
-                            && DEFAULT_COMPOSED_DIRECTIVES.contains(&feature.name_in_spec)
+                        if link.url.identity.domain == APOLLO_SPEC_DOMAIN
+                            && DEFAULT_COMPOSED_DIRECTIVES.contains(&name_in_spec)
                         {
                             error_reporter
                                 .add_compose_directive_hint_for_default_composed_directive(
                                     compose_directive.arguments.name,
                                     directive.locations(subgraph),
                                 );
-                        } else if feature.link.url.identity.domain == APOLLO_SPEC_DOMAIN {
+                        } else if link.url.identity.domain == APOLLO_SPEC_DOMAIN {
                             error_reporter.add_compose_directive_error_for_unsupported_directive(
                                 compose_directive.arguments.name,
                                 subgraph.name.as_str(),
@@ -347,7 +365,9 @@ impl ComposeDirectiveManager {
                             let item = MergeDirectiveItem::new(
                                 subgraph.name.clone(),
                                 directive.as_ref().clone(),
-                                feature,
+                                link,
+                                name_in_spec,
+                                directive.name.clone(),
                             );
                             items_by_subgraph.insert(subgraph.name.clone(), item.clone());
                             items_by_directive_name.insert(directive.name.clone(), item.clone());
@@ -383,8 +403,7 @@ impl ComposeDirectiveManager {
                     subgraph
                         .schema()
                         .metadata()?
-                        .links
-                        .iter()
+                        .all_links()
                         .map(|link| &link.url.identity),
                 )
             })
@@ -651,6 +670,12 @@ impl ErrorReporter {
     ) {
         self.add_error(CompositionError::DirectiveCompositionError {
             message: format!("Argument to @composeDirective \"{invalid_name}\" in subgraph \"{subgraph}\" must have a leading \"@\""),
+        });
+    }
+
+    fn add_compose_directive_error_for_invalid_name_in_spec(&mut self, name: &str, subgraph: &str) {
+        self.add_error(CompositionError::DirectiveCompositionError {
+            message: format!("Directive \"{name}\" in subgraph \"{subgraph}\" cannot be composed because its spec name is invalid or imported to a different name")
         });
     }
 

--- a/apollo-federation/src/merger/merge_enum.rs
+++ b/apollo-federation/src/merger/merge_enum.rs
@@ -457,11 +457,12 @@ pub(crate) mod tests {
             join_spec_definition,
             join_directive_identities: Default::default(),
             directives_using_join_directive: Default::default(),
-            schema_to_import_to_feature_url: Default::default(),
             latest_federation_version_used: FEDERATION_VERSIONS.latest().version().clone(),
             applied_directives_to_merge: Default::default(),
             access_control_directives_in_supergraph: Default::default(),
             access_control_additional_sources: FallibleOnceCell::new(),
+            import_conflicts_by_identity: Default::default(),
+            compute_unique_spec_name_in_schema: None,
         })
     }
 }

--- a/apollo-federation/src/merger/merge_links.rs
+++ b/apollo-federation/src/merger/merge_links.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use apollo_compiler::Name;
 use apollo_compiler::ast::DirectiveDefinition;
 use apollo_compiler::collections::IndexMap;
@@ -9,9 +7,11 @@ use tracing::trace;
 use crate::bail;
 use crate::error::CompositionError;
 use crate::error::FederationError;
+use crate::internal_error;
 use crate::link::Import;
 use crate::link::Link;
 use crate::link::authenticated_spec_definition::AUTHENTICATED_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::metadata::LinkedElement;
 use crate::link::policy_spec_definition::POLICY_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::requires_scopes_spec_definition::REQUIRES_SCOPES_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::spec::Identity;
@@ -39,11 +39,17 @@ impl std::fmt::Debug for CoreDirectiveInSubgraphs {
     }
 }
 
-struct CoreDirectiveInSupergraph {
-    spec_in_supergraph: &'static dyn SpecDefinition,
-    name_in_feature: Name,
-    name_in_supergraph: Name,
-    composition_spec: DirectiveCompositionSpecification,
+pub(crate) type SupergraphInfoByIdentity = IndexMap<Identity, SupergraphInfo>;
+
+pub(crate) struct SupergraphInfo {
+    pub(crate) spec_in_supergraph: &'static dyn SpecDefinition,
+    pub(crate) directives: Vec<SupergraphDirectiveInfo>,
+}
+
+pub(crate) struct SupergraphDirectiveInfo {
+    pub(crate) name_in_feature: Name,
+    pub(crate) name_in_supergraph: Name,
+    pub(crate) composition_spec: DirectiveCompositionSpecification,
 }
 
 impl Merger {
@@ -64,38 +70,21 @@ impl Merger {
             };
 
             for (directive, referencers) in &subgraph.schema().referencers().directives {
-                let Some(linked_elem) = features.source_link_of_directive(directive) else {
+                let Some(LinkedElement {
+                    link: source,
+                    name_in_spec,
+                }) = features.source_link_of_directive(directive)
+                else {
+                    continue;
+                };
+                let Some(name_in_spec) = name_in_spec else {
                     continue;
                 };
                 if referencers.is_empty() {
                     continue;
                 }
-                let source = linked_elem.link;
-                let import = match linked_elem.import {
-                    Some(import) => import,
-                    None => {
-                        // If there is no explicit import, we create a synthetic import for
-                        // merging. The directive name in the spec is either derived from the
-                        // "__" prefix (e.g., "join__field" -> "field") or, for directives
-                        // that match their spec's identity name (e.g., @requiresScopes from
-                        // the requiresScopes spec), from the linked element's name_in_spec.
-                        let element_name =
-                            if let Some((_, name_in_spec)) = directive.split_once("__") {
-                                let Ok(name) = Name::new(name_in_spec) else {
-                                    continue;
-                                };
-                                name
-                            } else {
-                                linked_elem.name_in_spec
-                            };
-                        Arc::new(Import {
-                            element: element_name,
-                            is_directive: true,
-                            alias: None,
-                        })
-                    }
-                };
-                let Some(composition_spec) = SPEC_REGISTRY.get_composition_spec(&source, &import)
+                let Some(composition_spec) =
+                    SPEC_REGISTRY.get_composition_spec(&source, &name_in_spec)
                 else {
                     trace!(
                         "Directive @{directive} from {} has no registered composition spec, skipping",
@@ -115,7 +104,7 @@ impl Merger {
                     )
                 };
 
-                let fqn = format!("{}-{}", import.element, source.url.identity);
+                let fqn = format!("{}-{}", name_in_spec, source.url.identity);
                 let for_feature = directives_per_feature_and_version.entry(fqn).or_default();
 
                 let major = if source.url.version.major > 0 {
@@ -136,7 +125,7 @@ impl Merger {
                     definitions_per_subgraph.insert(subgraph.name.clone(), (**definition).clone());
                     let for_version = CoreDirectiveInSubgraphs {
                         url: source.url.clone(),
-                        name: import.element.clone(),
+                        name: name_in_spec.clone(),
                         definitions_per_subgraph,
                         composition_spec,
                     };
@@ -151,12 +140,12 @@ impl Merger {
             .collect())
     }
 
-    pub(crate) fn validate_and_maybe_add_specs(
+    pub(crate) fn validate_core_directive_info(
         &mut self,
-        directives_merge_info: &[CoreDirectiveInSubgraphs],
-    ) -> Result<(), FederationError> {
-        let mut supergraph_info_by_identity: IndexMap<Identity, Vec<CoreDirectiveInSupergraph>> =
-            IndexMap::default();
+        directives_merge_info: Vec<CoreDirectiveInSubgraphs>,
+    ) -> Result<SupergraphInfoByIdentity, FederationError> {
+        let mut supergraph_info_by_identity: IndexMap<Identity, SupergraphInfo> =
+            Default::default();
 
         trace!("Determining supergraph names for directives used in subgraphs");
         for subgraph_core_directive in directives_merge_info {
@@ -195,7 +184,7 @@ impl Merger {
                         |def| Some(format!("\"@{}\"", def.name)),
                         |def, _| Some(format!("\"@{}\"", def.name)),
                     );
-                    return Ok(());
+                    return Ok(supergraph_info_by_identity);
                 }
             }
 
@@ -218,30 +207,31 @@ impl Merger {
                 );
                 continue;
             };
+
             let supergraph_info = supergraph_info_by_identity
                 .entry(spec_in_supergraph.identity().clone())
-                .or_default();
-
-            if !supergraph_info
-                .iter()
-                .any(|d| d.name_in_feature == subgraph_core_directive.name)
-            {
-                supergraph_info.push(CoreDirectiveInSupergraph {
+                .or_insert(SupergraphInfo {
                     spec_in_supergraph,
-                    name_in_feature: subgraph_core_directive.name.clone(),
-                    name_in_supergraph: name_in_supergraph.clone(),
-                    composition_spec: subgraph_core_directive.composition_spec.clone(),
+                    directives: Default::default(),
                 });
-            }
 
-            if supergraph_info
-                .iter()
-                .any(|s| s.spec_in_supergraph.url() != spec_in_supergraph.url())
-            {
+            if supergraph_info.spec_in_supergraph.url() != spec_in_supergraph.url() {
                 bail!(
                     "Spec {} directives disagree on version for supergraph",
                     spec_in_supergraph.url()
                 )
+            }
+
+            if !supergraph_info
+                .directives
+                .iter()
+                .any(|d| d.name_in_feature == subgraph_core_directive.name)
+            {
+                supergraph_info.directives.push(SupergraphDirectiveInfo {
+                    name_in_feature: subgraph_core_directive.name.clone(),
+                    name_in_supergraph: name_in_supergraph.clone(),
+                    composition_spec: subgraph_core_directive.composition_spec.clone(),
+                });
             }
 
             if subgraph_core_directive.composition_spec.use_join_directive {
@@ -250,9 +240,42 @@ impl Merger {
             }
         }
 
-        for supergraph_core_directives in supergraph_info_by_identity.values() {
+        Ok(supergraph_info_by_identity)
+    }
+
+    pub(crate) fn maybe_add_specs(
+        &mut self,
+        supergraph_info_by_identity: &SupergraphInfoByIdentity,
+    ) -> Result<(), FederationError> {
+        for SupergraphInfo {
+            spec_in_supergraph,
+            directives,
+        } in supergraph_info_by_identity.values()
+        {
+            let spec_name_in_schema = if self
+                .merged
+                .metadata()
+                .map(|metadata| {
+                    metadata.is_spec_name_in_schema_valid(
+                        &spec_in_supergraph.identity().name,
+                        spec_in_supergraph.identity(),
+                        &self.import_conflicts_by_identity,
+                    )
+                })
+                .unwrap_or(false)
+            {
+                Name::new_unchecked(&spec_in_supergraph.identity().name)
+            } else {
+                self.compute_unique_spec_name_in_schema
+                    .as_mut()
+                    .ok_or_else(|| {
+                        internal_error!(
+                            "compute_unique_spec_name_in_schema() unexpectedly uninitialized"
+                        )
+                    })?(&spec_in_supergraph.identity().name)
+            };
             let mut imports = Vec::new();
-            for supergraph_core_directive in supergraph_core_directives {
+            for supergraph_core_directive in directives {
                 // Directives composed via @join__directive are not imported in the supergraph schema.
                 if supergraph_core_directive
                     .composition_spec
@@ -261,12 +284,8 @@ impl Merger {
                     continue;
                 }
                 let default_name_in_supergraph = Link::directive_name_in_schema_for_core_arguments(
-                    supergraph_core_directive.spec_in_supergraph.url(),
-                    &supergraph_core_directive
-                        .spec_in_supergraph
-                        .url()
-                        .identity
-                        .name,
+                    spec_in_supergraph.url(),
+                    &spec_name_in_schema,
                     &[],
                     &supergraph_core_directive.name_in_feature,
                 );
@@ -288,22 +307,20 @@ impl Merger {
 
             self.link_spec_definition.apply_feature_to_schema(
                 &mut self.merged,
-                supergraph_core_directives[0].spec_in_supergraph,
-                None,
-                supergraph_core_directives[0].spec_in_supergraph.purpose(),
+                *spec_in_supergraph,
+                Some(spec_name_in_schema).take_if(|spec_name_in_schema| {
+                    spec_name_in_schema.as_str() != spec_in_supergraph.identity().name.as_ref()
+                }),
+                spec_in_supergraph.purpose(),
                 Some(imports),
+                |error| Self::push_non_internal_errors(&mut self.error_reporter, error),
             )?;
 
             let Some(links_metadata) = self.merged.metadata() else {
                 bail!("Missing links metadata in supergraph schema");
             };
-            let feature = links_metadata.for_identity(
-                &supergraph_core_directives[0]
-                    .spec_in_supergraph
-                    .url()
-                    .identity,
-            );
-            for supergraph_core_directive in supergraph_core_directives {
+            let feature = links_metadata.for_identity(&spec_in_supergraph.url().identity);
+            for supergraph_core_directive in directives {
                 let arguments_merger = if let Some(merger_factory) = supergraph_core_directive
                     .composition_spec
                     .argument_merger
@@ -328,55 +345,31 @@ impl Merger {
                     );
                 // If we encounter the @inaccessible directive, we need to record its definition so
                 // certain merge validations that care about @inaccessible can act accordingly.
-                if *supergraph_core_directive.spec_in_supergraph.identity()
-                    == Identity::inaccessible_identity()
-                    && supergraph_core_directive.name_in_feature
-                        == supergraph_core_directive
-                            .spec_in_supergraph
-                            .url()
-                            .identity
-                            .name
+                if *spec_in_supergraph.identity() == Identity::inaccessible_identity()
+                    && supergraph_core_directive.name_in_feature == Identity::INACCESSIBLE_NAME
                 {
                     self.inaccessible_directive_name_in_supergraph =
                         Some(supergraph_core_directive.name_in_supergraph.clone());
                 }
 
-                if *supergraph_core_directive.spec_in_supergraph.identity()
-                    == Identity::authenticated_identity()
-                    && supergraph_core_directive.name_in_feature
-                        == supergraph_core_directive
-                            .spec_in_supergraph
-                            .url()
-                            .identity
-                            .name
+                if *spec_in_supergraph.identity() == Identity::authenticated_identity()
+                    && supergraph_core_directive.name_in_feature == Identity::AUTHENTICATED_NAME
                 {
                     self.access_control_directives_in_supergraph.push((
                         AUTHENTICATED_DIRECTIVE_NAME_IN_SPEC,
                         supergraph_core_directive.name_in_supergraph.clone(),
                     ));
                 }
-                if *supergraph_core_directive.spec_in_supergraph.identity()
-                    == Identity::requires_scopes_identity()
-                    && supergraph_core_directive.name_in_feature
-                        == supergraph_core_directive
-                            .spec_in_supergraph
-                            .url()
-                            .identity
-                            .name
+                if *spec_in_supergraph.identity() == Identity::requires_scopes_identity()
+                    && supergraph_core_directive.name_in_feature == Identity::REQUIRES_SCOPES_NAME
                 {
                     self.access_control_directives_in_supergraph.push((
                         REQUIRES_SCOPES_DIRECTIVE_NAME_IN_SPEC,
                         supergraph_core_directive.name_in_supergraph.clone(),
                     ));
                 }
-                if *supergraph_core_directive.spec_in_supergraph.identity()
-                    == Identity::policy_identity()
-                    && supergraph_core_directive.name_in_feature
-                        == supergraph_core_directive
-                            .spec_in_supergraph
-                            .url()
-                            .identity
-                            .name
+                if *spec_in_supergraph.identity() == Identity::policy_identity()
+                    && supergraph_core_directive.name_in_feature == Identity::POLICY_NAME
                 {
                     self.access_control_directives_in_supergraph.push((
                         POLICY_DIRECTIVE_NAME_IN_SPEC,

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Debug;
@@ -34,6 +35,7 @@ use crate::bail;
 use crate::composition::CompositionOptions;
 use crate::connectors::spec::CONNECT_VERSIONS;
 use crate::error::CompositionError;
+use crate::error::ErrorCode;
 use crate::error::FederationError;
 use crate::error::HasLocations;
 use crate::error::SubgraphLocation;
@@ -49,10 +51,15 @@ use crate::link::join_spec_definition::JOIN_FIELD_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::join_spec_definition::JOIN_GRAPH_ARGUMENT_NAME;
 use crate::link::join_spec_definition::JOIN_VERSIONS;
 use crate::link::join_spec_definition::JoinSpecDefinition;
+use crate::link::link_spec_definition::LINK_DIRECTIVE_AS_ARGUMENT_NAME;
 use crate::link::link_spec_definition::LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME;
 use crate::link::link_spec_definition::LINK_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::link_spec_definition::LINK_DIRECTIVE_URL_ARGUMENT_NAME;
 use crate::link::link_spec_definition::LINK_VERSIONS;
+use crate::link::metadata::ImportConflictsByIdentity;
+use crate::link::metadata::LinksMetadata;
+use crate::link::metadata::SpecConflictInfo;
+use crate::link::metadata::UniqueSpecNameInSchema;
 use crate::link::spec::Identity;
 use crate::link::spec::Url;
 use crate::link::spec::Version;
@@ -68,6 +75,8 @@ use crate::merger::merge_enum::EnumExampleAst;
 use crate::merger::merge_enum::EnumTypeUsage;
 use crate::merger::merge_field::FieldMergeContext;
 use crate::merger::merge_field::JoinFieldBuilder;
+use crate::merger::merge_links::SupergraphDirectiveInfo;
+use crate::merger::merge_links::SupergraphInfo;
 use crate::schema::FederationSchema;
 use crate::schema::ValidFederationSchema;
 use crate::schema::directive_location::DirectiveLocationExt;
@@ -159,7 +168,6 @@ pub(crate) struct Merger {
     pub(in crate::merger) fields_with_from_context: DirectiveReferencers,
     pub(in crate::merger) fields_with_override: DirectiveReferencers,
     pub(in crate::merger) inaccessible_directive_name_in_supergraph: Option<Name>,
-    pub(in crate::merger) schema_to_import_to_feature_url: HashMap<String, HashMap<String, Url>>,
     pub(in crate::merger) link_spec_definition: &'static LinkSpecDefinition,
     pub(in crate::merger) join_directive_identities: HashSet<Identity>,
     /// Directives that are composed via `@join__directive` in the supergraph. Populated by
@@ -172,6 +180,8 @@ pub(crate) struct Merger {
     pub(in crate::merger) access_control_directives_in_supergraph: Vec<(Name, Name)>,
     pub(in crate::merger) access_control_additional_sources:
         FallibleOnceCell<HashMap<String, AdditionalDirectiveSources>>,
+    pub(in crate::merger) import_conflicts_by_identity: ImportConflictsByIdentity,
+    pub(in crate::merger) compute_unique_spec_name_in_schema: Option<UniqueSpecNameInSchema>,
 }
 
 impl Merger {
@@ -201,19 +211,6 @@ impl Merger {
         };
         let fields_with_from_context = Self::get_fields_with_from_context_directive(&subgraphs);
         let fields_with_override = Self::get_fields_with_override_directive(&subgraphs);
-
-        let schema_to_import_to_feature_url = subgraphs
-            .iter()
-            .map(|s| {
-                (
-                    s.name.clone(),
-                    s.schema()
-                        .metadata()
-                        .map(|l| l.import_to_feature_url_map())
-                        .unwrap_or_default(),
-                )
-            })
-            .collect();
         let merged = FederationSchema::new(Schema::new())?;
         let join_directive_identities = HashSet::from([Identity::connect_identity()]);
 
@@ -236,7 +233,6 @@ impl Merger {
             enum_usages: HashMap::new(),
             fields_with_from_context,
             fields_with_override,
-            schema_to_import_to_feature_url,
             link_spec_definition,
             join_directive_identities,
             directives_using_join_directive: HashSet::new(),
@@ -246,6 +242,8 @@ impl Merger {
             applied_directives_to_merge: Vec::new(),
             access_control_directives_in_supergraph: Vec::new(),
             access_control_additional_sources: FallibleOnceCell::new(),
+            import_conflicts_by_identity: Default::default(),
+            compute_unique_spec_name_in_schema: None,
         };
 
         // Now call prepare_supergraph as a member function
@@ -292,7 +290,6 @@ impl Merger {
                 .and_then(|links| {
                     links
                         .all_links()
-                        .iter()
                         .find(|link| link.url.identity == *spec.identity())
                 })
                 .map(|link| link.locations(subgraph))
@@ -380,11 +377,119 @@ impl Merger {
             None,
             self.join_spec_definition.purpose(),
             None, // imports
+            |error| Self::push_non_internal_errors(&mut self.error_reporter, error),
         )?;
 
+        // Validate @links for Apollo specs that compose.
         let directives_merge_info = self.collect_core_directives_to_compose()?;
+        let supergraph_info_by_identity =
+            self.validate_core_directive_info(directives_merge_info)?;
 
-        self.validate_and_maybe_add_specs(&directives_merge_info)?;
+        // Validate @links for user specs that compose via @composeDirective, and record usages.
+        trace!("Validating @composeDirective applications");
+        self.compose_directive_manager
+            .validate(&self.subgraphs, &mut self.error_reporter)?;
+
+        // Gather information relevant for conflicts for specs being added to the schema.
+        let all_composed_core_features =
+            self.compose_directive_manager.all_composed_core_features();
+        let spec_conflict_infos =
+            self.merged
+                .metadata()
+                .map(LinksMetadata::all_links)
+                .into_iter()
+                .flatten()
+                .map(|link| SpecConflictInfo {
+                    spec_name_in_schema: &link.url.identity.name,
+                    url: &link.url,
+                    imports: Box::new(
+                        link.imports
+                            .iter()
+                            .map(|import| Cow::Borrowed(import.as_ref())),
+                    ),
+                })
+                .chain(supergraph_info_by_identity.values().map(
+                    |SupergraphInfo {
+                         spec_in_supergraph,
+                         directives,
+                     }| SpecConflictInfo {
+                        spec_name_in_schema: &spec_in_supergraph.url().identity.name,
+                        url: spec_in_supergraph.url(),
+                        imports: Box::new(directives.iter().map(
+                            |SupergraphDirectiveInfo {
+                                 name_in_feature,
+                                 name_in_supergraph,
+                                 ..
+                             }| {
+                                Cow::Owned(Import {
+                                    is_directive: true,
+                                    element: name_in_feature.clone(),
+                                    alias: Some(name_in_supergraph.clone()),
+                                })
+                            },
+                        )),
+                    },
+                ))
+                .chain(all_composed_core_features.iter().map(|(link, directives)| {
+                    SpecConflictInfo {
+                        spec_name_in_schema: &link.url.identity.name,
+                        url: &link.url,
+                        imports: Box::new(directives.iter().map(
+                            |(name_in_schema, name_in_spec)| {
+                                Cow::Owned(Import {
+                                    is_directive: true,
+                                    element: name_in_spec.clone(),
+                                    alias: Some(name_in_schema.clone()),
+                                })
+                            },
+                        )),
+                    }
+                }));
+
+        // Gather names of elements that may be added to the schema, but remove federation operation
+        // types (which won't be in the schema) and built-ins (which start with double underscores
+        // and are guaranteed not to conflict with any unique prefix we find).
+        let all_element_names = self
+            .merged
+            .get_types()
+            .map(|pos| pos.type_name().clone())
+            .chain(
+                self.merged
+                    .get_directive_definitions()
+                    .map(|pos| pos.directive_name.clone()),
+            )
+            .chain(self.subgraphs.iter().flat_map(|subgraph| {
+                subgraph
+                    .schema()
+                    .get_types()
+                    .map(|pos| pos.type_name().clone())
+                    .chain(
+                        subgraph
+                            .schema()
+                            .get_directive_definitions()
+                            .map(|pos| pos.directive_name.clone()),
+                    )
+            }))
+            .filter(|name| {
+                if FEDERATION_OPERATION_TYPES.contains(name) {
+                    return false;
+                }
+                if name.starts_with("__") {
+                    return false;
+                }
+                true
+            });
+
+        let (import_conflicts_by_identity, compute_unique_spec_name_in_schema) =
+            LinksMetadata::compute_spec_name_in_schema_conflicts(
+                spec_conflict_infos,
+                all_element_names,
+            );
+        self.import_conflicts_by_identity = import_conflicts_by_identity;
+        self.compute_unique_spec_name_in_schema = Some(compute_unique_spec_name_in_schema);
+
+        // Now that we've tracked @link conflicts, we can start adding specs to the schema.
+        self.maybe_add_specs(&supergraph_info_by_identity)?;
 
         // Populate the graph enum with subgraph information and store the mapping
         self.subgraph_names_to_join_spec_name = self
@@ -462,13 +567,10 @@ impl Merger {
     /// `MergeResult::errors`. If the merge is successful, `MergeResult::errors` will be empty, and
     /// a supergraph will be returned along with any hints collected during the merge process.
     pub(crate) fn merge(mut self) -> Result<MergeResult, FederationError> {
-        // Validate and record usages of @composeDirective
-        trace!("Validating @composeDirective applications");
-        self.compose_directive_manager
-            .validate(&self.subgraphs, &mut self.error_reporter)?;
-        // TODO: JS doesn't include this, but we're bailing here to test error generation while the
-        // rest of merge is unimplemented. Once merge can complete without panicking, we can remove
-        // this block.
+        // If compose directive manager detected errors during [Merger] construction, the same
+        // errors will likely be re-caught by `self.add_core_features()` (but with less helpful
+        // error messages, since they're caught at the schema level). To avoid this double-listing
+        // of errors, we return early in that case.
         if self.error_reporter.has_errors() {
             let (errors, hints) = self.error_reporter.into_errors_and_hints();
             return Ok(MergeResult {
@@ -481,6 +583,18 @@ impl Merger {
         // Add core features to the merged schema
         trace!("Adding core features to merged schema");
         self.add_core_features()?;
+
+        // If core feature addition detected errors, the schema's `@link`s may be in an incomplete
+        // state, which could cause later code to emit internal errors. To avoid this, we return
+        // early in that case.
+        if self.error_reporter.has_errors() {
+            let (errors, hints) = self.error_reporter.into_errors_and_hints();
+            return Ok(MergeResult {
+                supergraph: None,
+                errors,
+                hints,
+            });
+        }
 
         // Create empty objects for all types and directive definitions
         trace!("Adding shallow types and directives to merged schema");
@@ -670,12 +784,53 @@ impl Merger {
             .collect()
     }
 
+    /// Push non-internal errors as merge errors, but bubble up the first internal error.
+    // PORT_NOTE: This is meant to mimic how assertion errors would bubble through in the JS
+    //            codebase, but errors derived from GraphQLError would be captured.
+    pub(crate) fn push_non_internal_errors(
+        reporter: &mut ErrorReporter,
+        error: FederationError,
+    ) -> Result<(), FederationError> {
+        for error in error.into_errors() {
+            if error.code() == ErrorCode::Internal {
+                return Err(error.into());
+            }
+            reporter.add_error(CompositionError::MergeError {
+                error,
+                locations: Vec::new(),
+            });
+        }
+        Ok(())
+    }
+
     fn add_core_features(&mut self) -> Result<(), FederationError> {
         for (feature, directives) in self
             .compose_directive_manager
             .all_composed_core_features()
             .iter()
         {
+            let spec_name_in_schema = if self
+                .merged
+                .metadata()
+                .map(|metadata| {
+                    metadata.is_spec_name_in_schema_valid(
+                        &feature.url.identity.name,
+                        &feature.url.identity,
+                        &self.import_conflicts_by_identity,
+                    )
+                })
+                .unwrap_or(false)
+            {
+                Name::new_unchecked(&feature.url.identity.name)
+            } else {
+                self.compute_unique_spec_name_in_schema
+                    .as_mut()
+                    .ok_or_else(|| {
+                        internal_error!(
+                            "compute_unique_spec_name_in_schema() unexpectedly uninitialized"
+                        )
+                    })?(&feature.url.identity.name)
+            };
             let imports = directives
                 .iter()
                 .map(|(alias, original)| {
@@ -699,21 +854,29 @@ impl Merger {
                 self.link_spec_definition.apply_feature_to_schema(
                     &mut self.merged,
                     *feature_definition,
-                    None,
+                    Some(spec_name_in_schema).take_if(|spec_name_in_schema| {
+                        spec_name_in_schema.as_str() != feature.url.identity.name.as_ref()
+                    }),
                     feature_definition.purpose(),
                     if imports.is_empty() {
                         None
                     } else {
                         Some(imports)
                     },
+                    |error| Self::push_non_internal_errors(&mut self.error_reporter, error),
                 )?;
             } else {
-                let mut directive =
-                    Directive::new(self.link_spec_definition.url().identity.name.clone());
+                let mut directive = Directive::new(self.link_spec_definition.name().clone());
                 directive.arguments.push(Node::new(Argument {
                     name: LINK_DIRECTIVE_URL_ARGUMENT_NAME,
                     value: Node::new(feature.url.to_string().into()),
                 }));
+                if spec_name_in_schema.as_str() != feature.url.identity.name.as_ref() {
+                    directive.arguments.push(Node::new(Argument {
+                        name: LINK_DIRECTIVE_AS_ARGUMENT_NAME,
+                        value: Node::new(spec_name_in_schema.as_str().into()),
+                    }));
+                }
                 if !imports.is_empty() {
                     directive.arguments.push(Node::new(Argument {
                         name: LINK_DIRECTIVE_IMPORT_ARGUMENT_NAME,
@@ -725,8 +888,11 @@ impl Merger {
                         )),
                     }));
                 }
-                SchemaDefinitionPosition
-                    .insert_directive(&mut self.merged, Component::new(directive))?;
+                if let Err(error) = SchemaDefinitionPosition
+                    .insert_directive(&mut self.merged, Component::new(directive))
+                {
+                    Self::push_non_internal_errors(&mut self.error_reporter, error)?
+                };
             }
         }
         Ok(())
@@ -2392,11 +2558,12 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                 // schema. For Connectors (see `should_use_join_directive_for_url`), this is an import name (the
                 // same name imported in the supergraph and the extracted subgraphs). For others, this is
                 // the fully qualified directive name in the subgraph schema (re-assigned below).
-                let directive_name_for_join_directive = if source_link
-                    .as_ref()
-                    .is_some_and(|e| e.link.url.identity == Identity::link_identity())
-                {
-                    if let Ok(link) = Link::from_directive_application(directive, schema.schema())
+                let directive_name_for_join_directive = if source_link.as_ref().is_some_and(|e| {
+                    e.link.url.identity == Identity::link_identity() && e.name_in_spec.is_some()
+                }) {
+                    if let Ok(link) = link_import_identity_url_map
+                        .link_spec_definition()
+                        .link_from_directive(directive, schema.schema())
                         && self.should_use_join_directive_for_url(&link.url)
                     {
                         // Persist link when the spec uses @join__directive and the feature
@@ -2419,15 +2586,18 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                     .directives_using_join_directive
                     .contains(&directive.name)
                 {
-                    if let Some(source_link) = source_link {
+                    if let Some(source_link) = source_link
+                        && let Some(name_in_spec) = &source_link.name_in_spec
+                    {
                         // Compute the fully qualified directive name in the subgraph schema without using
                         // `import`, so it can be referenced in the extracted subgraph schema via
                         // `@join__directive`.
                         Some(Link::directive_name_in_schema_for_core_arguments(
                             &source_link.link.url,
-                            &source_link.link.url.identity.name,
+                            // For Apollo specs, their names are valid GraphQL, so this is fine.
+                            &Name::new_unchecked(&source_link.link.url.identity.name),
                             &[],
-                            &source_link.name_in_spec,
+                            name_in_spec,
                         ))
                     } else {
                         Some(directive.name.clone())

--- a/apollo-federation/src/schema/blueprint.rs
+++ b/apollo-federation/src/schema/blueprint.rs
@@ -295,14 +295,26 @@ impl FederationBlueprint {
     pub(crate) fn complete_subgraph_schema(
         schema: &mut FederationSchema,
     ) -> Result<(), FederationError> {
-        if schema.is_fed_2() {
-            // subgraph metadata was already computed which means we have @link with fed spec and its definition
-            Self::complete_fed_2_subgraph_schema(schema)
+        if schema.links_metadata.is_some() {
+            if schema.is_fed_2() {
+                // An @link schema that contains an @link for v2.x of the federation spec.
+                Self::complete_fed_2_subgraph_schema(schema)
+            } else {
+                // An @link schema that contains no @link for the federation spec, or for a non-v2.x
+                // version. In the non-v2.x version case, `expand_known_features()` will emit an
+                // error.
+                Self::complete_fed_1_subgraph_schema(schema)
+            }
         } else if has_federation_spec_link(schema.schema()) {
-            // we have @link with fed spec but we don't have @link directive definition
+            // A non-@link schema that contains an @link for some federation spec version. Add an
+            // @link for the latest link spec along with definitions, which will populate link
+            // metadata.
             LinkSpecDefinition::latest().add_to_schema(schema, None)?;
+            // Again, if the federation spec is unknown, `expand_known_features()` will emit an
+            // error.
             Self::complete_fed_2_subgraph_schema(schema)
         } else {
+            // A non-@link schema with no @link for the federation spec.
             Self::complete_fed_1_subgraph_schema(schema)
         }
     }
@@ -319,7 +331,8 @@ impl FederationBlueprint {
         schema: &mut FederationSchema,
     ) -> Result<(), FederationError> {
         Self::remove_federation_definitions_broken_in_known_ways(schema)?;
-        // fed 1 schema won't have @link so we cannot use FederationSpecDefinition#add_elements_to_schema
+        // Fed 1 schema won't have @link for the federation spec so we cannot use
+        // FederationSpecDefinition#add_elements_to_schema
         let mut errors = MultipleFederationErrors { errors: vec![] };
         let fed_1_link_spec_definition = LinkSpecDefinition::fed1_latest();
         let fed_1_link = Arc::new(Link {
@@ -423,6 +436,7 @@ impl FederationBlueprint {
         // See: https://github.com/apollographql/federation/blob/8200b154/internals-js/src/federation.ts#L2238
         let skip = [
             Identity::link_identity(),
+            Identity::core_identity(),
             Identity::federation_identity(),
             Identity::join_identity(),
         ];

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -342,11 +342,9 @@ impl FederationSchema {
     }
 
     // PORT_NOTE: Corresponds to `FederationMetadata.federationFeature` in JS
-    fn federation_link(&self) -> Option<&Arc<Link>> {
+    fn federation_link(&self) -> Option<Arc<Link>> {
         self.metadata().and_then(|metadata| {
-            metadata
-                .by_identity
-                .get(FederationSpecDefinition::latest().identity())
+            metadata.for_identity(FederationSpecDefinition::latest().identity())
         })
     }
 
@@ -390,9 +388,8 @@ impl FederationSchema {
             let Some(links) = self.metadata() else {
                 bail!("Schema should be a core schema")
             };
-            let Some(federation_link) = links
-                .by_identity
-                .get(FederationSpecDefinition::latest().identity())
+            let Some(federation_link) =
+                links.for_identity(FederationSpecDefinition::latest().identity())
             else {
                 bail!("Schema should have the latest federation link")
             };
@@ -1298,6 +1295,13 @@ impl ValidFederationSchema {
     pub fn new_assume_valid(
         mut schema: FederationSchema,
     ) -> Result<ValidFederationSchema, (FederationSchema, FederationError)> {
+        // While LinksMetadata::from_schema() partially validated @link usages, we need to run
+        // further @link validations after the schema is confirmed to be valid GraphQL.
+        if let Some(links_metadata) = &schema.links_metadata
+            && let Err(error) = links_metadata.validate_no_shadowing_imports(&schema)
+        {
+            return Err((schema, error));
+        }
         // Populating subgraph metadata requires a mutable FederationSchema, while computing the subgraph
         // metadata requires a valid FederationSchema. Since valid schemas are immutable, we have
         // to jump through some hoops here. We already assume that `schema` is valid GraphQL, so we

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -2179,9 +2179,9 @@ impl SchemaDefinitionPosition {
     fn is_link(schema: &FederationSchema, name: &str) -> Result<bool, FederationError> {
         Ok(match schema.metadata() {
             Some(metadata) => {
-                let link_spec_definition = metadata.link_spec_definition()?;
+                let link_spec_definition = metadata.link_spec_definition();
                 let link_name_in_schema = link_spec_definition
-                    .directive_name_in_schema(schema, &link_spec_definition.identity().name)
+                    .directive_name_in_schema(schema, link_spec_definition.name())
                     .ok_or_else(|| SingleFederationError::Internal {
                         message: "Unexpectedly could not find core/link spec usage".to_owned(),
                     })?;

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -73,7 +73,8 @@ impl Subgraph {
             .get_all(&default_link_name);
 
         for directive in link_directives {
-            let link_directive = Link::from_directive_application(directive, &schema)?;
+            let link_directive =
+                Link::from_directive_application_when_link_spec_unknown(directive, &schema)?;
             if link_directive.url.identity == Identity::federation_identity() {
                 if imported_federation_definitions.is_some() {
                     let msg = "Invalid use of @link in schema: invalid graphql schema - multiple @link imports for the federation specification are not supported";

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -192,10 +192,10 @@ macro_rules! applied_specification {
                         if i.alias.is_some() {
                             Value::Object(vec![
                                 (name!("name"), i.element.as_str().into()),
-                                (name!("as"), i.imported_display_name().to_string().into()),
+                                (name!("as"), i.element_name_in_schema().to_string().into()),
                             ])
                         } else {
-                            i.imported_display_name().to_string().into()
+                            i.element_name_in_schema().to_string().into()
                         }.into()
                     })
                     .collect::<Vec<Node<Value>>>();

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -270,7 +270,7 @@ impl Subgraph<Initial> {
             .make_mut()
             .directives
             .push(Component::new(Directive {
-                name: Identity::link_identity().name,
+                name: Identity::LINK_NAME,
                 arguments: vec![
                     Node::new(ast::Argument {
                         name: LINK_DIRECTIVE_URL_ARGUMENT_NAME,
@@ -768,7 +768,7 @@ pub(crate) fn schema_as_fed2_subgraph(
     use_latest: bool,
 ) -> Result<(), FederationError> {
     let (link_name_in_schema, metadata) = if let Some(metadata) = schema.metadata() {
-        let link_spec = metadata.link_spec_definition()?;
+        let link_spec = metadata.link_spec_definition();
         // We don't accept pre-1.0 @core: this avoid having to care about what the name
         // of the argument below is, and why would be bother?
         ensure!(
@@ -779,10 +779,7 @@ pub(crate) fn schema_as_fed2_subgraph(
             "Fed2 schema must use @link with version >= 1.0, but schema uses {spec_url}",
             spec_url = link_spec.url()
         );
-        let Some(link) = link_spec.link_in_schema(schema) else {
-            bail!("Core schema is missing the link spec link directive");
-        };
-        (link.spec_name_in_schema().clone(), metadata)
+        (metadata.link_itself().spec_name_in_schema(), metadata)
     } else {
         let link_spec = LinkSpecDefinition::latest();
         let link_name_in_schema = add_link_spec_to_schema(schema, link_spec)?;
@@ -986,7 +983,7 @@ fn add_link_spec_to_schema(
     schema: &mut FederationSchema,
     link_spec: &'static LinkSpecDefinition,
 ) -> Result<Name, FederationError> {
-    let link_spec_name = &link_spec.identity().name;
+    let link_spec_name = link_spec.name();
     let alias = find_unused_name_for_directive(schema, link_spec_name)?;
     let link_name_in_schema = alias.clone().unwrap_or_else(|| link_spec_name.clone());
     link_spec.add_to_schema(schema, alias)?;

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -957,17 +957,17 @@ mod inconsistent_imports {
     fn errors_when_different_exported_directives_have_the_same_name() {
         let subgraph_a = generate_subgraph(
             "subgraphA",
-            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@foo"])"#,
-            r#"@composeDirective(name: "@foo")"#,
-            "directive @foo(name: String!) on FIELD_DEFINITION",
-            r#"@foo(name: "a")"#,
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: ["@baz"])"#,
+            r#"@composeDirective(name: "@baz")"#,
+            "directive @baz(name: String!) on FIELD_DEFINITION",
+            r#"@baz(name: "a")"#,
         );
         let subgraph_b = generate_subgraph(
             "subgraphA",
-            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: [{ name: "@bar", as: "@foo" }])"#,
-            r#"@composeDirective(name: "@foo")"#,
-            "directive @foo(name: String!) on FIELD_DEFINITION",
-            r#"@foo(name: "a")"#,
+            r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: [{ name: "@bar", as: "@baz" }])"#,
+            r#"@composeDirective(name: "@baz")"#,
+            "directive @baz(name: String!) on FIELD_DEFINITION",
+            r#"@baz(name: "a")"#,
         );
 
         let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
@@ -979,7 +979,7 @@ mod inconsistent_imports {
         );
         assert_eq!(
             error.to_string(),
-            r#"Composed directive "@foo" does not refer to the same directive in every subgraph"#
+            r#"Composed directive "@baz" does not refer to the same directive in every subgraph"#
         );
     }
 
@@ -1028,38 +1028,37 @@ mod inconsistent_imports {
         );
     }
 
-    // TODO: Re-work this test after further @link validations have been added.
-    // #[rstest]
-    // #[case("@join__field")]
-    // #[case("@join__graph")]
-    // #[case("@join__implements")]
-    // #[case("@join__type")]
-    // #[case("@join__unionMember")]
-    // #[case("@join__enumValue")]
-    // fn errors_when_exported_directives_conflict_with_join_spec_directives(#[case] directive: &str) {
-    //     let subgraph_a = generate_subgraph(
-    //         "subgraphA",
-    //         &r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: [{ name: "@foo", as: "<DIRECTIVE>" }])"#.replace("<DIRECTIVE>", directive),
-    //         &r#"@composeDirective(name: "<DIRECTIVE>")"#.replace("<DIRECTIVE>", directive),
-    //         &r#"directive <DIRECTIVE>(name: String!) on FIELD_DEFINITION"#.replace("<DIRECTIVE>", directive),
-    //         &r#"<DIRECTIVE>(name: "a")"#.replace("<DIRECTIVE>", directive),
-    //     );
-    //     let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
-    //
-    //     let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err();
-    //     assert_eq!(result.len(), 1);
-    //     let error = result.first().unwrap();
-    //     assert_eq!(
-    //         error.code().definition().code().to_string(),
-    //         "DIRECTIVE_COMPOSITION_ERROR"
-    //     );
-    //     assert_eq!(
-    //         error.to_string(),
-    //         format!(
-    //             "Directive \"{directive}\" in subgraph \"subgraphA\" cannot be composed because it is not a member of a core feature"
-    //         )
-    //     );
-    // }
+    #[rstest]
+    #[case("@join__field")]
+    #[case("@join__graph")]
+    #[case("@join__implements")]
+    #[case("@join__type")]
+    #[case("@join__unionMember")]
+    #[case("@join__enumValue")]
+    fn errors_when_exported_directives_conflict_with_join_spec_directives(#[case] directive: &str) {
+        let subgraph_a = generate_subgraph(
+            "subgraphA",
+            &r#"@link(url: "https://specs.custom.dev/foo/v1.0", import: [{ name: "@foo", as: "<DIRECTIVE>" }])"#.replace("<DIRECTIVE>", directive),
+            &r#"@composeDirective(name: "<DIRECTIVE>")"#.replace("<DIRECTIVE>", directive),
+            &r#"directive <DIRECTIVE>(name: String!) on FIELD_DEFINITION"#.replace("<DIRECTIVE>", directive),
+            &r#"<DIRECTIVE>(name: "a")"#.replace("<DIRECTIVE>", directive),
+        );
+        let subgraph_b = generate_subgraph("subgraphB", "", "", "", "");
+
+        let result = compose(vec![subgraph_a, subgraph_b]).unwrap_err().errors;
+        assert_eq!(result.len(), 1);
+        let error = result.first().unwrap();
+        assert_eq!(
+            error.code().definition().code().to_string(),
+            "INVALID_LINK_DIRECTIVE_USAGE"
+        );
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "Cannot import \"@foo\" as \"{directive}\" from feature \"https://specs.custom.dev/foo\" since it can be confused with a namespaced name from another linked feature \"https://specs.apollo.dev/join\". Please rename the import or feature to avoid conflicts via \"as\"."
+            )
+        );
+    }
 }
 
 mod validation {
@@ -1161,7 +1160,7 @@ mod composition {
             extend schema
                 @link(url: "https://specs.apollo.dev/link/v1.0")
                 @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@tag"])
-                @link(url: "https://custom.dev/myspec/v1.0", import: [{ name: "@tag", as: "@mytag"}])
+                @link(url: "https://custom.dev/tag/v1.0", as: "mytag", import: [{ name: "@tag", as: "@mytag"}])
                 @composeDirective(name: "@mytag")
 
             directive @mytag(name: String!, prop: String!) on FIELD_DEFINITION | OBJECT
@@ -1208,9 +1207,12 @@ mod composition {
         assert_eq!(tag_directive.to_string(), r#"@tag(name: "c")"#);
 
         assert!(schema.to_string().contains(
-                r#"@link(url: "https://custom.dev/myspec/v1.0", import: [{name: "@tag", as: "@mytag"}])"#,
-            ),
-            "Expected link to custom spec to be in composed schema, but got schema:\n{schema}",
+            r#"@link(url: "https://custom.dev/tag/v1.0", as: "_0tag", import: [{name: "@tag", as: "@mytag"}])"#,
+        ));
+        assert!(
+            schema
+                .to_string()
+                .contains(r#"@link(url: "https://specs.apollo.dev/tag/v0.3")"#,)
         );
     }
 
@@ -1285,11 +1287,9 @@ mod composition {
                 .to_string()
                 .contains(r#"@link(url: "https://custom.dev/myspec/v1.0", import: ["@tag"])"#)
         );
-        assert!(
-            schema
-                .to_string()
-                .contains(r#"@link(url: "https://specs.apollo.dev/tag/v0.3", import: [{name: "@tag", as: "@mytag"}])"#)
-        );
+        assert!(schema .to_string() .contains(
+            r#"@link(url: "https://specs.apollo.dev/tag/v0.3", as: "_0tag", import: [{name: "@tag", as: "@mytag"}])"#
+        ));
     }
 
     #[test]

--- a/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
@@ -443,6 +443,62 @@ mod validations {
             )],
         );
     }
+
+    #[test]
+    fn errors_when_trying_to_use_supergraph_tag_spec() {
+        let subgraph_a = ServiceDefinition {
+            name: "subgraphA",
+            type_defs: r#"
+                schema
+                    @link(url: "https://specs.apollo.dev/link/v1.0")
+                    @link(url: "https://specs.apollo.dev/tag/v0.2")
+                {
+                    query: Query
+                }
+
+                type Query {
+                    q: Int
+                }
+            "#,
+        };
+
+        let result = compose_services(&[subgraph_a]);
+        assert_composition_errors(
+            &result,
+            &[(
+                "INVALID_LINK_DIRECTIVE_USAGE",
+                r#"[subgraphA] Please import "@tag" from the feature "https://specs.apollo.dev/federation" instead of using "https://specs.apollo.dev/tag" to avoid potential unexpected behavior in the future."#,
+            )],
+        );
+    }
+
+    #[test]
+    fn errors_when_trying_to_use_supergraph_inaccessible_spec() {
+        let subgraph_a = ServiceDefinition {
+            name: "subgraphA",
+            type_defs: r#"
+                schema
+                    @link(url: "https://specs.apollo.dev/link/v1.0")
+                    @link(url: "https://specs.apollo.dev/inaccessible/v0.2")
+                {
+                    query: Query
+                }
+
+                type Query {
+                    q: Int
+                }
+            "#,
+        };
+
+        let result = compose_services(&[subgraph_a]);
+        assert_composition_errors(
+            &result,
+            &[(
+                "INVALID_LINK_DIRECTIVE_USAGE",
+                r#"[subgraphA] Please import "@inaccessible" from the feature "https://specs.apollo.dev/federation" instead of using "https://specs.apollo.dev/inaccessible" to avoid potential unexpected behavior in the future."#,
+            )],
+        );
+    }
 }
 
 mod shareable {

--- a/apollo-federation/tests/composition/compose_misc.rs
+++ b/apollo-federation/tests/composition/compose_misc.rs
@@ -653,7 +653,7 @@ mod supergraph_spec_imports {
             &result,
             &[(
                 "INVALID_LINK_DIRECTIVE_USAGE",
-                r#"[products] Invalid use of @link in schema: import for '@inaccessible' of https://specs.apollo.dev/federation/v2.5 conflicts with spec https://specs.apollo.dev/inaccessible/v0.2"#,
+                r#"[products] Please import "@inaccessible" from the feature "https://specs.apollo.dev/federation" instead of using "https://specs.apollo.dev/inaccessible" to avoid potential unexpected behavior in the future."#,
             )],
         );
     }
@@ -683,7 +683,7 @@ mod supergraph_spec_imports {
             &result,
             &[(
                 "INVALID_LINK_DIRECTIVE_USAGE",
-                r#"[accounts] Invalid use of @link in schema: import for '@policy' of https://specs.apollo.dev/federation/v2.6 conflicts with spec https://specs.apollo.dev/policy/v0.1"#,
+                r#"[accounts] Cannot import "@requiresScopes" from feature "https://specs.apollo.dev/federation" since it can be confused with a namespaced name from another linked feature "https://specs.apollo.dev/requiresScopes". Please rename the import or feature to avoid conflicts via "as"."#,
             )],
         );
     }
@@ -751,7 +751,7 @@ mod supergraph_spec_imports {
             &result,
             &[(
                 "INVALID_LINK_DIRECTIVE_USAGE",
-                r#"[products] Invalid use of @link in schema: import for '@inaccessible' of https://specs.apollo.dev/federation/v2.4 conflicts with spec https://specs.apollo.dev/inaccessible/v0.2"#,
+                r#"[products] Please import "@inaccessible" from the feature "https://specs.apollo.dev/federation" instead of using "https://specs.apollo.dev/inaccessible" to avoid potential unexpected behavior in the future."#,
             )],
         );
     }

--- a/apollo-federation/tests/composition/compose_validation.rs
+++ b/apollo-federation/tests/composition/compose_validation.rs
@@ -672,7 +672,7 @@ fn duplicate_link_spec_application_is_rejected() {
         err.format_errors(),
         vec![(
             "INVALID_LINK_DIRECTIVE_USAGE".to_string(),
-            r#"[subgraphA] Invalid use of @link in schema: the @link for the link specification itself ("https://specs.apollo.dev/link/v1.0") is applied multiple times"#.to_string(),
+            r#"[subgraphA] Cannot link the link/core feature itself in `@link(url: "https://specs.apollo.dev/link/v1.0", import: ["@link", "Import"])` since it has already been linked in `@link(url: "https://specs.apollo.dev/link/v1.0", import: ["@link", "Purpose"])`"#.to_string(),
         )],
     );
 }

--- a/apollo-federation/tests/dhat_profiling/supergraph.rs
+++ b/apollo-federation/tests/dhat_profiling/supergraph.rs
@@ -11,36 +11,36 @@ fn valid_supergraph_schema() {
     const SCHEMA: &str = "../examples/graphql/supergraph.graphql";
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
-    // Actual number: 143_792.
-    const MAX_BYTES_SUPERGRAPH: usize = 150_982; // ~147 KiB
+    // Actual number: 166_028.
+    const MAX_BYTES_SUPERGRAPH: usize = 174_330; // ~171 KiB
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 4_961.
-    const MAX_ALLOCATIONS_SUPERGRAPH: u64 = 5_209;
+    // Actual number: 5_400.
+    const MAX_ALLOCATIONS_SUPERGRAPH: u64 = 5_670;
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
-    // Actual number: 203_359.
+    // Actual number: 225_691.
     //
-    // API schema generation allocates additional 59_567 bytes (203_359-143_792=59_567).
-    const MAX_BYTES_API_SCHEMA: usize = 213_527; // ~209 KiB
+    // API schema generation allocates additional 59_567 bytes (225_691-166_028=59_663).
+    const MAX_BYTES_API_SCHEMA: usize = 236_976; // ~232 KiB
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 5_526.
+    // Actual number: 6_019.
     //
-    // API schema has an additional 565 allocations (= 5_526 - 4_961).
-    const MAX_ALLOCATIONS_API_SCHEMA: u64 = 5_802;
+    // API schema has an additional 619 allocations (= 6_019 - 5_400).
+    const MAX_ALLOCATIONS_API_SCHEMA: u64 = 6_320;
 
     // Number of bytes when the heap size reached its global maximum with a 5% buffer.
-    // Actual number: 629_765.
+    // Actual number: 661_387.
     //
-    // Extract subgraphs allocates additional 416_238 bytes (629_765-213_527=416_238).
-    const MAX_BYTES_SUBGRAPHS: usize = 661_253; // ~646 KiB
+    // Extract subgraphs allocates additional 416_238 bytes (661_387-225_691=435_696).
+    const MAX_BYTES_SUBGRAPHS: usize = 694_457; // ~679 KiB
 
     // Total number of allocations with a 5% buffer.
-    // Actual number: 11_770.
+    // Actual number: 12_371.
     //
-    // Extract subgraphs from supergraph has an additional 6_287 allocations (= 11_989 - 5_702).
-    const MAX_ALLOCATIONS_SUBGRAPHS: u64 = 12_359;
+    // Extract subgraphs from supergraph has an additional 6_352 allocations (= 12_371 - 6_019).
+    const MAX_ALLOCATIONS_SUBGRAPHS: u64 = 12_990;
 
     let schema = std::fs::read_to_string(SCHEMA).unwrap();
 


### PR DESCRIPTION
This PR ports the changes from https://github.com/apollographql/federation/pull/3430 to Rust. Note that:
1. The constructor logic for `LinksMetadata` (which takes an input schema) is a bit different from `CoreFeatures` (which builds things gradually and has some of its bootstrapping logic in its caller). I haven't changed the `LinksMetadata` to reflect `CoreFeatures` in this regard, though I've tried to align the functions that constructor logic calls where possible.
2. There's some logic around the callers to `LinksMetadata` methods that I've cleaned up as well, to align more closely to the JS codebase.

<!-- FED-1011 -->