### PR TITLE
refactor: Remove oneshot from SupergraphService

### DIFF
--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -107,9 +107,11 @@ impl Service<SupergraphRequest> for SupergraphService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.query_planner_service
-            .poll_ready(cx)
-            .map_err(|err| err.into())
+        match self.query_planner_service.poll_ready(cx) {
+            Poll::Ready(Ok(())) => {}
+            other => return other.map_err(|err| err.into()),
+        }
+        self.execution_service.poll_ready(cx)
     }
 
     fn call(&mut self, req: SupergraphRequest) -> Self::Future {
@@ -119,16 +121,18 @@ impl Service<SupergraphRequest> for SupergraphService {
         }
 
         // Consume our cloned services and allow ownership to be transferred to the async block.
-        let clone = self.query_planner_service.clone();
+        let planning_clone = self.query_planner_service.clone();
+        let planning = std::mem::replace(&mut self.query_planner_service, planning_clone);
 
-        let planning = std::mem::replace(&mut self.query_planner_service, clone);
+        let execution_clone = self.execution_service.clone();
+        let execution = std::mem::replace(&mut self.execution_service, execution_clone);
 
         let schema = self.schema.clone();
 
         let context_cloned = req.context.clone();
         let fut = service_call(
             planning,
-            self.execution_service.clone(),
+            execution,
             schema,
             req,
             self.strict_variable_validation,
@@ -154,7 +158,7 @@ impl Service<SupergraphRequest> for SupergraphService {
 
 async fn service_call(
     planning: CachingQueryPlanner<QueryPlannerService>,
-    execution_service: execution::BoxCloneService,
+    mut execution_service: execution::BoxCloneService,
     schema: Arc<Schema>,
     req: SupergraphRequest,
     strict_variable_validation: Mode,
@@ -326,7 +330,7 @@ async fn service_call(
                 Ok(res)
             } else {
                 let execution_response = execution_service
-                    .oneshot(
+                    .call(
                         ExecutionRequest::internal_builder()
                             .supergraph_request(req.supergraph_request)
                             .query_plan(plan.clone())


### PR DESCRIPTION
Previously we were oneshotting the execution service rather than using the standard mem replace pattern. Fixing this now means that any backpressure from the execution service is now propagated to the supergraph service. Note that query planning may take time, so any reserved capacity for execution will be held until query planning is complete.

<!-- start metadata -->

<!-- [ROUTER-1867] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1867]: https://apollographql.atlassian.net/browse/ROUTER-1867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