### PR TITLE
fix(deps): fix file_upload test compilation after itertools 0.15.0 upgrade

### DIFF
--- a/apollo-router/tests/integration/file_upload.rs
+++ b/apollo-router/tests/integration/file_upload.rs
@@ -1951,17 +1951,7 @@ mod helper {
             count += chunk.len();
 
             // Make sure that the bytes match what is expected
-            let unexpected = match chunk.into_iter().all_equal_value() {
-                Ok(value) => (value != byte_value).then_some(value),
-                Err(Some((lhs, rhs))) => {
-                    if lhs != byte_value {
-                        Some(lhs)
-                    } else {
-                        Some(rhs)
-                    }
-                }
-                Err(None) => None,
-            };
+            let unexpected = chunk.into_iter().find(|&b| b != byte_value);
             if let Some(unexpected_byte) = unexpected {
                 return Err(FileUploadError::UnexpectedData(byte_value, unexpected_byte));
             }


### PR DESCRIPTION
## What

Fixes a compilation error introduced by the itertools 0.15.0 upgrade in #9712.

`all_equal_value()` previously returned `Result<T, Option<(T, T)>>`, so callers could match on `Err(Some((lhs, rhs)))` and `Err(None)`. In 0.15.0, the error type changed to `AllEqualValueError<T>`, breaking those match arms in `apollo-router/tests/integration/file_upload.rs`.

The fix replaces the match with a simpler `find()` call that is equivalent and avoids the changed API.

## Verified
- `cargo fmt --check` passed
- `cargo clippy -- -D warnings` passed
- CHANGELOG.md not modified