### PR TITLE
perf(query-planning): Reuse the condition resolver cache during query planning/satisfiability

### DIFF
--- a/.changesets/feat_sachin_global_condition_resolver_cache.md
+++ b/.changesets/feat_sachin_global_condition_resolver_cache.md
@@ -1,0 +1,5 @@
+### Reuse condition planning cache during query planning and satisfiability validation ([PR #9740](https://github.com/apollographql/router/pull/9740))
+
+Router query planning and composition satisfiability validation have optimizations that cache the results of planning a "condition" (e.g. the fields of an `@key` or `@requires`). However, when this condition planning happened recursively, this resulted in new caches being constructed instead of reusing the existing cache. This behavior inhibited the reuse of previous condition planning work, increasing planning/validation time significantly in some circumstances. This code has now been changed to reuse the existing cache.
+
+By [@sachindshinde](https://github.com/sachindshinde) in https://github.com/apollographql/router/pull/9740

--- a/apollo-federation/src/composition/satisfiability/conditions_validation.rs
+++ b/apollo-federation/src/composition/satisfiability/conditions_validation.rs
@@ -39,6 +39,7 @@ pub(super) fn resolve_condition_plan(
     excluded_destinations: &ExcludedDestinations,
     excluded_conditions: &ExcludedConditions,
     extra_conditions: Option<&SelectionSet>,
+    condition_resolver_cache: &mut ConditionResolverCache,
 ) -> Result<ConditionResolution, FederationError> {
     let edge_weight = query_graph.edge_weight(edge)?;
     let conditions = match (extra_conditions, &edge_weight.conditions) {
@@ -60,30 +61,32 @@ pub(super) fn resolve_condition_plan(
         query_graph.clone(),
         initial_option,
         conditions.iter().cloned(),
+        condition_resolver_cache,
     );
     traversal.find_resolution()
 }
 
-struct ConditionValidationTraversal {
+struct ConditionValidationTraversal<'a> {
     /// The federated query graph for the supergraph schema.
     query_graph: Arc<QueryGraph>,
     /// The cache for condition resolution.
-    condition_resolver_cache: ConditionResolverCache,
+    condition_resolver_cache: &'a mut ConditionResolverCache,
     /// The stack of open branches left to plan, along with state indicating the next selection to
     /// plan for them.
     // PORT_NOTE: This implementation closely follows the way `QueryPlanningTraversal` was ported.
     open_branches: Vec<OpenBranchAndSelections>,
 }
 
-impl ConditionValidationTraversal {
+impl<'a> ConditionValidationTraversal<'a> {
     fn new(
         query_graph: Arc<QueryGraph>,
         initial_option: SimultaneousPathsWithLazyIndirectPaths,
         selections: impl IntoIterator<Item = Selection>,
+        condition_resolver_cache: &'a mut ConditionResolverCache,
     ) -> Self {
         Self {
             query_graph,
-            condition_resolver_cache: ConditionResolverCache::new(),
+            condition_resolver_cache,
             open_branches: vec![OpenBranchAndSelections {
                 selections: selections.into_iter().collect(),
                 open_branch: OpenBranch(vec![initial_option]),
@@ -169,17 +172,17 @@ pub(crate) fn never_cancel() -> Result<(), SingleFederationError> {
     Ok(())
 }
 
-impl CachingConditionResolver for ConditionValidationTraversal {
+impl<'a> CachingConditionResolver for ConditionValidationTraversal<'a> {
     fn query_graph(&self) -> &QueryGraph {
         &self.query_graph
     }
 
     fn resolver_cache(&mut self) -> &mut ConditionResolverCache {
-        &mut self.condition_resolver_cache
+        self.condition_resolver_cache
     }
 
     fn resolve_without_cache(
-        &self,
+        &mut self,
         edge: EdgeIndex,
         context: &OpGraphPathContext,
         excluded_destinations: &ExcludedDestinations,
@@ -193,6 +196,7 @@ impl CachingConditionResolver for ConditionValidationTraversal {
             excluded_destinations,
             excluded_conditions,
             extra_conditions,
+            self.condition_resolver_cache,
         )
     }
 }
@@ -307,6 +311,7 @@ type T
                 &Default::default(),
                 &Default::default(),
                 None,
+                &mut ConditionResolverCache::new(),
             )
             .unwrap();
             // All edges are expected to be satisfiable.

--- a/apollo-federation/src/composition/satisfiability/validation_traversal.rs
+++ b/apollo-federation/src/composition/satisfiability/validation_traversal.rs
@@ -334,7 +334,7 @@ impl CachingConditionResolver for TopLevelConditionResolver {
     }
 
     fn resolve_without_cache(
-        &self,
+        &mut self,
         edge: EdgeIndex,
         context: &OpGraphPathContext,
         excluded_destinations: &ExcludedDestinations,
@@ -348,6 +348,7 @@ impl CachingConditionResolver for TopLevelConditionResolver {
             excluded_destinations,
             excluded_conditions,
             extra_conditions,
+            &mut self.condition_resolver_cache,
         )
     }
 }

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -188,7 +188,7 @@ pub(crate) trait CachingConditionResolver {
     fn query_graph(&self) -> &QueryGraph;
 
     fn resolve_without_cache(
-        &self,
+        &mut self,
         edge: EdgeIndex,
         context: &OpGraphPathContext,
         excluded_destinations: &ExcludedDestinations,

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -31,6 +31,7 @@ use crate::query_graph::OverrideConditions;
 use crate::query_graph::QueryGraph;
 use crate::query_graph::QueryGraphNodeType;
 use crate::query_graph::build_federated_query_graph;
+use crate::query_graph::condition_resolver::ConditionResolverCache;
 use crate::query_graph::path_tree::OpPathTree;
 use crate::query_plan::PlanNode;
 use crate::query_plan::QueryPlan;
@@ -496,12 +497,14 @@ impl QueryPlanner {
         let mut non_local_selection_state = options
             .non_local_selections_limit_enabled
             .then(non_local_selections_estimation::State::default);
+        let mut resolver_cache = ConditionResolverCache::new();
         let (root_node, cost) = if !defer_conditions.is_empty() {
             compute_plan_for_defer_conditionals(
                 &mut parameters,
                 &mut processor,
                 defer_conditions,
                 &mut non_local_selection_state,
+                &mut resolver_cache,
             )
         } else {
             compute_plan_internal(
@@ -509,6 +512,7 @@ impl QueryPlanner {
                 &mut processor,
                 has_defers,
                 &mut non_local_selection_state,
+                &mut resolver_cache,
             )
         }?;
 
@@ -594,6 +598,7 @@ fn compute_root_serial_dependency_graph_for_mutation(
     parameters: &QueryPlanningParameters,
     has_defers: bool,
     non_local_selection_state: &mut Option<non_local_selections_estimation::State>,
+    resolver_cache: &mut ConditionResolverCache,
 ) -> Result<Vec<FetchDependencyGraph>, FederationError> {
     let QueryPlanningParameters {
         supergraph_schema,
@@ -625,6 +630,7 @@ fn compute_root_serial_dependency_graph_for_mutation(
         selection_set,
         has_defers,
         non_local_selection_state,
+        resolver_cache,
     )?;
     let mut prev_subgraph = only_root_subgraph(&fetch_dependency_graph)?;
     for selection_set in split_roots {
@@ -637,6 +643,7 @@ fn compute_root_serial_dependency_graph_for_mutation(
             selection_set,
             has_defers,
             non_local_selection_state,
+            resolver_cache,
         )?;
         let new_subgraph = only_root_subgraph(&new_dep_graph)?;
         if new_subgraph == prev_subgraph {
@@ -761,6 +768,7 @@ fn compute_root_parallel_dependency_graph(
     parameters: &QueryPlanningParameters,
     has_defers: bool,
     non_local_selection_state: &mut Option<non_local_selections_estimation::State>,
+    resolver_cache: &mut ConditionResolverCache,
 ) -> Result<(FetchDependencyGraph, QueryPlanCost), FederationError> {
     trace!("Starting process to construct a parallel fetch dependency graph");
     let selection_set = parameters.operation.selection_set.clone();
@@ -769,6 +777,7 @@ fn compute_root_parallel_dependency_graph(
         selection_set,
         has_defers,
         non_local_selection_state,
+        resolver_cache,
     )?;
     snapshot!(
         "FetchDependencyGraph",
@@ -783,6 +792,7 @@ fn compute_root_parallel_best_plan(
     selection: SelectionSet,
     has_defers: bool,
     non_local_selection_state: &mut Option<non_local_selections_estimation::State>,
+    resolver_cache: &mut ConditionResolverCache,
 ) -> Result<BestQueryPlanInfo, FederationError> {
     let planning_traversal = QueryPlanningTraversal::new(
         parameters,
@@ -792,6 +802,7 @@ fn compute_root_parallel_best_plan(
         FetchDependencyGraphToCostProcessor,
         non_local_selection_state.as_mut(),
         None,
+        resolver_cache,
     )?;
 
     // Getting no plan means the query is essentially unsatisfiable (it's a valid query, but we can prove it will never return a result),
@@ -806,6 +817,7 @@ fn compute_root_parallel_best_plan_for_mutation(
     selection: SelectionSet,
     has_defers: bool,
     non_local_selection_state: &mut Option<non_local_selections_estimation::State>,
+    resolver_cache: &mut ConditionResolverCache,
 ) -> Result<BestQueryPlanInfo, FederationError> {
     parameters.federated_query_graph.out_edges(parameters.head).into_iter().map(|edge_ref| {
         let mutation_subgraph = parameters.federated_query_graph.node_weight(edge_ref.target())?.source.clone();
@@ -817,6 +829,7 @@ fn compute_root_parallel_best_plan_for_mutation(
             FetchDependencyGraphToCostProcessor,
             non_local_selection_state.as_mut(),
             Some(mutation_subgraph),
+            resolver_cache,
         )?;
         planning_traversal.find_best_plan()
     }).process_results(|iter| iter
@@ -843,6 +856,7 @@ fn compute_plan_internal(
     processor: &mut FetchDependencyGraphToQueryPlanProcessor,
     has_defers: bool,
     non_local_selection_state: &mut Option<non_local_selections_estimation::State>,
+    resolver_cache: &mut ConditionResolverCache,
 ) -> Result<(Option<PlanNode>, QueryPlanCost), FederationError> {
     let root_kind = parameters.operation.root_kind;
 
@@ -853,6 +867,7 @@ fn compute_plan_internal(
             parameters,
             has_defers,
             non_local_selection_state,
+            resolver_cache,
         )?;
         let mut main = None;
         let mut deferred = vec![];
@@ -882,6 +897,7 @@ fn compute_plan_internal(
             parameters,
             has_defers,
             non_local_selection_state,
+            resolver_cache,
         )?;
 
         let (main, deferred) = dependency_graph.process(&mut *processor, root_kind)?;
@@ -912,13 +928,20 @@ fn compute_plan_for_defer_conditionals(
     processor: &mut FetchDependencyGraphToQueryPlanProcessor,
     defer_conditions: IndexMap<Name, IndexSet<String>>,
     non_local_selection_state: &mut Option<non_local_selections_estimation::State>,
+    resolver_cache: &mut ConditionResolverCache,
 ) -> Result<(Option<PlanNode>, QueryPlanCost), FederationError> {
     generate_condition_nodes(
         parameters.operation.clone(),
         defer_conditions.iter(),
         &mut |op| {
             parameters.operation = op;
-            compute_plan_internal(parameters, processor, true, non_local_selection_state)
+            compute_plan_internal(
+                parameters,
+                processor,
+                true,
+                non_local_selection_state,
+                resolver_cache,
+            )
         },
     )
 }

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -111,7 +111,7 @@ impl QueryPlanningParameters<'_> {
     }
 }
 
-pub(crate) struct QueryPlanningTraversal<'a, 'b> {
+pub(crate) struct QueryPlanningTraversal<'a: 'b, 'b> {
     /// The parameters given to query planning.
     parameters: &'a QueryPlanningParameters<'b>,
     /// The root kind of the operation.
@@ -142,7 +142,7 @@ pub(crate) struct QueryPlanningTraversal<'a, 'b> {
     best_plan: Option<BestQueryPlanInfo>,
     /// The cache for condition resolution.
     // PORT_NOTE: This is different from JS version. See `ConditionResolver` trait implementation below.
-    resolver_cache: ConditionResolverCache,
+    resolver_cache: &'a mut ConditionResolverCache,
 }
 
 struct PlanInfo {
@@ -206,6 +206,8 @@ pub(crate) fn convert_type_from_subgraph(
 }
 
 impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
+    // Many arguments is okay for a crate-private constructor function.
+    #[allow(clippy::too_many_arguments)]
     #[cfg_attr(
         feature = "snapshot_tracing",
         tracing::instrument(level = "trace", skip_all, name = "QueryPlanningTraversal::new")
@@ -222,6 +224,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         cost_processor: FetchDependencyGraphToCostProcessor,
         non_local_selection_state: Option<&mut non_local_selections_estimation::State>,
         initial_subgraph_constraint: Option<Arc<str>>,
+        resolver_cache: &'a mut ConditionResolverCache,
     ) -> Result<Self, FederationError> {
         Self::new_inner(
             parameters,
@@ -235,6 +238,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             Default::default(),
             Default::default(),
             Default::default(),
+            resolver_cache,
         )
     }
 
@@ -256,6 +260,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         initial_context: OpGraphPathContext,
         excluded_destinations: ExcludedDestinations,
         excluded_conditions: ExcludedConditions,
+        resolver_cache: &'a mut ConditionResolverCache,
     ) -> Result<Self, FederationError> {
         let is_top_level = parameters.head_must_be_root;
 
@@ -295,7 +300,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             open_branches: Default::default(),
             closed_branches: Default::default(),
             best_plan: None,
-            resolver_cache: ConditionResolverCache::new(),
+            resolver_cache,
         };
 
         let initial_options = create_initial_options(
@@ -1125,7 +1130,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         )
     )]
     fn resolve_condition_plan(
-        &self,
+        &mut self,
         edge: EdgeIndex,
         context: &OpGraphPathContext,
         excluded_destinations: &ExcludedDestinations,
@@ -1171,6 +1176,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             context.clone(),
             excluded_destinations.clone(),
             excluded_conditions.add_item(edge_conditions),
+            self.resolver_cache,
         )?
         .find_best_plan()?;
         match best_plan_opt {
@@ -1236,17 +1242,17 @@ impl<'a: 'b, 'b> PlanBuilder<PlanInfo, Arc<OpPathTree>> for QueryPlanningTravers
     }
 }
 
-impl CachingConditionResolver for QueryPlanningTraversal<'_, '_> {
+impl<'a: 'b, 'b> CachingConditionResolver for QueryPlanningTraversal<'a, 'b> {
     fn query_graph(&self) -> &QueryGraph {
         &self.parameters.federated_query_graph
     }
 
     fn resolver_cache(&mut self) -> &mut ConditionResolverCache {
-        &mut self.resolver_cache
+        self.resolver_cache
     }
 
     fn resolve_without_cache(
-        &self,
+        &mut self,
         edge: EdgeIndex,
         context: &OpGraphPathContext,
         excluded_destinations: &ExcludedDestinations,


### PR DESCRIPTION
This PR:
- Updates query planning for a query to use the same condition resolver cache, instead of constructing a new one per `QueryPlanningTraversal`.
- Updates satisfiability validation to use the same condition resolver cache, instead of constructing a new one per `ConditionValidationTraversal`.

This PR is not expected to change the outcome of query planning/satisfiability, only the performance (time and memory).

For reviewing, the main thing to check for is that the outcome of `resolve_condition_plan()` doesn't change if the inputs to `ConditionResolverCache::contains()` don't change (i.e. `edge`, `context`, `excluded_destinations`, `excluded_conditions`, and `extra_conditions`). From what I've seen:
- This is trivially the case for satisfiability (the only other input is `query_graph`, which remains the same across satisfiability).
- This is also true for query planning, but less trivially so:
  - `QueryPlanningParameters.head` and `QueryPlanningParameters.head_must_be_root` only change when `edge` changes.
  - `QueryPlanningParameters.statistics` has interior mutability, but doesn't affect query planning (and is only set at the end of top-level query planning).
  - `QueryPlanningParameters.fetch_id_generator` has interior mutability, and can affect query planning during `compute_best_plan_from_closed_branches()`. But it only mutates for `@defer` selections, and conditions (`@key`/`@requires`/`@fromContext`/`@interfaceObject` `__typename`) aren't allowed to have `@defer`. So it remains the same until the top-level `compute_best_plan_from_closed_branches()` runs, which is after any condition resolution.

<!-- FED-1057 -->