### PR TITLE
test(redis): fix entity_cache_basic TTL race and ambiguous key lookup

### DIFF
--- a/.changesets/maint_fix_entity_cache_basic_flake.md
+++ b/.changesets/maint_fix_entity_cache_basic_flake.md
@@ -1,0 +1,5 @@
+### Fix flaky `entity_cache_basic` integration test ([Issue #9729](https://github.com/apollographql/router/issues/9729))
+
+The test's short cache TTLs (2s/10s) could expire mid-test under CI load, racing against the wall-clock cost of building three sequential `TestHarness` instances and causing the invalidation-count assertion to see an already-expired (rather than freshly-invalidated) entity. TTLs are widened to 60s so they're no longer load-bearing for timing. (A separate, already-fixed failure mode in this same test — non-deterministic Redis key lookup — was resolved in #9666.) No production code changed.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9732

--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -543,7 +543,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
                         "redis": {
                             "urls": [redis_url],
                             "namespace": namespace,
-                            "ttl": "2s",
+                            "ttl": "60s",
                             "required_to_start": true,
                             "pool_size": 3
                         },
@@ -555,7 +555,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
                         },
                         "reviews": {
                             "enabled": true,
-                            "ttl": "10s"
+                            "ttl": "60s"
                         }
                     }
                 }
@@ -685,7 +685,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
                             "urls": [redis_url],
                             "namespace": namespace,
                             "required_to_start": true,
-                            "ttl": "2s"
+                            "ttl": "60s"
                         },
                     },
                     "subgraphs": {
@@ -695,7 +695,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
                         },
                         "reviews": {
                             "enabled": true,
-                            "ttl": "10s"
+                            "ttl": "60s"
                         }
                     }
                 }
@@ -761,7 +761,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
                             "urls": [redis_url],
                             "namespace": namespace,
                             "required_to_start": true,
-                            "ttl": "2s"
+                            "ttl": "60s"
                         },
                         "invalidation": {
                             "enabled": true,
@@ -779,7 +779,7 @@ async fn entity_cache_basic() -> Result<(), BoxError> {
                         },
                         "reviews": {
                             "enabled": true,
-                            "ttl": "10s",
+                            "ttl": "60s",
                             "invalidation": {
                                 "enabled": true,
                                 "shared_key": SECRET_SHARED_KEY


### PR DESCRIPTION
## Problem

`integration::redis::entity_cache_basic` flaked with two different failure modes:

- 2026-06-25, `dev`, build [387774](https://circleci.com/gh/apollographql/router/387774): `insta` snapshot mismatch — wrong reviews body returned.
- 2026-06-30, `v2.16.0` tag build [390734](https://circleci.com/gh/apollographql/router/390734): `assert_eq!(count, 1)` got `0` in the invalidation check.

Full investigation in #9729.

**Update**: the first failure mode (non-deterministic Redis key lookup, root-caused to Redis 7.4.9's changed SCAN ordering) was already independently fixed and merged in #9666 (2026-06-26) — before this PR was opened. This PR is now scoped to just the second, still-unfixed failure mode.

## Root cause (remaining failure mode)

The test builds three `TestHarness` instances in sequence, each doing real schema parsing + query planning, sharing one Redis namespace. Its cache TTLs (2s/10s) are short enough that, under CI load, the wall-clock time to build the later harnesses can exceed the TTL of an entity cached by an earlier one. By the time the third harness's `/invalidation` request reaches Redis, the entity it's trying to invalidate may have already expired on its own — so the invalidation `SCAN` legitimately finds nothing, and `count` is 0 instead of 1.

## Fix

Widen the test's TTLs to 60s. The test isn't exercising TTL-expiry behavior, so the short TTLs were incidental, not load-bearing — this removes the race without touching production code.

## Caveat

I wasn't able to run this test locally (no Redis/Docker daemon in this environment, and the test is gated behind `graph_os_enabled()`), so I'm relying on CI to confirm.

Jira: https://apollographql.atlassian.net/browse/ROUTER-1950 (originally GitHub issue #9729, closed in favor of Jira)