### PR TITLE
fix(ci): reduce Windows CARGO_BUILD_JOBS to 2 to prevent OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ executors:
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows
-      CARGO_BUILD_JOBS: 4
+      CARGO_BUILD_JOBS: 2
   windows_test: &windows_test_executor
     machine:
       image: "windows-server-2019-vs2019:2024.02.21"
@@ -94,7 +94,7 @@ executors:
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows
-      CARGO_BUILD_JOBS: 4
+      CARGO_BUILD_JOBS: 2
 
 # We don't use {{ arch }} because on windows it is unstable https://discuss.circleci.com/t/value-of-arch-unstable-on-windows/40079
 parameters:


### PR DESCRIPTION
## Summary

- Commit `02da7dbec` downsized the `windows_build` and `windows_test` executors from `windows.2xlarge` (8 vCPUs, 32 GB RAM) to `windows.medium` (4 vCPUs, 15 GB RAM) but left `CARGO_BUILD_JOBS: 4` in place.
- Each `rustc` codegen process consumes ~3–4 GB of RAM. With 4 parallel jobs on a 15 GB runner, peak memory usage exceeds available RAM, causing OOM kills.
- OOM kills surface as spurious `E0463` ("can't find crate") errors rather than clear out-of-memory messages, making the root cause hard to diagnose.
- This PR reduces `CARGO_BUILD_JOBS` from `4` to `2` on both Windows executors only. Linux and macOS executors are unchanged.

Fixes ROUTER-1928.

## Test plan

- [ ] Confirm Windows CI jobs complete without OOM-induced `E0463` errors after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ROUTER-1928 -->