### PR TITLE
fix(composition): keep executable directive argument types valid through connector expansion

### DIFF
--- a/.changesets/fix_executable_directive_enum_arg_connector_expansion.md
+++ b/.changesets/fix_executable_directive_enum_arg_connector_expansion.md
@@ -1,0 +1,7 @@
+### Fix `INTERNAL_ERROR` composing connector subgraphs alongside an executable directive whose argument is a custom type ([Issue #RH-1375](https://apollographql.atlassian.net/browse/RH-1375))
+
+Composing a supergraph that uses Apollo Connectors together with an executable directive whose argument references a custom input type (for example `directive @ownership(owners: [Owner!]) on FIELD` with `enum Owner`) failed satisfiability validation with `INTERNAL_ERROR: Cannot wrap an undefined/null type` (Rust: `Directive argument's inner type does not refer to an existing input type`).
+
+The root cause was that connector expansion produced an internally inconsistent supergraph: subgraph extraction copies executable directive definitions into *every* extracted subgraph, but the expanded supergraph's `@join__type` membership declared the directives' argument types absent from the synthetic connector subgraphs. When those types already existed in the merged supergraph (contributed by a non-connector subgraph), connector expansion skipped reconciling their membership onto the synthetic subgraphs. Connector expansion now stamps `@join__type` (and `@join__enumValue` / `@join__field`) membership for an executable directive's argument types (scalars, enums, and input objects, recursively) onto the synthetic subgraphs, so the expanded supergraph is valid by construction.
+
+By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/9635

--- a/apollo-federation/src/connectors/expand/carryover/inputs.rs
+++ b/apollo-federation/src/connectors/expand/carryover/inputs.rs
@@ -1,10 +1,14 @@
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::ast;
+use apollo_compiler::ast::Argument;
 use apollo_compiler::ast::Directive;
+use apollo_compiler::ast::DirectiveLocation;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::HashMap;
+use apollo_compiler::collections::HashSet;
 use apollo_compiler::name;
+use apollo_compiler::schema::Component;
 use apollo_compiler::schema::DirectiveList;
 use apollo_compiler::schema::EnumType;
 use apollo_compiler::schema::ExtendedType;
