### PR TITLE
Remove `preview_connect_v0_4: true` opt-in for connect/v0.4

### DIFF
--- a/.changesets/config_remove_preview_connect_v0_4_flag.md
+++ b/.changesets/config_remove_preview_connect_v0_4_flag.md
@@ -1,0 +1,5 @@
+### Remove the `preview_connect_v0_4` opt-in for Connect v0.4
+
+Using Connect spec v0.4 in a subgraph (via `@link(url: "https://specs.apollo.dev/connect/v0.4")`) no longer requires setting `connectors.preview_connect_v0_4: true` in `router.yaml`. Linking the v0.4 spec is itself a sufficient opt-in, so the router no longer rejects these schemas at startup. The `preview_connect_v0_4` configuration key is now a deprecated no-op; it continues to be accepted so existing configurations keep working, and can be safely removed.
+
+By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/9644

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2958,7 +2958,8 @@ expression: "&schema"
         },
         "preview_connect_v0_4": {
           "default": null,
-          "description": "Feature gate for Connect spec v0.3. Set to `true` to enable the using\nthe v0.3 spec during the preview phase.",
+          "deprecated": true,
+          "description": "Feature gate for Connect spec v0.4. Previously required to opt into the\nv0.4 spec during its preview phase; now a no-op, since `@link`-ing\nconnect/v0.4 in a subgraph is itself a sufficient opt-in.",
           "type": [
             "boolean",
             "null"

--- a/apollo-router/src/plugins/connectors/configuration.rs
+++ b/apollo-router/src/plugins/connectors/configuration.rs
@@ -64,9 +64,11 @@ pub(crate) struct ConnectorsConfig {
     #[deprecated(note = "Connect spec v0.3 is now available.")]
     pub(crate) preview_connect_v0_3: Option<bool>,
 
-    /// Feature gate for Connect spec v0.3. Set to `true` to enable the using
-    /// the v0.3 spec during the preview phase.
+    /// Feature gate for Connect spec v0.4. Previously required to opt into the
+    /// v0.4 spec during its preview phase; now a no-op, since `@link`-ing
+    /// connect/v0.4 in a subgraph is itself a sufficient opt-in.
     #[serde(default)]
+    #[deprecated(note = "Connect spec v0.4 no longer requires this flag.")]
     pub(crate) preview_connect_v0_4: Option<bool>,
 }
 

--- a/apollo-router/src/uplink/feature_gate_enforcement.rs
+++ b/apollo-router/src/uplink/feature_gate_enforcement.rs
@@ -103,28 +103,18 @@ impl FeatureGateEnforcementReport {
     }
 
     fn schema_restrictions() -> Vec<FeatureRestriction> {
-        // @link(url: "https://specs.apollo.dev/connect/v0.4") requires `connectors.preview_connect_v0_4: true`
-        // This uses join__directives to find specs because the we're looking
-        // at links within individual subgraphs.
-        vec![FeatureRestriction::SpecInJoinDirective {
-            name: "Connect v0.4".to_string(),
-            spec_url: "https://specs.apollo.dev/connect".to_string(),
-            version_req: semver::VersionReq {
-                comparators: vec![semver::Comparator {
-                    op: semver::Op::Exact,
-                    major: 0,
-                    minor: 4.into(),
-                    patch: 0.into(),
-                    pre: semver::Prerelease::EMPTY,
-                }],
-            },
-            feature_gate_configuration_path: "$.connectors.preview_connect_v0_4".to_string(),
-            expected_value: Value::Bool(true),
-            to_enable: "  connectors:
-    preview_connect_v0_4: true"
-                .to_string(),
-            warning: Some("Support for @link(url: \"https://specs.apollo.dev/connect/v0.4\") is in preview. See https://go.apollo.dev/connectors/preview for more information.".to_string())
-        }]
+        // No connect spec version is currently feature-gated.
+        //
+        // connect/v0.4 used to require `connectors.preview_connect_v0_4: true` in
+        // router.yaml, but that opt-in was removed: `@link`-ing connect/v0.4 in a
+        // subgraph is itself a sufficient opt-in, and the extra config hoop was
+        // just friction we'd want to drop eventually anyway.
+        //
+        // The enforcement machinery below is intentionally retained. To gate a
+        // future preview spec (e.g. connect/v0.5), push a `FeatureRestriction`
+        // entry here with `feature_gate_configuration_path` pointing at that
+        // version's own config key (e.g. `$.connectors.preview_connect_v0_5`).
+        vec![]
     }
 }
 
@@ -144,7 +134,12 @@ impl Display for FeatureGateEnforcementReport {
     }
 }
 
