### PR TITLE
fix: propagate backpressure from HTTP client to subgraph service

### DIFF
--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -5,10 +5,13 @@
 //! - At the router service, a batch query is split apart into multiple requests.
 //! - A single [Batch] structure is created, which is responsible for handling the batch lifecycle.
 //! - Each individual request gets a [BatchQuery] extension.
-//! - After query planning of each individual request, that request's [BatchQuery::set_query_hashes]
-//!   is called to set the expected number of subgraph requests. This includes only the subgraph
-//!   requests that are unconditionally executed, not subsequent entity fetches for example that can
-//!   only be executed based on data obtained during query plan execution.
+//! - After query planning of each individual request, we collect the hashes of the plan nodes that
+//!   will be executed unconditionally as part of the query plan. Those query nodes are candidates
+//!   for being batched up into a single request at the subgraph side, as they do not depend on
+//!   other data being fetched first.
+//! - [BatchQuery::set_query_hashes] is called with those hashes, to set the expected number of
+//!   subgraph requests. The hashes are also used to track successful and unsuccessful responses to
+//!   each individual subgraph request.
 //! - Once each subgraph request that is part of the batch reaches the subgraph service, instead of
 //!   submitting the request to the HTTP client, it calls into [BatchQuery::signal_progress]. This
 //!   is how subgraph requests are eventually batched up. When a [BatchQuery] has received all

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -25,32 +25,32 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
+use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 
-use opentelemetry::trace::TraceContextExt;
 use opentelemetry::Context as otelContext;
+use opentelemetry::trace::TraceContextExt;
 use parking_lot::Mutex as PMutex;
+use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tower::BoxError;
 use tracing::Instrument;
 use tracing::Span;
 
+use crate::Context;
 use crate::error::FetchError;
 use crate::error::SubgraphBatchingError;
 use crate::plugins::telemetry::otel::span_ext::OpenTelemetrySpanExt;
+use crate::services::SubgraphRequest;
+use crate::services::SubgraphResponse;
 use crate::services::process_batches;
 use crate::services::router;
 use crate::services::router::body::RouterBody;
 use crate::services::subgraph::SubgraphRequestId;
-use crate::services::SubgraphRequest;
-use crate::services::SubgraphResponse;
 use crate::spec::QueryHash;
-use crate::Context;
 
 /// A query that is part of a batch.
 /// Note: It's ok to make transient clones of this struct, but *do not* store clones anywhere apart
