### PR TITLE
perf(query-planning): defer followup-edge precompute on startup

### DIFF
--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -94,7 +94,7 @@ pub fn build_federated_query_graph(
                 )?
                 .build()
             })?;
-    FederatedQueryGraphBuilder::new(query_graph, supergraph_schema)?.build()
+    FederatedQueryGraphBuilder::new(query_graph, supergraph_schema, for_query_planning)?.build()
 }
 
 // PORT_NOTE: Corresponds to `buildSupergraphAPIQueryGraph` from JS.
@@ -1155,12 +1155,14 @@ struct FederatedQueryGraphBuilder {
     base: BaseQueryGraphBuilder,
     supergraph_schema: ValidFederationSchema,
     subgraphs: FederatedQueryGraphBuilderSubgraphs,
+    for_query_planning: bool,
 }
 
 impl FederatedQueryGraphBuilder {
     fn new(
         mut query_graph: QueryGraph,
         supergraph_schema: ValidFederationSchema,
+        for_query_planning: bool,
     ) -> Result<Self, FederationError> {
         query_graph.supergraph_schema = Some(supergraph_schema.clone());
         let base = BaseQueryGraphBuilder::new(
@@ -1176,6 +1178,7 @@ impl FederatedQueryGraphBuilder {
             base,
             supergraph_schema,
             subgraphs,
+            for_query_planning,
         })
     }
 
@@ -1196,7 +1199,11 @@ impl FederatedQueryGraphBuilder {
         // more details).
         self.handle_interface_object()?;
         // This method adds no nodes/edges, but just precomputes followup edge information.
-        self.base.precompute_non_trivial_followup_edges()?;
+        // For router startup/query-planning, we skip eager materialization and let callers
+        // fall back to ordinary out-edge traversal when no precomputed entry exists.
+        if !self.for_query_planning {
+            self.base.precompute_non_trivial_followup_edges()?;
+        }
         // This method adds no nodes/edges, but just precomputes metadata for estimating the count
         // of non_local_selections.
         self.base.query_graph.non_local_selection_metadata =

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -996,15 +996,9 @@ where
         // https://github.com/apollographql/federation/pull/1653 for more details).
         if let Some(last_edge) = self.edges.last()
             && let Some(last_edge) = (*last_edge).into()
-        {
-            let Some(non_trivial_followup_edges) =
+            && let Some(non_trivial_followup_edges) =
                 self.graph.non_trivial_followup_edges.get(&last_edge)
-            else {
-                return Err(FederationError::internal(format!(
-                    "Unexpectedly missing entry for {last_edge} in non-trivial followup edges map",
-                    last_edge = EdgeIndexDisplay::new(last_edge, &self.graph)
-                )));
-            };
+        {
             return Ok(Either::Right(non_trivial_followup_edges.iter().copied()));
         }
 


### PR DESCRIPTION
> **Stacked on #9690** (`benjamn/qg-cache-out-edges`). Review/merge that first; this PR's diff is only the second commit.

## What

`precompute_non_trivial_followup_edges()` eagerly materializes, for **every** edge in the federated query graph, the list of non-trivial followup edges. On connector-heavy supergraphs the graph has O(S²) cross-subgraph key edges, so this precompute dominates both peak heap and startup time.

This change skips that eager precompute on the **query-planning** graph-build path (`for_query_planning == true`, i.e. `QueryPlanner::new`). When no precomputed entry exists, `GraphPath::next_edges()` now falls back to ordinary `out_edges()` traversal instead of erroring.

The composition **satisfiability** path passes `for_query_planning = Some(false)` and is unchanged — it still precomputes.

## Why it's sound (not just faster)

The non-trivial-followup map is, by the existing code's own contract (`graph_path.rs`, "this is purely an optimization", per apollographql/federation#1653), a **pruning subset** of `out_edges()`. The fallback returns the full out-edge set — a **superset** — so:

- No valid or optimal query plan can be lost or invented; produced plans are unchanged.
- Termination is unaffected: the unpruned `out_edges()` traversal is already the pre-existing fallback for the `last_edge == None` case, so the planner is already required to be correct and terminating without the pruning.
- The full `apollo-federation` test suite passes unchanged, including the query-planner snapshot tests — which build via `QueryPlanner::new` and therefore exercise this pruning-off path directly.

**One honest behavioral note:** with pruning off on the planning path, a "trivial" key edge (one that loops back to the previous vertex) is now *explored and discarded by cost* rather than *recorded as a dead-end*. This can make the `Unadvanceable` diagnostics that feed "field cannot be reached" error messages slightly less rich on the runtime planning path. It does **not** affect which plan is chosen or whether a query is satisfiable, and composition-side error messages are unaffected (that path keeps the precompute).

## Open question for reviewers (the reason this is a separate PR)

This trades eager startup work for a runtime fallback. For startup it's a clear win, but it disables the followup-edge pruning for **every** query plan computed against the graph. **Before this lands, it should get a steady-state query-planning latency benchmark** to confirm we didn't move unacceptable cost from startup into request-time planning. I have not run that benchmark yet.

## Measured startup impact (connector repro, stacked on #9690)

| N (connectors) | peak heap | total alloc | startup |
|---|---|---|---|
| N32 | 411 MB → 170 MB | (on top of PR A) → 0.59 GB | 31.7 s → 30.1 s |

At N64, the full stack (PR A + this) vs. the pre-mitigation baseline: peak heap **2.13 GB → 367 MB (−83%)**, total alloc **40.4 GB → 1.27 GB (−97%)**, startup **129 s → 52 s**. The relative win grows with connector count, as expected for a fix targeting the super-linear term — though peak heap remains super-linear (the O(S²) key-edge graph is still materialized; flattening that needs a separate source-aware-planning change).