-/// An individual check for the supergraph schema
+/// An individual check for the supergraph schema.
+///
+/// No variant is constructed while `schema_restrictions` is empty, but the
+/// machinery is retained for gating future preview specs — see the comment in
+/// [`FeatureGateEnforcementReport::schema_restrictions`].
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub(crate) enum FeatureRestriction {
     SpecInJoinDirective {
@@ -190,6 +185,7 @@ mod test {
 
     use super::FeatureGateEnforcementReport;
     use super::FeatureGateViolation;
+    use super::FeatureRestriction;
     use crate::Configuration;
     use crate::spec::Schema;
 
@@ -201,25 +197,25 @@ mod test {
     }
 
     #[test]
-    fn feature_gate_connectors_v0_3() {
+    fn connect_v0_4_no_longer_gated() {
+        // connect/v0.4 used to require `connectors.preview_connect_v0_4: true`.
+        // With the opt-in removed it must load with no flag and no violation.
         let report = check(
             include_str!("testdata/oss.router.yaml"),
             include_str!("testdata/feature_enforcement_connect_v0_4.graphql"),
         );
 
         assert_eq!(
-            1,
+            0,
             report.gated_features_in_use.len(),
-            "should have found restricted connect feature"
+            "connect/v0.4 should no longer be feature-gated"
         );
-        let FeatureGateViolation::Spec { url, name, .. } = &report.gated_features_in_use[0];
-
-        assert_eq!("https://specs.apollo.dev/connect/v0.4", url);
-        assert_eq!("Connect v0.4", name);
     }
 
     #[test]
-    fn feature_gate_connectors_v0_3_enabled() {
+    fn preview_connect_v0_4_flag_is_a_noop() {
+        // The flag is now a deprecated no-op, but configs that still set it must
+        // continue to parse and load without a violation.
         let report = check(
             include_str!("testdata/connectv0_4.router.yaml"),
             include_str!("testdata/feature_enforcement_connect_v0_4.graphql"),
@@ -228,7 +224,7 @@ mod test {
         assert_eq!(
             0,
             report.gated_features_in_use.len(),
-            "should not have found restricted connect feature"
+            "setting the deprecated flag should not produce a violation"
         );
     }
 
@@ -243,6 +239,66 @@ mod test {
             0,
             report.gated_features_in_use.len(),
             "should not have found restricted connect feature"
+        );
+    }
+
+    fn connect_v0_4_restriction() -> FeatureRestriction {
+        FeatureRestriction::SpecInJoinDirective {
+            name: "Connect v0.4".to_string(),
+            spec_url: "https://specs.apollo.dev/connect".to_string(),
+            version_req: semver::VersionReq {
+                comparators: vec![semver::Comparator {
+                    op: semver::Op::Exact,
+                    major: 0,
+                    minor: 4.into(),
+                    patch: 0.into(),
+                    pre: semver::Prerelease::EMPTY,
+                }],
+            },
+            feature_gate_configuration_path: "$.connectors.preview_connect_v0_4".to_string(),
+            expected_value: serde_json::Value::Bool(true),
+            to_enable: "  connectors:\n    preview_connect_v0_4: true".to_string(),
+            warning: None,
+        }
+    }
+
+    fn violations(
+        router_yaml: &str,
+        restrictions: &[FeatureRestriction],
+    ) -> Vec<FeatureGateViolation> {
+        let config = Configuration::from_str(router_yaml).expect("router config must be valid");
+        let schema = Schema::parse(
+            include_str!("testdata/feature_enforcement_connect_v0_4.graphql"),
+            &config,
+        )
+        .expect("supergraph schema must be valid");
+        FeatureGateEnforcementReport::validate_schema(&schema, &restrictions.to_vec(), &config)
+    }
+
+    /// `schema_restrictions` is currently empty, so exercise the enforcement
+    /// machinery directly to prove it still gates a spec when configured — the
+    /// shape a future connect/v0.5 gate would take.
+    #[test]
+    fn machinery_still_gates_when_a_restriction_is_present() {
+        let restrictions = [connect_v0_4_restriction()];
+
+        let without_flag = violations(include_str!("testdata/oss.router.yaml"), &restrictions);
+        assert_eq!(
+            1,
+            without_flag.len(),
+            "a configured restriction should still flag the gated spec"
+        );
+        let FeatureGateViolation::Spec { url, name, .. } = &without_flag[0];
+        assert_eq!("https://specs.apollo.dev/connect/v0.4", url);
+        assert_eq!("Connect v0.4", name);
+
+        let with_flag = violations(
+            include_str!("testdata/connectv0_4.router.yaml"),
+            &restrictions,
+        );
+        assert!(
+            with_flag.is_empty(),
+            "enabling the gate's config key should clear the violation"
         );
     }
 }


### PR DESCRIPTION
Using Connect spec v0.4 in a subgraph (`@link(url: "https://specs.apollo.dev/connect/v0.4")`) no longer requires setting `connectors.preview_connect_v0_4: true` in `router.yaml`. Linking the v0.4 spec is itself a sufficient opt-in, so the router no longer rejects these schemas at startup.

Rather than declaring connect/v0.4 fully GA, this just removes the extra config hoop — since the upcoming release is LTS, we don't want to be stuck carrying the required flag even after deciding it should have been GA.

### Details

- `feature_gate_enforcement.rs`: `schema_restrictions()` now returns no restrictions, so connect/v0.4 loads with no flag, no startup error, and no warning. The enforcement machinery (`FeatureRestriction` etc.) is intentionally retained (behind `#[allow(dead_code)]`) so a future preview spec (e.g. connect/v0.5) can be gated by adding a new `FeatureRestriction` pointing at its own config key (e.g. `$.connectors.preview_connect_v0_5`).
- `configuration.rs`: `preview_connect_v0_4` is now `#[deprecated]` and a no-op. It continues to be accepted so existing configurations keep parsing; the copy-pasted "v0.3" doc-comment is also corrected.
- `ConnectSpec::latest()` (v0.3) and the `add_preview(v0.4)` registration are **unchanged** — this does not make v0.4 the default for new schemas, and does not change GA status.

### Testing

- `cargo test -p apollo-router --lib` (feature gate + schema generation): all pass, including a new test that drives `validate_schema` with a synthetic restriction to prove the gate machinery still enforces when configured.
- `cargo xtask lint --fmt` and `cargo xtask lint` (clippy `-D warnings` + rustdoc): clean.

A changeset will follow in a separate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)