### PR TITLE
docs: add deprecation note for connectors.subgraphs

### DIFF
--- a/docs/shared/config/connectors.mdx
+++ b/docs/shared/config/connectors.mdx
@@ -6,5 +6,5 @@ connectors:
   expose_sources_in_context: false
   max_requests_per_operation_per_source: null
   sources: {}
-  subgraphs: {}
+  subgraphs: {} # Deprecated. Use `sources` instead.
 ```

--- a/docs/shared/router-yaml-complete.mdx
+++ b/docs/shared/router-yaml-complete.mdx
@@ -83,7 +83,7 @@ connectors:
   expose_sources_in_context: false
   max_requests_per_operation_per_source: null
   sources: {}
-  subgraphs: {}
+  subgraphs: {} # Deprecated. Use `sources` instead.
 coprocessor:
   client:
     dns_resolution_strategy: ipv4_only


### PR DESCRIPTION
Adds comment about connectors.subgraphs deprecation in favour of using connectors.sources.