### PR TITLE
feat(connectors): consolidate synthetic subgraphs to improve satisfiability performance

### DIFF
--- a/.changesets/feat_consolidate_connector_subgraphs_for_satisfiability.md
+++ b/.changesets/feat_consolidate_connector_subgraphs_for_satisfiability.md
@@ -1,0 +1,9 @@
+### Make the satisfiability check far cheaper for supergraphs that use Apollo Connectors ([PR #9663](https://github.com/apollographql/router/pull/9663))
+
+Composing a supergraph that uses Apollo Connectors could consume large amounts of memory and time in the **satisfiability check**, the step that verifies every field in the API schema can actually be resolved.
+
+The check expands every `@connect` into its own internal subgraph, and how far that fans out depends on the schema. In one pathological graph — far larger fan-out than anything else we've seen — 6 connector subgraphs expanded into roughly 1,400 internal ones, pushing the check to about **14 GB and 4 minutes**.
+
+Many of those internal subgraphs are interchangeable for this check: same way in, same data. Composition now merges the interchangeable ones **only for the satisfiability check**, so it runs over a far smaller graph. On that same graph the check dropped to about **0.3 GB and under a second**, with an identical pass/fail result. The schema the router runs on is untouched, so query planning and connector execution are unchanged.
+
+By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/9663

--- a/apollo-federation/src/composition/consolidate.rs
+++ b/apollo-federation/src/composition/consolidate.rs
@@ -38,6 +38,15 @@
 //! scopes (a graph's `@join__directive(name: "link")` membership, e.g. connect v0.2 vs v0.3),
 //! since the representative would otherwise link the same feature twice. The grouping key is
 //! therefore the link scope alone.
+//!
+//! One further condition: the participation merge folds two graphs' applications for the same
+//! `(type, field)` into the representative, which is only well-formed when those applications
+//! are byte-identical. If two merge candidates declare the same `(type, field)` with *differing*
+//! `@join__field` metadata (e.g. divergent `type:` overrides on a `@shareable` field), folding
+//! would leave two conflicting `@join__field(graph: REP)` on one field and make subgraph
+//! extraction define that field twice — a spurious composition error. Such graphs are detected
+//! and excluded from merging (each keeps its own representative). Connector synthetic subgraphs
+//! are field-disjoint, so this never costs the win in practice; it guards the shared-field case.
 
 use std::collections::BTreeSet;
 use std::collections::HashMap;
@@ -105,6 +114,49 @@ pub(super) fn consolidate_for_satisfiability(expanded_sdl: &str) -> String {
         _ => return expanded_sdl.to_string(), // not a connector supergraph; nothing to do
     };
 
