### PR TITLE
fix(connectors): shape `->filter` and `->find` conditions against array elements

### DIFF
--- a/.changesets/fix_connectors_chained_method_shape.md
+++ b/.changesets/fix_connectors_chained_method_shape.md
@@ -1,0 +1,9 @@
+### Fix connector composition failures for chained `->filter`/`->find` selections
+
+A `connect/v0.4` connector selection that places one of the iterative array methods after another array-producing method — for example `$.items->filter(@.a->eq("x"))->filter(@.b->gt(0)) { id name }` or `$.items->filter(@.a->eq("x"))->find(@.b->gt(0)) { id name }` — could fail to compose with a `SATISFIABILITY_ERROR`.
+
+`->filter` and `->find` shaped their condition against the whole input array instead of its element. A single method applied to an `Unknown` input happened to pass a lenient boolean check, but once a prior method handed it a concrete `List<…>`, the condition `@.field->…` was evaluated against the list, produced a spurious "condition must return a boolean value" error, and connector expansion collapsed the output object to a type with no fields — an invalid subgraph that surfaced downstream as a composition error.
+
+Both methods now shape their condition against the array element (`any_item`), matching the per-element runtime semantics, so chained selections expand and compose correctly. (`->map` already shaped its callback per element and was unaffected.)
+
+By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/9643

