### PR TITLE
refactor: Subgraph tower buffer to mutex

### DIFF
--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -5,10 +5,13 @@
 //! - At the router service, a batch query is split apart into multiple requests.
 //! - A single [Batch] structure is created, which is responsible for handling the batch lifecycle.
 //! - Each individual request gets a [BatchQuery] extension.
-//! - After query planning of each individual request, that request's [BatchQuery::set_query_hashes]
-//!   is called to set the expected number of subgraph requests. This includes only the subgraph
-//!   requests that are unconditionally executed, not subsequent entity fetches for example that can
-//!   only be executed based on data obtained during query plan execution.
+//! - After query planning of each individual request, we collect the hashes of the plan nodes that
+//!   will be executed unconditionally as part of the query plan. Those query nodes are candidates
+//!   for being batched up into a single request at the subgraph side, as they do not depend on
+//!   other data being fetched first.
+//! - [BatchQuery::set_query_hashes] is called with those hashes, to set the expected number of
+//!   subgraph requests. The hashes are also used to track successful and unsuccessful responses to
+//!   each individual subgraph request.
 //! - Once each subgraph request that is part of the batch reaches the subgraph service, instead of
 //!   submitting the request to the HTTP client, it calls into [BatchQuery::signal_progress]. This
 //!   is how subgraph requests are eventually batched up. When a [BatchQuery] has received all

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -418,18 +418,18 @@ impl Drop for Batch {
     }
 }
 
