### PR TITLE
chore: understand Batching

### DIFF
--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -5,10 +5,13 @@
 //! - At the router service, a batch query is split apart into multiple requests.
 //! - A single [Batch] structure is created, which is responsible for handling the batch lifecycle.
 //! - Each individual request gets a [BatchQuery] extension.
-//! - After query planning of each individual request, that request's [BatchQuery::set_query_hashes]
-//!   is called to set the expected number of subgraph requests. This includes only the subgraph
-//!   requests that are unconditionally executed, not subsequent entity fetches for example that can
-//!   only be executed based on data obtained during query plan execution.
+//! - After query planning of each individual request, we collect the hashes of the plan nodes that
+//!   will be executed unconditionally as part of the query plan. Those query nodes are candidates
+//!   for being batched up into a single request at the subgraph side, as they do not depend on
+//!   other data being fetched first.
+//! - [BatchQuery::set_query_hashes] is called with those hashes, to set the expected number of
+//!   subgraph requests. The hashes are also used to track successful and unsuccessful responses to
+//!   each individual subgraph request.
 //! - Once each subgraph request that is part of the batch reaches the subgraph service, instead of
 //!   submitting the request to the HTTP client, it calls into [BatchQuery::signal_progress]. This
 //!   is how subgraph requests are eventually batched up. When a [BatchQuery] has received all

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -418,18 +418,18 @@ impl Drop for Batch {
     }
 }
 