--- a/apollo-federation/src/connectors/expand/tests/schemas/expand/chained_filter_v0_4.graphql
+++ b/apollo-federation/src/connectors/expand/tests/schemas/expand/chained_filter_v0_4.graphql
@@ -1,0 +1,84 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "v1", http: {baseURL: "http://127.0.0.1"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+# Regression coverage for chained `->filter(...)` in a connector selection.
+#
+# `things` (no filter) and `activeThings` (two chained `->filter`s) both return
+# the same `ThingConnection { things: [Thing] }`. Before the filter-shape fix,
+# the chained-filter connector expanded `Thing` with *no fields* (the chained
+# filter's element shape collapsed to an error), producing an invalid subgraph
+# that surfaced downstream as a composition SATISFIABILITY_ERROR. The snapshot
+# must show `Thing` carrying `id`/`name` under both connectors.
+type Query
+  @join__type(graph: CONNECTORS)
+{
+  things: ThingConnection @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {GET: "/things"}, selection: "things: $.results { id name }"})
+  activeThings: ThingConnection @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {GET: "/things"}, selection: "things: $.results->filter(@.status->eq(\"A\"))->filter(@.rank->gt(0)) { id name }"})
+}
+
+type ThingConnection
+  @join__type(graph: CONNECTORS)
+{
+  things: [Thing]
+}
+
+type Thing
+  @join__type(graph: CONNECTORS)
+{
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/expand/tests/schemas/expand/chained_methods_v0_4.graphql
+++ b/apollo-federation/src/connectors/expand/tests/schemas/expand/chained_methods_v0_4.graphql
@@ -1,0 +1,97 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "v1", http: {baseURL: "http://127.0.0.1"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+# Regression coverage for moderately complex chains of the iterative array
+# methods (`->filter`, `->map`, `->find`) in a connector selection.
+#
+# All of these put a *concrete* list in front of the method whose condition
+# dereferences `@.field`. Before the element-shape fix, that condition was
+# shaped against the whole list, collapsed to an error shape, and the expander
+# emitted output object types with *no fields* — an invalid subgraph that
+# surfaced downstream as a composition SATISFIABILITY_ERROR. Each connector's
+# output type must carry `id`/`name` in the snapshot.
+#
+# Coverage:
+# - `mappedActive`  : `->map(@)->filter(...)`            — map produces the list, filter is the victim.
+# - `firstActive`   : `->filter(...)->find(...)`         — filter produces the list, find is the victim.
+# - `deepFind`      : `->filter(...)->map(@)->find(...)` — three-method chain, find terminal.
+type Query
+  @join__type(graph: CONNECTORS)
+{
+  mappedActive: ThingConnection @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {GET: "/things"}, selection: "things: $.results->map(@)->filter(@.rank->gt(0)) { id name }"})
+  firstActive: ThingResult @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {GET: "/things"}, selection: "thing: $.results->filter(@.status->eq(\"A\"))->find(@.rank->gt(0)) { id name }"})
+  deepFind: ThingResult @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {GET: "/things"}, selection: "thing: $.results->filter(@.status->eq(\"A\"))->map(@)->find(@.rank->gt(0)) { id name }"})
+}
+
+type ThingConnection
+  @join__type(graph: CONNECTORS)
+{
+  things: [Thing]
+}
+
+type ThingResult
+  @join__type(graph: CONNECTORS)
+{
+  thing: Thing
+}
+
+type Thing
+  @join__type(graph: CONNECTORS)
+{
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/api@chained_filter_v0_4.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/api@chained_filter_v0_4.graphql.snap
@@ -1,0 +1,21 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+assertion_line: 25
+expression: api_schema
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/chained_filter_v0_4.graphql
+---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type Query {
+  things: ThingConnection
+  activeThings: ThingConnection
+}
+
+type ThingConnection {
+  things: [Thing]
+}
+
+type Thing {
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/api@chained_methods_v0_4.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/api@chained_methods_v0_4.graphql.snap
@@ -1,0 +1,25 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: api_schema
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/chained_methods_v0_4.graphql
+---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type Query {
+  mappedActive: ThingConnection
+  firstActive: ThingResult
+  deepFind: ThingResult
+}
+
+type ThingConnection {
+  things: [Thing]
+}
+
+type ThingResult {
+  thing: Thing
+}
+
+type Thing {
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@chained_filter_v0_4.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@chained_filter_v0_4.graphql.snap
@@ -1,0 +1,626 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+assertion_line: 26
+expression: connectors.by_service_name
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/chained_filter_v0_4.graphql
+---
+{
+    "connectors_Query_things_0": Connector {
+        id: ConnectId {
+            subgraph_name: "connectors",
+            source_name: Some(
+                "v1",
+            ),
+            named: None,
+            directive: Field(
+                ObjectOrInterfaceFieldDirectivePosition {
+                    field: Object(Query.things),
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            ),
+        },
+        transport: Some(
+            HttpJsonTransport {
+                source_template: Some(
+                    StringTemplate {
+                        parts: [
+                            Constant(
+                                Constant {
+                                    value: "http://127.0.0.1",
+                                    location: 0..16,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                connect_template: StringTemplate {
+                    parts: [
+                        Constant(
+                            Constant {
+                                value: "/things",
+                                location: 0..7,
+                            },
+                        ),
+                    ],
+                },
+                method: Get,
+                headers: [],
+                body: None,
+                source_path: None,
+                source_query_params: None,
+                connect_path: None,
+                connect_query_params: None,
+            },
+        ),
+        selection: JSONSelection {
+            inner: Named(
+                SubSelection {
+                    selections: [
+                        NamedSelection {
+                            prefix: Alias(
+                                Alias {
+                                    name: WithRange {
+                                        node: Field(
+                                            "things",
+                                        ),
+                                        range: Some(
+                                            0..6,
+                                        ),
+                                    },
+                                    range: Some(
+                                        0..7,
+                                    ),
+                                },
+                            ),
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Var(
+                                                WithRange {
+                                                    node: $,
+                                                    range: Some(
+                                                        8..9,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Key(
+                                                        WithRange {
+                                                            node: Field(
+                                                                "results",
+                                                            ),
+                                                            range: Some(
+                                                                10..17,
+                                                            ),
+                                                        },
+                                                        WithRange {
+                                                            node: Selection(
+                                                                SubSelection {
+                                                                    selections: [
+                                                                        NamedSelection {
+                                                                            prefix: None,
+                                                                            path: WithRange {
+                                                                                node: Path(
+                                                                                    PathSelection {
+                                                                                        path: WithRange {
+                                                                                            node: Key(
+                                                                                                WithRange {
+                                                                                                    node: Field(
+                                                                                                        "id",
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        20..22,
+                                                                                                    ),
+                                                                                                },
+                                                                                                WithRange {
+                                                                                                    node: Empty,
+                                                                                                    range: Some(
+                                                                                                        22..22,
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                20..22,
+                                                                                            ),
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                range: Some(
+                                                                                    20..22,
+                                                                                ),
+                                                                            },
+                                                                        },
+                                                                        NamedSelection {
+                                                                            prefix: None,
+                                                                            path: WithRange {
+                                                                                node: Path(
+                                                                                    PathSelection {
+                                                                                        path: WithRange {
+                                                                                            node: Key(
+                                                                                                WithRange {
+                                                                                                    node: Field(
+                                                                                                        "name",
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        23..27,
+                                                                                                    ),
+                                                                                                },
+                                                                                                WithRange {
+                                                                                                    node: Empty,
+                                                                                                    range: Some(
+                                                                                                        27..27,
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                23..27,
+                                                                                            ),
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                range: Some(
+                                                                                    23..27,
+                                                                                ),
+                                                                            },
+                                                                        },
+                                                                    ],
+                                                                    range: Some(
+                                                                        18..29,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                18..29,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    range: Some(
+                                                        9..29,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                8..29,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    8..29,
+                                ),
+                            },
+                        },
+                    ],
+                    range: Some(
+                        0..29,
+                    ),
+                },
+            ),
+            spec: V0_4,
+        },
+        config: None,
+        max_requests: None,
+        entity_resolver: None,
+        spec: V0_4,
+        schema_subtypes_map: {},
+        request_headers: {},
+        response_headers: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
+        batch_settings: None,
+        error_settings: ConnectorErrorsSettings {
+            message: None,
+            source_extensions: None,
+            connect_extensions: None,
+            connect_is_success: None,
+        },
+        label: Label(
+            "connectors.v1 http: GET /things",
+        ),
+    },
+    "connectors_Query_activeThings_0": Connector {
+        id: ConnectId {
+            subgraph_name: "connectors",
+            source_name: Some(
+                "v1",
+            ),
+            named: None,
+            directive: Field(
+                ObjectOrInterfaceFieldDirectivePosition {
+                    field: Object(Query.activeThings),
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            ),
+        },
+        transport: Some(
+            HttpJsonTransport {
+                source_template: Some(
+                    StringTemplate {
+                        parts: [
+                            Constant(
+                                Constant {
+                                    value: "http://127.0.0.1",
+                                    location: 0..16,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                connect_template: StringTemplate {
+                    parts: [
+                        Constant(
+                            Constant {
+                                value: "/things",
+                                location: 0..7,
+                            },
+                        ),
+                    ],
+                },
+                method: Get,
+                headers: [],
+                body: None,
+                source_path: None,
+                source_query_params: None,
+                connect_path: None,
+                connect_query_params: None,
+            },
+        ),
+        selection: JSONSelection {
+            inner: Named(
+                SubSelection {
+                    selections: [
+                        NamedSelection {
+                            prefix: Alias(
+                                Alias {
+                                    name: WithRange {
+                                        node: Field(
+                                            "things",
+                                        ),
+                                        range: Some(
+                                            0..6,
+                                        ),
+                                    },
+                                    range: Some(
+                                        0..7,
+                                    ),
+                                },
+                            ),
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Var(
+                                                WithRange {
+                                                    node: $,
+                                                    range: Some(
+                                                        8..9,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Key(
+                                                        WithRange {
+                                                            node: Field(
+                                                                "results",
+                                                            ),
+                                                            range: Some(
+                                                                10..17,
+                                                            ),
+                                                        },
+                                                        WithRange {
+                                                            node: Method(
+                                                                WithRange {
+                                                                    node: "filter",
+                                                                    range: Some(
+                                                                        19..25,
+                                                                    ),
+                                                                },
+                                                                Some(
+                                                                    MethodArgs {
+                                                                        args: [
+                                                                            WithRange {
+                                                                                node: Path(
+                                                                                    PathSelection {
+                                                                                        path: WithRange {
+                                                                                            node: Var(
+                                                                                                WithRange {
+                                                                                                    node: @,
+                                                                                                    range: Some(
+                                                                                                        26..27,
+                                                                                                    ),
+                                                                                                },
+                                                                                                WithRange {
+                                                                                                    node: Key(
+                                                                                                        WithRange {
+                                                                                                            node: Field(
+                                                                                                                "status",
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                28..34,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        WithRange {
+                                                                                                            node: Method(
+                                                                                                                WithRange {
+                                                                                                                    node: "eq",
+                                                                                                                    range: Some(
+                                                                                                                        36..38,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                Some(
+                                                                                                                    MethodArgs {
+                                                                                                                        args: [
+                                                                                                                            WithRange {
+                                                                                                                                node: String(
+                                                                                                                                    "A",
+                                                                                                                                ),
+                                                                                                                                range: Some(
+                                                                                                                                    39..42,
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        range: Some(
+                                                                                                                            38..43,
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        43..43,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                34..43,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        27..43,
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                26..43,
+                                                                                            ),
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                range: Some(
+                                                                                    26..43,
+                                                                                ),
+                                                                            },
+                                                                        ],
+                                                                        range: Some(
+                                                                            25..44,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                WithRange {
+                                                                    node: Method(
+                                                                        WithRange {
+                                                                            node: "filter",
+                                                                            range: Some(
+                                                                                46..52,
+                                                                            ),
+                                                                        },
+                                                                        Some(
+                                                                            MethodArgs {
+                                                                                args: [
+                                                                                    WithRange {
+                                                                                        node: Path(
+                                                                                            PathSelection {
+                                                                                                path: WithRange {
+                                                                                                    node: Var(
+                                                                                                        WithRange {
+                                                                                                            node: @,
+                                                                                                            range: Some(
+                                                                                                                53..54,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "rank",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        55..59,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Method(
+                                                                                                                        WithRange {
+                                                                                                                            node: "gt",
+                                                                                                                            range: Some(
+                                                                                                                                61..63,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                        Some(
+                                                                                                                            MethodArgs {
+                                                                                                                                args: [
+                                                                                                                                    WithRange {
+                                                                                                                                        node: Number(
+                                                                                                                                            Number(0),
+                                                                                                                                        ),
+                                                                                                                                        range: Some(
+                                                                                                                                            64..65,
+                                                                                                                                        ),
+                                                                                                                                    },
+                                                                                                                                ],
+                                                                                                                                range: Some(
+                                                                                                                                    63..66,
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                        WithRange {
+                                                                                                                            node: Empty,
+                                                                                                                            range: Some(
+                                                                                                                                66..66,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        59..66,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                54..66,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        53..66,
+                                                                                                    ),
+                                                                                                },
+                                                                                            },
+                                                                                        ),
+                                                                                        range: Some(
+                                                                                            53..66,
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                range: Some(
+                                                                                    52..67,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        WithRange {
+                                                                            node: Selection(
+                                                                                SubSelection {
+                                                                                    selections: [
+                                                                                        NamedSelection {
+                                                                                            prefix: None,
+                                                                                            path: WithRange {
+                                                                                                node: Path(
+                                                                                                    PathSelection {
+                                                                                                        path: WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "id",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        70..72,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        72..72,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                70..72,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                range: Some(
+                                                                                                    70..72,
+                                                                                                ),
+                                                                                            },
+                                                                                        },
+                                                                                        NamedSelection {
+                                                                                            prefix: None,
+                                                                                            path: WithRange {
+                                                                                                node: Path(
+                                                                                                    PathSelection {
+                                                                                                        path: WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "name",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        73..77,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        77..77,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                73..77,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                range: Some(
+                                                                                                    73..77,
+                                                                                                ),
+                                                                                            },
+                                                                                        },
+                                                                                    ],
+                                                                                    range: Some(
+                                                                                        68..79,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                68..79,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        44..79,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                17..79,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    range: Some(
+                                                        9..79,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                8..79,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    8..79,
+                                ),
+                            },
+                        },
+                    ],
+                    range: Some(
+                        0..79,
+                    ),
+                },
+            ),
+            spec: V0_4,
+        },
+        config: None,
+        max_requests: None,
+        entity_resolver: None,
+        spec: V0_4,
+        schema_subtypes_map: {},
+        request_headers: {},
+        response_headers: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
+        batch_settings: None,
+        error_settings: ConnectorErrorsSettings {
+            message: None,
+            source_extensions: None,
+            connect_extensions: None,
+            connect_is_success: None,
+        },
+        label: Label(
+            "connectors.v1 http: GET /things",
+        ),
+    },
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@chained_methods_v0_4.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@chained_methods_v0_4.graphql.snap
@@ -1,0 +1,1224 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: connectors.by_service_name
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/chained_methods_v0_4.graphql
+---
+{
+    "connectors_Query_mappedActive_0": Connector {
+        id: ConnectId {
+            subgraph_name: "connectors",
+            source_name: Some(
+                "v1",
+            ),
+            named: None,
+            directive: Field(
+                ObjectOrInterfaceFieldDirectivePosition {
+                    field: Object(Query.mappedActive),
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            ),
+        },
+        transport: Some(
+            HttpJsonTransport {
+                source_template: Some(
+                    StringTemplate {
+                        parts: [
+                            Constant(
+                                Constant {
+                                    value: "http://127.0.0.1",
+                                    location: 0..16,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                connect_template: StringTemplate {
+                    parts: [
+                        Constant(
+                            Constant {
+                                value: "/things",
+                                location: 0..7,
+                            },
+                        ),
+                    ],
+                },
+                method: Get,
+                headers: [],
+                body: None,
+                source_path: None,
+                source_query_params: None,
+                connect_path: None,
+                connect_query_params: None,
+            },
+        ),
+        selection: JSONSelection {
+            inner: Named(
+                SubSelection {
+                    selections: [
+                        NamedSelection {
+                            prefix: Alias(
+                                Alias {
+                                    name: WithRange {
+                                        node: Field(
+                                            "things",
+                                        ),
+                                        range: Some(
+                                            0..6,
+                                        ),
+                                    },
+                                    range: Some(
+                                        0..7,
+                                    ),
+                                },
+                            ),
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Var(
+                                                WithRange {
+                                                    node: $,
+                                                    range: Some(
+                                                        8..9,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Key(
+                                                        WithRange {
+                                                            node: Field(
+                                                                "results",
+                                                            ),
+                                                            range: Some(
+                                                                10..17,
+                                                            ),
+                                                        },
+                                                        WithRange {
+                                                            node: Method(
+                                                                WithRange {
+                                                                    node: "map",
+                                                                    range: Some(
+                                                                        19..22,
+                                                                    ),
+                                                                },
+                                                                Some(
+                                                                    MethodArgs {
+                                                                        args: [
+                                                                            WithRange {
+                                                                                node: Path(
+                                                                                    PathSelection {
+                                                                                        path: WithRange {
+                                                                                            node: Var(
+                                                                                                WithRange {
+                                                                                                    node: @,
+                                                                                                    range: Some(
+                                                                                                        23..24,
+                                                                                                    ),
+                                                                                                },
+                                                                                                WithRange {
+                                                                                                    node: Empty,
+                                                                                                    range: Some(
+                                                                                                        24..24,
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                23..24,
+                                                                                            ),
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                range: Some(
+                                                                                    23..24,
+                                                                                ),
+                                                                            },
+                                                                        ],
+                                                                        range: Some(
+                                                                            22..25,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                WithRange {
+                                                                    node: Method(
+                                                                        WithRange {
+                                                                            node: "filter",
+                                                                            range: Some(
+                                                                                27..33,
+                                                                            ),
+                                                                        },
+                                                                        Some(
+                                                                            MethodArgs {
+                                                                                args: [
+                                                                                    WithRange {
+                                                                                        node: Path(
+                                                                                            PathSelection {
+                                                                                                path: WithRange {
+                                                                                                    node: Var(
+                                                                                                        WithRange {
+                                                                                                            node: @,
+                                                                                                            range: Some(
+                                                                                                                34..35,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "rank",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        36..40,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Method(
+                                                                                                                        WithRange {
+                                                                                                                            node: "gt",
+                                                                                                                            range: Some(
+                                                                                                                                42..44,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                        Some(
+                                                                                                                            MethodArgs {
+                                                                                                                                args: [
+                                                                                                                                    WithRange {
+                                                                                                                                        node: Number(
+                                                                                                                                            Number(0),
+                                                                                                                                        ),
+                                                                                                                                        range: Some(
+                                                                                                                                            45..46,
+                                                                                                                                        ),
+                                                                                                                                    },
+                                                                                                                                ],
+                                                                                                                                range: Some(
+                                                                                                                                    44..47,
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                        WithRange {
+                                                                                                                            node: Empty,
+                                                                                                                            range: Some(
+                                                                                                                                47..47,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        40..47,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                35..47,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        34..47,
+                                                                                                    ),
+                                                                                                },
+                                                                                            },
+                                                                                        ),
+                                                                                        range: Some(
+                                                                                            34..47,
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                range: Some(
+                                                                                    33..48,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        WithRange {
+                                                                            node: Selection(
+                                                                                SubSelection {
+                                                                                    selections: [
+                                                                                        NamedSelection {
+                                                                                            prefix: None,
+                                                                                            path: WithRange {
+                                                                                                node: Path(
+                                                                                                    PathSelection {
+                                                                                                        path: WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "id",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        51..53,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        53..53,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                51..53,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                range: Some(
+                                                                                                    51..53,
+                                                                                                ),
+                                                                                            },
+                                                                                        },
+                                                                                        NamedSelection {
+                                                                                            prefix: None,
+                                                                                            path: WithRange {
+                                                                                                node: Path(
+                                                                                                    PathSelection {
+                                                                                                        path: WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "name",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        54..58,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        58..58,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                54..58,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                range: Some(
+                                                                                                    54..58,
+                                                                                                ),
+                                                                                            },
+                                                                                        },
+                                                                                    ],
+                                                                                    range: Some(
+                                                                                        49..60,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                49..60,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        25..60,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                17..60,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    range: Some(
+                                                        9..60,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                8..60,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    8..60,
+                                ),
+                            },
+                        },
+                    ],
+                    range: Some(
+                        0..60,
+                    ),
+                },
+            ),
+            spec: V0_4,
+        },
+        config: None,
+        max_requests: None,
+        entity_resolver: None,
+        spec: V0_4,
+        schema_subtypes_map: {},
+        request_headers: {},
+        response_headers: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
+        batch_settings: None,
+        error_settings: ConnectorErrorsSettings {
+            message: None,
+            source_extensions: None,
+            connect_extensions: None,
+            connect_is_success: None,
+        },
+        label: Label(
+            "connectors.v1 http: GET /things",
+        ),
+    },
+    "connectors_Query_firstActive_0": Connector {
+        id: ConnectId {
+            subgraph_name: "connectors",
+            source_name: Some(
+                "v1",
+            ),
+            named: None,
+            directive: Field(
+                ObjectOrInterfaceFieldDirectivePosition {
+                    field: Object(Query.firstActive),
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            ),
+        },
+        transport: Some(
+            HttpJsonTransport {
+                source_template: Some(
+                    StringTemplate {
+                        parts: [
+                            Constant(
+                                Constant {
+                                    value: "http://127.0.0.1",
+                                    location: 0..16,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                connect_template: StringTemplate {
+                    parts: [
+                        Constant(
+                            Constant {
+                                value: "/things",
+                                location: 0..7,
+                            },
+                        ),
+                    ],
+                },
+                method: Get,
+                headers: [],
+                body: None,
+                source_path: None,
+                source_query_params: None,
+                connect_path: None,
+                connect_query_params: None,
+            },
+        ),
+        selection: JSONSelection {
+            inner: Named(
+                SubSelection {
+                    selections: [
+                        NamedSelection {
+                            prefix: Alias(
+                                Alias {
+                                    name: WithRange {
+                                        node: Field(
+                                            "thing",
+                                        ),
+                                        range: Some(
+                                            0..5,
+                                        ),
+                                    },
+                                    range: Some(
+                                        0..6,
+                                    ),
+                                },
+                            ),
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Var(
+                                                WithRange {
+                                                    node: $,
+                                                    range: Some(
+                                                        7..8,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Key(
+                                                        WithRange {
+                                                            node: Field(
+                                                                "results",
+                                                            ),
+                                                            range: Some(
+                                                                9..16,
+                                                            ),
+                                                        },
+                                                        WithRange {
+                                                            node: Method(
+                                                                WithRange {
+                                                                    node: "filter",
+                                                                    range: Some(
+                                                                        18..24,
+                                                                    ),
+                                                                },
+                                                                Some(
+                                                                    MethodArgs {
+                                                                        args: [
+                                                                            WithRange {
+                                                                                node: Path(
+                                                                                    PathSelection {
+                                                                                        path: WithRange {
+                                                                                            node: Var(
+                                                                                                WithRange {
+                                                                                                    node: @,
+                                                                                                    range: Some(
+                                                                                                        25..26,
+                                                                                                    ),
+                                                                                                },
+                                                                                                WithRange {
+                                                                                                    node: Key(
+                                                                                                        WithRange {
+                                                                                                            node: Field(
+                                                                                                                "status",
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                27..33,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        WithRange {
+                                                                                                            node: Method(
+                                                                                                                WithRange {
+                                                                                                                    node: "eq",
+                                                                                                                    range: Some(
+                                                                                                                        35..37,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                Some(
+                                                                                                                    MethodArgs {
+                                                                                                                        args: [
+                                                                                                                            WithRange {
+                                                                                                                                node: String(
+                                                                                                                                    "A",
+                                                                                                                                ),
+                                                                                                                                range: Some(
+                                                                                                                                    38..41,
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        range: Some(
+                                                                                                                            37..42,
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        42..42,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                33..42,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        26..42,
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                25..42,
+                                                                                            ),
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                range: Some(
+                                                                                    25..42,
+                                                                                ),
+                                                                            },
+                                                                        ],
+                                                                        range: Some(
+                                                                            24..43,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                WithRange {
+                                                                    node: Method(
+                                                                        WithRange {
+                                                                            node: "find",
+                                                                            range: Some(
+                                                                                45..49,
+                                                                            ),
+                                                                        },
+                                                                        Some(
+                                                                            MethodArgs {
+                                                                                args: [
+                                                                                    WithRange {
+                                                                                        node: Path(
+                                                                                            PathSelection {
+                                                                                                path: WithRange {
+                                                                                                    node: Var(
+                                                                                                        WithRange {
+                                                                                                            node: @,
+                                                                                                            range: Some(
+                                                                                                                50..51,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "rank",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        52..56,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Method(
+                                                                                                                        WithRange {
+                                                                                                                            node: "gt",
+                                                                                                                            range: Some(
+                                                                                                                                58..60,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                        Some(
+                                                                                                                            MethodArgs {
+                                                                                                                                args: [
+                                                                                                                                    WithRange {
+                                                                                                                                        node: Number(
+                                                                                                                                            Number(0),
+                                                                                                                                        ),
+                                                                                                                                        range: Some(
+                                                                                                                                            61..62,
+                                                                                                                                        ),
+                                                                                                                                    },
+                                                                                                                                ],
+                                                                                                                                range: Some(
+                                                                                                                                    60..63,
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ),
+                                                                                                                        WithRange {
+                                                                                                                            node: Empty,
+                                                                                                                            range: Some(
+                                                                                                                                63..63,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        56..63,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                51..63,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        50..63,
+                                                                                                    ),
+                                                                                                },
+                                                                                            },
+                                                                                        ),
+                                                                                        range: Some(
+                                                                                            50..63,
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                range: Some(
+                                                                                    49..64,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        WithRange {
+                                                                            node: Selection(
+                                                                                SubSelection {
+                                                                                    selections: [
+                                                                                        NamedSelection {
+                                                                                            prefix: None,
+                                                                                            path: WithRange {
+                                                                                                node: Path(
+                                                                                                    PathSelection {
+                                                                                                        path: WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "id",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        67..69,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        69..69,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                67..69,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                range: Some(
+                                                                                                    67..69,
+                                                                                                ),
+                                                                                            },
+                                                                                        },
+                                                                                        NamedSelection {
+                                                                                            prefix: None,
+                                                                                            path: WithRange {
+                                                                                                node: Path(
+                                                                                                    PathSelection {
+                                                                                                        path: WithRange {
+                                                                                                            node: Key(
+                                                                                                                WithRange {
+                                                                                                                    node: Field(
+                                                                                                                        "name",
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        70..74,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        74..74,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                70..74,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                range: Some(
+                                                                                                    70..74,
+                                                                                                ),
+                                                                                            },
+                                                                                        },
+                                                                                    ],
+                                                                                    range: Some(
+                                                                                        65..76,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                65..76,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        43..76,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                16..76,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    range: Some(
+                                                        8..76,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                7..76,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    7..76,
+                                ),
+                            },
+                        },
+                    ],
+                    range: Some(
+                        0..76,
+                    ),
+                },
+            ),
+            spec: V0_4,
+        },
+        config: None,
+        max_requests: None,
+        entity_resolver: None,
+        spec: V0_4,
+        schema_subtypes_map: {},
+        request_headers: {},
+        response_headers: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
+        batch_settings: None,
+        error_settings: ConnectorErrorsSettings {
+            message: None,
+            source_extensions: None,
+            connect_extensions: None,
+            connect_is_success: None,
+        },
+        label: Label(
+            "connectors.v1 http: GET /things",
+        ),
+    },
+    "connectors_Query_deepFind_0": Connector {
+        id: ConnectId {
+            subgraph_name: "connectors",
+            source_name: Some(
+                "v1",
+            ),
+            named: None,
+            directive: Field(
+                ObjectOrInterfaceFieldDirectivePosition {
+                    field: Object(Query.deepFind),
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            ),
+        },
+        transport: Some(
+            HttpJsonTransport {
+                source_template: Some(
+                    StringTemplate {
+                        parts: [
+                            Constant(
+                                Constant {
+                                    value: "http://127.0.0.1",
+                                    location: 0..16,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                connect_template: StringTemplate {
+                    parts: [
+                        Constant(
+                            Constant {
+                                value: "/things",
+                                location: 0..7,
+                            },
+                        ),
+                    ],
+                },
+                method: Get,
+                headers: [],
+                body: None,
+                source_path: None,
+                source_query_params: None,
+                connect_path: None,
+                connect_query_params: None,
+            },
+        ),
+        selection: JSONSelection {
+            inner: Named(
+                SubSelection {
+                    selections: [
+                        NamedSelection {
+                            prefix: Alias(
+                                Alias {
+                                    name: WithRange {
+                                        node: Field(
+                                            "thing",
+                                        ),
+                                        range: Some(
+                                            0..5,
+                                        ),
+                                    },
+                                    range: Some(
+                                        0..6,
+                                    ),
+                                },
+                            ),
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Var(
+                                                WithRange {
+                                                    node: $,
+                                                    range: Some(
+                                                        7..8,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Key(
+                                                        WithRange {
+                                                            node: Field(
+                                                                "results",
+                                                            ),
+                                                            range: Some(
+                                                                9..16,
+                                                            ),
+                                                        },
+                                                        WithRange {
+                                                            node: Method(
+                                                                WithRange {
+                                                                    node: "filter",
+                                                                    range: Some(
+                                                                        18..24,
+                                                                    ),
+                                                                },
+                                                                Some(
+                                                                    MethodArgs {
+                                                                        args: [
+                                                                            WithRange {
+                                                                                node: Path(
+                                                                                    PathSelection {
+                                                                                        path: WithRange {
+                                                                                            node: Var(
+                                                                                                WithRange {
+                                                                                                    node: @,
+                                                                                                    range: Some(
+                                                                                                        25..26,
+                                                                                                    ),
+                                                                                                },
+                                                                                                WithRange {
+                                                                                                    node: Key(
+                                                                                                        WithRange {
+                                                                                                            node: Field(
+                                                                                                                "status",
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                27..33,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        WithRange {
+                                                                                                            node: Method(
+                                                                                                                WithRange {
+                                                                                                                    node: "eq",
+                                                                                                                    range: Some(
+                                                                                                                        35..37,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                Some(
+                                                                                                                    MethodArgs {
+                                                                                                                        args: [
+                                                                                                                            WithRange {
+                                                                                                                                node: String(
+                                                                                                                                    "A",
+                                                                                                                                ),
+                                                                                                                                range: Some(
+                                                                                                                                    38..41,
+                                                                                                                                ),
+                                                                                                                            },
+                                                                                                                        ],
+                                                                                                                        range: Some(
+                                                                                                                            37..42,
+                                                                                                                        ),
+                                                                                                                    },
+                                                                                                                ),
+                                                                                                                WithRange {
+                                                                                                                    node: Empty,
+                                                                                                                    range: Some(
+                                                                                                                        42..42,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                33..42,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        26..42,
+                                                                                                    ),
+                                                                                                },
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                25..42,
+                                                                                            ),
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                range: Some(
+                                                                                    25..42,
+                                                                                ),
+                                                                            },
+                                                                        ],
+                                                                        range: Some(
+                                                                            24..43,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                WithRange {
+                                                                    node: Method(
+                                                                        WithRange {
+                                                                            node: "map",
+                                                                            range: Some(
+                                                                                45..48,
+                                                                            ),
+                                                                        },
+                                                                        Some(
+                                                                            MethodArgs {
+                                                                                args: [
+                                                                                    WithRange {
+                                                                                        node: Path(
+                                                                                            PathSelection {
+                                                                                                path: WithRange {
+                                                                                                    node: Var(
+                                                                                                        WithRange {
+                                                                                                            node: @,
+                                                                                                            range: Some(
+                                                                                                                49..50,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                        WithRange {
+                                                                                                            node: Empty,
+                                                                                                            range: Some(
+                                                                                                                50..50,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        49..50,
+                                                                                                    ),
+                                                                                                },
+                                                                                            },
+                                                                                        ),
+                                                                                        range: Some(
+                                                                                            49..50,
+                                                                                        ),
+                                                                                    },
+                                                                                ],
+                                                                                range: Some(
+                                                                                    48..51,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        WithRange {
+                                                                            node: Method(
+                                                                                WithRange {
+                                                                                    node: "find",
+                                                                                    range: Some(
+                                                                                        53..57,
+                                                                                    ),
+                                                                                },
+                                                                                Some(
+                                                                                    MethodArgs {
+                                                                                        args: [
+                                                                                            WithRange {
+                                                                                                node: Path(
+                                                                                                    PathSelection {
+                                                                                                        path: WithRange {
+                                                                                                            node: Var(
+                                                                                                                WithRange {
+                                                                                                                    node: @,
+                                                                                                                    range: Some(
+                                                                                                                        58..59,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                                WithRange {
+                                                                                                                    node: Key(
+                                                                                                                        WithRange {
+                                                                                                                            node: Field(
+                                                                                                                                "rank",
+                                                                                                                            ),
+                                                                                                                            range: Some(
+                                                                                                                                60..64,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                        WithRange {
+                                                                                                                            node: Method(
+                                                                                                                                WithRange {
+                                                                                                                                    node: "gt",
+                                                                                                                                    range: Some(
+                                                                                                                                        66..68,
+                                                                                                                                    ),
+                                                                                                                                },
+                                                                                                                                Some(
+                                                                                                                                    MethodArgs {
+                                                                                                                                        args: [
+                                                                                                                                            WithRange {
+                                                                                                                                                node: Number(
+                                                                                                                                                    Number(0),
+                                                                                                                                                ),
+                                                                                                                                                range: Some(
+                                                                                                                                                    69..70,
+                                                                                                                                                ),
+                                                                                                                                            },
+                                                                                                                                        ],
+                                                                                                                                        range: Some(
+                                                                                                                                            68..71,
+                                                                                                                                        ),
+                                                                                                                                    },
+                                                                                                                                ),
+                                                                                                                                WithRange {
+                                                                                                                                    node: Empty,
+                                                                                                                                    range: Some(
+                                                                                                                                        71..71,
+                                                                                                                                    ),
+                                                                                                                                },
+                                                                                                                            ),
+                                                                                                                            range: Some(
+                                                                                                                                64..71,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        59..71,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            range: Some(
+                                                                                                                58..71,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    },
+                                                                                                ),
+                                                                                                range: Some(
+                                                                                                    58..71,
+                                                                                                ),
+                                                                                            },
+                                                                                        ],
+                                                                                        range: Some(
+                                                                                            57..72,
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                WithRange {
+                                                                                    node: Selection(
+                                                                                        SubSelection {
+                                                                                            selections: [
+                                                                                                NamedSelection {
+                                                                                                    prefix: None,
+                                                                                                    path: WithRange {
+                                                                                                        node: Path(
+                                                                                                            PathSelection {
+                                                                                                                path: WithRange {
+                                                                                                                    node: Key(
+                                                                                                                        WithRange {
+                                                                                                                            node: Field(
+                                                                                                                                "id",
+                                                                                                                            ),
+                                                                                                                            range: Some(
+                                                                                                                                75..77,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                        WithRange {
+                                                                                                                            node: Empty,
+                                                                                                                            range: Some(
+                                                                                                                                77..77,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        75..77,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            75..77,
+                                                                                                        ),
+                                                                                                    },
+                                                                                                },
+                                                                                                NamedSelection {
+                                                                                                    prefix: None,
+                                                                                                    path: WithRange {
+                                                                                                        node: Path(
+                                                                                                            PathSelection {
+                                                                                                                path: WithRange {
+                                                                                                                    node: Key(
+                                                                                                                        WithRange {
+                                                                                                                            node: Field(
+                                                                                                                                "name",
+                                                                                                                            ),
+                                                                                                                            range: Some(
+                                                                                                                                78..82,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                        WithRange {
+                                                                                                                            node: Empty,
+                                                                                                                            range: Some(
+                                                                                                                                82..82,
+                                                                                                                            ),
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    range: Some(
+                                                                                                                        78..82,
+                                                                                                                    ),
+                                                                                                                },
+                                                                                                            },
+                                                                                                        ),
+                                                                                                        range: Some(
+                                                                                                            78..82,
+                                                                                                        ),
+                                                                                                    },
+                                                                                                },
+                                                                                            ],
+                                                                                            range: Some(
+                                                                                                73..84,
+                                                                                            ),
+                                                                                        },
+                                                                                    ),
+                                                                                    range: Some(
+                                                                                        73..84,
+                                                                                    ),
+                                                                                },
+                                                                            ),
+                                                                            range: Some(
+                                                                                51..84,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                    range: Some(
+                                                                        43..84,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            range: Some(
+                                                                16..84,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    range: Some(
+                                                        8..84,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                7..84,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    7..84,
+                                ),
+                            },
+                        },
+                    ],
+                    range: Some(
+                        0..84,
+                    ),
+                },
+            ),
+            spec: V0_4,
+        },
+        config: None,
+        max_requests: None,
+        entity_resolver: None,
+        spec: V0_4,
+        schema_subtypes_map: {},
+        request_headers: {},
+        response_headers: {},
+        request_variable_keys: {},
+        response_variable_keys: {},
+        batch_settings: None,
+        error_settings: ConnectorErrorsSettings {
+            message: None,
+            source_extensions: None,
+            connect_extensions: None,
+            connect_is_success: None,
+        },
+        label: Label(
+            "connectors.v1 http: GET /things",
+        ),
+    },
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@chained_filter_v0_4.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@chained_filter_v0_4.graphql.snap
@@ -1,0 +1,68 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+assertion_line: 27
+expression: raw_sdl
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/chained_filter_v0_4.graphql
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(graphs: [CONNECTORS_QUERY_THINGS_0, CONNECTORS_QUERY_ACTIVETHINGS_0], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]}) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String, usedOverridden: Boolean, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments!) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """EXECUTION features provide metadata necessary for operation execution."""
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+enum join__Graph {
+  CONNECTORS_QUERY_ACTIVETHINGS_0 @join__graph(name: "connectors_Query_activeThings_0", url: "none")
+  CONNECTORS_QUERY_THINGS_0 @join__graph(name: "connectors_Query_things_0", url: "none")
+}
+
+type Thing @join__type(graph: CONNECTORS_QUERY_ACTIVETHINGS_0) @join__type(graph: CONNECTORS_QUERY_THINGS_0) {
+  id: ID! @join__field(graph: CONNECTORS_QUERY_ACTIVETHINGS_0, type: "ID!") @join__field(graph: CONNECTORS_QUERY_THINGS_0, type: "ID!")
+  name: String @join__field(graph: CONNECTORS_QUERY_ACTIVETHINGS_0, type: "String") @join__field(graph: CONNECTORS_QUERY_THINGS_0, type: "String")
+}
+
+type ThingConnection @join__type(graph: CONNECTORS_QUERY_ACTIVETHINGS_0) @join__type(graph: CONNECTORS_QUERY_THINGS_0) {
+  things: [Thing] @join__field(graph: CONNECTORS_QUERY_ACTIVETHINGS_0, type: "[Thing]") @join__field(graph: CONNECTORS_QUERY_THINGS_0, type: "[Thing]")
+}
+
+type Query @join__type(graph: CONNECTORS_QUERY_ACTIVETHINGS_0) @join__type(graph: CONNECTORS_QUERY_THINGS_0) {
+  activeThings: ThingConnection @join__field(graph: CONNECTORS_QUERY_ACTIVETHINGS_0, type: "ThingConnection")
+  things: ThingConnection @join__field(graph: CONNECTORS_QUERY_THINGS_0, type: "ThingConnection")
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@chained_methods_v0_4.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@chained_methods_v0_4.graphql.snap
@@ -1,0 +1,73 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: raw_sdl
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/chained_methods_v0_4.graphql
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(graphs: [CONNECTORS_QUERY_MAPPEDACTIVE_0, CONNECTORS_QUERY_FIRSTACTIVE_0, CONNECTORS_QUERY_DEEPFIND_0], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]}) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String, usedOverridden: Boolean, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments!) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """EXECUTION features provide metadata necessary for operation execution."""
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+enum join__Graph {
+  CONNECTORS_QUERY_DEEPFIND_0 @join__graph(name: "connectors_Query_deepFind_0", url: "none")
+  CONNECTORS_QUERY_FIRSTACTIVE_0 @join__graph(name: "connectors_Query_firstActive_0", url: "none")
+  CONNECTORS_QUERY_MAPPEDACTIVE_0 @join__graph(name: "connectors_Query_mappedActive_0", url: "none")
+}
+
+type Thing @join__type(graph: CONNECTORS_QUERY_DEEPFIND_0) @join__type(graph: CONNECTORS_QUERY_FIRSTACTIVE_0) @join__type(graph: CONNECTORS_QUERY_MAPPEDACTIVE_0) {
+  id: ID! @join__field(graph: CONNECTORS_QUERY_DEEPFIND_0, type: "ID!") @join__field(graph: CONNECTORS_QUERY_FIRSTACTIVE_0, type: "ID!") @join__field(graph: CONNECTORS_QUERY_MAPPEDACTIVE_0, type: "ID!")
+  name: String @join__field(graph: CONNECTORS_QUERY_DEEPFIND_0, type: "String") @join__field(graph: CONNECTORS_QUERY_FIRSTACTIVE_0, type: "String") @join__field(graph: CONNECTORS_QUERY_MAPPEDACTIVE_0, type: "String")
+}
+
+type ThingResult @join__type(graph: CONNECTORS_QUERY_DEEPFIND_0) @join__type(graph: CONNECTORS_QUERY_FIRSTACTIVE_0) {
+  thing: Thing @join__field(graph: CONNECTORS_QUERY_DEEPFIND_0, type: "Thing") @join__field(graph: CONNECTORS_QUERY_FIRSTACTIVE_0, type: "Thing")
+}
+
+type Query @join__type(graph: CONNECTORS_QUERY_DEEPFIND_0) @join__type(graph: CONNECTORS_QUERY_FIRSTACTIVE_0) @join__type(graph: CONNECTORS_QUERY_MAPPEDACTIVE_0) {
+  deepFind: ThingResult @join__field(graph: CONNECTORS_QUERY_DEEPFIND_0, type: "ThingResult")
+  firstActive: ThingResult @join__field(graph: CONNECTORS_QUERY_FIRSTACTIVE_0, type: "ThingResult")
+  mappedActive: ThingConnection @join__field(graph: CONNECTORS_QUERY_MAPPEDACTIVE_0, type: "ThingConnection")
+}
+
+type ThingConnection @join__type(graph: CONNECTORS_QUERY_MAPPEDACTIVE_0) {
+  things: [Thing] @join__field(graph: CONNECTORS_QUERY_MAPPEDACTIVE_0, type: "[Thing]")
+}

--- a/apollo-federation/src/connectors/json_selection/methods/public/filter.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/filter.rs
@@ -142,9 +142,21 @@ fn filter_shape(
         );
     };
 
-    // Compute the shape of the filter condition argument
+    // Compute the shape of the filter condition argument.
+    //
+    // The runtime applies the condition once per array element (`@` = element),
+    // so the condition must be shaped against the array's ELEMENT shape, not the
+    // whole array. Passing `input_shape` directly only happened to work when the
+    // input was `Unknown` (the lenient check below accepts it); for a concrete
+    // list — e.g. the output of a prior `->filter`, which is `List<…>` — a
+    // condition like `@.field->eq(…)` mapped `.field` across the list and then
+    // applied the comparison to a list, yielding a non-boolean shape and a
+    // spurious `Error<"->filter condition must return a boolean value">`. That
+    // error then propagated into expansion as an empty output object type.
+    // `any_item` matches the per-element runtime semantics and is robust to
+    // chaining.
     let condition_shape =
-        first_arg.compute_output_shape(context, input_shape.clone(), dollar_shape);
+        first_arg.compute_output_shape(context, input_shape.any_item([]), dollar_shape);
 
     // Validate that the condition evaluates to a boolean or
     // something that could become a boolean
@@ -344,10 +356,12 @@ mod shape_tests {
     use shape::location::SourceId;
 
     use super::*;
+    use crate::connectors::ConnectSpec;
     use crate::connectors::Key;
     use crate::connectors::PathSelection;
     use crate::connectors::json_selection::PathList;
     use crate::connectors::json_selection::lit_expr::LitExpr;
+    use crate::connectors::json_selection::location::new_span_with_spec;
 
     fn get_location() -> Location {
         Location {
@@ -480,5 +494,48 @@ mod shape_tests {
         // Unknown shapes should be accepted as they could produce boolean values at runtime
         let result = get_shape(vec![path.into_with_range()], input_shape.clone());
         assert_eq!(result, Shape::list(input_shape.any_item([]), []));
+    }
+
+    // Parse a `@`-rooted condition expression (e.g. `@.x->eq(true)`) the way it
+    // appears inside `->filter(...)`.
+    fn parse_condition(input: &str) -> WithRange<LitExpr> {
+        LitExpr::parse(new_span_with_spec(input, ConnectSpec::V0_4))
+            .unwrap()
+            .1
+    }
+
+    // Regression: chained `->filter(...)` must shape each condition against the
+    // array's element, not the whole array. The first filter turns an `Unknown`
+    // input into a concrete `List<Unknown>`; the second filter then receives that
+    // list. Before the fix, the second filter's condition (`@.field->gt(0)`)
+    // mapped `.field` across the list and applied `->gt` to a list, producing
+    // `Error<"->filter condition must return a boolean value">`. The expander
+    // turned that error shape into an empty output object type, which slipped
+    // past release builds (validation skipped) and surfaced downstream as a
+    // composition `SATISFIABILITY_ERROR` (e.g. Relay-pagination connectors with
+    // `active*` filters). See integration fixture `chained_filter_v0_4.graphql`.
+    #[test]
+    fn filter_shape_supports_chained_filters() {
+        // First filter over an `Unknown` input (e.g. `$.results`), as a connector
+        // mapping would produce.
+        let after_first = get_shape(
+            vec![parse_condition("@.inactiveSwitch->eq(\"A\")")],
+            Shape::unknown([]),
+        );
+        assert!(
+            !matches!(after_first.case(), ShapeCase::Error(_)),
+            "first ->filter unexpectedly errored: {}",
+            after_first.pretty_print()
+        );
+
+        // Second filter receives the first filter's concrete list output. This is
+        // the case that previously produced a spurious non-boolean-condition
+        // error.
+        let after_second = get_shape(vec![parse_condition("@.locNumber->gt(0)")], after_first);
+        assert!(
+            !matches!(after_second.case(), ShapeCase::Error(_)),
+            "chained ->filter produced an error shape (regression): {}",
+            after_second.pretty_print()
+        );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/find.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/find.rs
@@ -140,9 +140,24 @@ fn find_shape(
         );
     };
 
-    // Compute the shape of the find condition argument
+    // Compute the shape of the find condition argument.
+    //
+    // The runtime applies the condition once per array element (`@` = element),
+    // so the condition must be shaped against the array's ELEMENT shape, not the
+    // whole array. Passing `input_shape` directly only happened to work when the
+    // input was `Unknown` (the lenient check below accepts it); for a concrete
+    // list — e.g. the output of a prior `->filter`, which is `List<…>` — a
+    // condition like `@.field->gt(…)` mapped `.field` across the list and then
+    // applied the comparison to a list, yielding a non-boolean shape and a
+    // spurious `Error<"->find condition must return a boolean value">`. That
+    // error then propagated into expansion as an empty output object type.
+    // Unlike `->filter`, `->find` returns a single item (not a list), so it is
+    // only ever the *victim* of this mismatch (as the terminal consumer of a
+    // list-producing method like `->filter`/`->map`), never the producer.
+    // `any_item` matches the per-element runtime semantics and is robust to
+    // chaining.
     let condition_shape =
-        first_arg.compute_output_shape(context, input_shape.clone(), dollar_shape);
+        first_arg.compute_output_shape(context, input_shape.any_item([]), dollar_shape);
 
     // Validate that the condition evaluates to a boolean or
     // something that could become a boolean
@@ -166,6 +181,7 @@ fn find_shape(
 
 #[cfg(test)]
 mod method_tests {
+    use serde_json_bytes::Value as JSON;
     use serde_json_bytes::json;
 
     use crate::connectors::ConnectSpec;
@@ -324,6 +340,76 @@ mod method_tests {
             ),
         );
     }
+
+    // Moderately complex chains of the iterative array methods, verifying the
+    // runtime produces the expected values. These complement the shape-level
+    // regression coverage (`find_shape_supports_concrete_list_condition` and the
+    // `chained_methods_v0_4.graphql` expand fixture): here we confirm behavior,
+    // there we confirm the chained element shapes don't collapse.
+    fn chain_data() -> JSON {
+        json!({
+            "results": [
+                { "id": "1", "name": "alpha", "status": "A", "rank": 0 },
+                { "id": "2", "name": "bravo", "status": "A", "rank": 5 },
+                { "id": "3", "name": "charlie", "status": "B", "rank": 9 },
+            ],
+        })
+    }
+
+    #[test]
+    fn find_should_work_after_filter() {
+        // filter -> find: filter hands find a concrete list; find returns the
+        // first surviving element whose rank is positive.
+        assert_eq!(
+            selection!("$.results->filter(@.status->eq(\"A\"))->find(@.rank->gt(0))")
+                .apply_to(&chain_data()),
+            (
+                Some(json!({ "id": "2", "name": "bravo", "status": "A", "rank": 5 })),
+                vec![]
+            ),
+        );
+    }
+
+    #[test]
+    fn find_should_work_after_map() {
+        // map -> find: map produces the concrete list consumed by find.
+        assert_eq!(
+            selection!("$.results->map(@)->find(@.rank->gt(0))").apply_to(&chain_data()),
+            (
+                Some(json!({ "id": "2", "name": "bravo", "status": "A", "rank": 5 })),
+                vec![]
+            ),
+        );
+    }
+
+    #[test]
+    fn find_should_work_after_filter_then_map() {
+        // filter -> map -> find: three-method chain, find terminal.
+        assert_eq!(
+            selection!("$.results->filter(@.status->eq(\"A\"))->map(@)->find(@.rank->gt(0))")
+                .apply_to(&chain_data()),
+            (
+                Some(json!({ "id": "2", "name": "bravo", "status": "A", "rank": 5 })),
+                vec![]
+            ),
+        );
+    }
+
+    #[test]
+    fn map_then_filter_should_chain() {
+        // map -> filter: map produces the concrete list, filter is the terminal
+        // consumer and returns every element with a positive rank.
+        assert_eq!(
+            selection!("$.results->map(@)->filter(@.rank->gt(0))").apply_to(&chain_data()),
+            (
+                Some(json!([
+                    { "id": "2", "name": "bravo", "status": "A", "rank": 5 },
+                    { "id": "3", "name": "charlie", "status": "B", "rank": 9 },
+                ])),
+                vec![]
+            ),
+        );
+    }
 }
 
 #[cfg(test)]
@@ -332,10 +418,12 @@ mod shape_tests {
     use shape::location::SourceId;
 
     use super::*;
+    use crate::connectors::ConnectSpec;
     use crate::connectors::Key;
     use crate::connectors::PathSelection;
     use crate::connectors::json_selection::PathList;
     use crate::connectors::json_selection::lit_expr::LitExpr;
+    use crate::connectors::json_selection::location::new_span_with_spec;
 
     fn get_location() -> Location {
         Location {
@@ -467,6 +555,43 @@ mod shape_tests {
         let input_shape = Shape::list(Shape::int([]), []);
         // Unknown shapes should be accepted as they could produce boolean values at runtime
         let result = get_shape(vec![path.into_with_range()], input_shape.clone());
+        assert_eq!(
+            result,
+            Shape::one([Shape::none(), input_shape.any_item([])], [])
+        );
+    }
+
+    // Parse a `@`-rooted condition expression (e.g. `@.x->eq(true)`) the way it
+    // appears inside `->find(...)`.
+    fn parse_condition(input: &str) -> WithRange<LitExpr> {
+        LitExpr::parse(new_span_with_spec(input, ConnectSpec::V0_4))
+            .unwrap()
+            .1
+    }
+
+    // Regression: `->find` must shape its condition against the array's element,
+    // not the whole array. Unlike `->filter`, `->find` returns a single item, so
+    // it is never the *producer* in a chain — but it is still a *victim* as the
+    // terminal consumer of a list-producing method (`->filter`/`->map`), which
+    // hands it a concrete `List<…>`. Before the fix, `->find`'s condition
+    // (`@.field->gt(0)`) mapped `.field` across that list and applied `->gt` to a
+    // list, producing `Error<"->find condition must return a boolean value">`.
+    // The expander turned that error shape into an empty output object type,
+    // which slipped past release builds (validation skipped) and surfaced
+    // downstream as a composition `SATISFIABILITY_ERROR`. A bare `->find` over an
+    // `Unknown` input does *not* reproduce this (the lenient check accepts it),
+    // so the concrete list input below is essential.
+    // See integration fixture `chained_methods_v0_4.graphql`.
+    #[test]
+    fn find_shape_supports_concrete_list_condition() {
+        // The concrete `List<Unknown>` a prior `->filter`/`->map` produces.
+        let input_shape = Shape::list(Shape::unknown([]), []);
+        let result = get_shape(vec![parse_condition("@.rank->gt(0)")], input_shape.clone());
+        assert!(
+            !matches!(result.case(), ShapeCase::Error(_)),
+            "->find over a concrete list produced an error shape (regression): {}",
+            result.pretty_print()
+        );
         assert_eq!(
             result,
             Shape::one([Shape::none(), input_shape.any_item([])], [])


### PR DESCRIPTION
A `connect/v0.4` connector selection that places one iterative array method after another array-producing method — e.g. a chained `$.items->filter(@.a->eq("x"))->filter(@.b->gt(0)) { id name }`, or `$.items->filter(@.a->eq("x"))->find(@.b->gt(0)) { id name }` — fails to compose, surfacing as a `SATISFIABILITY_ERROR`.

## Cause
`filter_shape` and `find_shape` computed their condition's shape against the whole input array instead of its element. A single method over an `Unknown` input happened to work (the lenient boolean check accepts it), but once a prior method handed it a concrete `List<…>` shape, the condition (`@.field->gt(0)`) was evaluated against a list → spurious `condition must return a boolean value` error. Connector expansion turned that error shape into an output object with no fields, producing an invalid synthetic subgraph that failed composition.

`->filter` is both producer and victim: it turns `Unknown → List<…>`, so a second `->filter` errors. `->find` returns a single item, not a list, so it is only ever the **victim** — as the terminal consumer of a list-producing method (`->filter`/`->map`). `->map` already shaped its callback per element and was unaffected.

## Fix
Shape the condition against the array element (`input_shape.any_item([])`), matching the per-element runtime semantics, for both `->filter` and `->find`. Robust to chaining.

## Tests
- `filter_shape_supports_chained_filters` and `find_shape_supports_concrete_list_condition` shape unit tests (both verified red without the fix).
- Runtime chain tests covering `filter→find`, `map→find`, `filter→map→find`, and `map→filter`.
- Expand integration fixtures + snapshots: `chained_filter_v0_4.graphql` (chained `->filter`) and `chained_methods_v0_4.graphql` (`map→filter`, `filter→find`, `filter→map→find`); snapshots show the object types retain their fields. Reverting either fix makes expansion fail with `` `Thing` has no fields ``.

This pattern is common in Relay-style pagination connectors that expose pre-filtered list fields (e.g. an `activeItems` companion to `items`).