### PR TITLE
fix(composition): `PartialEq` for `DirectiveListInner` should compare list lengths

### DIFF
--- a/apollo-federation/src/operation/directive_list.rs
+++ b/apollo-federation/src/operation/directive_list.rs
@@ -129,6 +129,7 @@ struct DirectiveListInner {
 impl PartialEq for DirectiveListInner {
     fn eq(&self, other: &Self) -> bool {
         self.hash == other.hash
+            && self.len() == other.len()
             && self
                 .iter_sorted()
                 .zip(other.iter_sorted())


### PR DESCRIPTION
This PR fixes a bug in the `PartialEq` implementation of `DirectiveListInner` where it would not check whether the lists were of equal length. This is necessary since `self.iter_sorted().zip(other.iter_sorted())` will just stop iterating when one of `self` or `other` is out of elements (so really that code was checking whether one list was a subset of another).

Note that because the `PartialEq` implementation checks `self.hash == other.hash` first, the odds of actually encountering this bug in the wild are very small (you'd need to find two different directive lists, one a subset of the other, where they hash to the same value via the default hasher, `SipHasher13`), so it probably doesn't need a changelog entry (nor does it need to be backported).

<!-- FED-1056 -->