### PR TITLE
test(connectors): widen timeout for live-AWS SigV4 integration test

### DIFF
--- a/.changesets/maint_fix_aws_sigv4_timeout_flake.md
+++ b/.changesets/maint_fix_aws_sigv4_timeout_flake.md
@@ -1,0 +1,5 @@
+### Fix flaky `test_aws_sig_v4_signing` integration test ([Issue #9728](https://github.com/apollographql/router/issues/9728))
+
+This test drives a real network call to live AWS EC2 (STS `AssumeRole` + SigV4-signed `DescribeInstances`), and the router's default 30s connector timeout was occasionally too tight for that round trip from CI, surfacing as a `GATEWAY_TIMEOUT`. The test fixture now overrides the connector's timeout to 60s. No production code changed.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9731

--- a/apollo-router/tests/integration/fixtures/connectors_sigv4.router.yaml
+++ b/apollo-router/tests/integration/fixtures/connectors_sigv4.router.yaml
@@ -10,3 +10,11 @@ authentication:
             assume_role:
               role_arn: ${env.AWS_ROLE_ARN}
               session_name: "connector"
+traffic_shaping:
+  connector:
+    sources:
+      subgraph.ec2:
+        # This connector signs and sends a real request to live AWS EC2 (STS AssumeRole +
+        # SigV4-signed DescribeInstances) -- the router's default 30s connector timeout has
+        # been observed to be too tight for that round trip from CI under load (#9728).
+        timeout: 60s


### PR DESCRIPTION
## Problem

`integration::connectors::authentication::test_aws_sig_v4_signing` failed on macOS in both CI runs of the v2.16.0 release pipeline (build [390724](https://circleci.com/gh/apollographql/router/390724) and [390738](https://circleci.com/gh/apollographql/router/390738)) with:

```
query generated errors: Some([{"message": "Your request has been timed out", "extensions": {"code": "GATEWAY_TIMEOUT"}}])
```

Full investigation in #9728.

## Root cause

This test drives a real network call to live AWS EC2 (`eu-north-1`) via an SigV4-signed connector with an STS `AssumeRole` step — there's no mock subgraph in the loop. `GATEWAY_TIMEOUT` is the router's own `traffic_shaping` connector timeout (`DEFAULT_TIMEOUT = 30s` in `traffic_shaping/mod.rs`) tripping before the `AssumeRole` + `DescribeInstances` round trip completes, which is plausible on a CI runner under load or AWS-side latency variance.

## Fix

Override the connector timeout for this source to 60s via `traffic_shaping.connector.sources."subgraph.ec2".timeout`, giving the round trip headroom. Validated with `router config validate` against the updated fixture.

## Out of scope

The larger fix — replacing the live AWS call with a local mock that validates SigV4 signature headers (same pattern used to de-flake the `apollo_reports` live-demo-subgraph family in #9497) — removes this test's dependency on live AWS entirely. Tracked separately; not done here to keep this PR a minimal, low-risk stabilization.

Jira: https://apollographql.atlassian.net/browse/ROUTER-1949 (originally GitHub issue #9728, closed in favor of Jira)