@@ -501,28 +501,28 @@ mod tests {
     use http::header::CONTENT_TYPE;
     use tokio::sync::oneshot;
     use tower::ServiceExt;
-    use wiremock::matchers;
     use wiremock::MockServer;
     use wiremock::ResponseTemplate;
+    use wiremock::matchers;
 
-    use super::assemble_batch;
     use super::Batch;
     use super::BatchQueryInfo;
     use super::SubgraphBatchRequest;
+    use super::assemble_batch;
+    use crate::Configuration;
+    use crate::Context;
+    use crate::TestHarness;
     use crate::graphql;
     use crate::graphql::Request;
     use crate::layers::ServiceExt as LayerExt;
+    use crate::services::SubgraphRequest;
+    use crate::services::SubgraphResponse;
     use crate::services::http::HttpClientServiceFactory;
     use crate::services::router;
     use crate::services::router::body;
     use crate::services::subgraph;
     use crate::services::subgraph::SubgraphRequestId;
-    use crate::services::SubgraphRequest;
-    use crate::services::SubgraphResponse;
     use crate::spec::QueryHash;
-    use crate::Configuration;
-    use crate::Context;
-    use crate::TestHarness;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn it_assembles_batch() {
@@ -702,11 +702,12 @@ mod tests {
 
         let bq = Batch::query_for_index(batch.clone(), 0).expect("its a valid index");
 
-        let factory = HttpClientServiceFactory::from_config(
+        let http_client = HttpClientServiceFactory::from_config(
             "testbatch",
             &Configuration::default(),
             crate::configuration::shared::Client::default(),
-        );
+        )
+        .create("whatever");
         let request = SubgraphRequest::fake_builder()
             .subgraph_request(
                 http::Request::builder()
@@ -721,11 +722,7 @@ mod tests {
                 .is_ok()
         );
         assert!(!bq.finished());
-        assert!(
-            bq.signal_progress(factory.create("whatever"), request)
-                .await
-                .is_ok()
-        );
+        assert!(bq.signal_progress(http_client, request).await.is_ok());
         assert!(bq.finished());
         assert!(
             bq.signal_cancelled("only once though".to_string())
@@ -740,11 +737,12 @@ mod tests {
 
         let bq = Batch::query_for_index(batch.clone(), 0).expect("its a valid index");
 
-        let factory = HttpClientServiceFactory::from_config(
+        let http_client = HttpClientServiceFactory::from_config(
             "testbatch",
             &Configuration::default(),
             crate::configuration::shared::Client::default(),
-        );
+        )
+        .create("whatever");
         let request = SubgraphRequest::fake_builder()
             .subgraph_request(
                 http::Request::builder()
@@ -756,11 +754,7 @@ mod tests {
         let qh = Arc::new(QueryHash::default());
         assert!(bq.set_query_hashes(vec![qh.clone(), qh]).await.is_ok());
         assert!(!bq.finished());
-        assert!(
-            bq.signal_progress(factory.create("whatever"), request)
-                .await
-                .is_ok()
-        );
+        assert!(bq.signal_progress(http_client, request).await.is_ok());
         assert!(!bq.finished());
         assert!(
             bq.signal_cancelled("only twice though".to_string())

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -480,7 +480,7 @@ pub(crate) async fn assemble_batch(
     }
 
     // Construct the actual byte body of the batched request
-    let bytes = router::body::into_bytes(serde_json::to_string(&gql_requests)?).await?;
+    let bytes = serde_json::to_vec(&gql_requests)?;
 
     // Generate the final request and pass it up
     let request = http::Request::from_parts(parts, router::body::from_bytes(bytes));

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -418,18 +418,18 @@ impl Drop for Batch {
     }
 }
 
+/// A batch of requests that we'll send to a subgraph (...as a single batch request).
+pub(crate) struct SubgraphBatchRequest {
+    pub(crate) operation_name: String,
+    pub(crate) contexts: Vec<(Context, SubgraphRequestId)>,
+    pub(crate) request: http::Request<RouterBody>,
+    pub(crate) txs: Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
+}
+
 // Assemble a single batch request to a subgraph
 pub(crate) async fn assemble_batch(
     requests: Vec<BatchQueryInfo>,
-) -> Result<
-    (
-        String,
-        Vec<(Context, SubgraphRequestId)>,
-        http::Request<RouterBody>,
-        Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
-    ),
-    BoxError,
-> {
+) -> Result<SubgraphBatchRequest, BoxError> {
     let (txs, requests): (Vec<_>, Vec<_>) =
         requests.into_iter().map(|r| (r.sender, r.request)).unzip();
 
@@ -465,7 +465,12 @@ pub(crate) async fn assemble_batch(
 
     // Generate the final request and pass it up
     let request = http::Request::from_parts(parts, router::body::from_bytes(bytes));
-    Ok((operation_name, contexts, request, txs))
+    Ok(SubgraphBatchRequest {
+        operation_name,
+        contexts,
+        request,
+        txs,
+    })
 }
 
 #[cfg(test)]
@@ -483,6 +488,7 @@ mod tests {
 
     use super::Batch;
     use super::BatchQueryInfo;
+    use super::SubgraphBatchRequest;
     use super::assemble_batch;
     use crate::Configuration;
     use crate::Context;
@@ -529,7 +535,12 @@ mod tests {
             .map(|r| r.request.context.id.clone())
             .collect::<Vec<String>>();
         // Assemble them
-        let (op_name, contexts, request, txs) = assemble_batch(requests)
+        let SubgraphBatchRequest {
+            operation_name,
+            contexts,
+            request,
+            txs,
+        } = assemble_batch(requests)
             .await
             .expect("it can assemble a batch");
 
@@ -541,7 +552,7 @@ mod tests {
         assert_eq!(input_context_ids, output_context_ids);
 
         // Make sure that the name of the entire batch is that of the first
-        assert_eq!(op_name, "batch_test_0");
+        assert_eq!(operation_name, "batch_test_0");
 
         // We should see the aggregation of all of the requests
         let actual: Vec<graphql::Request> = serde_json::from_str(

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -25,33 +25,32 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
-use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
-use opentelemetry::Context as otelContext;
 use opentelemetry::trace::TraceContextExt;
+use opentelemetry::Context as otelContext;
 use parking_lot::Mutex as PMutex;
-use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tower::BoxError;
 use tracing::Instrument;
 use tracing::Span;
 
-use crate::Context;
 use crate::error::FetchError;
 use crate::error::SubgraphBatchingError;
 use crate::plugins::telemetry::otel::span_ext::OpenTelemetrySpanExt;
-use crate::services::SubgraphRequest;
-use crate::services::SubgraphResponse;
-use crate::services::http::HttpClientServiceFactory;
 use crate::services::process_batches;
 use crate::services::router;
 use crate::services::router::body::RouterBody;
 use crate::services::subgraph::SubgraphRequestId;
+use crate::services::SubgraphRequest;
+use crate::services::SubgraphResponse;
 use crate::spec::QueryHash;
+use crate::Context;
 
 /// A query that is part of a batch.
 /// Note: It's ok to make transient clones of this struct, but *do not* store clones anywhere apart
@@ -104,7 +103,8 @@ impl BatchQuery {
                 index: self.index,
                 query_hashes,
             })
-            .await?;
+            .await
+            .map_err(|e| SubgraphBatchingError::ProcessingFailed(e.to_string()))?;
         Ok(())
     }
 
@@ -113,7 +113,7 @@ impl BatchQuery {
     /// The returned channel can be awaited to receive the GraphQL response, when ready.
     pub(crate) async fn signal_progress(
         &self,
-        client_factory: HttpClientServiceFactory,
+        http_client: crate::services::http::BoxCloneService,
         request: SubgraphRequest,
     ) -> Result<oneshot::Receiver<Result<SubgraphResponse, BoxError>>, BoxError> {
         // Create a receiver for this query so that it can eventually get the request meant for it
@@ -132,13 +132,14 @@ impl BatchQuery {
             .send(BatchHandlerMessage::Progress(Box::new(
                 BatchHandlerMessageProgress {
                     index: self.index,
-                    client_factory,
+                    http_client,
                     request,
                     response_sender: tx,
                     span_context: Span::current().context(),
                 },
             )))
-            .await?;
+            .await
+            .map_err(|e| SubgraphBatchingError::ProcessingFailed(e.to_string()))?;
 
         if !self.finished() {
             self.remaining.fetch_sub(1, Ordering::AcqRel);
@@ -164,7 +165,8 @@ impl BatchQuery {
                 index: self.index,
                 reason,
             })
-            .await?;
+            .await
+            .map_err(|e| SubgraphBatchingError::ProcessingFailed(e.to_string()))?;
 
         if !self.finished() {
             self.remaining.fetch_sub(1, Ordering::AcqRel);
@@ -201,7 +203,7 @@ enum BatchHandlerMessage {
 /// A query has reached the subgraph service and we should update its state
 struct BatchHandlerMessageProgress {
     index: usize,
-    client_factory: HttpClientServiceFactory,
+    http_client: crate::services::http::BoxCloneService,
     request: SubgraphRequest,
     response_sender: oneshot::Sender<Result<SubgraphResponse, BoxError>>,
     span_context: otelContext,
@@ -211,7 +213,7 @@ struct BatchHandlerMessageProgress {
 pub(crate) struct BatchQueryInfo {
     /// The owning subgraph request
     request: SubgraphRequest,
-
+    http_client: crate::services::http::BoxCloneService,
     /// Notifier for the subgraph service handler
     ///
     /// Note: This must be used or else the subgraph request will time out
@@ -278,7 +280,6 @@ impl Batch {
             let mut requests: Vec<Vec<BatchQueryInfo>> =
                 Vec::from_iter((0..size).map(|_| Vec::new()));
 
-            let mut master_client_factory = None;
             tracing::debug!("Batch about to await messages...");
             // Start handling messages from various portions of the request lifecycle
             // When recv() returns None, we want to stop processing messages
@@ -331,7 +332,7 @@ impl Batch {
                         // Progress the index
                         let BatchHandlerMessageProgress {
                             index,
-                            client_factory,
+                            http_client,
                             request,
                             response_sender,
                             span_context,
@@ -343,11 +344,9 @@ impl Batch {
                             state.committed.insert(request.query_hash.clone());
                         }
 
-                        if master_client_factory.is_none() {
-                            master_client_factory = Some(client_factory);
-                        }
                         Span::current().add_link(span_context.span().span_context().clone());
                         requests[index].push(BatchQueryInfo {
+                            http_client,
                             request,
                             sender: response_sender,
                         })
@@ -372,6 +371,7 @@ impl Batch {
             // Now build up a Service oriented view to use in constructing our batches
             let mut svc_map: HashMap<String, Vec<BatchQueryInfo>> = HashMap::new();
             for BatchQueryInfo {
+                http_client,
                 request: sg_request,
                 sender: tx,
             } in all_in_one
@@ -383,15 +383,13 @@ impl Batch {
                     )
                     .or_default();
                 value.push(BatchQueryInfo {
+                    http_client,
                     request: sg_request,
                     sender: tx,
                 });
             }
 
-            // If we don't have a master_client_factory, we can't do anything.
-            if let Some(client_factory) = master_client_factory {
-                process_batches(client_factory, svc_map).await?;
-            }
+            process_batches(svc_map).await?;
             Ok(())
         }.instrument(tracing::info_span!("batch_request", size)));
 
@@ -441,6 +439,7 @@ impl Drop for Batch {
 
 /// A batch of requests that we'll send to a subgraph (...as a single batch request).
 pub(crate) struct SubgraphBatchRequest {
+    pub(crate) http_client: crate::services::http::BoxCloneService,
     pub(crate) contexts: Vec<(Context, SubgraphRequestId)>,
     pub(crate) request: http::Request<RouterBody>,
     pub(crate) txs: Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
@@ -450,6 +449,11 @@ pub(crate) struct SubgraphBatchRequest {
 pub(crate) async fn assemble_batch(
     requests: Vec<BatchQueryInfo>,
 ) -> Result<SubgraphBatchRequest, BoxError> {
+    let http_client = requests
+        .first()
+        .ok_or(SubgraphBatchingError::RequestsIsEmpty)?
+        .http_client
+        .clone();
     let (txs, requests): (Vec<_>, Vec<_>) =
         requests.into_iter().map(|r| (r.sender, r.request)).unzip();
 
@@ -481,6 +485,7 @@ pub(crate) async fn assemble_batch(
     // Generate the final request and pass it up
     let request = http::Request::from_parts(parts, router::body::from_bytes(bytes));
     Ok(SubgraphBatchRequest {
+        http_client,
         contexts,
         request,
         txs,
@@ -496,28 +501,28 @@ mod tests {
     use http::header::CONTENT_TYPE;
     use tokio::sync::oneshot;
     use tower::ServiceExt;
+    use wiremock::matchers;
     use wiremock::MockServer;
     use wiremock::ResponseTemplate;
-    use wiremock::matchers;
 
+    use super::assemble_batch;
     use super::Batch;
     use super::BatchQueryInfo;
     use super::SubgraphBatchRequest;
-    use super::assemble_batch;
-    use crate::Configuration;
-    use crate::Context;
-    use crate::TestHarness;
     use crate::graphql;
     use crate::graphql::Request;
     use crate::layers::ServiceExt as LayerExt;
-    use crate::services::SubgraphRequest;
-    use crate::services::SubgraphResponse;
     use crate::services::http::HttpClientServiceFactory;
     use crate::services::router;
     use crate::services::router::body;
     use crate::services::subgraph;
     use crate::services::subgraph::SubgraphRequestId;
+    use crate::services::SubgraphRequest;
+    use crate::services::SubgraphResponse;
     use crate::spec::QueryHash;
+    use crate::Configuration;
+    use crate::Context;
+    use crate::TestHarness;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn it_assembles_batch() {
@@ -533,6 +538,12 @@ mod tests {
                 (
                     rx,
                     BatchQueryInfo {
+                        http_client: HttpClientServiceFactory::from_config(
+                            "test",
+                            &Configuration::default(),
+                            crate::configuration::shared::Client::default(),
+                        )
+                        .create("test"),
                         request: SubgraphRequest::fake_builder()
                             .subgraph_request(http::Request::builder().body(gql_request).unwrap())
                             .subgraph_name(format!("slot{index}"))
@@ -550,6 +561,7 @@ mod tests {
             .collect::<Vec<String>>();
         // Assemble them
         let SubgraphBatchRequest {
+            http_client: _,
             contexts,
             request,
             txs,
@@ -654,11 +666,13 @@ mod tests {
 
         let bq = Batch::query_for_index(batch.clone(), 0).expect("its a valid index");
 
-        let factory = HttpClientServiceFactory::from_config(
+        let http_client = HttpClientServiceFactory::from_config(
             "testbatch",
             &Configuration::default(),
             crate::configuration::shared::Client::default(),
-        );
+        )
+        .create("whatever");
+
         let request = SubgraphRequest::fake_builder()
             .subgraph_request(
                 http::Request::builder()
@@ -674,12 +688,12 @@ mod tests {
         );
         assert!(!bq.finished());
         assert!(
-            bq.signal_progress(factory.clone(), request.clone())
+            bq.signal_progress(http_client.clone(), request.clone())
                 .await
                 .is_ok()
         );
         assert!(bq.finished());
-        assert!(bq.signal_progress(factory, request).await.is_err());
+        assert!(bq.signal_progress(http_client, request).await.is_err());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -707,7 +721,11 @@ mod tests {
                 .is_ok()
         );
         assert!(!bq.finished());
-        assert!(bq.signal_progress(factory, request).await.is_ok());
+        assert!(
+            bq.signal_progress(factory.create("whatever"), request)
+                .await
+                .is_ok()
+        );
         assert!(bq.finished());
         assert!(
             bq.signal_cancelled("only once though".to_string())
@@ -738,7 +756,11 @@ mod tests {
         let qh = Arc::new(QueryHash::default());
         assert!(bq.set_query_hashes(vec![qh.clone(), qh]).await.is_ok());
         assert!(!bq.finished());
-        assert!(bq.signal_progress(factory, request).await.is_ok());
+        assert!(
+            bq.signal_progress(factory.create("whatever"), request)
+                .await
+                .is_ok()
+        );
         assert!(!bq.finished());
         assert!(
             bq.signal_cancelled("only twice though".to_string())

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -449,40 +449,32 @@ pub(crate) struct SubgraphBatchRequest {
 
 // Assemble a single batch request to a subgraph
 pub(crate) async fn assemble_batch(
-    requests: Vec<BatchQueryInfo>,
+    batch_queries: Vec<BatchQueryInfo>,
 ) -> Result<SubgraphBatchRequest, BoxError> {
-    let http_client = requests
-        .first()
-        .ok_or(SubgraphBatchingError::RequestsIsEmpty)?
-        .http_client
-        .clone();
-    let (txs, requests): (Vec<_>, Vec<_>) =
-        requests.into_iter().map(|r| (r.sender, r.request)).unzip();
+    let mut txs = Vec::with_capacity(batch_queries.len());
+    let mut contexts = Vec::with_capacity(batch_queries.len());
+    let mut graphql_bodies = Vec::with_capacity(batch_queries.len());
 
-    // Retain the various contexts for later use
-    let contexts = requests
-        .iter()
-        .map(|request| (request.context.clone(), request.id.clone()))
-        .collect::<Vec<(Context, SubgraphRequestId)>>();
+    let mut iter = batch_queries.into_iter();
 
-    // Extract the GraphQL body from each request. The first request also provides the HTTP
-    // parts (URI, headers, etc.) used as the transport envelope for the whole batch.
-    let mut requests_iter = requests.into_iter();
-    let first_request = requests_iter
-        .next()
-        .ok_or(SubgraphBatchingError::RequestsIsEmpty)?
-        .subgraph_request;
-    let (parts, first_body) = first_request.into_parts();
+    let first = iter.next().ok_or(SubgraphBatchingError::RequestsIsEmpty)?;
+    let http_client = first.http_client;
+    txs.push(first.sender);
+    contexts.push((first.request.context, first.request.id));
+    // We'll use the HTTP parts (headers, URI etc) from the first request for the whole batch
+    let (parts, first_body) = first.request.subgraph_request.into_parts();
+    graphql_bodies.push(first_body);
 
-    let mut gql_requests = Vec::with_capacity(txs.len());
-    gql_requests.push(first_body);
-    for r in requests_iter {
-        let (_, body) = r.subgraph_request.into_parts();
-        gql_requests.push(body);
+    for batch_query in iter {
+        txs.push(batch_query.sender);
+        contexts.push((batch_query.request.context, batch_query.request.id));
+        graphql_bodies.push(batch_query.request.subgraph_request.into_body());
     }
+    debug_assert_eq!(txs.len(), contexts.len());
+    debug_assert_eq!(txs.len(), graphql_bodies.len());
 
     // Construct the actual byte body of the batched request
-    let bytes = serde_json::to_vec(&gql_requests)?;
+    let bytes = serde_json::to_vec(&graphql_bodies)?;
 
     // Generate the final request and pass it up
     let request = http::Request::from_parts(parts, router::body::from_bytes(bytes));

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -509,7 +509,6 @@ mod tests {
     use super::BatchQueryInfo;
     use super::SubgraphBatchRequest;
     use super::assemble_batch;
-    use crate::Configuration;
     use crate::Context;
     use crate::TestHarness;
     use crate::graphql;
@@ -538,12 +537,7 @@ mod tests {
                 (
                     rx,
                     BatchQueryInfo {
-                        http_client: HttpClientServiceFactory::from_config(
-                            "test",
-                            &Configuration::default(),
-                            crate::configuration::shared::Client::default(),
-                        )
-                        .create("test"),
+                        http_client: HttpClientServiceFactory::for_test("test"),
                         request: SubgraphRequest::fake_builder()
                             .subgraph_request(http::Request::builder().body(gql_request).unwrap())
                             .subgraph_name(format!("slot{index}"))
@@ -666,12 +660,7 @@ mod tests {
 
         let bq = Batch::query_for_index(batch.clone(), 0).expect("its a valid index");
 
-        let http_client = HttpClientServiceFactory::from_config(
-            "testbatch",
-            &Configuration::default(),
-            crate::configuration::shared::Client::default(),
-        )
-        .create("whatever");
+        let http_client = HttpClientServiceFactory::for_test("whatever");
 
         let request = SubgraphRequest::fake_builder()
             .subgraph_request(
@@ -702,12 +691,7 @@ mod tests {
 
         let bq = Batch::query_for_index(batch.clone(), 0).expect("its a valid index");
 
-        let http_client = HttpClientServiceFactory::from_config(
-            "testbatch",
-            &Configuration::default(),
-            crate::configuration::shared::Client::default(),
-        )
-        .create("whatever");
+        let http_client = HttpClientServiceFactory::for_test("whatever");
         let request = SubgraphRequest::fake_builder()
             .subgraph_request(
                 http::Request::builder()
@@ -737,12 +721,7 @@ mod tests {
 
         let bq = Batch::query_for_index(batch.clone(), 0).expect("its a valid index");
 
-        let http_client = HttpClientServiceFactory::from_config(
-            "testbatch",
-            &Configuration::default(),
-            crate::configuration::shared::Client::default(),
-        )
-        .create("whatever");
+        let http_client = HttpClientServiceFactory::for_test("whatever");
         let request = SubgraphRequest::fake_builder()
             .subgraph_request(
                 http::Request::builder()

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -1,5 +1,23 @@
 //! Various utility functions and core structures used to implement batching support within
 //! the router.
+//!
+//! Batching works roughly along these lines:
+//! - At the router service, a batch query is split apart into multiple requests.
+//! - A single [Batch] structure is created, which is responsible for handling the batch lifecycle.
+//! - Each individual request gets a [BatchQuery] extension.
+//! - After query planning of each individual request, that request's [BatchQuery::set_query_hashes]
+//!   is called to set the expected number of subgraph requests. This includes only the subgraph
+//!   requests that are unconditionally executed, not subsequent entity fetches for example that can
+//!   only be executed based on data obtained during query plan execution.
+//! - Once each subgraph request that is part of the batch reaches the subgraph service, instead of
+//!   submitting the request to the HTTP client, it calls into [BatchQuery::signal_progress]. This
+//!   is how subgraph requests are eventually batched up. When a [BatchQuery] has received all
+//!   expected progress calls (per [BatchQuery::set_query_hashes]), that query is considered
+//!   "finished".
+//! - The [Batch] lifecycle handler receives messages from each [BatchQuery]. Once _all_
+//!   [BatchQuery]s are finished, no more messages come in, and this is when the [Batch] lifecycle
+//!   handler actually batches up the requests to each subgraph, and sends the batched subgraph
+//!   requests to the HTTP client.
 
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -918,15 +918,9 @@ mod tests {
 
         // We have to provide pre-readied HTTP clients.
         let client1 = http_client.clone().ready_oneshot().await.unwrap();
-        let response1 = query1
-            .signal_progress(client1, request1)
-            .await
-            .unwrap();
+        let response1 = query1.signal_progress(client1, request1).await.unwrap();
         let client2 = http_client.clone().ready_oneshot().await.unwrap();
-        let response2 = query2
-            .signal_progress(client2, request2)
-            .await
-            .unwrap();
+        let response2 = query2.signal_progress(client2, request2).await.unwrap();
 
         let (request, responder) =
             tokio::time::timeout(Duration::from_secs(5), handle.next_request())

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -111,6 +111,8 @@ impl BatchQuery {
     /// Signal to the batch handler that this specific batch query has made some progress.
     ///
     /// The returned channel can be awaited to receive the GraphQL response, when ready.
+    ///
+    /// The HTTP client must be pre-readied.
     pub(crate) async fn signal_progress(
         &self,
         http_client: crate::services::http::BoxCloneService,
@@ -499,6 +501,7 @@ mod tests {
 
     use http::header::ACCEPT;
     use http::header::CONTENT_TYPE;
+    use http_body_util::BodyExt;
     use tokio::sync::oneshot;
     use tower::ServiceExt;
     use wiremock::MockServer;
@@ -514,9 +517,12 @@ mod tests {
     use crate::graphql;
     use crate::graphql::Request;
     use crate::layers::ServiceExt as LayerExt;
+    use crate::services::APPLICATION_JSON_HEADER_VALUE;
     use crate::services::SubgraphRequest;
     use crate::services::SubgraphResponse;
     use crate::services::http::HttpClientServiceFactory;
+    use crate::services::http::HttpRequest;
+    use crate::services::http::HttpResponse;
     use crate::services::router;
     use crate::services::router::body;
     use crate::services::subgraph;
@@ -656,11 +662,12 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn it_limits_the_number_of_progressed_sends() {
+        let (mock, handle) = tower_test::mock::pair::<HttpRequest, HttpResponse>();
         let batch = Arc::new(Batch::spawn_handler(2));
 
         let bq = Batch::query_for_index(batch.clone(), 0).expect("its a valid index");
 
-        let http_client = HttpClientServiceFactory::for_test("whatever");
+        let http_client = mock.boxed_clone();
 
         let request = SubgraphRequest::fake_builder()
             .subgraph_request(
@@ -683,15 +690,20 @@ mod tests {
         );
         assert!(bq.finished());
         assert!(bq.signal_progress(http_client, request).await.is_err());
+
+        // We're only finishing one of two batch queries in this test,
+        // so we should not see a subgraph request actually being sent.
+        crate::plugin::test::assert_no_mock_calls(handle).await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn it_limits_the_number_of_mixed_sends() {
+        let (mock, handle) = tower_test::mock::pair::<HttpRequest, HttpResponse>();
         let batch = Arc::new(Batch::spawn_handler(2));
 
         let bq = Batch::query_for_index(batch.clone(), 0).expect("its a valid index");
 
-        let http_client = HttpClientServiceFactory::for_test("whatever");
+        let http_client = mock.boxed_clone();
         let request = SubgraphRequest::fake_builder()
             .subgraph_request(
                 http::Request::builder()
@@ -713,15 +725,20 @@ mod tests {
                 .await
                 .is_err()
         );
+
+        // We're only finishing one of two batch queries in this test,
+        // so we should not see a subgraph request actually being sent.
+        crate::plugin::test::assert_no_mock_calls(handle).await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn it_limits_the_number_of_mixed_sends_two_query_hashes() {
+        let (mock, handle) = tower_test::mock::pair::<HttpRequest, HttpResponse>();
         let batch = Arc::new(Batch::spawn_handler(2));
 
         let bq = Batch::query_for_index(batch.clone(), 0).expect("its a valid index");
 
-        let http_client = HttpClientServiceFactory::for_test("whatever");
+        let http_client = mock.boxed_clone();
         let request = SubgraphRequest::fake_builder()
             .subgraph_request(
                 http::Request::builder()
@@ -746,6 +763,10 @@ mod tests {
                 .await
                 .is_err()
         );
+
+        // We're only finishing one of two batch queries in this test,
+        // so we should not see a subgraph request actually being sent.
+        crate::plugin::test::assert_no_mock_calls(handle).await;
     }
 
     fn expect_batch(request: &wiremock::Request) -> ResponseTemplate {
@@ -807,24 +828,22 @@ mod tests {
         let schema = include_str!("../tests/fixtures/batching/schema.graphql");
         let service = TestHarness::builder()
             .configuration_json(serde_json::json!({
-            "include_subgraph_errors": {
-                "all": true
-            },
-            "include_subgraph_errors": {
-                "all": true
-            },
-            "batching": {
-                "enabled": true,
-                "mode": "batch_http_link",
-                "subgraph": {
-                    "all": {
-                        "enabled": true
+                "include_subgraph_errors": {
+                    "all": true
+                },
+                "batching": {
+                    "enabled": true,
+                    "mode": "batch_http_link",
+                    "subgraph": {
+                        "all": {
+                            "enabled": true
+                        }
                     }
-                }
-            },
-            "override_subgraph_url": {
-                "a": format!("{}/a", mock_server.uri())
-            }}))
+                },
+                "override_subgraph_url": {
+                    "a": format!("{}/a", mock_server.uri())
+                },
+            }))
             .unwrap()
             .schema(schema)
             .subgraph_hook(move |_subgraph_name, service| {
@@ -846,7 +865,7 @@ mod tests {
 
         let requests: Vec<_> = (0..3)
             .map(|index| {
-                Request::fake_builder()
+                graphql::Request::builder()
                     .query(format!("query op{index}{{ entryA(count: 3) {{ index }} }}"))
                     .build()
             })
@@ -875,5 +894,102 @@ mod tests {
 
         let response: serde_json::Value = serde_json::from_slice(&response).unwrap();
         insta::assert_json_snapshot!(response);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn it_sends_batched_request() {
+        let (mock, mut handle) = tower_test::mock::pair::<HttpRequest, HttpResponse>();
+        let batch = Arc::new(Batch::spawn_handler(2));
+
+        let http_client = mock.boxed_clone();
+
+        let query1 = Batch::query_for_index(batch.clone(), 0).unwrap();
+        let query2 = Batch::query_for_index(batch.clone(), 1).unwrap();
+
+        let request1 = SubgraphRequest::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .body(graphql::Request::builder().query("{ field1 }").build())
+                    .unwrap(),
+            )
+            .subgraph_name("a")
+            .build();
+
+        let request2 = SubgraphRequest::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .body(graphql::Request::builder().query("{ field2 }").build())
+                    .unwrap(),
+            )
+            .subgraph_name("a")
+            .build();
+
+        // We have to provide pre-readied HTTP clients.
+        let client1 = http_client.clone().ready_oneshot().await.unwrap();
+        let response1 = query1
+            .signal_progress(client1, request1)
+            .await
+            .unwrap();
+        let client2 = http_client.clone().ready_oneshot().await.unwrap();
+        let response2 = query2
+            .signal_progress(client2, request2)
+            .await
+            .unwrap();
+
+        let (request, responder) =
+            tokio::time::timeout(Duration::from_secs(5), handle.next_request())
+                .await
+                .expect("should get a request")
+                .expect("service closed without request?");
+
+        let body = request
+            .http_request
+            .into_body()
+            .collect()
+            .await
+            .expect("should read subgraph request body");
+        let (body1, body2) =
+            serde_json::from_slice::<(graphql::Request, graphql::Request)>(&body.to_bytes())
+                .expect("should have a two-element array json body");
+        assert_eq!(body1.query.as_deref(), Some("{ field1 }"));
+        assert_eq!(body2.query.as_deref(), Some("{ field2 }"));
+
+        responder.send_response(HttpResponse {
+            http_response: http::Response::builder()
+                .header(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone())
+                .body(router::body::from_bytes(
+                    r#"[
+                    { "data": { "field1": "value1" } },
+                    { "data": { "field2": "value2" } }
+                ]"#,
+                ))
+                .unwrap(),
+            context: request.context,
+        });
+
+        // Check that the batch response was split up correctly
+        let response1 = response1
+            .await
+            .expect("channel should be open")
+            .expect("successful response");
+        let response1 = response1.response.into_body();
+        assert_eq!(
+            response1.data,
+            Some(serde_json_bytes::json!({ "field1": "value1" }))
+        );
+
+        let response2 = response2
+            .await
+            .expect("channel should be open")
+            .expect("successful response");
+        let response2 = response2.response.into_body();
+        assert_eq!(
+            response2.data,
+            Some(serde_json_bytes::json!({ "field2": "value2" }))
+        );
+
+        // Only 1 call is expected
+        drop(http_client);
+        crate::plugin::test::assert_no_mock_calls(handle).await;
     }
 }

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -420,7 +420,6 @@ impl Drop for Batch {
 
 /// A batch of requests that we'll send to a subgraph (...as a single batch request).
 pub(crate) struct SubgraphBatchRequest {
-    pub(crate) operation_name: String,
     pub(crate) contexts: Vec<(Context, SubgraphRequestId)>,
     pub(crate) request: http::Request<RouterBody>,
     pub(crate) txs: Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
@@ -446,11 +445,6 @@ pub(crate) async fn assemble_batch(
         .next()
         .ok_or(SubgraphBatchingError::RequestsIsEmpty)?
         .subgraph_request;
-    let operation_name = first_request
-        .body()
-        .operation_name
-        .clone()
-        .unwrap_or_default();
     let (parts, first_body) = first_request.into_parts();
 
     let mut gql_requests = Vec::with_capacity(txs.len());
@@ -466,7 +460,6 @@ pub(crate) async fn assemble_batch(
     // Generate the final request and pass it up
     let request = http::Request::from_parts(parts, router::body::from_bytes(bytes));
     Ok(SubgraphBatchRequest {
-        operation_name,
         contexts,
         request,
         txs,
@@ -536,7 +529,6 @@ mod tests {
             .collect::<Vec<String>>();
         // Assemble them
         let SubgraphBatchRequest {
-            operation_name,
             contexts,
             request,
             txs,
@@ -550,9 +542,6 @@ mod tests {
             .collect::<Vec<String>>();
         // Make sure all of our contexts are preserved during assembly
         assert_eq!(input_context_ids, output_context_ids);
-
-        // Make sure that the name of the entire batch is that of the first
-        assert_eq!(operation_name, "batch_test_0");
 
         // We should see the aggregation of all of the requests
         let actual: Vec<graphql::Request> = serde_json::from_str(

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -395,7 +395,7 @@ pub(crate) async fn create_subgraph_services(
 ) -> Result<IndexMap<String, subgraph::BoxCloneService>, BoxError> {
     let mut subgraph_services = IndexMap::default();
     for (name, http_service_factory) in http_service_factory.iter() {
-        let svc = SubgraphService::new(name.clone(), http_service_factory.clone())?;
+        let svc = SubgraphService::new(name, http_service_factory.create(name))?;
         subgraph_services.insert(name.clone(), svc.boxed_clone());
     }
 

--- a/apollo-router/src/services/http.rs
+++ b/apollo-router/src/services/http.rs
@@ -72,6 +72,16 @@ impl HttpClientServiceFactory {
                 e.http_client_service(name, acc)
             })
     }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(name: &str) -> BoxCloneService {
+        Self::from_config(
+            name,
+            &crate::Configuration::default(),
+            crate::configuration::shared::Client::default(),
+        )
+        .create(name)
+    }
 }
 
 /// The kind of remote service an [`HttpClientService`] is configured to talk to.

--- a/apollo-router/src/services/http.rs
+++ b/apollo-router/src/services/http.rs
@@ -43,7 +43,7 @@ impl HttpClientServiceFactory {
 
     #[cfg(test)]
     pub(crate) fn from_config(
-        service: impl Into<String>,
+        service: &str,
         configuration: &crate::Configuration,
         client_config: crate::configuration::shared::Client,
     ) -> Self {

--- a/apollo-router/src/services/layers/apq/subgraph.rs
+++ b/apollo-router/src/services/layers/apq/subgraph.rs
@@ -676,7 +676,8 @@ mod tests {
                         name,
                         &Configuration::default(),
                         crate::configuration::shared::Client::default(),
-                    ),
+                    )
+                    .create(name),
                 )
                 .expect("can create a SubgraphService"),
             )

--- a/apollo-router/src/services/layers/apq/subgraph.rs
+++ b/apollo-router/src/services/layers/apq/subgraph.rs
@@ -586,7 +586,6 @@ mod tests {
         use tower::ServiceExt;
 
         use super::*;
-        use crate::Configuration;
         use crate::graphql::Response;
         use crate::query_planner::fetch::OperationKind;
         use crate::services::SubgraphService;
@@ -670,16 +669,8 @@ mod tests {
             enable_apq: bool,
         ) -> SubgraphApqService<SubgraphService> {
             SubgraphApqLayer::new(enable_apq).layer(
-                SubgraphService::new(
-                    name,
-                    HttpClientServiceFactory::from_config(
-                        name,
-                        &Configuration::default(),
-                        crate::configuration::shared::Client::default(),
-                    )
-                    .create(name),
-                )
-                .expect("can create a SubgraphService"),
+                SubgraphService::new(name, HttpClientServiceFactory::for_test(name))
+                    .expect("can create a SubgraphService"),
             )
         }
 

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -46,6 +46,7 @@ use crate::Context;
 use crate::Notify;
 use crate::batching::BatchQuery;
 use crate::batching::BatchQueryInfo;
+use crate::batching::SubgraphBatchRequest;
 use crate::batching::assemble_batch;
 use crate::configuration::Batching;
 use crate::configuration::BatchingMode;
@@ -262,7 +263,7 @@ fn http_response_to_graphql_response(
 
 /// Process a single subgraph batch request
 #[instrument(skip(client_factory, contexts, request))]
-pub(crate) async fn process_batch(
+async fn process_batch(
     client_factory: HttpClientServiceFactory,
     service: String,
     mut contexts: Vec<(Context, SubgraphRequestId)>,
@@ -517,7 +518,7 @@ pub(crate) async fn process_batch(
 }
 
 /// Notify all listeners of a batch query of the results
-pub(crate) async fn notify_batch_query(
+async fn notify_batch_query(
     service: String,
     senders: Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
     responses: Result<Vec<SubgraphResponse>, FetchError>,
@@ -596,7 +597,6 @@ type BatchInfo = (
         String,
         http::Request<RouterBody>,
         Vec<(Context, SubgraphRequestId)>,
-        usize,
     ),
     Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
 );
@@ -611,9 +611,14 @@ pub(crate) async fn process_batches(
     let mut errors = vec![];
     let (info, txs): (Vec<_>, Vec<_>) =
         futures::future::join_all(svc_map.into_iter().map(|(service, requests)| async {
-            let (_op_name, contexts, request, txs) = assemble_batch(requests).await?;
+            let SubgraphBatchRequest {
+                operation_name: _,
+                contexts,
+                request,
+                txs,
+            } = assemble_batch(requests).await?;
 
-            Ok(((service, request, contexts, txs.len()), txs))
+            Ok(((service, request, contexts), txs))
         }))
         .await
         .into_iter()
@@ -641,20 +646,22 @@ pub(crate) async fn process_batches(
         )
         .into());
     }
-    let batch_futures = info.into_iter().zip_eq(txs).map(
-        |((service, request, contexts, listener_count), senders)| async move {
-            let batch_result = process_batch(
-                cf.clone(),
-                service.clone(),
-                contexts,
-                request,
-                listener_count,
-            )
-            .await;
+    let batch_futures =
+        info.into_iter()
+            .zip_eq(txs)
+            .map(|((service, request, contexts), senders)| async move {
+                let listener_count = senders.len();
+                let batch_result = process_batch(
+                    cf.clone(),
+                    service.clone(),
+                    contexts,
+                    request,
+                    listener_count,
+                )
+                .await;
 
-            notify_batch_query(service, senders, batch_result).await
-        },
-    );
+                notify_batch_query(service, senders, batch_result).await
+            });
 
     futures::future::try_join_all(batch_futures).await?;
 
@@ -701,7 +708,7 @@ async fn call_http(
 }
 
 /// call_single_http makes http calls with modified graphql::Request (body)
-pub(crate) async fn call_single_http(
+async fn call_single_http(
     request: SubgraphRequest,
     client: crate::services::http::BoxCloneService,
     service_name: &str,

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -37,7 +37,6 @@ use tracing::Instrument;
 use tracing::instrument;
 
 use super::Plugins;
-use super::http::HttpClientServiceFactory;
 use super::http::HttpRequest;
 use super::layers::content_negotiation::GRAPHQL_JSON_RESPONSE_HEADER_VALUE;
 use super::router::body::RouterBody;
@@ -91,22 +90,17 @@ pub(crate) struct SubgraphService {
     /// Pre-built HTTP client service with all plugin layers already folded in.
     /// Used on the hot (non-batching) path to avoid re-folding plugins per request.
     http_client: crate::services::http::BoxCloneService,
-    /// Kept only for the batching path, where a single factory may be used to
-    /// `.create()` clients for different subgraph names.
-    pub(crate) client_factory: HttpClientServiceFactory,
     service: Arc<String>,
 }
 
 impl SubgraphService {
     pub(crate) fn new(
         service: impl Into<String>,
-        client_factory: crate::services::http::HttpClientServiceFactory,
+        http_client: crate::services::http::BoxCloneService,
     ) -> Result<Self, BoxError> {
         let name = service.into();
-        let http_client = client_factory.create(&name);
         Ok(Self {
             http_client,
-            client_factory,
             service: Arc::new(name),
         })
     }
@@ -142,18 +136,17 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
     type Error = BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-    fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.http_client.poll_ready(cx)
     }
 
     fn call(&mut self, request: SubgraphRequest) -> Self::Future {
-        let service_name = (*self.service).to_owned();
-        let client_factory = self.client_factory.clone();
-        let http_client = self.http_client.clone();
+        let service_name = self.service.clone();
 
-        Box::pin(
-            async move { call_http(request, client_factory, http_client, &service_name).await },
-        )
+        let fresh_client = self.http_client.clone();
+        let http_client = std::mem::replace(&mut self.http_client, fresh_client);
+
+        Box::pin(async move { call_http(request, http_client, &service_name).await })
     }
 }
 
@@ -262,10 +255,10 @@ fn http_response_to_graphql_response(
 }
 
 /// Process a single subgraph batch request
-#[instrument(skip(client_factory, contexts, request))]
+#[instrument(skip(http_client, contexts, request))]
 async fn process_batch(
-    client_factory: HttpClientServiceFactory,
-    service: String,
+    http_client: crate::services::http::BoxCloneService,
+    service: &str,
     mut contexts: Vec<(Context, SubgraphRequestId)>,
     mut request: http::Request<RouterBody>,
     listener_count: usize,
@@ -316,7 +309,6 @@ async fn process_batch(
         .expect("we have at least one context in the batch")
         .0
         .clone();
-    let client = client_factory.create(&service);
 
     // Update our batching metrics (just before we fetch)
     u64_histogram!(
@@ -324,7 +316,7 @@ async fn process_batch(
         "Number of queries contained within each query batch",
         listener_count as u64,
         mode = BatchingMode::BatchHttpLink.to_string(), // Only supported mode right now
-        subgraph = service.clone()
+        subgraph = service.to_string()
     );
 
     u64_counter!(
@@ -334,12 +326,12 @@ async fn process_batch(
         // XXX(@goto-bus-stop): Should these be `batching.mode`, `batching.subgraph`?
         // Also, other metrics use a different convention to report the subgraph name
         mode = BatchingMode::BatchHttpLink.to_string(), // Only supported mode right now
-        subgraph = service.clone()
+        subgraph = service.to_string()
     );
 
     // Perform the actual fetch. If this fails then we didn't manage to make the call at all, so we can't do anything with it.
     tracing::debug!("fetching from subgraph: {service}");
-    let (parts, content_type, body) = match do_fetch(client, &batch_context, &service, request)
+    let (parts, content_type, body) = match do_fetch(http_client, &batch_context, service, request)
         .instrument(subgraph_req_span)
         .await
     {
@@ -350,14 +342,14 @@ async fn process_batch(
                 .body(err.to_graphql_error(None))
                 .map_err(|err| FetchError::SubrequestHttpError {
                     status_code: None,
-                    service: service.clone(),
+                    service: service.to_string(),
                     reason: format!("cannot create the http response from error: {err:?}"),
                 })?;
             let (parts, body) = resp.into_parts();
             let body =
                 serde_json::to_vec(&body).map_err(|err| FetchError::SubrequestHttpError {
                     status_code: None,
-                    service: service.clone(),
+                    service: service.to_string(),
                     reason: format!("cannot serialize the error: {err:?}"),
                 })?;
             (
@@ -374,7 +366,7 @@ async fn process_batch(
     let headers_str = crate::services::header_masking::masked_headers_for_log(
         &batch_context,
         crate::services::header_masking::Direction::Response,
-        Some(&service),
+        Some(service),
         &parts.headers,
     );
 
@@ -403,7 +395,7 @@ async fn process_batch(
         }
         attrs.push(KeyValue::new(
             Key::from_static_str("subgraph.name"),
-            opentelemetry::Value::String(service.clone().into()),
+            opentelemetry::Value::String(service.to_string().into()),
         ));
         log_event(
             event.level,
@@ -454,7 +446,7 @@ async fn process_batch(
         );
 
         let graphql_response =
-            http_response_to_graphql_response(&service, content_type.clone(), body, &parts);
+            http_response_to_graphql_response(service, content_type.clone(), body, &parts);
         graphql_responses.push(graphql_response);
     }
 
@@ -463,7 +455,7 @@ async fn process_batch(
     // response
     if graphql_responses.len() != contexts.len() {
         return Err(FetchError::SubrequestBatchingError {
-            service,
+            service: service.to_string(),
             reason: format!(
                 "number of contexts ({}) is not equal to number of graphql responses ({})",
                 contexts.len(),
@@ -474,12 +466,10 @@ async fn process_batch(
 
     // We are going to pop contexts from the back, so let's reverse our contexts
     contexts.reverse();
-    let subgraph_name = service.clone();
     // Build an http Response for each graphql response
     let subgraph_responses: Result<Vec<_>, _> = graphql_responses
         .into_iter()
         .map(|res| {
-            let subgraph_name = subgraph_name.clone();
             http::Response::builder()
                 .status(parts.status)
                 .version(parts.version)
@@ -489,8 +479,12 @@ async fn process_batch(
                     // Use the original context for the request to create the response
                     let (context, id) =
                         contexts.pop().expect("we have a context for each response");
-                    let resp =
-                        SubgraphResponse::new_from_response(http_res, context, subgraph_name, id);
+                    let resp = SubgraphResponse::new_from_response(
+                        http_res,
+                        context,
+                        service.to_string(),
+                        id,
+                    );
 
                     // Avoid `{resp:?}`: SubgraphResponse's derived Debug prints
                     // the response HeaderMap unmasked. Log the non-header parts.
@@ -595,6 +589,7 @@ async fn notify_batch_query(
 type BatchInfo = (
     (
         String,
+        crate::services::http::BoxCloneService,
         http::Request<RouterBody>,
         Vec<(Context, SubgraphRequestId)>,
     ),
@@ -604,7 +599,6 @@ type BatchInfo = (
 /// Collect all batch requests and process them concurrently
 #[instrument(skip_all)]
 pub(crate) async fn process_batches(
-    client_factory: HttpClientServiceFactory,
     svc_map: HashMap<String, Vec<BatchQueryInfo>>,
 ) -> Result<(), BoxError> {
     // We need to strip out the senders so that we can work with them separately.
@@ -612,12 +606,13 @@ pub(crate) async fn process_batches(
     let (info, txs): (Vec<_>, Vec<_>) =
         futures::future::join_all(svc_map.into_iter().map(|(service, requests)| async {
             let SubgraphBatchRequest {
+                http_client: client,
                 contexts,
                 request,
                 txs,
             } = assemble_batch(requests).await?;
 
-            Ok(((service, request, contexts), txs))
+            Ok(((service, client, request, contexts), txs))
         }))
         .await
         .into_iter()
@@ -635,8 +630,6 @@ pub(crate) async fn process_batches(
         )
         .into());
     }
-    // Collect all of the processing logic and run them concurrently, collecting all errors
-    let cf = &client_factory;
     // It is not ok to panic if the length of the txs and info do not match. Let's make sure they
     // do
     if txs.len() != info.len() {
@@ -648,16 +641,10 @@ pub(crate) async fn process_batches(
     let batch_futures =
         info.into_iter()
             .zip_eq(txs)
-            .map(|((service, request, contexts), senders)| async move {
+            .map(|((service, http_client, request, contexts), senders)| async move {
                 let listener_count = senders.len();
-                let batch_result = process_batch(
-                    cf.clone(),
-                    service.clone(),
-                    contexts,
-                    request,
-                    listener_count,
-                )
-                .await;
+                let batch_result =
+                    process_batch(http_client, &service, contexts, request, listener_count).await;
 
                 notify_batch_query(service, senders, batch_result).await
             });
@@ -669,7 +656,6 @@ pub(crate) async fn process_batches(
 
 async fn call_http(
     request: SubgraphRequest,
-    client_factory: HttpClientServiceFactory,
     http_client: crate::services::http::BoxCloneService,
     service_name: &str,
 ) -> Result<SubgraphResponse, BoxError> {
@@ -689,9 +675,7 @@ async fn call_http(
 
     // If we have a batch query, then it's time for batching
     if let Some(query) = opt_batch_query {
-        // The batch path needs the factory because a single batch handler may
-        // create clients for different subgraph names.
-        let response_rx = query.signal_progress(client_factory, request).await?;
+        let response_rx = query.signal_progress(http_client, request).await?;
 
         // Park this query until we have our response and pass it back up
         response_rx
@@ -1164,6 +1148,7 @@ mod tests {
     use crate::protocols::websocket::ServerMessage;
     use crate::protocols::websocket::WebSocketProtocol;
     use crate::query_planner::fetch::OperationKind;
+    use crate::services::http::HttpClientServiceFactory;
     use crate::services::router;
 
     async fn serve<Handler, Fut>(listener: TcpListener, handle: Handler) -> std::io::Result<()>
@@ -1625,7 +1610,8 @@ mod tests {
                     "testbis",
                     &Configuration::default(),
                     crate::configuration::shared::Client::default(),
-                ),
+                )
+                .create("testbis"),
             )
             .expect("can create a SubgraphService"),
         );
@@ -1667,7 +1653,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -1698,7 +1685,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -1730,7 +1718,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -1765,7 +1754,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -1799,7 +1789,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -1846,7 +1837,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -1889,7 +1881,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -1929,7 +1922,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -1968,7 +1962,8 @@ mod tests {
                     "test",
                     &Configuration::default(),
                     crate::configuration::shared::Client::default(),
-                ),
+                )
+                .create("test"),
             )
             .expect("can create a SubgraphService"),
         );
@@ -2021,7 +2016,7 @@ mod tests {
                         "test",
                         &Configuration::default(),
                         crate::configuration::shared::Client::default(),
-                    ),
+                    ).create("test"),
                 )
                 .expect("can create a SubgraphService"),
             );
@@ -2075,7 +2070,8 @@ mod tests {
                         "test",
                         &Configuration::default(),
                         crate::configuration::shared::Client::default(),
-                    ),
+                    )
+                    .create("test"),
                 )
                 .expect("can create a SubgraphService"),
             );
@@ -2143,7 +2139,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2182,7 +2179,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2217,7 +2215,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2252,7 +2251,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 
@@ -2286,7 +2286,8 @@ mod tests {
                 "test",
                 &Configuration::default(),
                 crate::configuration::shared::Client::default(),
-            ),
+            )
+            .create("test"),
         )
         .expect("can create a SubgraphService");
 

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -309,8 +309,6 @@ async fn process_batch(
         .expect("we have at least one context in the batch")
         .0
         .clone();
-    // `service` is a shared `&str`, but the various error/telemetry sinks below need an
-    // owned copy; compute it once here instead of re-converting at each call site.
     let service_name = service.to_string();
 
     // Update our batching metrics (just before we fetch)
@@ -1148,7 +1146,6 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::Configuration;
     use crate::Context;
     use crate::assert_response_eq_ignoring_error_id;
     use crate::configuration::subgraph::SubgraphConfiguration;
@@ -1624,16 +1621,8 @@ mod tests {
         let socket_addr = listener.local_addr().unwrap();
         let spawned_task = tokio::task::spawn(emulate_subgraph_with_callback_data(listener));
         let subgraph_service = with_subscription_layer(
-            SubgraphService::new(
-                "testbis",
-                HttpClientServiceFactory::from_config(
-                    "testbis",
-                    &Configuration::default(),
-                    crate::configuration::shared::Client::default(),
-                )
-                .create("testbis"),
-            )
-            .expect("can create a SubgraphService"),
+            SubgraphService::new("testbis", HttpClientServiceFactory::for_test("testbis"))
+                .expect("can create a SubgraphService"),
         );
         let (tx, _rx) = mpsc::channel(2);
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
@@ -1667,16 +1656,9 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_application_graphql_response(listener));
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service
@@ -1699,16 +1681,9 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_application_json_response(listener));
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service
@@ -1732,16 +1707,9 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_panic(listener));
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service
@@ -1768,16 +1736,9 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_ok_status_invalid_response(listener));
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service
@@ -1803,16 +1764,9 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_large_response(listener));
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let context = Context::new();
         context
@@ -1851,16 +1805,9 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_application_json_response(listener));
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let context = Context::new();
         // Limit of 1000 bytes — well above {"data": null} (14 bytes)
@@ -1895,16 +1842,9 @@ mod tests {
         tokio::task::spawn(
             emulate_subgraph_invalid_response_invalid_status_application_json(listener),
         );
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service
@@ -1936,16 +1876,9 @@ mod tests {
         tokio::task::spawn(
             emulate_subgraph_invalid_response_invalid_status_application_graphql(listener),
         );
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service
@@ -1976,16 +1909,8 @@ mod tests {
         let socket_addr = listener.local_addr().unwrap();
         let spawned_task = tokio::task::spawn(emulate_correct_websocket_server(listener));
         let subgraph_service = with_subscription_layer(
-            SubgraphService::new(
-                "test",
-                HttpClientServiceFactory::from_config(
-                    "test",
-                    &Configuration::default(),
-                    crate::configuration::shared::Client::default(),
-                )
-                .create("test"),
-            )
-            .expect("can create a SubgraphService"),
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService"),
         );
         let (tx, rx) = mpsc::channel(2);
         let mut rx_stream = ReceiverStream::new(rx);
@@ -2030,15 +1955,8 @@ mod tests {
             let socket_addr = listener.local_addr().unwrap();
             tokio::task::spawn(emulate_incorrect_websocket_server(listener));
             let subgraph_service = with_subscription_layer(
-                SubgraphService::new(
-                    "test",
-                    HttpClientServiceFactory::from_config(
-                        "test",
-                        &Configuration::default(),
-                        crate::configuration::shared::Client::default(),
-                    ).create("test"),
-                )
-                .expect("can create a SubgraphService"),
+                SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                    .expect("can create a SubgraphService"),
             );
             let (tx, _rx) = mpsc::channel(2);
 
@@ -2084,16 +2002,8 @@ mod tests {
             let spawned_task =
                 tokio::task::spawn(emulate_websocket_server_that_completes(listener));
             let subgraph_service = with_subscription_layer(
-                SubgraphService::new(
-                    "test",
-                    HttpClientServiceFactory::from_config(
-                        "test",
-                        &Configuration::default(),
-                        crate::configuration::shared::Client::default(),
-                    )
-                    .create("test"),
-                )
-                .expect("can create a SubgraphService"),
+                SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                    .expect("can create a SubgraphService"),
             );
             let (tx, rx) = mpsc::channel(2);
             let mut rx_stream = ReceiverStream::new(rx);
@@ -2153,16 +2063,9 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_bad_request(listener));
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service
@@ -2193,16 +2096,9 @@ mod tests {
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_missing_content_type(listener));
 
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service
@@ -2229,16 +2125,9 @@ mod tests {
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_invalid_content_type(listener));
 
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service
@@ -2265,16 +2154,9 @@ mod tests {
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_unsupported_content_type(listener));
 
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service
@@ -2300,16 +2182,9 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let socket_addr = listener.local_addr().unwrap();
         tokio::task::spawn(emulate_subgraph_unauthorized(listener));
-        let subgraph_service = SubgraphService::new(
-            "test",
-            HttpClientServiceFactory::from_config(
-                "test",
-                &Configuration::default(),
-                crate::configuration::shared::Client::default(),
-            )
-            .create("test"),
-        )
-        .expect("can create a SubgraphService");
+        let subgraph_service =
+            SubgraphService::new("test", HttpClientServiceFactory::for_test("test"))
+                .expect("can create a SubgraphService");
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -309,6 +309,9 @@ async fn process_batch(
         .expect("we have at least one context in the batch")
         .0
         .clone();
+    // `service` is a shared `&str`, but the various error/telemetry sinks below need an
+    // owned copy; compute it once here instead of re-converting at each call site.
+    let service_name = service.to_string();
 
     // Update our batching metrics (just before we fetch)
     u64_histogram!(
@@ -316,7 +319,7 @@ async fn process_batch(
         "Number of queries contained within each query batch",
         listener_count as u64,
         mode = BatchingMode::BatchHttpLink.to_string(), // Only supported mode right now
-        subgraph = service.to_string()
+        subgraph = service_name.clone()
     );
 
     u64_counter!(
@@ -326,7 +329,7 @@ async fn process_batch(
         // XXX(@goto-bus-stop): Should these be `batching.mode`, `batching.subgraph`?
         // Also, other metrics use a different convention to report the subgraph name
         mode = BatchingMode::BatchHttpLink.to_string(), // Only supported mode right now
-        subgraph = service.to_string()
+        subgraph = service_name.clone()
     );
 
     // Perform the actual fetch. If this fails then we didn't manage to make the call at all, so we can't do anything with it.
@@ -342,14 +345,14 @@ async fn process_batch(
                 .body(err.to_graphql_error(None))
                 .map_err(|err| FetchError::SubrequestHttpError {
                     status_code: None,
-                    service: service.to_string(),
+                    service: service_name.clone(),
                     reason: format!("cannot create the http response from error: {err:?}"),
                 })?;
             let (parts, body) = resp.into_parts();
             let body =
                 serde_json::to_vec(&body).map_err(|err| FetchError::SubrequestHttpError {
                     status_code: None,
-                    service: service.to_string(),
+                    service: service_name.clone(),
                     reason: format!("cannot serialize the error: {err:?}"),
                 })?;
             (
@@ -395,7 +398,7 @@ async fn process_batch(
         }
         attrs.push(KeyValue::new(
             Key::from_static_str("subgraph.name"),
-            opentelemetry::Value::String(service.to_string().into()),
+            opentelemetry::Value::String(service_name.clone().into()),
         ));
         log_event(
             event.level,
@@ -412,25 +415,25 @@ async fn process_batch(
     );
     let value =
         serde_json::from_slice(&body.ok_or(FetchError::SubrequestMalformedResponse {
-            service: service.to_string(),
+            service: service_name.clone(),
             reason: "no body in response".to_string(),
         })??)
         .map_err(|error| FetchError::SubrequestMalformedResponse {
-            service: service.to_string(),
+            service: service_name.clone(),
             reason: error.to_string(),
         })?;
 
     tracing::debug!("json value from body is: {value:?}");
 
     let array = ensure_array!(value).map_err(|error| FetchError::SubrequestMalformedResponse {
-        service: service.to_string(),
+        service: service_name.clone(),
         reason: error.to_string(),
     })?;
     let mut graphql_responses = Vec::with_capacity(array.len());
     for value in array {
         let object =
             ensure_object!(value).map_err(|error| FetchError::SubrequestMalformedResponse {
-                service: service.to_string(),
+                service: service_name.clone(),
                 reason: error.to_string(),
             })?;
 
@@ -440,7 +443,7 @@ async fn process_batch(
             serde_json::to_vec(&object)
                 .map(|v| v.into())
                 .map_err(|error| FetchError::SubrequestMalformedResponse {
-                    service: service.to_string(),
+                    service: service_name.clone(),
                     reason: error.to_string(),
                 }),
         );
@@ -455,7 +458,7 @@ async fn process_batch(
     // response
     if graphql_responses.len() != contexts.len() {
         return Err(FetchError::SubrequestBatchingError {
-            service: service.to_string(),
+            service: service_name.clone(),
             reason: format!(
                 "number of contexts ({}) is not equal to number of graphql responses ({})",
                 contexts.len(),
@@ -482,7 +485,7 @@ async fn process_batch(
                     let resp = SubgraphResponse::new_from_response(
                         http_res,
                         context,
-                        service.to_string(),
+                        service_name.clone(),
                         id,
                     );
 

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -254,7 +254,10 @@ fn http_response_to_graphql_response(
     graphql_response
 }
 
-/// Process a single subgraph batch request
+/// Process a single subgraph batch request.
+///
+/// # Panics
+/// The HTTP client service must already be readied: otherwise, it may panic.
 #[instrument(skip(http_client, contexts, request))]
 async fn process_batch(
     http_client: crate::services::http::BoxCloneService,
@@ -589,6 +592,7 @@ async fn notify_batch_query(
 
 struct BatchInfo {
     service: String,
+    /// A pre-readied HTTP client service for this subgraph.
     http_client: crate::services::http::BoxCloneService,
     request: http::Request<RouterBody>,
     contexts: Vec<(Context, SubgraphRequestId)>,
@@ -600,6 +604,9 @@ type BatchResult = (
 );
 
 /// Collect all batch requests and process them concurrently
+///
+/// # Panics
+/// The HTTP client services inside the svc_map must already be readied: otherwise, it may panic.
 #[instrument(skip_all)]
 pub(crate) async fn process_batches(
     svc_map: HashMap<String, Vec<BatchQueryInfo>>,

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -589,13 +589,15 @@ async fn notify_batch_query(
     Ok(())
 }
 
-type BatchInfo = (
-    (
-        String,
-        crate::services::http::BoxCloneService,
-        http::Request<RouterBody>,
-        Vec<(Context, SubgraphRequestId)>,
-    ),
+struct BatchInfo {
+    service: String,
+    http_client: crate::services::http::BoxCloneService,
+    request: http::Request<RouterBody>,
+    contexts: Vec<(Context, SubgraphRequestId)>,
+}
+
+type BatchResult = (
+    BatchInfo,
     Vec<oneshot::Sender<Result<SubgraphResponse, BoxError>>>,
 );
 
@@ -609,17 +611,25 @@ pub(crate) async fn process_batches(
     let (info, txs): (Vec<_>, Vec<_>) =
         futures::future::join_all(svc_map.into_iter().map(|(service, requests)| async {
             let SubgraphBatchRequest {
-                http_client: client,
+                http_client,
                 contexts,
                 request,
                 txs,
             } = assemble_batch(requests).await?;
 
-            Ok(((service, client, request, contexts), txs))
+            Ok((
+                BatchInfo {
+                    service,
+                    http_client,
+                    request,
+                    contexts,
+                },
+                txs,
+            ))
         }))
         .await
         .into_iter()
-        .filter_map(|x: Result<BatchInfo, BoxError>| x.map_err(|e| errors.push(e)).ok())
+        .filter_map(|x: Result<BatchResult, BoxError>| x.map_err(|e| errors.push(e)).ok())
         .unzip();
 
     // If errors isn't empty, then process_batches cannot proceed. Let's log out the errors and
@@ -641,16 +651,23 @@ pub(crate) async fn process_batches(
         )
         .into());
     }
-    let batch_futures =
-        info.into_iter()
-            .zip_eq(txs)
-            .map(|((service, http_client, request, contexts), senders)| async move {
-                let listener_count = senders.len();
-                let batch_result =
-                    process_batch(http_client, &service, contexts, request, listener_count).await;
+    let batch_futures = info.into_iter().zip_eq(txs).map(
+        |(
+            BatchInfo {
+                service,
+                http_client,
+                request,
+                contexts,
+            },
+            senders,
+        )| async move {
+            let listener_count = senders.len();
+            let batch_result =
+                process_batch(http_client, &service, contexts, request, listener_count).await;
 
-                notify_batch_query(service, senders, batch_result).await
-            });
+            notify_batch_query(service, senders, batch_result).await
+        },
+    );
 
     futures::future::try_join_all(batch_futures).await?;
 

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -612,7 +612,6 @@ pub(crate) async fn process_batches(
     let (info, txs): (Vec<_>, Vec<_>) =
         futures::future::join_all(svc_map.into_iter().map(|(service, requests)| async {
             let SubgraphBatchRequest {
-                operation_name: _,
                 contexts,
                 request,
                 txs,


### PR DESCRIPTION
Cleans up subgraph service, this now has a single http client service field that is cloned and used in a standard tower way rather than using the factory to create clients every request.

Batching code was included in the blast radius as this was the primary user of the factory. (Closes #9717)

<!-- start metadata -->

<!-- [ROUTER-1858] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1858]: https://apollographql.atlassian.net/browse/ROUTER-1858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