### PR TITLE
refactor: move request modification out of `call` in `HeadersService` and into returned future

### DIFF
--- a/apollo-router/src/plugins/authorization/tests.rs
+++ b/apollo-router/src/plugins/authorization/tests.rs
@@ -1103,6 +1103,9 @@ async fn cache_key_metadata() {
         .schema(CACHE_KEY_SCHEMA)
         .subgraph_hook(|_name, _service| {
             let mut mock_subgraph_service = MockSubgraphService::new();
+            mock_subgraph_service
+                .expect_clone()
+                .return_once(MockSubgraphService::new);
             mock_subgraph_service.expect_call().times(1).returning(
                 move |req: subgraph::Request| {
                     assert_eq!(

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -5,6 +5,7 @@ use std::task::Context;
 use std::task::Poll;
 
 use apollo_federation::connectors::runtime::http_json_transport::TransportRequest;
+use futures::future::BoxFuture;
 use http::HeaderMap;
 use http::HeaderValue;
 use http::header::ACCEPT;
@@ -555,42 +556,56 @@ static RESERVED_HEADERS: [HeaderName; 14] = [
 
 impl<S> Service<SubgraphRequest> for HeadersService<S>
 where
-    S: Service<SubgraphRequest>,
+    S: Service<SubgraphRequest> + Clone + Send + 'static,
+    S::Future: Send + 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = S::Future;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, mut req: SubgraphRequest) -> Self::Future {
-        self.modify_subgraph_request(&mut req);
-        self.inner.call(req)
+        let inner = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, inner);
+        let operations = self.operations.clone();
+
+        Box::pin(async move {
+            Self::modify_subgraph_request(&operations, &mut req);
+            inner.call(req).await
+        })
     }
 }
 
 impl<S> Service<connector::request_service::Request> for HeadersService<S>
 where
-    S: Service<connector::request_service::Request>,
+    S: Service<connector::request_service::Request> + Clone + Send + 'static,
+    S::Future: Send + 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = S::Future;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, mut req: connector::request_service::Request) -> Self::Future {
-        self.modify_connector_request(&mut req);
-        self.inner.call(req)
+        let inner = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, inner);
+        let operations = self.operations.clone();
+
+        Box::pin(async move {
+            Self::modify_connector_request(&operations, &mut req);
+            inner.call(req).await
+        })
     }
 }
 
 impl<S> HeadersService<S> {
-    fn modify_subgraph_request(&self, req: &mut SubgraphRequest) {
+    fn modify_subgraph_request(operations: &Arc<Vec<Operation>>, req: &mut SubgraphRequest) {
         let mut already_propagated: HashSet<String> = HashSet::new();
 
         let body_to_value = serde_json_bytes::value::to_value(req.supergraph_request.body()).ok();
@@ -598,7 +613,7 @@ impl<S> HeadersService<S> {
         let context = &req.context;
         let headers_mut = req.subgraph_request.headers_mut();
 
-        for operation in &*self.operations {
+        for operation in &**operations {
             operation.process_header_rules(
                 &mut already_propagated,
                 supergraph_headers,
@@ -610,7 +625,10 @@ impl<S> HeadersService<S> {
         }
     }
 
-    fn modify_connector_request(&self, req: &mut connector::request_service::Request) {
+    fn modify_connector_request(
+        operations: &Arc<Vec<Operation>>,
+        req: &mut connector::request_service::Request,
+    ) {
         let mut already_propagated: HashSet<String> = HashSet::new();
 
         let TransportRequest::Http(ref mut http_request) = req.transport_request else {
@@ -623,7 +641,7 @@ impl<S> HeadersService<S> {
         let existing_headers = http_request.inner.headers().clone();
         let headers_mut = http_request.inner.headers_mut();
 
-        for operation in &*self.operations {
+        for operation in &**operations {
             operation.process_header_rules(
                 &mut already_propagated,
                 supergraph_headers,
@@ -1192,6 +1210,7 @@ mod test {
     #[tokio::test]
     async fn test_insert_static() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1219,6 +1238,7 @@ mod test {
     #[tokio::test]
     async fn test_connector_insert_static() -> Result<(), BoxError> {
         let mut mock = MockConnectorService::new();
+        mock.expect_clone().return_once(MockConnectorService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1250,6 +1270,7 @@ mod test {
     #[tokio::test]
     async fn test_insert_from_context() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1277,6 +1298,7 @@ mod test {
     #[tokio::test]
     async fn test_connector_insert_from_context() -> Result<(), BoxError> {
         let mut mock = MockConnectorService::new();
+        mock.expect_clone().return_once(MockConnectorService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1308,6 +1330,7 @@ mod test {
     #[tokio::test]
     async fn test_insert_from_request_body() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1336,6 +1359,7 @@ mod test {
     #[tokio::test]
     async fn test_connector_insert_from_request_body() -> Result<(), BoxError> {
         let mut mock = MockConnectorService::new();
+        mock.expect_clone().return_once(MockConnectorService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1368,6 +1392,7 @@ mod test {
     #[tokio::test]
     async fn test_insert_from_request_body_with_old_access_json_notation() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1397,6 +1422,7 @@ mod test {
     async fn test_connector_insert_from_request_body_with_old_access_json_notation()
     -> Result<(), BoxError> {
         let mut mock = MockConnectorService::new();
+        mock.expect_clone().return_once(MockConnectorService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1429,6 +1455,7 @@ mod test {
     #[tokio::test]
     async fn test_remove_exact() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| request.assert_headers(vec![("ac", "vac"), ("ab", "vab")]))
@@ -1446,6 +1473,7 @@ mod test {
     #[tokio::test]
     async fn test_remove_exact_multiple() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| request.assert_headers(vec![("ac", "vac"), ("ab", "vab")]))
@@ -1506,6 +1534,7 @@ mod test {
     #[tokio::test]
     async fn test_connector_remove_exact() -> Result<(), BoxError> {
         let mut mock = MockConnectorService::new();
+        mock.expect_clone().return_once(MockConnectorService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| request.assert_headers(vec![("ac", "vac"), ("ab", "vab")]))
@@ -1527,6 +1556,7 @@ mod test {
     #[tokio::test]
     async fn test_remove_matching() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| request.assert_headers(vec![("ac", "vac")]))
@@ -1544,6 +1574,7 @@ mod test {
     #[tokio::test]
     async fn test_connector_remove_matching() -> Result<(), BoxError> {
         let mut mock = MockConnectorService::new();
+        mock.expect_clone().return_once(MockConnectorService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| request.assert_headers(vec![("ac", "vac")]))
@@ -1565,6 +1596,7 @@ mod test {
     #[tokio::test]
     async fn test_propagate_matching() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1592,6 +1624,7 @@ mod test {
     #[tokio::test]
     async fn test_connector_propagate_matching() -> Result<(), BoxError> {
         let mut mock = MockConnectorService::new();
+        mock.expect_clone().return_once(MockConnectorService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1623,6 +1656,7 @@ mod test {
     #[tokio::test]
     async fn test_propagate_exact() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1650,6 +1684,7 @@ mod test {
     #[tokio::test]
     async fn test_connector_propagate_exact() -> Result<(), BoxError> {
         let mut mock = MockConnectorService::new();
+        mock.expect_clone().return_once(MockConnectorService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1681,6 +1716,7 @@ mod test {
     #[tokio::test]
     async fn test_propagate_exact_rename() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1708,6 +1744,7 @@ mod test {
     #[tokio::test]
     async fn test_connect_propagate_exact_rename() -> Result<(), BoxError> {
         let mut mock = MockConnectorService::new();
+        mock.expect_clone().return_once(MockConnectorService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1739,6 +1776,7 @@ mod test {
     #[tokio::test]
     async fn test_propagate_multiple() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1779,6 +1817,7 @@ mod test {
     #[tokio::test]
     async fn test_connector_propagate_multiple() -> Result<(), BoxError> {
         let mut mock = MockConnectorService::new();
+        mock.expect_clone().return_once(MockConnectorService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1823,6 +1862,7 @@ mod test {
     #[tokio::test]
     async fn test_propagate_exact_default() -> Result<(), BoxError> {
         let mut mock = MockSubgraphService::new();
+        mock.expect_clone().return_once(MockSubgraphService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1850,6 +1890,7 @@ mod test {
     #[tokio::test]
     async fn test_connector_propagate_exact_default() -> Result<(), BoxError> {
         let mut mock = MockConnectorService::new();
+        mock.expect_clone().return_once(MockConnectorService::new);
         mock.expect_call()
             .times(1)
             .withf(|request| {
@@ -1927,7 +1968,10 @@ mod test {
             executable_document: None,
             id: SubgraphRequestId(String::new()),
         };
-        service.modify_subgraph_request(&mut request);
+        HeadersService::<MockSubgraphService>::modify_subgraph_request(
+            &service.operations,
+            &mut request,
+        );
         let headers = request
             .subgraph_request
             .headers()
@@ -1999,7 +2043,10 @@ mod test {
             executable_document: None,
             id: SubgraphRequestId(String::new()),
         };
-        service.modify_subgraph_request(&mut request);
+        HeadersService::<MockSubgraphService>::modify_subgraph_request(
+            &service.operations,
+            &mut request,
+        );
         let headers = request
             .subgraph_request
             .headers()

--- a/examples/cache-control/rhai/src/main.rs
+++ b/examples/cache-control/rhai/src/main.rs
@@ -24,6 +24,9 @@ mod tests {
 
         mock_service1.expect_clone().returning(move || {
             let mut mock_service = test::MockSubgraphService::new();
+            mock_service
+                .expect_clone()
+                .return_once(test::MockSubgraphService::new);
             let value = header_one.clone();
             mock_service
                 .expect_call()
@@ -44,6 +47,9 @@ mod tests {
 
         mock_service2.expect_clone().returning(move || {
             let mut mock_service = test::MockSubgraphService::new();
+            mock_service
+                .expect_clone()
+                .return_once(test::MockSubgraphService::new);
             let value = header_two.clone();
             mock_service
                 .expect_call()

--- a/examples/cookies-to-headers/rhai/src/main.rs
+++ b/examples/cookies-to-headers/rhai/src/main.rs
@@ -51,6 +51,9 @@ mod tests {
         mock_service.expect_clone().returning(move || {
             let mut mock_service = test::MockSubgraphService::new();
             mock_service
+                .expect_clone()
+                .return_once(test::MockSubgraphService::new);
+            mock_service
                 .expect_call()
                 .once()
                 .returning(move |req: subgraph::Request| {


### PR DESCRIPTION
`modify_subgraph_request` and `modify_connector_request` both perform work that shouldn't be done in call, they're now moved into a future that is returned instead.

<!-- start metadata -->

<!-- [ROUTER-1874] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1874]: https://apollographql.atlassian.net/browse/ROUTER-1874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