### PR TITLE
chore(3.0): remove apollo_telemetry::client_name/version fallback read path

### DIFF
--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -613,18 +613,8 @@ impl PluginPrivate for Telemetry {
                         // that processing is deferred until the future is polled.
                         let get_from_context =
                             |ctx: &Context, key| ctx.get::<&str, String>(key).ok().flatten();
-                        let client_name = get_from_context(&ctx, CLIENT_NAME).or_else(|| {
-                            get_from_context(
-                                &ctx,
-                                crate::context::deprecated::DEPRECATED_CLIENT_NAME,
-                            )
-                        });
-                        let client_version = get_from_context(&ctx, CLIENT_VERSION).or_else(|| {
-                            get_from_context(
-                                &ctx,
-                                crate::context::deprecated::DEPRECATED_CLIENT_VERSION,
-                            )
-                        });
+                        let client_name = get_from_context(&ctx, CLIENT_NAME);
+                        let client_version = get_from_context(&ctx, CLIENT_VERSION);
 
                         if let Some(key) = client_name_key {
                             span.set_span_dyn_attribute(

--- a/apollo-router/tests/integration/telemetry/fixtures/deprecated_client_name.rhai
+++ b/apollo-router/tests/integration/telemetry/fixtures/deprecated_client_name.rhai
@@ -1,0 +1,8 @@
+fn router_service(service) {
+    const request_callback = Fn("process_request");
+    service.map_request(request_callback);
+}
+
+fn process_request(request) {
+    request.context["apollo_telemetry::client_name"] = "deprecated_client";
+}

--- a/apollo-router/tests/integration/telemetry/fixtures/otlp_deprecated_client_name.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/otlp_deprecated_client_name.router.yaml
@@ -1,0 +1,31 @@
+rhai:
+  scripts: "tests/integration/telemetry/fixtures"
+  main: "deprecated_client_name.rhai"
+telemetry:
+  instrumentation:
+    spans:
+      mode: spec_compliant
+    events:
+      router:
+        request: info
+        response: info
+        error: info
+  exporters:
+    tracing:
+      common:
+        service_name: router
+      otlp:
+        enabled: true
+        protocol: http
+        endpoint: <otel-collector-endpoint>
+        batch_processor:
+          scheduled_delay: 10ms
+    metrics:
+      common:
+        service_name: router
+      otlp:
+        enabled: true
+        endpoint: <otel-collector-endpoint>/metrics
+        protocol: http
+        batch_processor:
+          scheduled_delay: 10ms

--- a/apollo-router/tests/integration/telemetry/otlp/tracing.rs
+++ b/apollo-router/tests/integration/telemetry/otlp/tracing.rs
@@ -833,6 +833,48 @@ async fn test_plugin_overridden_client_name_is_included_in_telemetry() -> Result
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_deprecated_client_name_context_key_is_not_read() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        return Ok(());
+    }
+    let mock_server = mock_otlp_server(1..).await;
+    let config = include_str!("../fixtures/otlp_deprecated_client_name.router.yaml")
+        .replace("<otel-collector-endpoint>", &mock_server.uri());
+    let reqwest_client = reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        .build()
+        .expect("reqwest client build");
+    let mut router = IntegrationTest::builder()
+        .telemetry(Telemetry::Otlp {
+            endpoint: Some(format!("{}/v1/traces", mock_server.uri())),
+        })
+        .config(config)
+        .reqwest_client(reqwest_client)
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    // The rhai script sets apollo_telemetry::client_name (the old 1.x key).
+    // In 3.x only apollo::telemetry::client_name is read, so client.name
+    // must be empty rather than the deprecated value.
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .attribute("client.name", "")
+        .build()
+        .validate_otlp_trace(
+            &mut router,
+            &mock_server,
+            Query::builder().traced(true).build(),
+        )
+        .await?;
+
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_otlp_ipv6() -> Result<(), BoxError> {
     if !graph_os_enabled() {
         return Ok(());


### PR DESCRIPTION
Closes ROUTER-1936.

## What

- Removed the `.or_else()` fallback in `telemetry/mod.rs` that read the 1.x context keys `apollo_telemetry::client_name` and `apollo_telemetry::client_version` when the canonical `apollo::telemetry::client_name` / `apollo::telemetry::client_version` keys were absent from context.
- The router span's `client.name` / `client.version` OTel attributes now only reflect the canonical 3.x keys.
- Added an integration test (`test_deprecated_client_name_context_key_is_not_read`) with a rhai fixture that sets the deprecated key and asserts `client.name = ""` on the resulting trace.

## Verified

- `cargo fmt --check` passed
- `cargo clippy -- -D warnings` passed
- CHANGELOG.md not modified
- Changeset titles contain no conventional-commit prefixes

## Notes

The `DEPRECATED_CLIENT_NAME` / `DEPRECATED_CLIENT_VERSION` constants in `context/deprecated.rs` are retained — they remain in use by the coprocessor key-conversion layer (`context_key_from_deprecated` / `context_key_to_deprecated`), which is a separate compatibility concern.