### PR TITLE
fix(connectors): don't flag scalar-list selections as group selections

### DIFF
--- a/.changesets/fix_connect_v04_scalar_list_group_selection.md
+++ b/.changesets/fix_connect_v04_scalar_list_group_selection.md
@@ -1,0 +1,15 @@
+### Connectors: don't flag scalar-list selections as group selections (connect v0.4) ([PR #9636](https://github.com/apollographql/router/pull/9636))
+
+Composition with connect v0.4 reported a spurious `GROUP_SELECTION_IS_NOT_OBJECT` error for a renamed
+arrow-method projection over a nested-list scalar field — e.g. `data: data->map(@->map(@->toString))`
+against `data: [[String]]` produced "selects a group `data {}`, but `ReportData.data` is of type `String`
+which is not an object." The selection is a scalar projection, not a group selection, and the field is
+`[[String]]`. The identical schema composed cleanly under connect v0.3.
+
+Cause: the shape-based group-selection check treated every `Array`-shaped selection as a group selection,
+then required the field's type to be an object. A list is now treated as a group selection only when its
+element shape is itself a group (a list of objects), so a list of scalars validates cleanly. This is a
+sibling fix to [PR #9619](https://github.com/apollographql/router/pull/9619), in the group-selection
+detector rather than the seen-fields walker.
+
+By [@benjamn](https://github.com/benjamn) in [PR #9636](https://github.com/apollographql/router/pull/9636)

--- a/apollo-federation/src/connectors/validation/connect/selection.rs
+++ b/apollo-federation/src/connectors/validation/connect/selection.rs
@@ -576,6 +576,28 @@ impl<'schema> SelectionValidator<'schema> {
         once(self.root).chain(self.path.iter().copied())
     }
 
+    /// Whether a selected field's value shape implies a group selection
+    /// (`field { ... }`), which requires the field's GraphQL type to be an object.
+    ///
+    /// An `Object` shape is a group selection. An `Array` shape is a group
+    /// selection only when its element shape is itself a group — i.e. a list of
+    /// objects. A list of scalars (for example `data: data->map(@->map(@->toString))`
+    /// over a `[[String]]` field) is a scalar projection, not a group selection,
+    /// so it must not require an object type.
+    fn shape_implies_group_selection(shape: &Shape) -> bool {
+        match shape.case() {
+            ShapeCase::Object { .. } => true,
+            ShapeCase::Array { prefix, tail } => {
+                prefix.iter().any(Self::shape_implies_group_selection)
+                    || Self::shape_implies_group_selection(tail)
+            }
+            ShapeCase::One(shapes) => shapes.iter().any(Self::shape_implies_group_selection),
+            ShapeCase::All(shapes) => shapes.iter().any(Self::shape_implies_group_selection),
+            // `ShapeCase::Name` is a placeholder; scalars/leaves are not groups.
+            _ => false,
+        }
+    }
+
     fn walk_selection_with_shape(
         &mut self,
         type_ref: SchemaTypeRef<'schema>,
@@ -648,13 +670,10 @@ impl<'schema> SelectionValidator<'schema> {
                         self.seen_fields
                             .push((type_ref.name().clone(), field_def.name.clone()));
 
-                        // Check if this field has subselections (group selection)
-                        // Object/Array shapes correspond to GraphQL object/list types with subselections
-                        let has_subselection = match field_shape.case() {
-                            ShapeCase::Object { .. } => true,
-                            ShapeCase::Array { .. } => true,
-                            _ => false, // ShapeCase::Name is a placeholder, don't assume subselections
-                        };
+                        // Check if this field has subselections (group selection).
+                        // An object shape (or a list of objects) is a group selection; a
+                        // list of scalars is a scalar projection, not a group selection.
+                        let has_subselection = Self::shape_implies_group_selection(field_shape);
 
                         if let Some(field_type_ref) =
                             SchemaTypeRef::new(self.schema, inner_type_name)

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@arrow_map_on_nested_list_scalar.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@arrow_map_on_nested_list_scalar.graphql.snap
@@ -1,0 +1,12 @@
+---
+source: apollo-federation/src/connectors/validation/mod.rs
+expression: result.errors
+input_file: apollo-federation/src/connectors/validation/test_data/arrow_map_on_nested_list_scalar.graphql
+---
+[
+    Message {
+        code: GroupSelectionIsNotObject,
+        message: "`@connect(selection:)` on `Query.report` selects a group `data {}`, but `ReportData.data` is of type `String` which is not an object.",
+        locations: [],
+    },
+]

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@arrow_map_on_nested_list_scalar.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@arrow_map_on_nested_list_scalar.graphql.snap
@@ -3,10 +3,4 @@ source: apollo-federation/src/connectors/validation/mod.rs
 expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/arrow_map_on_nested_list_scalar.graphql
 ---
-[
-    Message {
-        code: GroupSelectionIsNotObject,
-        message: "`@connect(selection:)` on `Query.report` selects a group `data {}`, but `ReportData.data` is of type `String` which is not an object.",
-        locations: [],
-    },
-]
+[]

--- a/apollo-federation/src/connectors/validation/test_data/arrow_map_on_nested_list_scalar.graphql
+++ b/apollo-federation/src/connectors/validation/test_data/arrow_map_on_nested_list_scalar.graphql
@@ -1,0 +1,30 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.4"
+    import: ["@connect", "@source"]
+)
+
+@source(name: "api", http: { baseURL: "http://127.0.0.1" })
+
+# Focused repro of the connect/v0.4 force-upgrade diagnostic seen on
+# `apollo-constellation` (ashby `generateReport`): a renamed arrow-method
+# projection over a nested-list scalar field. This is NOT a group selection
+# (`data { ... }`); it is `data: data->map(...)`. Under the 2.14.1 connector
+# validation it was reported as `GROUP_SELECTION_IS_NOT_OBJECT` ("selects a
+# group `data {}` … is of type `String`"), which mischaracterizes both the
+# construct and the (`[[String]]`) type.
+type Query {
+    report: ReportData
+      @connect(
+        source: "api"
+        http: { GET: "/report" }
+        selection: """
+        data: data->map(@->map(@->toString))
+        """
+      )
+}
+
+type ReportData {
+    "List of rows; each row is a list of stringified cells."
+    data: [[String]]
+}

--- a/apollo-federation/src/connectors/validation/test_data/arrow_map_on_nested_list_scalar.graphql
+++ b/apollo-federation/src/connectors/validation/test_data/arrow_map_on_nested_list_scalar.graphql
@@ -6,13 +6,17 @@ extend schema
 
 @source(name: "api", http: { baseURL: "http://127.0.0.1" })
 
-# Focused repro of the connect/v0.4 force-upgrade diagnostic seen on
-# `apollo-constellation` (ashby `generateReport`): a renamed arrow-method
-# projection over a nested-list scalar field. This is NOT a group selection
-# (`data { ... }`); it is `data: data->map(...)`. Under the 2.14.1 connector
-# validation it was reported as `GROUP_SELECTION_IS_NOT_OBJECT` ("selects a
-# group `data {}` … is of type `String`"), which mischaracterizes both the
-# construct and the (`[[String]]`) type.
+# A renamed arrow-method projection over a nested-list scalar field
+# (`data: data->map(...)` where `ReportData.data: [[String]]`). This is a
+# scalar projection, NOT a group selection (`data { ... }`), so it must
+# validate cleanly.
+#
+# Regression test: this previously emitted a false-positive
+# `GROUP_SELECTION_IS_NOT_OBJECT` ("selects a group `data {}` … is of type
+# `String`") because the validator treated every `Array`-shaped selection as
+# a group. It now only treats a list whose *element* shape is an object as a
+# group. Surfaced while force-upgrading apollo-constellation connector
+# subgraphs (ashby `generateReport`) from connect/v0.3 to v0.4.
 type Query {
     report: ReportData
       @connect(


### PR DESCRIPTION
## Summary

Composition with **connect v0.4** reported a spurious `GROUP_SELECTION_IS_NOT_OBJECT` for a renamed arrow-method projection over a nested-list scalar field — e.g. `data: data->map(@->map(@->toString))` against `data: [[String]]`:

> `@connect(selection:)` on `Query.report` selects a group `data {}`, but `ReportData.data` is of type `String` which is not an object.

The selection is a scalar projection, not a group selection (`data { … }`), and the field is `[[String]]`, not `String`. The identical schema composed cleanly under connect v0.3. Surfaced while force-upgrading `apollo-constellation` connector subgraphs (ashby `generateReport`) from connect/v0.3 to v0.4.

## Cause

The shape-based group-selection check treated **every `Array`-shaped selection** as a group selection, then required the field's GraphQL type to be an object. A list of scalars therefore tripped the check.

## Fix

A list is a group selection only when its **element** shape is itself a group (a list of objects). Replace the blanket `Array => true` with a recursive `shape_implies_group_selection` that unwraps `Array`/`One`/`All` to the innermost shape: objects are groups, scalars/placeholders are not.

This is a sibling fix to #9619 — the same "v0.4 shape validator must unwrap `Array` shapes" defect, here in the **group-selection detector** rather than the seen-fields walker. Together the two make the v0.4 validator handle both list-of-object and list-of-scalar selections correctly (ashby had one instance of each).

## Tests

Adds an `arrow_map_on_nested_list_scalar.graphql` validation fixture + snapshot. Genuine group-on-scalar cases still error; full connectors suite passes (`cargo test -p apollo-federation --lib connectors::` → 1506 passed).