+/// A batch of requests that we'll send to a subgraph (...as a single batch request).
+pub(crate) struct SubgraphBatchRequest {
+    pub(crate) operation_name: String,
+    pub(crate) contexts: Vec<(Context, SubgraphRequestId)>,
+    pub(crate) request: http::Request<RouterBody>,
+    pub(crate) txs: Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
+}
+
 // Assemble a single batch request to a subgraph
 pub(crate) async fn assemble_batch(
     requests: Vec<BatchQueryInfo>,
-) -> Result<
-    (
-        String,
-        Vec<(Context, SubgraphRequestId)>,
-        http::Request<RouterBody>,
-        Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
-    ),
-    BoxError,
-> {
+) -> Result<SubgraphBatchRequest, BoxError> {
     let (txs, requests): (Vec<_>, Vec<_>) =
         requests.into_iter().map(|r| (r.sender, r.request)).unzip();
 
@@ -465,7 +465,12 @@ pub(crate) async fn assemble_batch(
 
     // Generate the final request and pass it up
     let request = http::Request::from_parts(parts, router::body::from_bytes(bytes));
-    Ok((operation_name, contexts, request, txs))
+    Ok(SubgraphBatchRequest {
+        operation_name,
+        contexts,
+        request,
+        txs,
+    })
 }
 
 #[cfg(test)]
@@ -483,6 +488,7 @@ mod tests {
 
     use super::Batch;
     use super::BatchQueryInfo;
+    use super::SubgraphBatchRequest;
     use super::assemble_batch;
     use crate::Configuration;
     use crate::Context;
@@ -529,7 +535,12 @@ mod tests {
             .map(|r| r.request.context.id.clone())
             .collect::<Vec<String>>();
         // Assemble them
-        let (op_name, contexts, request, txs) = assemble_batch(requests)
+        let SubgraphBatchRequest {
+            operation_name,
+            contexts,
+            request,
+            txs,
+        } = assemble_batch(requests)
             .await
             .expect("it can assemble a batch");
 
@@ -541,7 +552,7 @@ mod tests {
         assert_eq!(input_context_ids, output_context_ids);
 
         // Make sure that the name of the entire batch is that of the first
-        assert_eq!(op_name, "batch_test_0");
+        assert_eq!(operation_name, "batch_test_0");
 
         // We should see the aggregation of all of the requests
         let actual: Vec<graphql::Request> = serde_json::from_str(

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -25,33 +25,32 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
-use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
-use opentelemetry::Context as otelContext;
 use opentelemetry::trace::TraceContextExt;
+use opentelemetry::Context as otelContext;
 use parking_lot::Mutex as PMutex;
-use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tower::BoxError;
 use tracing::Instrument;
 use tracing::Span;
 
-use crate::Context;
 use crate::error::FetchError;
 use crate::error::SubgraphBatchingError;
 use crate::plugins::telemetry::otel::span_ext::OpenTelemetrySpanExt;
-use crate::services::SubgraphRequest;
-use crate::services::SubgraphResponse;
-use crate::services::http::HttpClientServiceFactory;
 use crate::services::process_batches;
 use crate::services::router;
 use crate::services::router::body::RouterBody;
 use crate::services::subgraph::SubgraphRequestId;
+use crate::services::SubgraphRequest;
+use crate::services::SubgraphResponse;
 use crate::spec::QueryHash;
+use crate::Context;
 
 /// A query that is part of a batch.
 /// Note: It's ok to make transient clones of this struct, but *do not* store clones anywhere apart
@@ -104,7 +103,8 @@ impl BatchQuery {
                 index: self.index,
                 query_hashes,
             })
-            .await?;
+            .await
+            .map_err(|e| SubgraphBatchingError::ProcessingFailed(e.to_string()))?;
         Ok(())
     }
 
@@ -113,7 +113,7 @@ impl BatchQuery {
     /// The returned channel can be awaited to receive the GraphQL response, when ready.
     pub(crate) async fn signal_progress(
         &self,
-        client_factory: HttpClientServiceFactory,
+        http_client: crate::services::http::BoxCloneService,
         request: SubgraphRequest,
     ) -> Result<oneshot::Receiver<Result<SubgraphResponse, BoxError>>, BoxError> {
         // Create a receiver for this query so that it can eventually get the request meant for it
@@ -132,13 +132,14 @@ impl BatchQuery {
             .send(BatchHandlerMessage::Progress(Box::new(
                 BatchHandlerMessageProgress {
                     index: self.index,
-                    client_factory,
+                    http_client,
                     request,
                     response_sender: tx,
                     span_context: Span::current().context(),
                 },
             )))
-            .await?;
+            .await
+            .map_err(|e| SubgraphBatchingError::ProcessingFailed(e.to_string()))?;
 
         if !self.finished() {
             self.remaining.fetch_sub(1, Ordering::AcqRel);
@@ -164,7 +165,8 @@ impl BatchQuery {
                 index: self.index,
                 reason,
             })
-            .await?;
+            .await
+            .map_err(|e| SubgraphBatchingError::ProcessingFailed(e.to_string()))?;
 
         if !self.finished() {
             self.remaining.fetch_sub(1, Ordering::AcqRel);
@@ -201,7 +203,7 @@ enum BatchHandlerMessage {
 /// A query has reached the subgraph service and we should update its state
 struct BatchHandlerMessageProgress {
     index: usize,
-    client_factory: HttpClientServiceFactory,
+    http_client: crate::services::http::BoxCloneService,
     request: SubgraphRequest,
     response_sender: oneshot::Sender<Result<SubgraphResponse, BoxError>>,
     span_context: otelContext,
@@ -211,7 +213,7 @@ struct BatchHandlerMessageProgress {
 pub(crate) struct BatchQueryInfo {
     /// The owning subgraph request
     request: SubgraphRequest,
-
+    http_client: crate::services::http::BoxCloneService,
     /// Notifier for the subgraph service handler
     ///
     /// Note: This must be used or else the subgraph request will time out
@@ -278,7 +280,6 @@ impl Batch {
             let mut requests: Vec<Vec<BatchQueryInfo>> =
                 Vec::from_iter((0..size).map(|_| Vec::new()));
 
-            let mut master_client_factory = None;
             tracing::debug!("Batch about to await messages...");
             // Start handling messages from various portions of the request lifecycle
             // When recv() returns None, we want to stop processing messages
@@ -331,7 +332,7 @@ impl Batch {
                         // Progress the index
                         let BatchHandlerMessageProgress {
                             index,
-                            client_factory,
+                            http_client,
                             request,
                             response_sender,
                             span_context,
@@ -343,11 +344,9 @@ impl Batch {
                             state.committed.insert(request.query_hash.clone());
                         }
 
-                        if master_client_factory.is_none() {
-                            master_client_factory = Some(client_factory);
-                        }
                         Span::current().add_link(span_context.span().span_context().clone());
                         requests[index].push(BatchQueryInfo {
+                            http_client,
                             request,
                             sender: response_sender,
                         })
@@ -372,6 +371,7 @@ impl Batch {
             // Now build up a Service oriented view to use in constructing our batches
             let mut svc_map: HashMap<String, Vec<BatchQueryInfo>> = HashMap::new();
             for BatchQueryInfo {
+                http_client,
                 request: sg_request,
                 sender: tx,
             } in all_in_one
@@ -383,15 +383,13 @@ impl Batch {
                     )
                     .or_default();
                 value.push(BatchQueryInfo {
+                    http_client,
                     request: sg_request,
                     sender: tx,
                 });
             }
 
-            // If we don't have a master_client_factory, we can't do anything.
-            if let Some(client_factory) = master_client_factory {
-                process_batches(client_factory, svc_map).await?;
-            }
+            process_batches(svc_map).await?;
             Ok(())
         }.instrument(tracing::info_span!("batch_request", size)));
 
@@ -441,6 +439,7 @@ impl Drop for Batch {
 
 /// A batch of requests that we'll send to a subgraph (...as a single batch request).
 pub(crate) struct SubgraphBatchRequest {
+    pub(crate) http_client: crate::services::http::BoxCloneService,
     pub(crate) contexts: Vec<(Context, SubgraphRequestId)>,
     pub(crate) request: http::Request<RouterBody>,
     pub(crate) txs: Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
@@ -450,6 +449,11 @@ pub(crate) struct SubgraphBatchRequest {
 pub(crate) async fn assemble_batch(
     requests: Vec<BatchQueryInfo>,
 ) -> Result<SubgraphBatchRequest, BoxError> {
+    let http_client = requests
+        .first()
+        .ok_or(SubgraphBatchingError::RequestsIsEmpty)?
+        .http_client
+        .clone();
     let (txs, requests): (Vec<_>, Vec<_>) =
         requests.into_iter().map(|r| (r.sender, r.request)).unzip();
 
@@ -481,6 +485,7 @@ pub(crate) async fn assemble_batch(
     // Generate the final request and pass it up
     let request = http::Request::from_parts(parts, router::body::from_bytes(bytes));
     Ok(SubgraphBatchRequest {
+        http_client,
         contexts,
         request,
         txs,
@@ -496,28 +501,28 @@ mod tests {
     use http::header::CONTENT_TYPE;
     use tokio::sync::oneshot;
     use tower::ServiceExt;
+    use wiremock::matchers;
     use wiremock::MockServer;
     use wiremock::ResponseTemplate;
-    use wiremock::matchers;
 
+    use super::assemble_batch;
     use super::Batch;
     use super::BatchQueryInfo;
     use super::SubgraphBatchRequest;
-    use super::assemble_batch;
-    use crate::Configuration;
-    use crate::Context;
-    use crate::TestHarness;
     use crate::graphql;
     use crate::graphql::Request;
     use crate::layers::ServiceExt as LayerExt;
-    use crate::services::SubgraphRequest;
-    use crate::services::SubgraphResponse;
     use crate::services::http::HttpClientServiceFactory;
     use crate::services::router;
     use crate::services::router::body;
     use crate::services::subgraph;
     use crate::services::subgraph::SubgraphRequestId;
+    use crate::services::SubgraphRequest;
+    use crate::services::SubgraphResponse;
     use crate::spec::QueryHash;
+    use crate::Configuration;
+    use crate::Context;
+    use crate::TestHarness;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn it_assembles_batch() {
@@ -533,6 +538,12 @@ mod tests {
                 (
                     rx,
                     BatchQueryInfo {
+                        http_client: HttpClientServiceFactory::from_config(
+                            "test",
+                            &Configuration::default(),
+                            crate::configuration::shared::Client::default(),
+                        )
+                        .create("test"),
                         request: SubgraphRequest::fake_builder()
                             .subgraph_request(http::Request::builder().body(gql_request).unwrap())
                             .subgraph_name(format!("slot{index}"))
@@ -550,6 +561,7 @@ mod tests {
             .collect::<Vec<String>>();
         // Assemble them
         let SubgraphBatchRequest {
+            http_client: _,
             contexts,
             request,
             txs,
@@ -654,11 +666,13 @@ mod tests {
 
         let bq = Batch::query_for_index(batch.clone(), 0).expect("its a valid index");
 
-        let factory = HttpClientServiceFactory::from_config(
+        let http_client = HttpClientServiceFactory::from_config(
             "testbatch",
             &Configuration::default(),
             crate::configuration::shared::Client::default(),
-        );
+        )
+        .create("whatever");
+
         let request = SubgraphRequest::fake_builder()
             .subgraph_request(
                 http::Request::builder()
@@ -674,12 +688,12 @@ mod tests {
         );
         assert!(!bq.finished());
         assert!(
-            bq.signal_progress(factory.clone(), request.clone())
+            bq.signal_progress(http_client.clone(), request.clone())
                 .await
                 .is_ok()
         );
         assert!(bq.finished());
-        assert!(bq.signal_progress(factory, request).await.is_err());
+        assert!(bq.signal_progress(http_client, request).await.is_err());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -707,7 +721,11 @@ mod tests {
                 .is_ok()
         );
         assert!(!bq.finished());
-        assert!(bq.signal_progress(factory, request).await.is_ok());
+        assert!(
+            bq.signal_progress(factory.create("whatever"), request)
+                .await
+                .is_ok()
+        );
         assert!(bq.finished());
         assert!(
             bq.signal_cancelled("only once though".to_string())
@@ -738,7 +756,11 @@ mod tests {
         let qh = Arc::new(QueryHash::default());
         assert!(bq.set_query_hashes(vec![qh.clone(), qh]).await.is_ok());
         assert!(!bq.finished());
-        assert!(bq.signal_progress(factory, request).await.is_ok());
+        assert!(
+            bq.signal_progress(factory.create("whatever"), request)
+                .await
+                .is_ok()
+        );
         assert!(!bq.finished());
         assert!(
             bq.signal_cancelled("only twice though".to_string())

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -1,5 +1,23 @@
 //! Various utility functions and core structures used to implement batching support within
 //! the router.
+//!
+//! Batching works roughly along these lines:
+//! - At the router service, a batch query is split apart into multiple requests.
+//! - A single [Batch] structure is created, which is responsible for handling the batch lifecycle.
+//! - Each individual request gets a [BatchQuery] extension.
+//! - After query planning of each individual request, that request's [BatchQuery::set_query_hashes]
+//!   is called to set the expected number of subgraph requests. This includes only the subgraph
+//!   requests that are unconditionally executed, not subsequent entity fetches for example that can
+//!   only be executed based on data obtained during query plan execution.
+//! - Once each subgraph request that is part of the batch reaches the subgraph service, instead of
+//!   submitting the request to the HTTP client, it calls into [BatchQuery::signal_progress]. This
+//!   is how subgraph requests are eventually batched up. When a [BatchQuery] has received all
+//!   expected progress calls (per [BatchQuery::set_query_hashes]), that query is considered
+//!   "finished".
+//! - The [Batch] lifecycle handler receives messages from each [BatchQuery]. Once _all_
+//!   [BatchQuery]s are finished, no more messages come in, and this is when the [Batch] lifecycle
+//!   handler actually batches up the requests to each subgraph, and sends the batched subgraph
+//!   requests to the HTTP client.
 
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -420,7 +420,6 @@ impl Drop for Batch {
 
 /// A batch of requests that we'll send to a subgraph (...as a single batch request).
 pub(crate) struct SubgraphBatchRequest {
-    pub(crate) operation_name: String,
     pub(crate) contexts: Vec<(Context, SubgraphRequestId)>,
     pub(crate) request: http::Request<RouterBody>,
     pub(crate) txs: Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
@@ -446,11 +445,6 @@ pub(crate) async fn assemble_batch(
         .next()
         .ok_or(SubgraphBatchingError::RequestsIsEmpty)?
         .subgraph_request;
-    let operation_name = first_request
-        .body()
-        .operation_name
-        .clone()
-        .unwrap_or_default();
     let (parts, first_body) = first_request.into_parts();
 
     let mut gql_requests = Vec::with_capacity(txs.len());
@@ -466,7 +460,6 @@ pub(crate) async fn assemble_batch(
     // Generate the final request and pass it up
     let request = http::Request::from_parts(parts, router::body::from_bytes(bytes));
     Ok(SubgraphBatchRequest {
-        operation_name,
         contexts,
         request,
         txs,
@@ -536,7 +529,6 @@ mod tests {
             .collect::<Vec<String>>();
         // Assemble them
         let SubgraphBatchRequest {
-            operation_name,
             contexts,
             request,
             txs,
@@ -550,9 +542,6 @@ mod tests {
             .collect::<Vec<String>>();
         // Make sure all of our contexts are preserved during assembly
         assert_eq!(input_context_ids, output_context_ids);
-
-        // Make sure that the name of the entire batch is that of the first
-        assert_eq!(operation_name, "batch_test_0");
 
         // We should see the aggregation of all of the requests
         let actual: Vec<graphql::Request> = serde_json::from_str(

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -396,11 +396,8 @@ pub(crate) async fn create_subgraph_services(
 ) -> Result<IndexMap<String, SubgraphService>, BoxError> {
     let mut subgraph_services = IndexMap::default();
     for (name, http_service_factory) in http_service_factory.iter() {
-        let subgraph_service = SubgraphService::from_config(
-            name.clone(),
-            configuration,
-            http_service_factory.clone(),
-        )?;
+        let subgraph_service =
+            SubgraphService::from_config(name, configuration, http_service_factory.clone())?;
         subgraph_services.insert(name.clone(), subgraph_service);
     }
 

--- a/apollo-router/src/services/http.rs
+++ b/apollo-router/src/services/http.rs
@@ -43,7 +43,7 @@ impl HttpClientServiceFactory {
 
     #[cfg(test)]
     pub(crate) fn from_config(
-        service: impl Into<String>,
+        service: &str,
         configuration: &crate::Configuration,
         client_config: crate::configuration::shared::Client,
     ) -> Self {

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -715,7 +715,6 @@ pub(crate) async fn process_batches(
     let (info, txs): (Vec<_>, Vec<_>) =
         futures::future::join_all(svc_map.into_iter().map(|(service, requests)| async {
             let SubgraphBatchRequest {
-                operation_name: _,
                 contexts,
                 request,
                 txs,

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -48,6 +48,7 @@ use crate::Context;
 use crate::Notify;
 use crate::batching::BatchQuery;
 use crate::batching::BatchQueryInfo;
+use crate::batching::SubgraphBatchRequest;
 use crate::batching::assemble_batch;
 use crate::configuration::Batching;
 use crate::configuration::BatchingMode;
@@ -365,7 +366,7 @@ fn http_response_to_graphql_response(
 
 /// Process a single subgraph batch request
 #[instrument(skip(client_factory, contexts, request))]
-pub(crate) async fn process_batch(
+async fn process_batch(
     client_factory: HttpClientServiceFactory,
     service: String,
     mut contexts: Vec<(Context, SubgraphRequestId)>,
@@ -620,7 +621,7 @@ pub(crate) async fn process_batch(
 }
 
 /// Notify all listeners of a batch query of the results
-pub(crate) async fn notify_batch_query(
+async fn notify_batch_query(
     service: String,
     senders: Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
     responses: Result<Vec<SubgraphResponse>, FetchError>,
@@ -699,7 +700,6 @@ type BatchInfo = (
         String,
         http::Request<RouterBody>,
         Vec<(Context, SubgraphRequestId)>,
-        usize,
     ),
     Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
 );
@@ -714,9 +714,14 @@ pub(crate) async fn process_batches(
     let mut errors = vec![];
     let (info, txs): (Vec<_>, Vec<_>) =
         futures::future::join_all(svc_map.into_iter().map(|(service, requests)| async {
-            let (_op_name, contexts, request, txs) = assemble_batch(requests).await?;
+            let SubgraphBatchRequest {
+                operation_name: _,
+                contexts,
+                request,
+                txs,
+            } = assemble_batch(requests).await?;
 
-            Ok(((service, request, contexts, txs.len()), txs))
+            Ok(((service, request, contexts), txs))
         }))
         .await
         .into_iter()
@@ -744,20 +749,22 @@ pub(crate) async fn process_batches(
         )
         .into());
     }
-    let batch_futures = info.into_iter().zip_eq(txs).map(
-        |((service, request, contexts, listener_count), senders)| async move {
-            let batch_result = process_batch(
-                cf.clone(),
-                service.clone(),
-                contexts,
-                request,
-                listener_count,
-            )
-            .await;
+    let batch_futures =
+        info.into_iter()
+            .zip_eq(txs)
+            .map(|((service, request, contexts), senders)| async move {
+                let listener_count = senders.len();
+                let batch_result = process_batch(
+                    cf.clone(),
+                    service.clone(),
+                    contexts,
+                    request,
+                    listener_count,
+                )
+                .await;
 
-            notify_batch_query(service, senders, batch_result).await
-        },
-    );
+                notify_batch_query(service, senders, batch_result).await
+            });
 
     futures::future::try_join_all(batch_futures).await?;
 
@@ -804,7 +811,7 @@ async fn call_http(
 }
 
 /// call_single_http makes http calls with modified graphql::Request (body)
-pub(crate) async fn call_single_http(
+async fn call_single_http(
     request: SubgraphRequest,
     client: crate::services::http::BoxCloneService,
     service_name: &str,

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -106,9 +106,6 @@ pub(crate) struct SubgraphService {
     /// Pre-built HTTP client service with all plugin layers already folded in.
     /// Used on the hot (non-batching) path to avoid re-folding plugins per request.
     http_client: crate::services::http::BoxCloneService,
-    /// Kept only for the batching path, where a single factory may be used to
-    /// `.create()` clients for different subgraph names.
-    pub(crate) client_factory: HttpClientServiceFactory,
     service: Arc<String>,
 
     /// Whether apq is enabled in the router for subgraph calls
@@ -122,33 +119,29 @@ pub(crate) struct SubgraphService {
 
 impl SubgraphService {
     pub(crate) fn from_config(
-        service: impl Into<String>,
+        name: &str,
         configuration: &Configuration,
         client_factory: HttpClientServiceFactory,
     ) -> Result<Self, BoxError> {
-        let name: String = service.into();
-
         let enable_apq = configuration
             .apq
             .subgraph
             .subgraphs
-            .get(&name)
+            .get(name)
             .map(|apq| apq.enabled)
             .unwrap_or(configuration.apq.subgraph.all.enabled);
 
-        SubgraphService::new(name, enable_apq, client_factory)
+        SubgraphService::new(name, enable_apq, client_factory.create(name))
     }
 
     pub(crate) fn new(
         service: impl Into<String>,
         enable_apq: bool,
-        client_factory: crate::services::http::HttpClientServiceFactory,
+        http_client: crate::services::http::BoxCloneService,
     ) -> Result<Self, BoxError> {
         let name = service.into();
-        let http_client = client_factory.create(&name);
         Ok(Self {
             http_client,
-            client_factory,
             service: Arc::new(name),
             apq: Arc::new(<AtomicBool>::new(enable_apq)),
         })
@@ -185,15 +178,15 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
     type Error = BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-    fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.http_client.poll_ready(cx)
     }
 
     fn call(&mut self, mut request: SubgraphRequest) -> Self::Future {
-        let service_name = (*self.service).to_owned();
+        let service_name = self.service.clone();
 
-        let client_factory = self.client_factory.clone();
-        let http_client = self.http_client.clone();
+        let fresh_client = self.http_client.clone();
+        let http_client = std::mem::replace(&mut self.http_client, fresh_client);
 
         let arc_apq_enabled = self.apq.clone();
 
@@ -202,13 +195,7 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
             // with the same request body.
             let apq_enabled = arc_apq_enabled.as_ref();
             if !apq_enabled.load(Relaxed) {
-                return call_http(
-                    request,
-                    client_factory.clone(),
-                    http_client.clone(),
-                    &service_name,
-                )
-                .await;
+                return call_http(request, http_client, &service_name).await;
             }
 
             // APQ works by sending the query hash via extensions with an empty query body.
@@ -226,13 +213,7 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
                 }),
             );
 
-            let response = call_http(
-                request.clone(),
-                client_factory.clone(),
-                http_client.clone(),
-                &service_name,
-            )
-            .await?;
+            let response = call_http(request.clone(), http_client.clone(), &service_name).await?;
 
             // Check the error for the request with only persistedQuery.
             // If PersistedQueryNotSupported, disable APQ for this subgraph
@@ -246,11 +227,11 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
                     body.query = original_query;
                     // Remove the persistedQuery extension we added for the APQ attempt.
                     body.extensions.remove(PERSISTED_QUERY_KEY);
-                    call_http(request, client_factory.clone(), http_client, &service_name).await
+                    call_http(request, http_client, &service_name).await
                 }
                 APQError::PersistedQueryNotFound => {
                     request.subgraph_request.body_mut().query = original_query;
-                    call_http(request, client_factory.clone(), http_client, &service_name).await
+                    call_http(request, http_client, &service_name).await
                 }
                 _ => Ok(response),
             }
@@ -365,10 +346,10 @@ fn http_response_to_graphql_response(
 }
 
 /// Process a single subgraph batch request
-#[instrument(skip(client_factory, contexts, request))]
+#[instrument(skip(http_client, contexts, request))]
 async fn process_batch(
-    client_factory: HttpClientServiceFactory,
-    service: String,
+    http_client: crate::services::http::BoxCloneService,
+    service: &str,
     mut contexts: Vec<(Context, SubgraphRequestId)>,
     mut request: http::Request<RouterBody>,
     listener_count: usize,
@@ -419,7 +400,6 @@ async fn process_batch(
         .expect("we have at least one context in the batch")
         .0
         .clone();
-    let client = client_factory.create(&service);
 
     // Update our batching metrics (just before we fetch)
     u64_histogram!(
@@ -427,7 +407,7 @@ async fn process_batch(
         "Number of queries contained within each query batch",
         listener_count as u64,
         mode = BatchingMode::BatchHttpLink.to_string(), // Only supported mode right now
-        subgraph = service.clone()
+        subgraph = service.to_string()
     );
 
     u64_counter!(
@@ -437,12 +417,12 @@ async fn process_batch(
         // XXX(@goto-bus-stop): Should these be `batching.mode`, `batching.subgraph`?
         // Also, other metrics use a different convention to report the subgraph name
         mode = BatchingMode::BatchHttpLink.to_string(), // Only supported mode right now
-        subgraph = service.clone()
+        subgraph = service.to_string()
     );
 
     // Perform the actual fetch. If this fails then we didn't manage to make the call at all, so we can't do anything with it.
     tracing::debug!("fetching from subgraph: {service}");
-    let (parts, content_type, body) = match do_fetch(client, &batch_context, &service, request)
+    let (parts, content_type, body) = match do_fetch(http_client, &batch_context, &service, request)
         .instrument(subgraph_req_span)
         .await
     {
@@ -453,14 +433,14 @@ async fn process_batch(
                 .body(err.to_graphql_error(None))
                 .map_err(|err| FetchError::SubrequestHttpError {
                     status_code: None,
-                    service: service.clone(),
+                    service: service.to_string(),
                     reason: format!("cannot create the http response from error: {err:?}"),
                 })?;
             let (parts, body) = resp.into_parts();
             let body =
                 serde_json::to_vec(&body).map_err(|err| FetchError::SubrequestHttpError {
                     status_code: None,
-                    service: service.clone(),
+                    service: service.to_string(),
                     reason: format!("cannot serialize the error: {err:?}"),
                 })?;
             (
@@ -506,7 +486,7 @@ async fn process_batch(
         }
         attrs.push(KeyValue::new(
             Key::from_static_str("subgraph.name"),
-            opentelemetry::Value::String(service.clone().into()),
+            opentelemetry::Value::String(service.to_string().into()),
         ));
         log_event(
             event.level,
@@ -566,7 +546,7 @@ async fn process_batch(
     // response
     if graphql_responses.len() != contexts.len() {
         return Err(FetchError::SubrequestBatchingError {
-            service,
+            service: service.to_string(),
             reason: format!(
                 "number of contexts ({}) is not equal to number of graphql responses ({})",
                 contexts.len(),
@@ -577,12 +557,10 @@ async fn process_batch(
 
     // We are going to pop contexts from the back, so let's reverse our contexts
     contexts.reverse();
-    let subgraph_name = service.clone();
     // Build an http Response for each graphql response
     let subgraph_responses: Result<Vec<_>, _> = graphql_responses
         .into_iter()
         .map(|res| {
-            let subgraph_name = subgraph_name.clone();
             http::Response::builder()
                 .status(parts.status)
                 .version(parts.version)
@@ -592,8 +570,12 @@ async fn process_batch(
                     // Use the original context for the request to create the response
                     let (context, id) =
                         contexts.pop().expect("we have a context for each response");
-                    let resp =
-                        SubgraphResponse::new_from_response(http_res, context, subgraph_name, id);
+                    let resp = SubgraphResponse::new_from_response(
+                        http_res,
+                        context,
+                        service.to_string(),
+                        id,
+                    );
 
                     // Avoid `{resp:?}`: SubgraphResponse's derived Debug prints
                     // the response HeaderMap unmasked. Log the non-header parts.
@@ -698,6 +680,7 @@ async fn notify_batch_query(
 type BatchInfo = (
     (
         String,
+        crate::services::http::BoxCloneService,
         http::Request<RouterBody>,
         Vec<(Context, SubgraphRequestId)>,
     ),
@@ -707,7 +690,6 @@ type BatchInfo = (
 /// Collect all batch requests and process them concurrently
 #[instrument(skip_all)]
 pub(crate) async fn process_batches(
-    client_factory: HttpClientServiceFactory,
     svc_map: HashMap<String, Vec<BatchQueryInfo>>,
 ) -> Result<(), BoxError> {
     // We need to strip out the senders so that we can work with them separately.
@@ -715,12 +697,13 @@ pub(crate) async fn process_batches(
     let (info, txs): (Vec<_>, Vec<_>) =
         futures::future::join_all(svc_map.into_iter().map(|(service, requests)| async {
             let SubgraphBatchRequest {
+                http_client: client,
                 contexts,
                 request,
                 txs,
             } = assemble_batch(requests).await?;
 
-            Ok(((service, request, contexts), txs))
+            Ok(((service, client, request, contexts), txs))
         }))
         .await
         .into_iter()
@@ -738,8 +721,6 @@ pub(crate) async fn process_batches(
         )
         .into());
     }
-    // Collect all of the processing logic and run them concurrently, collecting all errors
-    let cf = &client_factory;
     // It is not ok to panic if the length of the txs and info do not match. Let's make sure they
     // do
     if txs.len() != info.len() {
@@ -751,16 +732,10 @@ pub(crate) async fn process_batches(
     let batch_futures =
         info.into_iter()
             .zip_eq(txs)
-            .map(|((service, request, contexts), senders)| async move {
+            .map(|((service, http_client, request, contexts), senders)| async move {
                 let listener_count = senders.len();
-                let batch_result = process_batch(
-                    cf.clone(),
-                    service.clone(),
-                    contexts,
-                    request,
-                    listener_count,
-                )
-                .await;
+                let batch_result =
+                    process_batch(http_client, &service, contexts, request, listener_count).await;
 
                 notify_batch_query(service, senders, batch_result).await
             });
@@ -772,7 +747,6 @@ pub(crate) async fn process_batches(
 
 async fn call_http(
     request: SubgraphRequest,
-    client_factory: HttpClientServiceFactory,
     http_client: crate::services::http::BoxCloneService,
     service_name: &str,
 ) -> Result<SubgraphResponse, BoxError> {
@@ -792,9 +766,9 @@ async fn call_http(
 
     // If we have a batch query, then it's time for batching
     if let Some(query) = opt_batch_query {
-        // The batch path needs the factory because a single batch handler may
-        // create clients for different subgraph names.
-        let response_rx = query.signal_progress(client_factory, request).await?;
+        // Hand off our http_client so the batch handler can use it once all
+        // requests in the batch have signalled progress.
+        let response_rx = query.signal_progress(http_client, request).await?;
 
         // Park this query until we have our response and pass it back up
         response_rx
@@ -2069,7 +2043,8 @@ mod tests {
                     "testbis",
                     &Configuration::default(),
                     crate::configuration::shared::Client::default(),
-                ),
+                )
+                .create("testbis"),
             )
             .expect("can create a SubgraphService"),
         );
@@ -2112,7 +2087,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2144,7 +2120,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2177,7 +2154,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2213,7 +2191,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2248,7 +2227,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2296,7 +2276,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2340,7 +2321,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2381,7 +2363,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2421,7 +2404,8 @@ mod tests {
                     "test",
                     &Configuration::default(),
                     crate::configuration::shared::Client::default(),
-                ),
+                )
+                .create("test"),
             )
             .expect("can create a SubgraphService"),
         );
@@ -2475,7 +2459,7 @@ mod tests {
                         "test",
                         &Configuration::default(),
                         crate::configuration::shared::Client::default(),
-                    ),
+                    ).create("test"),
                 )
                 .expect("can create a SubgraphService"),
             );
@@ -2530,7 +2514,8 @@ mod tests {
                         "test",
                         &Configuration::default(),
                         crate::configuration::shared::Client::default(),
-                    ),
+                    )
+                    .create("test"),
                 )
                 .expect("can create a SubgraphService"),
             );
@@ -2599,7 +2584,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2639,7 +2625,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2675,7 +2662,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2711,7 +2699,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2746,7 +2735,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2781,7 +2771,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2825,7 +2816,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2867,7 +2859,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2906,7 +2899,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2945,7 +2939,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2984,7 +2979,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -3041,7 +3037,8 @@ mod tests {
                     "test",
                     &Configuration::default(),
                     ClientConfiguration::default(),
-                ),
+                )
+                .create("test"),
             )
             .expect("can create a SubgraphService");
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     security_opt:
       - no-new-privileges:true
     read_only: true
+    tmpfs:
+      - /data
     ports:
       - 6379:6379
 


### PR DESCRIPTION
Subgraphs services are held in a map against subgraph name. They are wrapped in a buffer because they were previously not clone.

Now that Subgraph services are clone we can remove the buffer and instead hold the subgraph services in a mutex. This means that future creation from the services does not need to be serialized.

Cloning a service is a cheap synchronous call. We should perf test this before merging.

<!-- start metadata -->

<!-- [ROUTER-1858] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1858]: https://apollographql.atlassian.net/browse/ROUTER-1858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