### PR TITLE
refactor: Move work from call to inside the future for http service

### DIFF
--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -35,7 +35,6 @@ use tower::ServiceBuilder;
 use tower::util::Either;
 use tower_http::decompression::Decompression;
 use tower_http::decompression::DecompressionLayer;
-use tracing::Instrument;
 use tracing::Span;
 
 use super::HttpRequest;
@@ -527,49 +526,46 @@ impl tower::Service<HttpRequest> for HttpClientService {
         };
 
         let service_name = self.service.clone();
-        let http_req_span = Span::current();
-
-        get_text_map_propagator(|propagator| {
-            propagator.inject_context(
-                &prepare_context(http_req_span.context()),
-                &mut opentelemetry_http::HeaderInjector(http_request.headers_mut()),
-            );
-        });
-
-        let (parts, body) = http_request.into_parts();
-        let content_encoding = parts.headers.get(&CONTENT_ENCODING);
-
-        let opt_compressor = content_encoding
-            .as_ref()
-            .and_then(|value| value.to_str().ok())
-            .and_then(|v| Compressor::new(v.split(',').map(|s| s.trim())));
-
-        let body = match opt_compressor {
-            None => body,
-            Some(compressor) => router::body::from_result_stream(compressor.process(body)),
-        };
-
-        let mut http_request = http::Request::from_parts(parts, body);
-
-        http_request
-            .headers_mut()
-            .insert(ACCEPT_ENCODING, ACCEPTED_ENCODINGS.clone());
-
-        let signing_params = http_request
-            .extensions()
-            .get::<Arc<SigningParamsConfig>>()
-            .cloned();
 
         Box::pin(async move {
+            get_text_map_propagator(|propagator| {
+                propagator.inject_context(
+                    &prepare_context(Span::current().context()),
+                    &mut opentelemetry_http::HeaderInjector(http_request.headers_mut()),
+                );
+            });
+
+            let (parts, body) = http_request.into_parts();
+            let content_encoding = parts.headers.get(&CONTENT_ENCODING);
+
+            let opt_compressor = content_encoding
+                .as_ref()
+                .and_then(|value| value.to_str().ok())
+                .and_then(|v| Compressor::new(v.split(',').map(|s| s.trim())));
+
+            let body = match opt_compressor {
+                None => body,
+                Some(compressor) => router::body::from_result_stream(compressor.process(body)),
+            };
+
+            let mut http_request = http::Request::from_parts(parts, body);
+
+            http_request
+                .headers_mut()
+                .insert(ACCEPT_ENCODING, ACCEPTED_ENCODINGS.clone());
+
+            let signing_params = http_request
+                .extensions()
+                .get::<Arc<SigningParamsConfig>>()
+                .cloned();
+
             let http_request = if let Some(signing_params) = signing_params {
                 signing_params.sign(http_request, &service_name).await?
             } else {
                 http_request
             };
 
-            let http_response = do_fetch(client, &service_name, http_request)
-                .instrument(http_req_span)
-                .await?;
+            let http_response = do_fetch(client, &service_name, http_request).await?;
 
             Ok(HttpResponse {
                 http_response,


### PR DESCRIPTION
Move work from call to inside the future for http service. This means that creating the future is fast and in line with tower best practice.
In addition, remove spurious instrument call as the parent span should come from the future.

<!-- start metadata -->

<!-- [ROUTER-1869] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1869]: https://apollographql.atlassian.net/browse/ROUTER-1869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