### PR TITLE
chore(cache): deprecate apollo.preview_entity_cache with startup warning

### DIFF
--- a/.changesets/maint_deprecate_preview_entity_cache.md
+++ b/.changesets/maint_deprecate_preview_entity_cache.md
@@ -1,4 +1,4 @@
-### Emit startup warning when deprecated `apollo.preview_entity_cache` plugin is used
+### Emit startup warning when deprecated `apollo.preview_entity_cache` plugin is used ([PR #9631](https://github.com/apollographql/router/pull/9631))
 
 The `apollo.preview_entity_cache` plugin is deprecated and will be removed in Router 3.0. A warning is now logged at startup when it is enabled.
 

--- a/.changesets/maint_deprecate_preview_entity_cache.md
+++ b/.changesets/maint_deprecate_preview_entity_cache.md
@@ -1,0 +1,5 @@
+### Emit startup warning when deprecated `apollo.preview_entity_cache` plugin is used ([Issue #1771](https://github.com/apollographql/router/issues/1771))
+
+The `apollo.preview_entity_cache` plugin is deprecated and will be removed in Router 3.x. A warning is now logged at startup when it is enabled.
+
+Migrate to `apollo.response_cache`, which supersedes it. The two plugins are mutually exclusive and cannot be enabled at the same time.

--- a/.changesets/maint_deprecate_preview_entity_cache.md
+++ b/.changesets/maint_deprecate_preview_entity_cache.md
@@ -1,5 +1,7 @@
-### Emit startup warning when deprecated `apollo.preview_entity_cache` plugin is used ([Issue #1771](https://github.com/apollographql/router/issues/1771))
+### Emit startup warning when deprecated `apollo.preview_entity_cache` plugin is used
 
-The `apollo.preview_entity_cache` plugin is deprecated and will be removed in Router 3.x. A warning is now logged at startup when it is enabled.
+The `apollo.preview_entity_cache` plugin is deprecated and will be removed in Router 3.0. A warning is now logged at startup when it is enabled.
 
 Migrate to `apollo.response_cache`, which supersedes it. The two plugins are mutually exclusive and cannot be enabled at the same time.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9631

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -210,7 +210,7 @@ impl PluginPrivate for EntityCache {
         if init.config.enabled {
             tracing::warn!(
                 "The `apollo.preview_entity_cache` plugin is deprecated and will be removed \
-                 in a future major release. Migrate to `apollo.response_cache`, which supersedes it. \
+                 in Router 3.x. Migrate to `apollo.response_cache`, which supersedes it. \
                  See https://www.apollographql.com/docs/graphos/routing/performance/caching/overview"
             );
         }

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -210,7 +210,7 @@ impl PluginPrivate for EntityCache {
         if init.config.enabled {
             tracing::warn!(
                 "The `apollo.preview_entity_cache` plugin is deprecated and will be removed \
-                 in Router 3.x. Migrate to `apollo.response_cache`, which supersedes it. \
+                 in Router 3.0. Migrate to `apollo.response_cache`, which supersedes it. \
                  See https://www.apollographql.com/docs/graphos/routing/performance/caching/overview"
             );
         }

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -207,6 +207,14 @@ impl PluginPrivate for EntityCache {
     where
         Self: Sized,
     {
+        if init.config.enabled {
+            tracing::warn!(
+                "The `apollo.preview_entity_cache` plugin is deprecated and will be removed \
+                 in a future major release. Migrate to `apollo.response_cache`, which supersedes it. \
+                 See https://www.apollographql.com/docs/graphos/routing/performance/caching/overview"
+            );
+        }
+
         let entity_type = init
             .supergraph_schema
             .schema_definition
@@ -2168,6 +2176,25 @@ mod tests {
         assert_eq!(
             hash,
             "e5faa4c491214ed07f53acc65189e6efacc8b7eedc0d88055d86a5307671f0e3"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deprecation_warning_on_startup() {
+        use crate::test_harness::tracing_test;
+        let _guard = tracing_test::dispatcher_guard();
+
+        let config: Config =
+            serde_json::from_value(serde_json::json!({ "enabled": true, "subgraph": {} }))
+                .unwrap();
+        let init = crate::plugin::PluginInit::fake_builder()
+            .config(config)
+            .build();
+
+        EntityCache::new(init).await.expect("plugin should init");
+        assert!(
+            tracing_test::logs_contain("apollo.preview_entity_cache"),
+            "expected deprecation warning to be logged"
         );
     }
 }

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -2185,8 +2185,7 @@ mod tests {
         let _guard = tracing_test::dispatcher_guard();
 
         let config: Config =
-            serde_json::from_value(serde_json::json!({ "enabled": true, "subgraph": {} }))
-                .unwrap();
+            serde_json::from_value(serde_json::json!({ "enabled": true, "subgraph": {} })).unwrap();
         let init = crate::plugin::PluginInit::fake_builder()
             .config(config)
             .build();


### PR DESCRIPTION
## What

- Adds a `tracing::warn!` at startup in `EntityCache::new()` when `apollo.preview_entity_cache` is enabled, directing operators to migrate to `apollo.response_cache`
- Adds a unit test `test_deprecation_warning_on_startup` that verifies the warning is emitted when the plugin is enabled

## Verified

- `cargo fmt --check` passed
- `cargo clippy -- -D warnings` passed
- CHANGELOG.md not modified
- Changeset titles contain no conventional-commit prefixes

## Notes

Closes ROUTER-1771. `apollo.response_cache` supersedes `apollo.preview_entity_cache`; the two are already enforced as mutually exclusive at configuration validation time.