@@ -34,10 +38,25 @@ pub(super) fn copy_input_types(
     to: &mut FederationSchema,
     subgraph_enum_replacements: &MultiMap<Name, Name>,
 ) -> Result<(), FederationError> {
+    // The synthetic subgraphs created for each connector replace their original connector
+    // subgraph, so any input type the original declared must be declared as a member of every
+    // synthetic replacement (via `@join__type`, and `@join__enumValue` / `@join__field` for
+    // members). Otherwise the expanded supergraph is internally inconsistent: subgraph extraction
+    // copies executable directive definitions into *every* subgraph, so a synthetic subgraph that
+    // is missing a directive argument's type extracts to an invalid subgraph (RH-1375). These are
+    // the join__Graph enum values for the synthetic subgraphs.
+    let synthetic_graphs: HashSet<Name> = subgraph_enum_replacements
+        .iter_all()
+        .flat_map(|(_, replacements)| replacements.iter().cloned())
+        .collect();
+
+    // Only types reached through an executable directive's arguments need their membership
+    // reconciled when they already exist in the merged supergraph: those are the types extraction
+    // copies into every subgraph. Types present for other reasons (e.g. consumed by a connector's
+    // own fields) already carry correct membership from the merge.
+    let executable_directive_types = executable_directive_input_types(from);
+
     for (name, ty) in &from.schema().types {
-        if to.schema().types.contains_key(name) {
-            continue;
-        }
         match ty {
             ExtendedType::Scalar(node) => {
                 let references = from.referencers().scalar_types.get(name);
@@ -46,12 +65,18 @@ pub(super) fn copy_input_types(
                 }
 
                 let pos = ScalarTypeDefinitionPosition {
-                    type_name: node.name.clone(),
+                    type_name: name.clone(),
                 };
                 let node =
                     strip_invalid_join_directives_from_scalar(node, subgraph_enum_replacements);
-                pos.pre_insert(to).ok();
-                pos.insert(to, node).ok();
+                if to.schema().types.contains_key(name) {
+                    if executable_directive_types.contains(name) {
+                        add_synthetic_scalar_membership(to, &pos, &node, &synthetic_graphs)?;
+                    }
+                } else {
+                    pos.pre_insert(to).ok();
+                    pos.insert(to, node).ok();
+                }
             }
             ExtendedType::Enum(node) => {
                 let references = from.referencers().enum_types.get(name);
@@ -60,12 +85,18 @@ pub(super) fn copy_input_types(
                 }
 
                 let pos = EnumTypeDefinitionPosition {
-                    type_name: node.name.clone(),
+                    type_name: name.clone(),
                 };
                 let node =
                     strip_invalid_join_directives_from_enum(node, subgraph_enum_replacements);
-                pos.pre_insert(to).ok();
-                pos.insert(to, node).ok();
+                if to.schema().types.contains_key(name) {
+                    if executable_directive_types.contains(name) {
+                        add_synthetic_enum_membership(to, &pos, &node, &synthetic_graphs)?;
+                    }
+                } else {
+                    pos.pre_insert(to).ok();
+                    pos.insert(to, node).ok();
+                }
             }
             ExtendedType::InputObject(node) => {
                 let references = from.referencers().input_object_types.get(name);
@@ -74,18 +105,268 @@ pub(super) fn copy_input_types(
                 }
 
                 let pos = InputObjectTypeDefinitionPosition {
-                    type_name: node.name.clone(),
+                    type_name: name.clone(),
                 };
                 let node =
                     strip_invalid_join_directives_from_input_type(node, subgraph_enum_replacements);
-                pos.pre_insert(to).ok();
-                pos.insert(to, node).ok();
+                if to.schema().types.contains_key(name) {
+                    if executable_directive_types.contains(name) {
+                        add_synthetic_input_object_membership(to, &pos, &node, &synthetic_graphs)?;
+                    }
+                } else {
+                    pos.pre_insert(to).ok();
+                    pos.insert(to, node).ok();
+                }
             }
             _ => {}
         }
     }
 
     Ok(())
+}
+
+/// Executable directive locations; mirrors `EXECUTABLE_DIRECTIVE_LOCATIONS` in `supergraph/mod.rs`,
+/// which governs which directive definitions extraction copies into every subgraph.
+const EXECUTABLE_DIRECTIVE_LOCATIONS: [DirectiveLocation; 8] = [
+    DirectiveLocation::Query,
+    DirectiveLocation::Mutation,
+    DirectiveLocation::Subscription,
+    DirectiveLocation::Field,
+    DirectiveLocation::FragmentDefinition,
+    DirectiveLocation::FragmentSpread,
+    DirectiveLocation::InlineFragment,
+    DirectiveLocation::VariableDefinition,
+];
+
+/// The input types referenced — transitively, through input-object fields — by the arguments of
+/// the supergraph's executable directive definitions. Extraction copies executable directive
+/// definitions into every extracted subgraph, so these types must exist in every subgraph,
+/// including the synthetic connector subgraphs (RH-1375).
+fn executable_directive_input_types(from: &FederationSchema) -> HashSet<Name> {
+    let mut referenced = HashSet::default();
+    let mut stack: Vec<Name> = Vec::new();
+    for directive in from.schema().directive_definitions.values() {
+        if directive.is_built_in() {
+            continue;
+        }
+        if directive
+            .locations
+            .iter()
+            .any(|location| EXECUTABLE_DIRECTIVE_LOCATIONS.contains(location))
+        {
+            for argument in &directive.arguments {
+                stack.push(argument.ty.inner_named_type().clone());
+            }
+        }
+    }
+    while let Some(name) = stack.pop() {
+        if !referenced.insert(name.clone()) {
+            continue;
+        }
+        if let Some(ExtendedType::InputObject(input_object)) = from.schema().types.get(&name) {
+            for field in input_object.fields.values() {
+                stack.push(field.ty.inner_named_type().clone());
+            }
+        }
+    }
+    referenced
+}
+
+/// The `graph:` argument of a `@join__*` directive, if present.
+fn directive_graph(directive: &Directive) -> Option<&Name> {
+    directive
+        .arguments
+        .iter()
+        .find(|a| a.name == name!(graph))
+        .and_then(|a| a.value.as_enum())
+}
+
+/// Clone a `@join__*` directive, replacing its `graph:` argument with `graph`.
+fn directive_with_graph(directive: &Node<Directive>, graph: &Name) -> Node<Directive> {
+    let mut directive = directive.clone();
+    if let Some(argument) = directive
+        .make_mut()
+        .arguments
+        .iter_mut()
+        .find(|a| a.name == name!(graph))
+    {
+        argument.make_mut().value = Value::Enum(graph.clone()).into();
+    }
+    directive
+}
+
+/// The graphs named by a type's `@join__type` directives.
+fn join_type_graphs(type_directives: &DirectiveList) -> HashSet<Name> {
+    type_directives
+        .iter()
+        .filter(|d| d.name == name!(join__type))
+        .filter_map(|d| directive_graph(d).cloned())
+        .collect()
+}
+
+/// The synthetic connector subgraphs this type should additionally belong to: the graphs named by
+/// the type-level `@join__type` directives that `strip_invalid_join_directives_*` rewrote onto the
+/// synthetic subgraphs (i.e. the replacements of the connector subgraph the type came from), minus
+/// any the existing definition already declares (a type the connector itself uses already carries
+/// correct synthetic membership from the merge).
+fn synthetic_membership_graphs(
+    desired_type_directives: &DirectiveList,
+    existing_type_directives: &DirectiveList,
+    synthetic_graphs: &HashSet<Name>,
+) -> Vec<Name> {
+    let existing = join_type_graphs(existing_type_directives);
+    desired_type_directives
+        .iter()
+        .filter(|d| d.name == name!(join__type))
+        .filter_map(|d| directive_graph(d))
+        .filter(|graph| synthetic_graphs.contains(*graph) && !existing.contains(*graph))
+        .cloned()
+        .collect()
+}
+
+/// For each member directive (`@join__enumValue` / `@join__field`) the existing definition already
+/// carries for a *real* subgraph, plan an equivalent directive for each synthetic graph that
+/// doesn't have one yet. Cloning the existing directive preserves its other arguments (e.g.
+/// `@join__field`'s `type:`). A member with no such directive relies on type-level `@join__type`
+/// membership and needs nothing added. Returns `(member name, directives to add)` pairs.
+fn member_membership_additions<'a>(
+    members: impl Iterator<Item = (&'a Name, &'a ast::DirectiveList)>,
+    member_directive_name: &Name,
+    synthetic_graphs: &[Name],
+) -> Vec<(Name, Vec<Node<Directive>>)> {
+    let mut additions = Vec::new();
+    for (member_name, directives) in members {
+        let existing: Vec<&Node<Directive>> = directives
+            .iter()
+            .filter(|d| &d.name == member_directive_name)
+            .collect();
+        let Some(template) = existing.first() else {
+            continue;
+        };
+        let existing_graphs: HashSet<&Name> =
+            existing.iter().filter_map(|d| directive_graph(d)).collect();
+        let to_add: Vec<Node<Directive>> = synthetic_graphs
+            .iter()
+            .filter(|graph| !existing_graphs.contains(*graph))
+            .map(|graph| directive_with_graph(template, graph))
+            .collect();
+        if !to_add.is_empty() {
+            additions.push((member_name.clone(), to_add));
+        }
+    }
+    additions
+}
+
+/// When a directive-referenced input type is already in the merged supergraph (contributed by a
+/// non-connector subgraph, so it only carries that subgraph's `@join__type` membership), add the
+/// membership for the synthetic connector subgraphs that replaced the original connector subgraph.
+/// `desired` is the original type with its type-level membership already rewritten onto the
+/// synthetic subgraphs by the `strip_invalid_join_directives_*` helpers.
+fn add_synthetic_scalar_membership(
+    to: &mut FederationSchema,
+    pos: &ScalarTypeDefinitionPosition,
+    desired: &Node<ScalarType>,
+    synthetic_graphs: &HashSet<Name>,
+) -> Result<(), FederationError> {
+    let graphs = match to.schema().types.get(&pos.type_name) {
+        Some(ExtendedType::Scalar(scalar)) => {
+            synthetic_membership_graphs(&desired.directives, &scalar.directives, synthetic_graphs)
+        }
+        _ => return Ok(()),
+    };
+    for graph in graphs {
+        pos.insert_directive(to, join_type_directive(&graph))?;
+    }
+    Ok(())
+}
+
+/// See [`add_synthetic_scalar_membership`]. Enum values carry their own `@join__enumValue`
+/// membership, so we mirror each value's existing membership onto the synthetic subgraphs.
+fn add_synthetic_enum_membership(
+    to: &mut FederationSchema,
+    pos: &EnumTypeDefinitionPosition,
+    desired: &Node<EnumType>,
+    synthetic_graphs: &HashSet<Name>,
+) -> Result<(), FederationError> {
+    let (graphs, value_additions) = match to.schema().types.get(&pos.type_name) {
+        Some(ExtendedType::Enum(enum_type)) => {
+            let graphs = synthetic_membership_graphs(
+                &desired.directives,
+                &enum_type.directives,
+                synthetic_graphs,
+            );
+            let value_additions = member_membership_additions(
+                enum_type
+                    .values
+                    .iter()
+                    .map(|(name, value)| (name, &value.directives)),
+                &name!(join__enumValue),
+                &graphs,
+            );
+            (graphs, value_additions)
+        }
+        _ => return Ok(()),
+    };
+    for graph in &graphs {
+        pos.insert_directive(to, join_type_directive(graph))?;
+    }
+    for (value_name, directives) in value_additions {
+        let value_pos = pos.value(value_name);
+        for directive in directives {
+            value_pos.insert_directive(to, directive)?;
+        }
+    }
+    Ok(())
+}
+
+/// See [`add_synthetic_scalar_membership`]. Input object fields carry their own `@join__field`
+/// membership, so we mirror each field's existing membership onto the synthetic subgraphs.
+fn add_synthetic_input_object_membership(
+    to: &mut FederationSchema,
+    pos: &InputObjectTypeDefinitionPosition,
+    desired: &Node<InputObjectType>,
+    synthetic_graphs: &HashSet<Name>,
+) -> Result<(), FederationError> {
+    let (graphs, field_additions) = match to.schema().types.get(&pos.type_name) {
+        Some(ExtendedType::InputObject(input_object)) => {
+            let graphs = synthetic_membership_graphs(
+                &desired.directives,
+                &input_object.directives,
+                synthetic_graphs,
+            );
+            let field_additions = member_membership_additions(
+                input_object
+                    .fields
+                    .iter()
+                    .map(|(name, field)| (name, &field.directives)),
+                &name!(join__field),
+                &graphs,
+            );
+            (graphs, field_additions)
+        }
+        _ => return Ok(()),
+    };
+    for graph in &graphs {
+        pos.insert_directive(to, join_type_directive(graph))?;
+    }
+    for (field_name, directives) in field_additions {
+        let field_pos = pos.field(field_name);
+        for directive in directives {
+            field_pos.insert_directive(to, directive)?;
+        }
+    }
+    Ok(())
+}
+
+/// A bare `@join__type(graph: <graph>)` type-level membership directive.
+fn join_type_directive(graph: &Name) -> Component<Directive> {
+    Component::new(Directive {
+        name: name!(join__type),
+        arguments: vec![Node::new(Argument {
+            name: name!(graph),
+            value: Node::new(Value::Enum(graph.clone())),
+        })],
+    })
 }
 
 /// Given an original join__Graph enum:

