### PR TITLE
fix: skip `@requires` field set validation during fed v1 schema upgrade

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -1082,6 +1082,7 @@ impl SelectionSet {
             type_position.type_name().clone(),
             source_text,
             false,
+            crate::schema::field_set::FieldSetValidation::Validate,
         )?
         .0;
         let fragments = Default::default();

--- a/apollo-federation/src/schema/field_set.rs
+++ b/apollo-federation/src/schema/field_set.rs
@@ -110,12 +110,20 @@ pub(crate) fn parse_field_set(
 /// a boolean indicating whether the field set was modified to fix such string/enum value issues.
 ///
 /// Outside these specific purposes, you should prefer to use `parse_field_set()` instead.
+#[derive(Clone, Copy)]
+pub(crate) enum FieldSetValidation {
+    Validate,
+    Skip,
+}
+
 pub(crate) fn parse_field_set_without_normalization(
     schema: &Valid<Schema>,
     parent_type_name: NamedType,
     field_set: &str,
     fix_string_enum_values: bool,
+    validation: FieldSetValidation,
 ) -> Result<(executable::SelectionSet, bool), FederationError> {
+    let validate = matches!(validation, FieldSetValidation::Validate);
     // Note this parsing takes care of adding curly braces ("{" and "}") if they aren't in the
     // string.
     let (field_set, is_modified) = if fix_string_enum_values {
@@ -126,15 +134,20 @@ pub(crate) fn parse_field_set_without_normalization(
             "field_set.graphql",
         )?;
         let is_modified = fix_string_enum_values_in_field_set(schema, &mut field_set);
-        field_set.validate(schema)?;
+        if validate {
+            field_set.validate(schema)?;
+        }
         // `FieldSet::validate()` strangely doesn't return `Valid<FieldSet>`, so we instead use
         // `Valid::assume_valid()` here.
         (Valid::assume_valid(field_set), is_modified)
-    } else {
+    } else if validate {
         (
             FieldSet::parse_and_validate(schema, parent_type_name, field_set, "field_set.graphql")?,
             false,
         )
+    } else {
+        let field_set = FieldSet::parse(schema, parent_type_name, field_set, "field_set.graphql")?;
+        (Valid::assume_valid(field_set), false)
     };
     Ok((field_set.into_inner().selection_set, is_modified))
 }

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -30,6 +30,7 @@ use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
 use crate::schema::SchemaElement;
 use crate::schema::SubgraphMetadata;
+use crate::schema::field_set::FieldSetValidation;
 use crate::subgraph::SubgraphError;
 use crate::subgraph::typestate::Expanded;
 use crate::subgraph::typestate::Subgraph;
@@ -520,9 +521,13 @@ impl SchemaUpgrader {
         schema: &mut FederationSchema,
     ) -> Result<(), FederationError> {
         let cloned_schema = schema.clone();
+        // NOTE: we should be passing a supergraph schema so we could verify the remaining `@requires`
+        // field set values are valid. Schema upgrader runs before merge process, we don't have
+        // access to the supergraph so we need to skip the validation.
         remove_inactive_requires_and_provides_from_subgraph(
-            &cloned_schema, // TODO: I don't know what this value should be
+            &cloned_schema,
             schema,
+            FieldSetValidation::Skip,
         )
     }
 

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -62,6 +62,7 @@ use crate::link::spec::Version;
 use crate::link::spec_definition::SpecDefinition;
 use crate::schema::FederationSchema;
 use crate::schema::ValidFederationSchema;
+use crate::schema::field_set::FieldSetValidation;
 use crate::schema::field_set::parse_field_set_without_normalization;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::DirectiveDefinitionPosition;
@@ -583,6 +584,7 @@ fn extract_subgraphs_from_fed_2_supergraph(
         remove_inactive_requires_and_provides_from_subgraph(
             supergraph_schema,
             &mut subgraph.schema,
+            FieldSetValidation::Validate,
         )?;
         remove_unused_types_from_subgraph(&mut subgraph.schema)?;
         for definition in all_executable_directive_definitions.iter() {
@@ -1996,6 +1998,7 @@ fn add_federation_operations(
 pub(crate) fn remove_inactive_requires_and_provides_from_subgraph(
     supergraph_schema: &FederationSchema,
     schema: &mut FederationSchema,
+    field_set_validation: FieldSetValidation,
 ) -> Result<(), FederationError> {
     let federation_spec_definition = get_federation_spec_definition_from_subgraph(schema)?;
     let requires_directive_definition_name = federation_spec_definition
@@ -2051,6 +2054,7 @@ pub(crate) fn remove_inactive_requires_and_provides_from_subgraph(
             FieldSetDirectiveKind::Requires,
             &requires_directive_definition_name,
             pos.clone(),
+            &field_set_validation,
         )?;
         remove_inactive_applications(
             supergraph_schema,
@@ -2059,6 +2063,7 @@ pub(crate) fn remove_inactive_requires_and_provides_from_subgraph(
             FieldSetDirectiveKind::Provides,
             &provides_directive_definition_name,
             pos,
+            &field_set_validation,
         )?;
     }
 
@@ -2077,6 +2082,7 @@ fn remove_inactive_applications(
     directive_kind: FieldSetDirectiveKind,
     name_in_schema: &Name,
     object_or_interface_field_definition_position: ObjectOrInterfaceFieldDefinitionPosition,
+    field_set_validation: &FieldSetValidation,
 ) -> Result<(), FederationError> {
     let mut replacement_directives = Vec::new();
     let field = object_or_interface_field_definition_position.get(schema.schema())?;
@@ -2126,6 +2132,7 @@ fn remove_inactive_applications(
             parent_type_pos.type_name().clone(),
             fields,
             true,
+            *field_set_validation,
         )?;
 
         if remove_non_external_leaf_fields(schema, &mut fields)? {

--- a/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
@@ -1,4 +1,6 @@
 use apollo_compiler::coord;
+use apollo_federation::composition::CompositionOptions;
+use apollo_federation::composition::compose;
 use apollo_federation::composition::upgrade_subgraphs_if_necessary;
 use apollo_federation::subgraph::typestate::Subgraph;
 use insta::assert_snapshot;
@@ -268,4 +270,78 @@ fn upgrade_does_not_add_shareable_to_key_fields_in_partial_schemas() {
 
     assert_snapshot!("s1", upgraded[0].schema_string());
     assert_snapshot!("s2", upgraded[1].schema_string());
+}
+
+/// Fed v1 subgraph with `@requires` containing an inline fragment type condition that is only
+/// valid in the supergraph should upgrade and compose successfully.
+///
+/// Subgraph A defines two unrelated interfaces (`Animal` and `Pet`) and uses
+/// `@requires(fields: "data { ... on Pet { name } }")` where `data` returns `Animal`.
+/// In subgraph A alone, `Animal` and `Pet` have no type intersection.
+/// Subgraph B defines `Dog implements Animal & Pet`, making the type condition valid
+/// in the supergraph.
+#[test]
+fn fed1_requires_with_cross_subgraph_inline_fragment_type_condition() {
+    let subgraph_a = Subgraph::parse(
+        "subgraphA",
+        "",
+        r#"
+            type Query {
+                records: [Record]
+            }
+
+            interface Animal {
+                id: ID!
+            }
+
+            interface Pet {
+                name: String!
+            }
+
+            type Record @key(fields: "id") @extends {
+                id: ID! @external
+                data: Animal! @external
+                label: String! @requires(fields: "data { id ... on Pet { name } }")
+            }
+        "#,
+    )
+    .expect("parses subgraphA");
+
+    let subgraph_b = Subgraph::parse(
+        "subgraphB",
+        "",
+        r#"
+            type Query {
+                animals: [Animal]
+            }
+
+            interface Animal {
+                id: ID!
+            }
+
+            interface Pet {
+                name: String!
+            }
+
+            type Dog implements Animal & Pet {
+                id: ID!
+                name: String!
+                breed: String!
+            }
+
+            type Cat implements Animal {
+                id: ID!
+                color: String!
+            }
+
+            type Record @key(fields: "id") {
+                id: ID!
+                data: Animal!
+            }
+        "#,
+    )
+    .expect("parses subgraphB");
+
+    compose(vec![subgraph_a, subgraph_b], CompositionOptions::default())
+        .expect("composition succeeds");
 }


### PR DESCRIPTION
During fed v1 → fed v2 upgrade, `fix_inactive_provides_and_requires` calls `remove_inactive_requires_and_provides_from_subgraph` with a clone of the subgraph as the "supergraph". This causes `@requires` field sets with inline fragment type conditions (e.g. `... on Pet`) to fail validation when the type condition is only valid cross-subgraph (the subgraph defines unrelated interfaces, but another subgraph has a type implementing both).

The fix adds a `FieldSetValidation` enum (`Validate`/`Skip`) to `parse_field_set_without_normalization` and threads it through `remove_inactive_requires_and_provides_from_subgraph`. The upgrade path passes `Skip` since the real supergraph isn't available yet — full validation happens later during post-merge against the merged supergraph. The supergraph extraction path continues to pass `Validate`.
