### PR TITLE
fix(config): headers operations migration now warns instead of erroring

### DIFF
--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -691,6 +691,38 @@ fn upgrade_old_configuration() {
     }
 }
 
+// Regression: old flat-list headers config must be accepted at startup (Mode::Upgrade)
+// without requiring the operator to manually add the `operations:` wrapper key.
+#[test]
+fn headers_operations_migration_applied_at_startup() {
+    let old_config = r#"
+headers:
+  all:
+    request:
+      - propagate:
+          named: x-request-id
+      - propagate:
+          named: authorization
+"#;
+    validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
+        .expect("old headers config should be accepted at startup via automatic migration");
+}
+
+#[test]
+fn headers_operations_rejected_without_migration() {
+    let old_config = r#"
+headers:
+  all:
+    request:
+      - propagate:
+          named: x-request-id
+      - propagate:
+          named: authorization
+"#;
+    validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::NoUpgrade)
+        .expect_err("old headers config should be rejected when migration is not applied");
+}
+
 #[derive(RustEmbed)]
 #[folder = "src/configuration/testdata/migrations/minor"]
 struct AssetMinor;

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -70,10 +70,6 @@ enum LogCondition {
 
 const REMOVAL_VALUE: &str = "__PLEASE_DELETE_ME";
 const REMOVAL_EXPRESSION: &str = r#"const("__PLEASE_DELETE_ME")"#;
-const HEADERS_OPS_MIGRATION_DESCRIPTION: &str = "`headers.all.request`, per-subgraph \
-     equivalents, and `headers.connector.{all,sources.*}.request` now require an `operations` \
-     key wrapping the list of propagation rules. Your configuration has been automatically \
-     migrated.";
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum UpgradeMode {
@@ -128,21 +124,24 @@ pub(crate) fn upgrade_configuration(
     // Handled in Rust rather than a proteus YAML action because the source path
     // is a prefix of the destination path and subgraph names are dynamic.
     let migrated = migrate_headers_operations(config.clone());
-    let headers_ops_migrated = migrated != config;
-    if headers_ops_migrated {
+    if migrated != config {
+        if log_warnings {
+            tracing::warn!(
+                "`headers.all.request`, per-subgraph equivalents, and \
+                 `headers.connector.{{all,sources.*}}.request` now require an `operations` key \
+                 wrapping the list of propagation rules. The router has applied this change \
+                 automatically. Please update your configuration file."
+            );
+        }
         config = migrated;
     }
 
-    if (!effective_migrations.is_empty() || headers_ops_migrated) && log_warnings {
-        let mut descriptions: Vec<String> = effective_migrations
+    if !effective_migrations.is_empty() && log_warnings {
+        let descriptions: Vec<String> = effective_migrations
             .iter()
             .enumerate()
             .map(|(idx, m)| format!("  {}. {}", idx + 1, m.description))
             .collect();
-        if headers_ops_migrated {
-            let idx = descriptions.len() + 1;
-            descriptions.push(format!("  {idx}. {HEADERS_OPS_MIGRATION_DESCRIPTION}"));
-        }
         tracing::error!(
             "router configuration contains unsupported options and needs to be upgraded to run the router: \n\n{}\n\n",
             descriptions.join("\n\n")


### PR DESCRIPTION
## What

- The `headers.all.request` flat-list migration added in #9155 logged a `tracing::error!` with the message "router configuration contains unsupported options and needs to be upgraded to run the router" even when it successfully applied the fix in memory and the router started normally.
- Changed that log to `tracing::warn!` with a message that accurately describes what happened: the change was applied automatically in memory and the operator should update their config file.
- Removed the now-unused `HEADERS_OPS_MIGRATION_DESCRIPTION` constant and simplified the surrounding conditional (the headers migration is no longer bundled into the YAML-migration error block).
- Added two regression tests in `configuration/tests.rs`:
  - `headers_operations_migration_applied_at_startup`: verifies the old flat-list shape is accepted when `Mode::Upgrade` is used (the startup path).
  - `headers_operations_rejected_without_migration`: verifies the old shape is correctly rejected when `Mode::NoUpgrade` is used (e.g. `router config validate`).

## Verified
- `cargo fmt --check` passed
- `cargo clippy -- -D warnings` passed
- CHANGELOG.md not modified
- No changeset files added

## Notes

The schema.rs `validator.is_valid` guard that gates whether the migration result is used is unchanged. If the migrated config passes validation (which it does when `headers` is the only issue), the router starts and emits the new `warn!`. If the migrated config is still invalid due to unrelated errors, the guard discards it and the original config's errors are reported — the same behaviour as before.