--- a/apollo-federation/tests/composition/connectors.rs
+++ b/apollo-federation/tests/composition/connectors.rs
@@ -2,6 +2,7 @@ use insta::assert_snapshot;
 
 use super::ServiceDefinition;
 use super::compose_as_fed2_subgraphs;
+use super::test_helpers::as_fed2_subgraphs;
 
 #[cfg(test)]
 mod tests {
@@ -569,5 +570,100 @@ mod tests {
         let api_schema_string = api_schema.schema().to_string();
 
         assert_snapshot!(api_schema_string);
+    }
+
+    /// Repro for RH-1375: composing (via the connectors expansion path) two
+    /// subgraphs that both define an executable directive whose argument types
+    /// (an enum, a custom scalar, and a — self-referential — input object) are
+    /// referenced nowhere else. Connector expansion replaces the connector
+    /// subgraph with synthetic subgraphs; those types must be declared as
+    /// members of the synthetic subgraphs (via `@join__type` / `@join__enumValue`
+    /// / `@join__field`) so the expanded supergraph stays valid through
+    /// subgraph extraction during satisfiability. Pre-fix, the expanded
+    /// supergraph declared the types absent from the synthetic subgraphs while
+    /// extraction copied the directive (which references them) into every
+    /// subgraph, producing an invalid subgraph and a composition error.
+    #[test]
+    fn executable_directive_enum_arg_survives_connector_expansion() {
+        use apollo_federation::composition::CompositionOptions;
+        use apollo_federation::composition::compose_with_connectors;
+
+        // Shared definitions: an executable directive whose arguments cover all
+        // three input-type kinds, plus those types. `OwnershipFilter` is
+        // self-referential to exercise the recursive input-object path.
+        let shared_defs = r#"
+            directive @ownership(
+                owners: [Owner!]
+                since: DateTime
+                filter: OwnershipFilter
+            ) on FIELD
+
+            enum Owner {
+                ALICE
+                BOB
+            }
+
+            scalar DateTime
+
+            input OwnershipFilter {
+                owner: Owner
+                parent: OwnershipFilter
+            }
+        "#;
+
+        let with_connectors = ServiceDefinition {
+            name: "with-connectors",
+            type_defs: format!(
+                r#"
+                extend schema
+                @link(
+                    url: "https://specs.apollo.dev/connect/v0.1"
+                    import: ["@connect", "@source"]
+                )
+                @source(name: "v1", http: {{ baseURL: "http://v1" }})
+
+                {shared_defs}
+
+                type Query {{
+                    resources: [Resource!]!
+                    @connect(source: "v1", http: {{ GET: "/resources" }}, selection: "id name")
+                }}
+
+                type Resource @key(fields: "id") {{
+                    id: ID!
+                    name: String!
+                }}
+            "#
+            )
+            .leak(),
+        };
+
+        let plain = ServiceDefinition {
+            name: "plain",
+            type_defs: format!(
+                r#"
+                {shared_defs}
+
+                type Query {{
+                    greeting: String
+                }}
+            "#
+            )
+            .leak(),
+        };
+
+        let subgraphs = as_fed2_subgraphs(&[with_connectors, plain])
+            .expect("Expected fed2 subgraph conversion to succeed");
+
+        let result = compose_with_connectors(subgraphs, CompositionOptions::default());
+
+        let supergraph = result.expect("Expected composition to succeed");
+        let schema_string = supergraph.schema().schema().to_string();
+        for expected in ["enum Owner", "scalar DateTime", "input OwnershipFilter"] {
+            assert!(
+                schema_string.contains(expected),
+                "expanded supergraph dropped `{expected}`: {schema_string}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Composing a supergraph that uses **Apollo Connectors** together with an **executable directive whose argument references a custom input type** (for example `directive @ownership(owners: [Owner!]) on FIELD` with `enum Owner`) failed satisfiability validation with an internal error:

```
INTERNAL_ERROR: ... Cannot wrap an undefined/null type
```

(Rust-native composition surfaces the equivalent: `Directive argument's inner type "Owner" does not refer to an existing input type`.) Removing the directive from the subgraphs lets composition succeed.

## Root cause

During subgraph extraction (`extract_subgraphs_from_fed_2_supergraph`), executable directive definitions are copied into **every** extracted subgraph, because a client operation carrying such a directive may be routed to any subgraph. However, a directive argument's *type* is only materialized in a subgraph that declares it via `@join__type`.

Connector expansion synthesizes new subgraphs (e.g. `…_Query_resources_0`) that do **not** declare the executable directive's argument types. The directive definition was then inserted into those synthetic subgraphs while the referenced type (`Owner`) was absent, leaving a dangling type reference that fails validation when the subgraph schema is built.

A non-connector composition is immune, because an executable directive must be defined in *all* real subgraphs, so every subgraph already declares the argument types.

## Fix

The real defect is that connector expansion emits an **internally inconsistent supergraph**: the synthetic connector subgraphs aren't declared as `@join__type` members of the executable directive's argument types, even though extraction copies the directive into *every* subgraph. Rather than have extraction paper over this, we fix the supergraph expansion produces.

`copy_input_types` (in `connectors/expand/carryover`) already rewrites `@join__type` membership onto the synthetic subgraphs for the types it carries over, but it skipped any type already present in the merged supergraph (e.g. one also contributed by a non-connector subgraph). It now reconciles those too: for each input type reachable through an executable directive's arguments (scalars, enums, and input objects — recursively, for nested input objects), it stamps the missing `@join__type` (and per-value `@join__enumValue` / per-field `@join__field`) membership onto the synthetic subgraphs, mirroring the membership the type already carries for the real subgraphs.

The expanded supergraph is therefore valid by construction, and subgraph extraction is left unchanged (it can continue to trust `@join__type`).

## Tests

- New regression test `executable_directive_enum_arg_survives_connector_expansion` exercises the real `compose_with_connectors` path with a connector subgraph + a plain subgraph that both define an executable directive whose arguments reference a custom enum, a custom scalar, and a (self-referential) input object — types referenced nowhere else — and asserts composition **succeeds** (it errors pre-fix).
- Full `apollo-federation` suite green (lib + integration), including the connectors composition and connector-expansion snapshot tests, with **no snapshot changes**.

## Note on parity / scope

This fixes the connector-expansion path in the `apollo-federation` Rust crate. In Fed 2.14's hybrid connectors composition, this Rust `expand_connectors` builds the expanded supergraph that is then handed to JS (`extractSubgraphsFromSupergraph`) for satisfiability — so emitting a valid supergraph here should resolve the user-facing report once shipped, since JS would then extract from a consistent supergraph. **(Worth confirming against the exact Fed 2.14 expansion path before closing the report.)**

Ref: RH-1375
