### PR TITLE
perf(query-graph): cache sorted out-edges during followup precompute

### DIFF
--- a/.changesets/perf_query_graph_cache_out_edges.md
+++ b/.changesets/perf_query_graph_cache_out_edges.md
@@ -1,0 +1,7 @@
+### Cache sorted out-edges during followup precompute ([PR #9690](https://github.com/apollographql/router/pull/9690))
+
+During federated query graph construction, `precompute_non_trivial_followup_edges()` called `out_edges()` once per edge, and each of those calls filtered and sorted a fresh list of the tail node's outgoing edges. On connector-heavy supergraphs, where many synthetic subgraphs share entity types and produce a dense cross-subgraph key graph, the same lists were rebuilt over and over.
+
+The filtered and sorted list is now computed once per tail node and reused. The edge set and its order are unchanged, so query plans are unaffected. On a connector-expanded supergraph with 32 connectors, total allocation during startup drops from 5.85 GB to 0.85 GB and startup time drops from 40.8s to 31.7s.
+
+By [@benjamn](https://github.com/benjamn) in <https://github.com/apollographql/router/pull/9690>

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -290,13 +290,31 @@ impl BaseQueryGraphBuilder {
 
     /// Precompute which followup edges for a given edge are non-trivial.
     fn precompute_non_trivial_followup_edges(&mut self) -> Result<(), FederationError> {
+        let mut out_edges_cache = IndexMap::default();
         for edge in self.query_graph.graph.edge_indices() {
-            let edge_weight = self.query_graph.edge_weight(edge)?;
+            let edge_weight = self.query_graph.edge_weight(edge)?.clone();
             let (_, tail) = self.query_graph.edge_endpoints(edge)?;
-            let out_edges = self.query_graph.out_edges(tail);
+            let out_edges = out_edges_cache.entry(tail).or_insert_with(|| {
+                let mut out_edges: Vec<_> = self
+                    .query_graph
+                    .graph
+                    .edges_directed(tail, Direction::Outgoing)
+                    .filter(|edge_ref| {
+                        !(edge_ref.source() == edge_ref.target()
+                            && matches!(
+                                edge_ref.weight().transition,
+                                QueryGraphEdgeTransition::KeyResolution
+                                    | QueryGraphEdgeTransition::RootTypeResolution { .. }
+                            ))
+                    })
+                    .map(|edge_ref| edge_ref.id())
+                    .collect();
+                out_edges.sort_by_key(|edge_id| -> EdgeIndex { *edge_id });
+                out_edges
+            });
             let mut non_trivial_followups = Vec::with_capacity(out_edges.len());
-            for followup_edge_ref in out_edges {
-                let followup_edge_weight = followup_edge_ref.weight();
+            for followup_edge in out_edges {
+                let followup_edge_weight = self.query_graph.edge_weight(*followup_edge)?;
                 match edge_weight.transition {
                     QueryGraphEdgeTransition::KeyResolution => {
                         // After taking a key from subgraph A to B, there is no point of following
@@ -356,7 +374,7 @@ impl BaseQueryGraphBuilder {
                     }
                     _ => {}
                 }
-                non_trivial_followups.push(followup_edge_ref.id());
+                non_trivial_followups.push(*followup_edge);
             }
             self.query_graph
                 .non_trivial_followup_edges

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -294,24 +294,9 @@ impl BaseQueryGraphBuilder {
         for edge in self.query_graph.graph.edge_indices() {
             let edge_weight = self.query_graph.edge_weight(edge)?.clone();
             let (_, tail) = self.query_graph.edge_endpoints(edge)?;
-            let out_edges = out_edges_cache.entry(tail).or_insert_with(|| {
-                let mut out_edges: Vec<_> = self
-                    .query_graph
-                    .graph
-                    .edges_directed(tail, Direction::Outgoing)
-                    .filter(|edge_ref| {
-                        !(edge_ref.source() == edge_ref.target()
-                            && matches!(
-                                edge_ref.weight().transition,
-                                QueryGraphEdgeTransition::KeyResolution
-                                    | QueryGraphEdgeTransition::RootTypeResolution { .. }
-                            ))
-                    })
-                    .map(|edge_ref| edge_ref.id())
-                    .collect();
-                out_edges.sort_by_key(|edge_id| -> EdgeIndex { *edge_id });
-                out_edges
-            });
+            let out_edges = out_edges_cache
+                .entry(tail)
+                .or_insert_with(|| self.query_graph.out_edge_ids(tail));
             let mut non_trivial_followups = Vec::with_capacity(out_edges.len());
             for followup_edge in out_edges {
                 let followup_edge_weight = self.query_graph.edge_weight(*followup_edge)?;

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -698,18 +698,37 @@ impl QueryGraph {
     }
 
     /// The outward edges from the given node, minus self-key and self-root-type-resolution edges,
-    /// as they're rarely useful (currently only used by `@defer`).
-    pub(crate) fn out_edges(&self, node: NodeIndex) -> Vec<EdgeReference<'_, QueryGraphEdge>> {
-        Self::sorted_edges(self.graph.edges_directed(node, Direction::Outgoing).filter(
-            |edge_ref| {
+    /// in petgraph's unspecified iteration order. The sole definition of which edges
+    /// [`Self::out_edges`] and [`Self::out_edge_ids`] consider, so that the two cannot drift apart.
+    fn out_edges_unsorted(
+        &self,
+        node: NodeIndex,
+    ) -> impl Iterator<Item = EdgeReference<'_, QueryGraphEdge>> {
+        self.graph
+            .edges_directed(node, Direction::Outgoing)
+            .filter(|edge_ref| {
                 !(edge_ref.source() == edge_ref.target()
                     && matches!(
                         edge_ref.weight().transition,
                         QueryGraphEdgeTransition::KeyResolution
                             | QueryGraphEdgeTransition::RootTypeResolution { .. }
                     ))
-            },
-        ))
+            })
+    }
+
+    /// The outward edges from the given node, minus self-key and self-root-type-resolution edges,
+    /// as they're rarely useful (currently only used by `@defer`).
+    pub(crate) fn out_edges(&self, node: NodeIndex) -> Vec<EdgeReference<'_, QueryGraphEdge>> {
+        Self::sorted_edges(self.out_edges_unsorted(node))
+    }
+
+    /// The same edges as [`Self::out_edges`], in the same order, as owned [`EdgeIndex`] values
+    /// rather than references borrowed from the graph. For callers that need to hold the list
+    /// across a mutation of the query graph, which an `EdgeReference` would forbid.
+    pub(crate) fn out_edge_ids(&self, node: NodeIndex) -> Vec<EdgeIndex> {
+        let mut edge_ids: Vec<EdgeIndex> = self.out_edges_unsorted(node).map(|e| e.id()).collect();
+        edge_ids.sort();
+        edge_ids
     }
 
     /// Edge iteration order is unspecified in petgraph, but appears to be


### PR DESCRIPTION
## What

During federated query-graph construction, `precompute_non_trivial_followup_edges()` calls `QueryGraph::out_edges(tail)` once per edge. `out_edges()` collects **and sorts** a fresh `Vec` on every call, so for a node that is the tail of many edges we re-filter and re-sort the same outgoing-edge list repeatedly. On connector-heavy supergraphs (many synthetic subgraphs sharing entity types → a dense cross-subgraph key graph), this churn is large.

This change caches the filtered+sorted out-edge list per tail node inside the precompute loop. The cached list is computed with the **exact same** filter and sort as `out_edges()` (self-key / self-root-type-resolution edges excluded; sorted by `EdgeIndex`), so the result is identical — this is purely an allocation/CPU optimization, no behavior change.

## Why it's safe

- The cached set is byte-for-byte the same edge set `out_edges()` would return (same filter predicate, same sort key).
- No change to which followup edges are recorded as non-trivial.
- Full `apollo-federation` test suite passes unchanged.

## Measured impact (router startup, connector repro)

Standalone startup repro over a connector-expanded supergraph (dhat-heap), this commit alone vs. the pre-change baseline:

| N (connectors) | total alloc | startup |
|---|---|---|
| N32 | 5.85 GB → 0.85 GB (−85%) | 40.8 s → 31.7 s |

Peak heap is essentially unchanged by this commit alone (it removes churn, not live data); the peak-heap win comes from the stacked follow-up PR.

## Notes

- Part of a stacked pair addressing router-startup memory/time on connector-heavy graphs. This is the low-risk half; the follow-up (deferring the precompute on the query-planning path) is sent separately for independent review.
- This does **not** change the asymptotic class of the startup cost — the query graph still materializes O(S²) cross-subgraph key edges. It removes a large constant/churn factor over that structure.
