### PR TITLE
chore(ci): remove unused coverage tools from ci-mac mise config

### DIFF
--- a/.config/mise/config.ci-mac.toml
+++ b/.config/mise/config.ci-mac.toml
@@ -1,5 +1,3 @@
 [tools]
 # renovate-automation: rustc version
 rust = { version = "1.96.0", targets = "x86_64-apple-darwin,aarch64-apple-darwin", profile = "default", components = "llvm-tools" }
-"cargo:cargo-llvm-cov" = "0.6.16"
-"ubi:codecov/codecov-cli" = "11.2.8"


### PR DESCRIPTION
## Summary

- Removes `cargo-llvm-cov` and `codecov-cli` pins from `.config/mise/config.ci-mac.toml`
- The coverage CI job was removed (the `do_coverage` step and `coverage_only` workflow are absent from the current CircleCI config), but these tool pins were left behind
- Both tools are installed on every CI mac run and then never invoked — pure install overhead

## Context

Identified while reviewing open Renovate dep-upgrade PRs. PR #9083 (`chore(deps): update dependency cargo:cargo-llvm-cov to 0.8.0`) is being closed as moot — better to remove the dead pin entirely than upgrade it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)