### PR TITLE
perf(query-planning): Short-circuit unsatisfied condition resolutions via monotonicity

### DIFF
--- a/.changesets/perf_condition_resolver_cache_unsatisfied_monotonicity.md
+++ b/.changesets/perf_condition_resolver_cache_unsatisfied_monotonicity.md
@@ -1,0 +1,46 @@
+### Short-circuit unsatisfied condition resolutions via monotonicity ([PR #9744](https://github.com/apollographql/router/pull/9744))
+
+Adds an unsatisfied-monotonicity optimization to the condition resolver
+cache. If a condition was previously resolved as `Unsatisfied` with a
+given set of excluded destinations and excluded conditions, it will
+remain `Unsatisfied` with any superset of those exclusions — adding
+more exclusions can only remove possible paths, never create new ones.
+
+When the cache finds an `Unsatisfied` entry whose exclusion sets are
+subsets of the current lookup's exclusion sets, it returns the cached
+`Unsatisfied` result immediately without re-evaluating the condition.
+
+Example: A type with three keys across four subgraphs.
+
+```graphql
+# Subgraph "A"
+type Product @key(fields: "id") @key(fields: "sku") @key(fields: "upc") {
+  id: ID!
+  sku: String!
+  upc: String!
+}
+
+# Subgraph "B"
+type Product @key(fields: "id") { id: ID!, name: String }
+
+# Subgraph "C"
+type Product @key(fields: "sku") { sku: String!, price: Int }
+
+# Subgraph "D"
+type Product @key(fields: "upc") { upc: String!, weight: Float }
+```
+
+When evaluating whether to reach subgraph D from A, the planner tries
+each key in order. Suppose the `id` key edge `A → B` is evaluated with
+`excluded_destinations: {B}` and found to be `Unsatisfied` (B can't
+reach D). Later, when evaluating a different path with
+`excluded_destinations: {B, C}`, the cache sees the previous
+`Unsatisfied` result with the smaller exclusion set `{B}`. Since
+`{B, C}` is a superset of `{B}`, the condition is still unsatisfiable
+— no need to re-evaluate.
+
+A quick `len()` check on both exclusion sets avoids the element-wise
+superset comparison in the common case where the cached set is larger
+than or equal in size to the lookup set.
+
+By [@tninesling](https://github.com/tninesling)

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -170,6 +170,16 @@ impl ConditionResolverCache {
                         return ConditionResolutionCacheResult::Hit(cached.resolution.clone());
                     }
                 }
+
+                // Unsatisfied monotonicity: if a condition was unsatisfied with fewer
+                // exclusions, it remains unsatisfied with a superset of exclusions.
+                if &cached.context == context
+                    && matches!(&cached.resolution, ConditionResolution::Unsatisfied { .. })
+                    && excluded_destinations.is_superset_of(&cached.excluded_destinations)
+                    && excluded_conditions.is_superset_of(&cached.excluded_conditions)
+                {
+                    return ConditionResolutionCacheResult::Hit(cached.resolution.clone());
+                }
             }
             ConditionResolutionCacheResult::Miss
         } else {

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -253,6 +253,10 @@ impl ExcludedDestinations {
             .map(|d| d.as_ref())
     }
 
+    pub(crate) fn is_superset_of(&self, other: &ExcludedDestinations) -> bool {
+        self.0.len() >= other.0.len() && other.0.iter().all(|d| self.is_excluded(d))
+    }
+
     fn add_excluded(&self, destination: &Arc<str>) -> Self {
         if !self.is_excluded(destination) {
             let mut new = self.0.as_ref().clone();
@@ -287,6 +291,10 @@ impl ExcludedConditions {
             return false;
         };
         self.0.contains(condition)
+    }
+
+    pub(crate) fn is_superset_of(&self, other: &ExcludedConditions) -> bool {
+        self.0.len() >= other.0.len() && other.0.iter().all(|c| self.0.contains(c))
     }
 
     /// Immutable version of `push`.


### PR DESCRIPTION
## Summary
- If a condition was `Unsatisfied` with a given set of exclusions, it remains `Unsatisfied` with any superset — more exclusions can only remove options, never create new ones
- Adds `is_superset_of` to `ExcludedDestinations` and `ExcludedConditions` with a fast `len()` pre-check to avoid element-wise comparison when unnecessary
- Particularly effective for satisfiability validation during composition, where many conditions are unsatisfiable and the exclusion sets grow monotonically

<!-- FED-1051 -->