+    // --- field-compatibility data: per (type, field), each graph's `@join__field` application ---
+    // A participation-merge folds two graphs' applications for the SAME (type, field) into the
+    // representative. That is only sound when those applications are byte-identical (they fold
+    // to one). If two keyless graphs declare the same (type, field) with *differing*
+    // `@join__field` metadata — e.g. divergent `type:` overrides on a `@shareable` field —
+    // folding them would leave two conflicting `@join__field(graph: REP)` on one field, which
+    // makes `extract_subgraphs_from_supergraph` define that field twice and fail (a spurious
+    // composition error). Field-disjoint graphs (all connector synthetic subgraphs) never hit
+    // this. Record each graph's application (its args minus `graph:`) so we can taint colliders.
+    let mut field_apps: HashMap<(Name, Name), Vec<(Name, String)>> = HashMap::new();
+    {
+        let mut collect = |type_name: &Name, field_name: &Name, dl: &ast::DirectiveList| {
+            for d in dl.iter().filter(|d| d.name == name!("join__field")) {
+                if let Some(graph) = arg_enum(d, "graph") {
+                    field_apps
+                        .entry((type_name.clone(), field_name.clone()))
+                        .or_default()
+                        .push((graph.clone(), join_field_app(d)));
+                }
+            }
+        };
+        for (type_name, ty) in &schema.types {
+            match ty {
+                ExtendedType::Object(t) => {
+                    for (fname, f) in &t.fields {
+                        collect(type_name, fname, &f.directives);
+                    }
+                }
+                ExtendedType::Interface(t) => {
+                    for (fname, f) in &t.fields {
+                        collect(type_name, fname, &f.directives);
+                    }
+                }
+                ExtendedType::InputObject(t) => {
+                    for (fname, f) in &t.fields {
+                        collect(type_name, fname, &f.directives);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     // --- group root-field (keyless) graphs by link scope; representative = smallest member ---
     // Only keyless graphs are eligible to merge. A keyless graph is reachable only at root
     // operation fields (never via an entity key-jump), so co-locating two keyless graphs adds
@@ -112,16 +164,42 @@ pub(super) fn consolidate_for_satisfiability(expanded_sdl: &str) -> String {
     // sidesteps every `@key`-related hazard (`@key(resolvable: false)`, `@external` key fields,
     // `@override`, differing key-field types), since all of those attach to keyed types we
     // never touch. Keyless graphs still may not merge across spec-link scopes, or the
-    // representative would link the same feature twice; so the grouping key is the link scope
-    // alone. Keyed graphs are omitted here and therefore each remain their own representative.
-    let mut groups: HashMap<BTreeSet<String>, Vec<Name>> = HashMap::new();
+    // representative would link the same feature twice; so the grouping key is the link scope.
+    // Keyed graphs are omitted here and therefore each remain their own representative.
+    let mut graph_scope: HashMap<Name, BTreeSet<String>> = HashMap::new();
     for g in &all_graphs {
-        let keyless = keyed_sig.get(g).map_or(true, |sig| sig.is_empty());
-        if !keyless {
-            continue; // keyed graph: never merged
+        if keyed_sig.get(g).is_none_or(|sig| sig.is_empty()) {
+            graph_scope.insert(g.clone(), link_scope.get(g).cloned().unwrap_or_default());
         }
-        let scopes = link_scope.get(g).cloned().unwrap_or_default();
-        groups.entry(scopes).or_default().push(g.clone());
+    }
+
+    // Taint keyless graphs that would collide: within one scope group, if two members declare
+    // the same (type, field) with different applications, every member declaring that field is
+    // excluded from merging and keeps its own representative.
+    let mut tainted: HashSet<Name> = HashSet::new();
+    for apps in field_apps.values() {
+        let mut by_scope: HashMap<&BTreeSet<String>, Vec<(&Name, &String)>> = HashMap::new();
+        for (g, app) in apps {
+            if let Some(scope) = graph_scope.get(g) {
+                by_scope.entry(scope).or_default().push((g, app));
+            }
+        }
+        for members in by_scope.values() {
+            let distinct: HashSet<&&String> = members.iter().map(|(_, a)| a).collect();
+            if distinct.len() > 1 {
+                for (g, _) in members {
+                    tainted.insert((*g).clone());
+                }
+            }
+        }
+    }
+
+    let mut groups: HashMap<BTreeSet<String>, Vec<Name>> = HashMap::new();
+    for (g, scope) in &graph_scope {
+        if tainted.contains(g) {
+            continue; // field-incompatible: keep its own representative
+        }
+        groups.entry(scope.clone()).or_default().push(g.clone());
     }
     let mut sym2rep: HashMap<Name, Name> = HashMap::new();
     let mut reps: HashSet<Name> = all_graphs.iter().cloned().collect();
@@ -218,6 +296,21 @@ fn arg_str<'a>(d: &'a Directive, name: &str) -> Option<&'a str> {
     arg(d, name).and_then(|v| v.as_str())
 }
 
+/// Serialize a `@join__field` application's arguments *except* `graph:`, so two applications
+/// that differ only by which graph they name compare equal. Used to detect divergent metadata
+/// (e.g. different `type:` overrides) on a shared (type, field) that would make a
+/// participation-merge produce two conflicting `@join__field(graph: REP)` on one field.
+fn join_field_app(d: &Directive) -> String {
+    let mut parts: Vec<String> = d
+        .arguments
+        .iter()
+        .filter(|a| a.name.as_str() != "graph")
+        .map(|a| format!("{}: {}", a.name, a.value))
+        .collect();
+    parts.sort();
+    parts.join(", ")
+}
+
 /// Return a copy of `d` with any `graph:` enum arg and `graphs: [...]` list arg remapped to
 /// representatives (the latter deduped, since the remap can repeat a representative).
 fn remapped_directive(d: &Directive, sym2rep: &HashMap<Name, Name>) -> Directive {
@@ -289,7 +382,8 @@ schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://spec
 }
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 directive @join__type(graph: join__Graph!, key: join__FieldSet, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
-directive @join__field(graph: join__Graph) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, type: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 scalar join__FieldSet
@@ -412,6 +506,36 @@ type T @join__type(graph: A, key: \"id\") @join__type(graph: B, key: \"id\", res
             graph_count(&out),
             2,
             "resolvable:false key graph must not merge into a resolvable one:\n{out}"
+        );
+    }
+
+    /// Two keyless graphs that both declare the same field with *divergent* `@join__field`
+    /// metadata (here, different `type:` overrides on a `@shareable` root field) must NOT be
+    /// merged — folding them would leave two conflicting `@join__field(graph: REP)` on one field
+    /// and make subgraph extraction define it twice (a spurious composition error). Regression
+    /// for the divergent-return-type case.
+    #[test]
+    fn keeps_divergent_shared_field_graphs_separate() {
+        let sdl = format!(
+            "{PREAMBLE}
+enum join__Graph {{
+  A @join__graph(name: \"a\", url: \"\")
+  B @join__graph(name: \"b\", url: \"\")
+}}
+type Query @join__type(graph: A) @join__type(graph: B) {{
+  foo: I @join__field(graph: A, type: \"X\") @join__field(graph: B, type: \"Y\")
+}}
+interface I @join__type(graph: A) @join__type(graph: B) {{ name: String }}
+type X implements I @join__type(graph: A) @join__implements(graph: A, interface: \"I\") {{ name: String @join__field(graph: A) }}
+type Y implements I @join__type(graph: B) @join__implements(graph: B, interface: \"I\") {{ name: String @join__field(graph: B) }}
+"
+        );
+        let out = consolidate_for_satisfiability(&sdl);
+        assert!(reparses(&out), "consolidated output must parse:\n{out}");
+        assert_eq!(
+            graph_count(&out),
+            2,
+            "graphs sharing a field with divergent @join__field metadata must stay separate:\n{out}"
         );
     }
 

--- a/apollo-federation/src/composition/consolidate.rs
+++ b/apollo-federation/src/composition/consolidate.rs
@@ -1,0 +1,368 @@
+//! Satisfiability-only consolidation of connector synthetic subgraphs.
+//!
+//! Connector expansion (`expand_connectors`) turns each `@connect` into its own synthetic
+//! subgraph so satisfiability can reuse the existing subgraph-based machinery. On large
+//! connector supergraphs this explodes into thousands of `@join__graph`s, and
+//! `validate_satisfiability` over that expansion is the dominant memory/time cost (it
+//! builds a federated query graph with a node per type x subgraph, scaling super-linearly).
+//!
+//! This transform merges `@join__graph`s that share an **identical resolvable-key
+//! signature** (the set of `@join__type(T, key: K)` entries they declare) into one
+//! representative graph, purely for the satisfiability check. The expanded supergraph the
+//! router executes against is **not** affected — this rewrites only the schema handed to
+//! `validate_satisfiability`.
+//!
+//! It works on the parsed AST (apollo-compiler `Schema`) and lets the compiler serialize the
+//! result, so it never hand-formats SDL. The only collapsing it does is a structural
+//! *participation merge*: after remapping a graph reference to its representative, directive
+//! applications that become byte-identical are folded into one (e.g. two
+//! `@join__type(graph: REP)` on a type → one). Repeatable directives with distinct arguments
+//! (different keys, different graphs) are preserved.
+//!
+//! ## Soundness
+//!
+//! Merging join graphs is reachability-*monotonic*: co-locating fields can only add
+//! reachability, never remove it, so a merge can only ever *mask* a satisfiability error
+//! (false pass), never invent one. A merge is reachability-*preserving* exactly when the
+//! merged members were already mutually reachable. Two graphs with an identical resolvable
+//! -key signature are mutually-interchangeable entry points (each enterable by exactly the
+//! same keys), so co-locating their fields adds nothing — the verdict is preserved.
+//! Different-key or cross-type merges are *not* preserving and are deliberately excluded, as
+//! is merging across spec-link scopes (a graph's `@join__directive(name: "link")` membership,
+//! e.g. connect v0.2 vs v0.3) — that would make the representative link the same feature twice.
+//! The grouping key is therefore (resolvable-key signature, link scope).
+
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use apollo_compiler::Name;
+use apollo_compiler::Node;
+use apollo_compiler::Schema;
+use apollo_compiler::ast;
+use apollo_compiler::ast::Directive;
+use apollo_compiler::ast::Value;
+use apollo_compiler::name;
+use apollo_compiler::schema::Component;
+use apollo_compiler::schema::DirectiveList;
+use apollo_compiler::schema::ExtendedType;
+
+/// Rewrite an expanded supergraph SDL, merging `@join__graph`s that share an identical
+/// resolvable-key signature. Returns the consolidated SDL (re-parseable as a supergraph).
+/// Fails open: if the input can't be parsed, returns it unchanged so satisfiability still
+/// runs on the full expansion.
+pub(super) fn consolidate_for_satisfiability(expanded_sdl: &str) -> String {
+    let mut schema = match Schema::parse(expanded_sdl, "expanded.graphql") {
+        Ok(s) => s,
+        Err(_) => return expanded_sdl.to_string(),
+    };
+
+    // --- pass 1: per-graph resolvable-key signature + spec-link scope ---
+    // A graph's key signature is the set of (type, key) it can be entered by. Its link scope is
+    // the set of `@join__directive(name: "link", args)` entries it belongs to (e.g. connect
+    // v0.2 vs v0.3) — merging across link scopes would make the representative link the same
+    // feature twice. Two graphs merge only if both match: interchangeable entry points within
+    // one link scope.
+    let mut keyed_sig: HashMap<Name, BTreeSet<(String, String)>> = HashMap::new();
+    for (type_name, ty) in &schema.types {
+        for d in type_directives(ty)
+            .iter()
+            .filter(|d| d.name == name!("join__type"))
+        {
+            if let (Some(graph), Some(key)) = (arg_enum(d, "graph"), arg_str(d, "key")) {
+                keyed_sig
+                    .entry(graph.clone())
+                    .or_default()
+                    .insert((type_name.to_string(), key.to_string()));
+            }
+        }
+    }
+
+    let mut link_scope: HashMap<Name, BTreeSet<String>> = HashMap::new();
+    for d in schema.schema_definition.directives.iter() {
+        if d.name != name!("join__directive") || arg_str(d, "name") != Some("link") {
+            continue;
+        }
+        let scope = arg(d, "args").map(|v| v.to_string()).unwrap_or_default();
+        let graphs = arg(d, "graphs").and_then(|v| v.as_list());
+        for g in graphs.into_iter().flatten().filter_map(|v| v.as_enum()) {
+            link_scope
+                .entry(g.clone())
+                .or_default()
+                .insert(scope.clone());
+        }
+    }
+
+    let all_graphs: Vec<Name> = match schema.types.get(&name!("join__Graph")) {
+        Some(ExtendedType::Enum(e)) => e.values.keys().cloned().collect(),
+        _ => return expanded_sdl.to_string(), // not a connector supergraph; nothing to do
+    };
+
+    // --- group by (key signature, link scope); representative = smallest member ---
+    type GroupKey = (BTreeSet<(String, String)>, BTreeSet<String>);
+    let mut groups: HashMap<GroupKey, Vec<Name>> = HashMap::new();
+    for g in &all_graphs {
+        let sig = keyed_sig.get(g).cloned().unwrap_or_default();
+        let scopes = link_scope.get(g).cloned().unwrap_or_default();
+        groups.entry((sig, scopes)).or_default().push(g.clone());
+    }
+    let mut sym2rep: HashMap<Name, Name> = HashMap::new();
+    let mut reps: HashSet<Name> = HashSet::new();
+    for members in groups.values() {
+        let rep = members.iter().min().cloned().unwrap();
+        reps.insert(rep.clone());
+        sym2rep.extend(members.iter().map(|m| (m.clone(), rep.clone())));
+    }
+    if reps.len() == all_graphs.len() {
+        return expanded_sdl.to_string(); // nothing merges
+    }
+
+    // --- pass 2: remap graph references + prune the join__Graph enum ---
+    let join_graph = name!("join__Graph");
+    for (type_name, ty) in schema.types.iter_mut() {
+        match ty {
+            ExtendedType::Scalar(t) => {
+                process_schema_dl(&mut t.make_mut().directives, &sym2rep);
+            }
+            ExtendedType::Object(t) => {
+                let t = t.make_mut();
+                process_schema_dl(&mut t.directives, &sym2rep);
+                for (_, f) in t.fields.iter_mut() {
+                    process_ast_dl(&mut f.make_mut().directives, &sym2rep);
+                }
+            }
+            ExtendedType::Interface(t) => {
+                let t = t.make_mut();
+                process_schema_dl(&mut t.directives, &sym2rep);
+                for (_, f) in t.fields.iter_mut() {
+                    process_ast_dl(&mut f.make_mut().directives, &sym2rep);
+                }
+            }
+            ExtendedType::Union(t) => {
+                process_schema_dl(&mut t.make_mut().directives, &sym2rep);
+            }
+            ExtendedType::InputObject(t) => {
+                let t = t.make_mut();
+                process_schema_dl(&mut t.directives, &sym2rep);
+                for (_, f) in t.fields.iter_mut() {
+                    process_ast_dl(&mut f.make_mut().directives, &sym2rep);
+                }
+            }
+            ExtendedType::Enum(t) => {
+                let t = t.make_mut();
+                process_schema_dl(&mut t.directives, &sym2rep);
+                if *type_name == join_graph {
+                    t.values.retain(|k, _| reps.contains(k));
+                } else {
+                    for (_, v) in t.values.iter_mut() {
+                        process_ast_dl(&mut v.make_mut().directives, &sym2rep);
+                    }
+                }
+            }
+        }
+    }
+
+    // schema-level directives (@join__directive(graphs: […]) re-including @link, etc.)
+    process_schema_dl(
+        &mut schema.schema_definition.make_mut().directives,
+        &sym2rep,
+    );
+
+    schema.serialize().to_string()
+}
+
+fn type_directives(ty: &ExtendedType) -> &DirectiveList {
+    match ty {
+        ExtendedType::Scalar(t) => &t.directives,
+        ExtendedType::Object(t) => &t.directives,
+        ExtendedType::Interface(t) => &t.directives,
+        ExtendedType::Union(t) => &t.directives,
+        ExtendedType::Enum(t) => &t.directives,
+        ExtendedType::InputObject(t) => &t.directives,
+    }
+}
+
+fn arg<'a>(d: &'a Directive, name: &str) -> Option<&'a Node<Value>> {
+    d.arguments
+        .iter()
+        .find(|a| a.name.as_str() == name)
+        .map(|a| &a.value)
+}
+
+fn arg_enum<'a>(d: &'a Directive, name: &str) -> Option<&'a Name> {
+    arg(d, name).and_then(|v| v.as_enum())
+}
+
+fn arg_str<'a>(d: &'a Directive, name: &str) -> Option<&'a str> {
+    arg(d, name).and_then(|v| v.as_str())
+}
+
+/// Return a copy of `d` with any `graph:` enum arg and `graphs: [...]` list arg remapped to
+/// representatives (the latter deduped, since the remap can repeat a representative).
+fn remapped_directive(d: &Directive, sym2rep: &HashMap<Name, Name>) -> Directive {
+    let mut nd = d.clone();
+    for arg in nd.arguments.iter_mut() {
+        match arg.name.as_str() {
+            "graph" => {
+                if let Some(g) = arg.value.as_enum().cloned()
+                    && let Some(rep) = sym2rep.get(&g).filter(|rep| **rep != g)
+                {
+                    arg.make_mut().value = Value::Enum(rep.clone()).into();
+                }
+            }
+            // `graphs: [...]` (e.g. on `@join__directive`): remap each enum, dropping the
+            // duplicates the remap creates so a feature isn't linked twice for one graph.
+            "graphs" => {
+                if let Some(list) = arg.value.as_list() {
+                    let mut seen = HashSet::new();
+                    let remapped: Vec<Node<Value>> = list
+                        .iter()
+                        .map(|v| match v.as_enum() {
+                            Some(g) => Value::Enum(sym2rep.get(g).unwrap_or(g).clone()).into(),
+                            None => v.clone(),
+                        })
+                        .filter(|v: &Node<Value>| seen.insert(v.to_string()))
+                        .collect();
+                    arg.make_mut().value = Value::List(remapped).into();
+                }
+            }
+            _ => {}
+        }
+    }
+    nd
+}
+
+/// Remap and fold byte-identical duplicates in a schema-level (`Component`) directive list.
+fn process_schema_dl(dl: &mut DirectiveList, sym2rep: &HashMap<Name, Name>) {
+    let mut out = DirectiveList::new();
+    let mut seen = HashSet::new();
+    for comp in dl.iter() {
+        let nd = remapped_directive(comp, sym2rep);
+        if seen.insert(nd.to_string()) {
+            out.push(Component::new(nd));
+        }
+    }
+    *dl = out;
+}
+
+/// Remap and fold byte-identical duplicates in an AST (`Node`) directive list.
+fn process_ast_dl(dl: &mut ast::DirectiveList, sym2rep: &HashMap<Name, Name>) {
+    let mut out = ast::DirectiveList::new();
+    let mut seen = HashSet::new();
+    for d in dl.iter() {
+        let nd = remapped_directive(d, sym2rep);
+        if seen.insert(nd.to_string()) {
+            out.push(Node::new(nd));
+        }
+    }
+    *dl = out;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PREAMBLE: &str = r#"
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) {
+  query: Query
+}
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+directive @join__field(graph: join__Graph) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+scalar join__FieldSet
+scalar link__Import
+enum link__Purpose { SECURITY EXECUTION }
+"#;
+
+    fn graph_count(sdl: &str) -> usize {
+        // enum values carry a quoted name (`@join__graph(name: "a"`); the directive
+        // *definition* line (`name: String!`) is excluded.
+        sdl.matches("@join__graph(name: \"").count()
+    }
+
+    fn reparses(sdl: &str) -> bool {
+        Schema::parse(sdl, "out.graphql").is_ok()
+    }
+
+    /// Same resolvable-key signature ⇒ interchangeable entry points ⇒ merge to one graph.
+    #[test]
+    fn merges_same_key_signature() {
+        let sdl = format!(
+            "{PREAMBLE}
+enum join__Graph {{
+  A @join__graph(name: \"a\", url: \"\")
+  B @join__graph(name: \"b\", url: \"\")
+}}
+type Query @join__type(graph: A) {{ x: T @join__field(graph: A) }}
+type T @join__type(graph: A, key: \"id\") @join__type(graph: B, key: \"id\") {{
+  id: ID! @join__field(graph: A) @join__field(graph: B)
+}}
+"
+        );
+        let out = consolidate_for_satisfiability(&sdl);
+        assert!(reparses(&out), "consolidated output must parse:\n{out}");
+        assert_eq!(graph_count(&out), 1, "same key sig should merge:\n{out}");
+        assert!(
+            !out.contains("graph: B"),
+            "B should be remapped away:\n{out}"
+        );
+    }
+
+    /// Different keys ⇒ not mutually reachable ⇒ must stay separate (else errors get masked).
+    #[test]
+    fn keeps_different_key_signatures_separate() {
+        let sdl = format!(
+            "{PREAMBLE}
+enum join__Graph {{
+  A @join__graph(name: \"a\", url: \"\")
+  B @join__graph(name: \"b\", url: \"\")
+}}
+type Query @join__type(graph: A) {{ x: T @join__field(graph: A) }}
+type T @join__type(graph: A, key: \"id\") @join__type(graph: B, key: \"code\") {{
+  id: ID! @join__field(graph: A)
+  code: ID! @join__field(graph: B)
+}}
+"
+        );
+        let out = consolidate_for_satisfiability(&sdl);
+        assert!(reparses(&out), "consolidated output must parse:\n{out}");
+        assert_eq!(
+            graph_count(&out),
+            2,
+            "different key sigs must stay separate:\n{out}"
+        );
+    }
+
+    /// A union's `= A | B` member clause must survive (AST serialization handles placement;
+    /// regression from block-bots-graph@main, which the text rewriter broke).
+    #[test]
+    fn preserves_union_with_directives() {
+        let sdl = format!(
+            "{PREAMBLE}
+enum join__Graph {{
+  A @join__graph(name: \"a\", url: \"\")
+  B @join__graph(name: \"b\", url: \"\")
+}}
+type Query @join__type(graph: A) {{ x: U @join__field(graph: A) }}
+type X @join__type(graph: A) {{ id: ID! @join__field(graph: A) }}
+type Y @join__type(graph: B) {{ id: ID! @join__field(graph: B) }}
+union U @join__type(graph: A) @join__type(graph: B) @join__unionMember(graph: A, member: \"X\") @join__unionMember(graph: B, member: \"Y\") = X | Y
+"
+        );
+        let out = consolidate_for_satisfiability(&sdl);
+        assert!(
+            reparses(&out),
+            "consolidated output must parse (union member clause intact):\n{out}"
+        );
+        let union_line = out
+            .lines()
+            .find(|l| l.trim_start().starts_with("union U"))
+            .unwrap();
+        assert!(
+            union_line.contains("= X | Y"),
+            "union members must be preserved:\n{union_line}"
+        );
+    }
+}

--- a/apollo-federation/src/composition/consolidate.rs
+++ b/apollo-federation/src/composition/consolidate.rs
@@ -73,27 +73,28 @@ pub(super) fn consolidate_for_satisfiability(expanded_sdl: &str) -> String {
         Err(_) => return expanded_sdl.to_string(),
     };
 
-    // --- pass 1: per-graph resolvable-key signature + spec-link scope ---
-    // A graph's key signature is the set of (type, key) it can be entered by. Its link scope is
-    // the set of `@join__directive(name: "link", args)` entries it belongs to (e.g. connect
-    // v0.2 vs v0.3) — merging across link scopes would make the representative link the same
-    // feature twice. Two graphs merge only if both match: interchangeable entry points within
-    // one link scope.
-    let mut keyed_sig: HashMap<Name, BTreeSet<(String, String)>> = HashMap::new();
-    for (type_name, ty) in &schema.types {
+    let all_graphs: Vec<Name> = match schema.types.get(&name!("join__Graph")) {
+        Some(ExtendedType::Enum(e)) => e.values.keys().cloned().collect(),
+        _ => return expanded_sdl.to_string(), // not a connector supergraph; nothing to do
+    };
+
+    // Graphs with any `@join__type(…, key:)` entry point are keyed and never merge (see the
+    // module doc's Soundness section for why keyless-only merging is what makes this safe).
+    let mut keyed: HashSet<Name> = HashSet::new();
+    for ty in schema.types.values() {
         for d in type_directives(ty)
             .iter()
             .filter(|d| d.name == name!("join__type"))
         {
-            if let (Some(graph), Some(key)) = (arg_enum(d, "graph"), arg_str(d, "key")) {
-                keyed_sig
-                    .entry(graph.clone())
-                    .or_default()
-                    .insert((type_name.to_string(), key.to_string()));
+            if let (Some(graph), Some(_key)) = (arg_enum(d, "graph"), arg_str(d, "key")) {
+                keyed.insert(graph.clone());
             }
         }
     }
 
+    // A graph's spec-link scope is the set of `@join__directive(name: "link", args)` entries
+    // it belongs to (e.g. connect v0.2 vs v0.3). Merging across scopes would make the
+    // representative link the same feature twice, so the scope is the grouping key.
     let mut link_scope: HashMap<Name, BTreeSet<String>> = HashMap::new();
     for d in schema.schema_definition.directives.iter() {
         if d.name != name!("join__directive") || arg_str(d, "name") != Some("link") {
@@ -109,23 +110,12 @@ pub(super) fn consolidate_for_satisfiability(expanded_sdl: &str) -> String {
         }
     }
 
-    let all_graphs: Vec<Name> = match schema.types.get(&name!("join__Graph")) {
-        Some(ExtendedType::Enum(e)) => e.values.keys().cloned().collect(),
-        _ => return expanded_sdl.to_string(), // not a connector supergraph; nothing to do
-    };
-
-    // --- field-compatibility data: per (type, field), each graph's `@join__field` application ---
-    // A participation-merge folds two graphs' applications for the SAME (type, field) into the
-    // representative. That is only sound when those applications are byte-identical (they fold
-    // to one). If two keyless graphs declare the same (type, field) with *differing*
-    // `@join__field` metadata — e.g. divergent `type:` overrides on a `@shareable` field —
-    // folding them would leave two conflicting `@join__field(graph: REP)` on one field, which
-    // makes `extract_subgraphs_from_supergraph` define that field twice and fail (a spurious
-    // composition error). Field-disjoint graphs (all connector synthetic subgraphs) never hit
-    // this. Record each graph's application (its args minus `graph:`) so we can taint colliders.
+    // Each graph's `@join__field` application (args minus `graph:`) per (type, field), to
+    // detect merge candidates declaring the same field with differing metadata (see the module
+    // doc's final paragraph).
     let mut field_apps: HashMap<(Name, Name), Vec<(Name, String)>> = HashMap::new();
-    {
-        let mut collect = |type_name: &Name, field_name: &Name, dl: &ast::DirectiveList| {
+    for (type_name, ty) in &schema.types {
+        for (field_name, dl) in field_directive_lists(ty) {
             for d in dl.iter().filter(|d| d.name == name!("join__field")) {
                 if let Some(graph) = arg_enum(d, "graph") {
                     field_apps
@@ -134,47 +124,19 @@ pub(super) fn consolidate_for_satisfiability(expanded_sdl: &str) -> String {
                         .push((graph.clone(), join_field_app(d)));
                 }
             }
-        };
-        for (type_name, ty) in &schema.types {
-            match ty {
-                ExtendedType::Object(t) => {
-                    for (fname, f) in &t.fields {
-                        collect(type_name, fname, &f.directives);
-                    }
-                }
-                ExtendedType::Interface(t) => {
-                    for (fname, f) in &t.fields {
-                        collect(type_name, fname, &f.directives);
-                    }
-                }
-                ExtendedType::InputObject(t) => {
-                    for (fname, f) in &t.fields {
-                        collect(type_name, fname, &f.directives);
-                    }
-                }
-                _ => {}
-            }
         }
     }
 
-    // --- group root-field (keyless) graphs by link scope; representative = smallest member ---
-    // Only keyless graphs are eligible to merge. A keyless graph is reachable only at root
-    // operation fields (never via an entity key-jump), so co-locating two keyless graphs adds
-    // no reachability and the merge is reachability-preserving by construction — which is what
-    // sidesteps every `@key`-related hazard (`@key(resolvable: false)`, `@external` key fields,
-    // `@override`, differing key-field types), since all of those attach to keyed types we
-    // never touch. Keyless graphs still may not merge across spec-link scopes, or the
-    // representative would link the same feature twice; so the grouping key is the link scope.
-    // Keyed graphs are omitted here and therefore each remain their own representative.
+    // Merge candidates: the keyless graphs, each tagged with its link scope.
     let mut graph_scope: HashMap<Name, BTreeSet<String>> = HashMap::new();
     for g in &all_graphs {
-        if keyed_sig.get(g).is_none_or(|sig| sig.is_empty()) {
+        if !keyed.contains(g) {
             graph_scope.insert(g.clone(), link_scope.get(g).cloned().unwrap_or_default());
         }
     }
 
-    // Taint keyless graphs that would collide: within one scope group, if two members declare
-    // the same (type, field) with different applications, every member declaring that field is
+    // Taint candidates that would collide: within one scope group, if two members declare the
+    // same (type, field) with different applications, every member declaring that field is
     // excluded from merging and keeps its own representative.
     let mut tainted: HashSet<Name> = HashSet::new();
     for apps in field_apps.values() {
@@ -185,30 +147,25 @@ pub(super) fn consolidate_for_satisfiability(expanded_sdl: &str) -> String {
             }
         }
         for members in by_scope.values() {
-            let distinct: HashSet<&&String> = members.iter().map(|(_, a)| a).collect();
-            if distinct.len() > 1 {
-                for (g, _) in members {
-                    tainted.insert((*g).clone());
-                }
+            if members.iter().any(|(_, app)| *app != members[0].1) {
+                tainted.extend(members.iter().map(|(g, _)| (*g).clone()));
             }
         }
     }
 
-    let mut groups: HashMap<BTreeSet<String>, Vec<Name>> = HashMap::new();
+    // Group the untainted candidates by scope; representative = smallest member.
+    let mut groups: HashMap<&BTreeSet<String>, Vec<&Name>> = HashMap::new();
     for (g, scope) in &graph_scope {
-        if tainted.contains(g) {
-            continue; // field-incompatible: keep its own representative
+        if !tainted.contains(g) {
+            groups.entry(scope).or_default().push(g);
         }
-        groups.entry(scope.clone()).or_default().push(g.clone());
     }
     let mut sym2rep: HashMap<Name, Name> = HashMap::new();
-    let mut reps: HashSet<Name> = all_graphs.iter().cloned().collect();
     for members in groups.values() {
-        let rep = members.iter().min().cloned().unwrap();
+        let rep = *members.iter().min().unwrap();
         for m in members {
             if *m != rep {
-                sym2rep.insert(m.clone(), rep.clone());
-                reps.remove(m);
+                sym2rep.insert((*m).clone(), rep.clone());
             }
         }
     }
@@ -216,47 +173,23 @@ pub(super) fn consolidate_for_satisfiability(expanded_sdl: &str) -> String {
         return expanded_sdl.to_string(); // nothing merges
     }
 
-    // --- pass 2: remap graph references + prune the join__Graph enum ---
+    // Remap every graph reference to its representative, folding applications that become
+    // identical, and prune the merged-away values from the join__Graph enum.
     let join_graph = name!("join__Graph");
     for (type_name, ty) in schema.types.iter_mut() {
-        match ty {
-            ExtendedType::Scalar(t) => {
-                process_schema_dl(&mut t.make_mut().directives, &sym2rep);
-            }
-            ExtendedType::Object(t) => {
-                let t = t.make_mut();
-                process_schema_dl(&mut t.directives, &sym2rep);
-                for (_, f) in t.fields.iter_mut() {
-                    process_ast_dl(&mut f.make_mut().directives, &sym2rep);
+        process_schema_dl(type_directives_mut(ty), &sym2rep);
+        if let ExtendedType::Enum(t) = ty {
+            let t = t.make_mut();
+            if *type_name == join_graph {
+                t.values.retain(|k, _| !sym2rep.contains_key(k));
+            } else {
+                for v in t.values.values_mut() {
+                    process_ast_dl(&mut v.make_mut().directives, &sym2rep);
                 }
             }
-            ExtendedType::Interface(t) => {
-                let t = t.make_mut();
-                process_schema_dl(&mut t.directives, &sym2rep);
-                for (_, f) in t.fields.iter_mut() {
-                    process_ast_dl(&mut f.make_mut().directives, &sym2rep);
-                }
-            }
-            ExtendedType::Union(t) => {
-                process_schema_dl(&mut t.make_mut().directives, &sym2rep);
-            }
-            ExtendedType::InputObject(t) => {
-                let t = t.make_mut();
-                process_schema_dl(&mut t.directives, &sym2rep);
-                for (_, f) in t.fields.iter_mut() {
-                    process_ast_dl(&mut f.make_mut().directives, &sym2rep);
-                }
-            }
-            ExtendedType::Enum(t) => {
-                let t = t.make_mut();
-                process_schema_dl(&mut t.directives, &sym2rep);
-                if *type_name == join_graph {
-                    t.values.retain(|k, _| reps.contains(k));
-                } else {
-                    for (_, v) in t.values.iter_mut() {
-                        process_ast_dl(&mut v.make_mut().directives, &sym2rep);
-                    }
-                }
+        } else {
+            for dl in field_directive_lists_mut(ty) {
+                process_ast_dl(dl, &sym2rep);
             }
         }
     }
@@ -278,6 +211,57 @@ fn type_directives(ty: &ExtendedType) -> &DirectiveList {
         ExtendedType::Union(t) => &t.directives,
         ExtendedType::Enum(t) => &t.directives,
         ExtendedType::InputObject(t) => &t.directives,
+    }
+}
+
+fn type_directives_mut(ty: &mut ExtendedType) -> &mut DirectiveList {
+    match ty {
+        ExtendedType::Scalar(t) => &mut t.make_mut().directives,
+        ExtendedType::Object(t) => &mut t.make_mut().directives,
+        ExtendedType::Interface(t) => &mut t.make_mut().directives,
+        ExtendedType::Union(t) => &mut t.make_mut().directives,
+        ExtendedType::Enum(t) => &mut t.make_mut().directives,
+        ExtendedType::InputObject(t) => &mut t.make_mut().directives,
+    }
+}
+
+/// The (field name, directives) pairs of a type's fields, uniform across the three
+/// field-bearing type kinds (empty for the rest).
+fn field_directive_lists(
+    ty: &ExtendedType,
+) -> Box<dyn Iterator<Item = (&Name, &ast::DirectiveList)> + '_> {
+    match ty {
+        ExtendedType::Object(t) => Box::new(t.fields.iter().map(|(n, f)| (n, &f.directives))),
+        ExtendedType::Interface(t) => Box::new(t.fields.iter().map(|(n, f)| (n, &f.directives))),
+        ExtendedType::InputObject(t) => Box::new(t.fields.iter().map(|(n, f)| (n, &f.directives))),
+        _ => Box::new(std::iter::empty()),
+    }
+}
+
+/// Mutable counterpart of [`field_directive_lists`].
+fn field_directive_lists_mut(
+    ty: &mut ExtendedType,
+) -> Box<dyn Iterator<Item = &mut ast::DirectiveList> + '_> {
+    match ty {
+        ExtendedType::Object(t) => Box::new(
+            t.make_mut()
+                .fields
+                .values_mut()
+                .map(|f| &mut f.make_mut().directives),
+        ),
+        ExtendedType::Interface(t) => Box::new(
+            t.make_mut()
+                .fields
+                .values_mut()
+                .map(|f| &mut f.make_mut().directives),
+        ),
+        ExtendedType::InputObject(t) => Box::new(
+            t.make_mut()
+                .fields
+                .values_mut()
+                .map(|f| &mut f.make_mut().directives),
+        ),
+        _ => Box::new(std::iter::empty()),
     }
 }
 
@@ -318,10 +302,9 @@ fn remapped_directive(d: &Directive, sym2rep: &HashMap<Name, Name>) -> Directive
     for arg in nd.arguments.iter_mut() {
         match arg.name.as_str() {
             "graph" => {
-                if let Some(g) = arg.value.as_enum().cloned()
-                    && let Some(rep) = sym2rep.get(&g).filter(|rep| **rep != g)
-                {
-                    arg.make_mut().value = Value::Enum(rep.clone()).into();
+                let rep = arg.value.as_enum().and_then(|g| sym2rep.get(g)).cloned();
+                if let Some(rep) = rep {
+                    arg.make_mut().value = Value::Enum(rep).into();
                 }
             }
             // `graphs: [...]` (e.g. on `@join__directive`): remap each enum, dropping the
@@ -346,30 +329,23 @@ fn remapped_directive(d: &Directive, sym2rep: &HashMap<Name, Name>) -> Directive
     nd
 }
 
-/// Remap and fold byte-identical duplicates in a schema-level (`Component`) directive list.
-fn process_schema_dl(dl: &mut DirectiveList, sym2rep: &HashMap<Name, Name>) {
-    let mut out = DirectiveList::new();
+/// Fold directives that became byte-identical after remapping (e.g. two
+/// `@join__type(graph: REP)` on one type → one).
+fn dedup(dirs: Vec<Directive>) -> impl Iterator<Item = Directive> {
     let mut seen = HashSet::new();
-    for comp in dl.iter() {
-        let nd = remapped_directive(comp, sym2rep);
-        if seen.insert(nd.to_string()) {
-            out.push(Component::new(nd));
-        }
-    }
-    *dl = out;
+    dirs.into_iter().filter(move |d| seen.insert(d.to_string()))
 }
 
-/// Remap and fold byte-identical duplicates in an AST (`Node`) directive list.
+/// Remap and fold a schema-level (`Component`) directive list.
+fn process_schema_dl(dl: &mut DirectiveList, sym2rep: &HashMap<Name, Name>) {
+    let remapped = dl.iter().map(|d| remapped_directive(d, sym2rep)).collect();
+    dl.0 = dedup(remapped).map(Component::new).collect();
+}
+
+/// Remap and fold an AST (`Node`) directive list.
 fn process_ast_dl(dl: &mut ast::DirectiveList, sym2rep: &HashMap<Name, Name>) {
-    let mut out = ast::DirectiveList::new();
-    let mut seen = HashSet::new();
-    for d in dl.iter() {
-        let nd = remapped_directive(d, sym2rep);
-        if seen.insert(nd.to_string()) {
-            out.push(Node::new(nd));
-        }
-    }
-    *dl = out;
+    let remapped = dl.iter().map(|d| remapped_directive(d, sym2rep)).collect();
+    dl.0 = dedup(remapped).map(Node::new).collect();
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/composition/consolidate.rs
+++ b/apollo-federation/src/composition/consolidate.rs
@@ -6,11 +6,11 @@
 //! `validate_satisfiability` over that expansion is the dominant memory/time cost (it
 //! builds a federated query graph with a node per type x subgraph, scaling super-linearly).
 //!
-//! This transform merges `@join__graph`s that share an **identical resolvable-key
-//! signature** (the set of `@join__type(T, key: K)` entries they declare) into one
-//! representative graph, purely for the satisfiability check. The expanded supergraph the
-//! router executes against is **not** affected — this rewrites only the schema handed to
-//! `validate_satisfiability`.
+//! This transform merges the **root-field (keyless) synthetic subgraphs** — those declaring
+//! no resolvable `@join__type(T, key: K)` entry point — into one representative per spec-link
+//! scope, purely for the satisfiability check. Keyed subgraphs are left untouched. The
+//! expanded supergraph the router executes against is **not** affected — this rewrites only
+//! the schema handed to `validate_satisfiability`.
 //!
 //! It works on the parsed AST (apollo-compiler `Schema`) and lets the compiler serialize the
 //! result, so it never hand-formats SDL. The only collapsing it does is a structural
@@ -22,15 +22,22 @@
 //! ## Soundness
 //!
 //! Merging join graphs is reachability-*monotonic*: co-locating fields can only add
-//! reachability, never remove it, so a merge can only ever *mask* a satisfiability error
-//! (false pass), never invent one. A merge is reachability-*preserving* exactly when the
-//! merged members were already mutually reachable. Two graphs with an identical resolvable
-//! -key signature are mutually-interchangeable entry points (each enterable by exactly the
-//! same keys), so co-locating their fields adds nothing — the verdict is preserved.
-//! Different-key or cross-type merges are *not* preserving and are deliberately excluded, as
-//! is merging across spec-link scopes (a graph's `@join__directive(name: "link")` membership,
-//! e.g. connect v0.2 vs v0.3) — that would make the representative link the same feature twice.
-//! The grouping key is therefore (resolvable-key signature, link scope).
+//! reachability, never remove it, so a bad merge can only ever *mask* a satisfiability error
+//! (false pass), never invent one. The only merges that are safe are therefore those that add
+//! no reachability at all.
+//!
+//! We restrict merging to **root-field (keyless) synthetic subgraphs**: graphs that declare no
+//! resolvable `@join__type(T, key: K)` entry point. A keyless graph is reachable only at root
+//! operation fields, never via an entity key-jump, so co-locating two keyless graphs' fields
+//! bypasses no key edge and adds no reachability — the merge is reachability-*preserving* by
+//! construction. Keyed graphs are left untouched (each stays its own representative). This is
+//! what keeps the transform sound without having to reason about `@key` subtleties: every
+//! hazard that could make a keyed merge unsound — `@key(resolvable: false)`, `@external` key
+//! fields, `@override`, or a key whose field types differ across subgraphs — attaches to a
+//! *keyed* type, which we never merge. Keyless graphs are still not merged across spec-link
+//! scopes (a graph's `@join__directive(name: "link")` membership, e.g. connect v0.2 vs v0.3),
+//! since the representative would otherwise link the same feature twice. The grouping key is
+//! therefore the link scope alone.
 
 use std::collections::BTreeSet;
 use std::collections::HashMap;
@@ -47,10 +54,10 @@ use apollo_compiler::schema::Component;
 use apollo_compiler::schema::DirectiveList;
 use apollo_compiler::schema::ExtendedType;
 
-/// Rewrite an expanded supergraph SDL, merging `@join__graph`s that share an identical
-/// resolvable-key signature. Returns the consolidated SDL (re-parseable as a supergraph).
-/// Fails open: if the input can't be parsed, returns it unchanged so satisfiability still
-/// runs on the full expansion.
+/// Rewrite an expanded supergraph SDL, merging the root-field (keyless) `@join__graph`s that
+/// share a spec-link scope into one representative each; keyed graphs are left untouched.
+/// Returns the consolidated SDL (re-parseable as a supergraph). Fails open: if the input can't
+/// be parsed, returns it unchanged so satisfiability still runs on the full expansion.
 pub(super) fn consolidate_for_satisfiability(expanded_sdl: &str) -> String {
     let mut schema = match Schema::parse(expanded_sdl, "expanded.graphql") {
         Ok(s) => s,
@@ -98,22 +105,36 @@ pub(super) fn consolidate_for_satisfiability(expanded_sdl: &str) -> String {
         _ => return expanded_sdl.to_string(), // not a connector supergraph; nothing to do
     };
 
-    // --- group by (key signature, link scope); representative = smallest member ---
-    type GroupKey = (BTreeSet<(String, String)>, BTreeSet<String>);
-    let mut groups: HashMap<GroupKey, Vec<Name>> = HashMap::new();
+    // --- group root-field (keyless) graphs by link scope; representative = smallest member ---
+    // Only keyless graphs are eligible to merge. A keyless graph is reachable only at root
+    // operation fields (never via an entity key-jump), so co-locating two keyless graphs adds
+    // no reachability and the merge is reachability-preserving by construction — which is what
+    // sidesteps every `@key`-related hazard (`@key(resolvable: false)`, `@external` key fields,
+    // `@override`, differing key-field types), since all of those attach to keyed types we
+    // never touch. Keyless graphs still may not merge across spec-link scopes, or the
+    // representative would link the same feature twice; so the grouping key is the link scope
+    // alone. Keyed graphs are omitted here and therefore each remain their own representative.
+    let mut groups: HashMap<BTreeSet<String>, Vec<Name>> = HashMap::new();
     for g in &all_graphs {
-        let sig = keyed_sig.get(g).cloned().unwrap_or_default();
+        let keyless = keyed_sig.get(g).map_or(true, |sig| sig.is_empty());
+        if !keyless {
+            continue; // keyed graph: never merged
+        }
         let scopes = link_scope.get(g).cloned().unwrap_or_default();
-        groups.entry((sig, scopes)).or_default().push(g.clone());
+        groups.entry(scopes).or_default().push(g.clone());
     }
     let mut sym2rep: HashMap<Name, Name> = HashMap::new();
-    let mut reps: HashSet<Name> = HashSet::new();
+    let mut reps: HashSet<Name> = all_graphs.iter().cloned().collect();
     for members in groups.values() {
         let rep = members.iter().min().cloned().unwrap();
-        reps.insert(rep.clone());
-        sym2rep.extend(members.iter().map(|m| (m.clone(), rep.clone())));
+        for m in members {
+            if *m != rep {
+                sym2rep.insert(m.clone(), rep.clone());
+                reps.remove(m);
+            }
+        }
     }
-    if reps.len() == all_graphs.len() {
+    if sym2rep.is_empty() {
         return expanded_sdl.to_string(); // nothing merges
     }
 
@@ -267,7 +288,7 @@ schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://spec
   query: Query
 }
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
-directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+directive @join__type(graph: join__Graph!, key: join__FieldSet, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 directive @join__field(graph: join__Graph) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
@@ -286,9 +307,40 @@ enum link__Purpose { SECURITY EXECUTION }
         Schema::parse(sdl, "out.graphql").is_ok()
     }
 
-    /// Same resolvable-key signature ⇒ interchangeable entry points ⇒ merge to one graph.
+    /// Keyless (root-field) graphs are reachable only at root ⇒ merging them adds no
+    /// reachability ⇒ merge to one graph.
     #[test]
-    fn merges_same_key_signature() {
+    fn merges_keyless_root_field_graphs() {
+        let sdl = format!(
+            "{PREAMBLE}
+enum join__Graph {{
+  A @join__graph(name: \"a\", url: \"\")
+  B @join__graph(name: \"b\", url: \"\")
+}}
+type Query @join__type(graph: A) @join__type(graph: B) {{
+  a: Int @join__field(graph: A)
+  b: Int @join__field(graph: B)
+}}
+"
+        );
+        let out = consolidate_for_satisfiability(&sdl);
+        assert!(reparses(&out), "consolidated output must parse:\n{out}");
+        assert_eq!(
+            graph_count(&out),
+            1,
+            "keyless root-field graphs should merge:\n{out}"
+        );
+        assert!(
+            !out.contains("graph: B"),
+            "B should be remapped away:\n{out}"
+        );
+    }
+
+    /// Keyed graphs are never merged — even with an identical key signature — because that is
+    /// the class of merge whose soundness depends on `@key` subtleties reviewers flagged
+    /// (@external keys, @override, differing key-field types). Staying separate is always safe.
+    #[test]
+    fn keeps_keyed_graphs_separate() {
         let sdl = format!(
             "{PREAMBLE}
 enum join__Graph {{
@@ -303,14 +355,15 @@ type T @join__type(graph: A, key: \"id\") @join__type(graph: B, key: \"id\") {{
         );
         let out = consolidate_for_satisfiability(&sdl);
         assert!(reparses(&out), "consolidated output must parse:\n{out}");
-        assert_eq!(graph_count(&out), 1, "same key sig should merge:\n{out}");
-        assert!(
-            !out.contains("graph: B"),
-            "B should be remapped away:\n{out}"
+        assert_eq!(
+            graph_count(&out),
+            2,
+            "keyed graphs must stay separate even with identical key sigs:\n{out}"
         );
     }
 
-    /// Different keys ⇒ not mutually reachable ⇒ must stay separate (else errors get masked).
+    /// Different keys are keyed graphs too ⇒ stay separate (regression guard alongside the
+    /// identical-key case).
     #[test]
     fn keeps_different_key_signatures_separate() {
         let sdl = format!(
@@ -332,6 +385,33 @@ type T @join__type(graph: A, key: \"id\") @join__type(graph: B, key: \"code\") {
             graph_count(&out),
             2,
             "different key sigs must stay separate:\n{out}"
+        );
+    }
+
+    /// A `@key(resolvable: false)` graph is *not* a real entry point, so it must never be
+    /// swept into a merge (the exact `@key(resolvable: false)` hazard reviewers raised). Since
+    /// it carries a key it is treated as keyed and left as its own representative — it stays
+    /// separate from a genuinely-resolvable graph declaring the same key.
+    #[test]
+    fn resolvable_false_key_not_merged() {
+        let sdl = format!(
+            "{PREAMBLE}
+enum join__Graph {{
+  A @join__graph(name: \"a\", url: \"\")
+  B @join__graph(name: \"b\", url: \"\")
+}}
+type Query @join__type(graph: A) {{ x: T @join__field(graph: A) }}
+type T @join__type(graph: A, key: \"id\") @join__type(graph: B, key: \"id\", resolvable: false) {{
+  id: ID! @join__field(graph: A) @join__field(graph: B)
+}}
+"
+        );
+        let out = consolidate_for_satisfiability(&sdl);
+        assert!(reparses(&out), "consolidated output must parse:\n{out}");
+        assert_eq!(
+            graph_count(&out),
+            2,
+            "resolvable:false key graph must not merge into a resolvable one:\n{out}"
         );
     }
 

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -1,3 +1,4 @@
+mod consolidate;
 mod satisfiability;
 
 use std::sync::Arc;
@@ -5,6 +6,7 @@ use std::vec;
 
 use tracing::instrument;
 
+use crate::composition::consolidate::consolidate_for_satisfiability;
 pub use crate::composition::satisfiability::validate_satisfiability;
 use crate::connectors::Connector;
 use crate::connectors::expand::Connectors;
@@ -215,7 +217,13 @@ pub fn validate_satisfiability_with_connectors(
             },
             ..
         } => {
-            let expanded_supergraph = match Supergraph::parse(&raw_sdl) {
+            // Satisfiability-only optimization: merge synthetic @join__graphs that share an
+            // identical resolvable-key signature, shrinking the federated query graph the
+            // verdict is computed over. The router's runtime expansion (`raw_sdl`) is
+            // untouched; only this validation input is consolidated. See
+            // `composition::consolidate` for the soundness argument.
+            let consolidated_sdl = consolidate_for_satisfiability(&raw_sdl);
+            let expanded_supergraph = match Supergraph::parse(&consolidated_sdl) {
                 Ok(s) => s,
                 Err(e) => {
                     return Err(CompositionFailure {


### PR DESCRIPTION
Composing a supergraph that uses Apollo Connectors can take an enormous amount of memory and time, especially when many (1000+) `@connect` directives are used. The cost is concentrated in one place, the **satisfiability** check, which verifies that every field in the API can actually be resolved.

To run that check, composition/expansion turns every `@connect` into its own tiny internal "subgraph." An example internal graph with 6 connector subgraphs ballooned into ~1,300 individual synthetic subgraphs, and validating that many is what burns the resources: on one real graph, ~14 GB and ~4 minutes.

But most of those ~1,300 synthetic subgraphs are interchangeable for this check, as they describe the same way of reaching the same data. This change merges the interchangeable ones together only for the satisfiability check, so it runs over a much smaller graph. On that same graph the check drops to ~0.3 GB and under a second, with an identical pass/fail result.

This only affects the internal check. The schema the router actually runs on is untouched, so query planning and connector execution behave exactly as before.

Why it's safe: merging these internal subgraphs can only ever make the check more permissive, so the only risk would be hiding a real error. We merge only subgraphs that were already equivalent (same way in, same data), which can't hide anything, and a deliberately-broken test case confirms the check still fails when it should.