+/// A batch of requests that we'll send to a subgraph (...as a single batch request).
+pub(crate) struct SubgraphBatchRequest {
+    pub(crate) operation_name: String,
+    pub(crate) contexts: Vec<(Context, SubgraphRequestId)>,
+    pub(crate) request: http::Request<RouterBody>,
+    pub(crate) txs: Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
+}
+
 // Assemble a single batch request to a subgraph
 pub(crate) async fn assemble_batch(
     requests: Vec<BatchQueryInfo>,
-) -> Result<
-    (
-        String,
-        Vec<(Context, SubgraphRequestId)>,
-        http::Request<RouterBody>,
-        Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
-    ),
-    BoxError,
-> {
+) -> Result<SubgraphBatchRequest, BoxError> {
     let (txs, requests): (Vec<_>, Vec<_>) =
         requests.into_iter().map(|r| (r.sender, r.request)).unzip();
 
@@ -465,7 +465,12 @@ pub(crate) async fn assemble_batch(
 
     // Generate the final request and pass it up
     let request = http::Request::from_parts(parts, router::body::from_bytes(bytes));
-    Ok((operation_name, contexts, request, txs))
+    Ok(SubgraphBatchRequest {
+        operation_name,
+        contexts,
+        request,
+        txs,
+    })
 }
 
 #[cfg(test)]
@@ -483,6 +488,7 @@ mod tests {
 
     use super::Batch;
     use super::BatchQueryInfo;
+    use super::SubgraphBatchRequest;
     use super::assemble_batch;
     use crate::Configuration;
     use crate::Context;
@@ -529,7 +535,12 @@ mod tests {
             .map(|r| r.request.context.id.clone())
             .collect::<Vec<String>>();
         // Assemble them
-        let (op_name, contexts, request, txs) = assemble_batch(requests)
+        let SubgraphBatchRequest {
+            operation_name,
+            contexts,
+            request,
+            txs,
+        } = assemble_batch(requests)
             .await
             .expect("it can assemble a batch");
 
@@ -541,7 +552,7 @@ mod tests {
         assert_eq!(input_context_ids, output_context_ids);
 
         // Make sure that the name of the entire batch is that of the first
-        assert_eq!(op_name, "batch_test_0");
+        assert_eq!(operation_name, "batch_test_0");
 
         // We should see the aggregation of all of the requests
         let actual: Vec<graphql::Request> = serde_json::from_str(

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -1,5 +1,23 @@
 //! Various utility functions and core structures used to implement batching support within
 //! the router.
+//!
+//! Batching works roughly along these lines:
+//! - At the router service, a batch query is split apart into multiple requests.
+//! - A single [Batch] structure is created, which is responsible for handling the batch lifecycle.
+//! - Each individual request gets a [BatchQuery] extension.
+//! - After query planning of each individual request, that request's [BatchQuery::set_query_hashes]
+//!   is called to set the expected number of subgraph requests. This includes only the subgraph
+//!   requests that are unconditionally executed, not subsequent entity fetches for example that can
+//!   only be executed based on data obtained during query plan execution.
+//! - Once each subgraph request that is part of the batch reaches the subgraph service, instead of
+//!   submitting the request to the HTTP client, it calls into [BatchQuery::signal_progress]. This
+//!   is how subgraph requests are eventually batched up. When a [BatchQuery] has received all
+//!   expected progress calls (per [BatchQuery::set_query_hashes]), that query is considered
+//!   "finished".
+//! - The [Batch] lifecycle handler receives messages from each [BatchQuery]. Once _all_
+//!   [BatchQuery]s are finished, no more messages come in, and this is when the [Batch] lifecycle
+//!   handler actually batches up the requests to each subgraph, and sends the batched subgraph
+//!   requests to the HTTP client.
 
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -420,7 +420,6 @@ impl Drop for Batch {
 
 /// A batch of requests that we'll send to a subgraph (...as a single batch request).
 pub(crate) struct SubgraphBatchRequest {
-    pub(crate) operation_name: String,
     pub(crate) contexts: Vec<(Context, SubgraphRequestId)>,
     pub(crate) request: http::Request<RouterBody>,
     pub(crate) txs: Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
@@ -446,11 +445,6 @@ pub(crate) async fn assemble_batch(
         .next()
         .ok_or(SubgraphBatchingError::RequestsIsEmpty)?
         .subgraph_request;
-    let operation_name = first_request
-        .body()
-        .operation_name
-        .clone()
-        .unwrap_or_default();
     let (parts, first_body) = first_request.into_parts();
 
     let mut gql_requests = Vec::with_capacity(txs.len());
@@ -466,7 +460,6 @@ pub(crate) async fn assemble_batch(
     // Generate the final request and pass it up
     let request = http::Request::from_parts(parts, router::body::from_bytes(bytes));
     Ok(SubgraphBatchRequest {
-        operation_name,
         contexts,
         request,
         txs,
@@ -536,7 +529,6 @@ mod tests {
             .collect::<Vec<String>>();
         // Assemble them
         let SubgraphBatchRequest {
-            operation_name,
             contexts,
             request,
             txs,
@@ -550,9 +542,6 @@ mod tests {
             .collect::<Vec<String>>();
         // Make sure all of our contexts are preserved during assembly
         assert_eq!(input_context_ids, output_context_ids);
-
-        // Make sure that the name of the entire batch is that of the first
-        assert_eq!(operation_name, "batch_test_0");
 
         // We should see the aggregation of all of the requests
         let actual: Vec<graphql::Request> = serde_json::from_str(

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -715,7 +715,6 @@ pub(crate) async fn process_batches(
     let (info, txs): (Vec<_>, Vec<_>) =
         futures::future::join_all(svc_map.into_iter().map(|(service, requests)| async {
             let SubgraphBatchRequest {
-                operation_name: _,
                 contexts,
                 request,
                 txs,

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -48,6 +48,7 @@ use crate::Context;
 use crate::Notify;
 use crate::batching::BatchQuery;
 use crate::batching::BatchQueryInfo;
+use crate::batching::SubgraphBatchRequest;
 use crate::batching::assemble_batch;
 use crate::configuration::Batching;
 use crate::configuration::BatchingMode;
@@ -365,7 +366,7 @@ fn http_response_to_graphql_response(
 
 /// Process a single subgraph batch request
 #[instrument(skip(client_factory, contexts, request))]
-pub(crate) async fn process_batch(
+async fn process_batch(
     client_factory: HttpClientServiceFactory,
     service: String,
     mut contexts: Vec<(Context, SubgraphRequestId)>,
@@ -620,7 +621,7 @@ pub(crate) async fn process_batch(
 }
 
 /// Notify all listeners of a batch query of the results
-pub(crate) async fn notify_batch_query(
+async fn notify_batch_query(
     service: String,
     senders: Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
     responses: Result<Vec<SubgraphResponse>, FetchError>,
@@ -699,7 +700,6 @@ type BatchInfo = (
         String,
         http::Request<RouterBody>,
         Vec<(Context, SubgraphRequestId)>,
-        usize,
     ),
     Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
 );
@@ -714,9 +714,14 @@ pub(crate) async fn process_batches(
     let mut errors = vec![];
     let (info, txs): (Vec<_>, Vec<_>) =
         futures::future::join_all(svc_map.into_iter().map(|(service, requests)| async {
-            let (_op_name, contexts, request, txs) = assemble_batch(requests).await?;
+            let SubgraphBatchRequest {
+                operation_name: _,
+                contexts,
+                request,
+                txs,
+            } = assemble_batch(requests).await?;
 
-            Ok(((service, request, contexts, txs.len()), txs))
+            Ok(((service, request, contexts), txs))
         }))
         .await
         .into_iter()
@@ -744,20 +749,22 @@ pub(crate) async fn process_batches(
         )
         .into());
     }
-    let batch_futures = info.into_iter().zip_eq(txs).map(
-        |((service, request, contexts, listener_count), senders)| async move {
-            let batch_result = process_batch(
-                cf.clone(),
-                service.clone(),
-                contexts,
-                request,
-                listener_count,
-            )
-            .await;
+    let batch_futures =
+        info.into_iter()
+            .zip_eq(txs)
+            .map(|((service, request, contexts), senders)| async move {
+                let listener_count = senders.len();
+                let batch_result = process_batch(
+                    cf.clone(),
+                    service.clone(),
+                    contexts,
+                    request,
+                    listener_count,
+                )
+                .await;
 
-            notify_batch_query(service, senders, batch_result).await
-        },
-    );
+                notify_batch_query(service, senders, batch_result).await
+            });
 
     futures::future::try_join_all(batch_futures).await?;
 
@@ -804,7 +811,7 @@ async fn call_http(
 }
 
 /// call_single_http makes http calls with modified graphql::Request (body)
-pub(crate) async fn call_single_http(
+async fn call_single_http(
     request: SubgraphRequest,
     client: crate::services::http::BoxCloneService,
     service_name: &str,


### PR DESCRIPTION
Making small code tweaks and adding documentation about how Batching fits together.

This is prep work for isolating batching into testable tower layers, and removing batching code from query planning and the subgraph service.