### PR TITLE
feat(telemetry): make http.server.request.duration cover the full request lifecycle, add opt-in time_to_first_response

### DIFF
--- a/.changesets/feat_ebylund_duration_full_lifecycle.md
+++ b/.changesets/feat_ebylund_duration_full_lifecycle.md
@@ -1,0 +1,13 @@
+### `http.server.request.duration` now covers the full request lifecycle, plus a new opt-in `http.server.request.time_to_first_response` ([PR #9754](https://github.com/apollographql/router/pull/9754))
+
+The standard `http.server.request.duration` histogram now measures the **entire** request lifecycle, from request start until the client-facing response stream closes, instead of stopping when the primary response is ready. For plain (non-streamed) responses this is unchanged. For `@defer` and subscription responses the recorded duration now includes the streamed tail that it previously missed.
+
+The sample is recorded **exactly once** per request: when the response stream completes normally, or, if the client disconnects or the stream is cancelled mid-flight, at the moment the stream is dropped (using the elapsed time at that point). This guarantees a duration is always recorded, including for a client that opens a request and then hangs.
+
+This is a behavior change to a widely-used metric. Dashboards and alerts built on `http.server.request.duration` for operations that use `@defer` or subscriptions will see larger values after upgrading, because the streamed tail is now included.
+
+To preserve the previous measurement, a new standard instrument records the time to the first response:
+
+- `http.server.request.time_to_first_response` records the time from request start until the router has the primary response ready to send (status, headers, and the first response chunk). This is exactly what `http.server.request.duration` measured before this change. It is measured inside the router, so it is not a client-observed time to first byte (it ends before response serialization and network transit). It is **opt-in** (disabled by default, even when `default_requirement_level` enables the other standard instruments), so upgrading does not add a new histogram unless you enable it.
+
+By [@ebylund](https://github.com/ebylund) in https://github.com/apollographql/router/pull/9754

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -22,6 +22,7 @@ use http::Request;
 use http::header::ACCEPT_ENCODING;
 use http::header::CONTENT_ENCODING;
 use http_body::Body;
+use http_body_util::BodyExt;
 use itertools::Itertools;
 use multimap::MultiMap;
 use once_cell::sync::Lazy;
@@ -55,6 +56,9 @@ use crate::http_server_factory::HttpServerFactory;
 use crate::http_server_factory::HttpServerHandle;
 use crate::http_server_factory::Listener;
 use crate::plugins::telemetry::SpanMode;
+use crate::plugins::telemetry::config_new::router::instruments::RequestDurationBody;
+use crate::plugins::telemetry::config_new::router::instruments::RequestDurationRecording;
+use crate::plugins::telemetry::config_new::router::instruments::RequestSpanExtension;
 use crate::plugins::telemetry::config_new::router::instruments::ResponseBodySizeRecording;
 use crate::plugins::telemetry::config_new::router::instruments::ResponseBodySizeRecordingStream;
 use crate::router::ApolloRouterError;
@@ -583,6 +587,25 @@ async fn handle_graphql<RF: RouterFactory>(
                         None => router::body::from_result_stream(stream),
                     }
                 }
+            };
+
+            // Wrap the final, client-facing body so `http.server.request.duration` is recorded
+            // when the body stream closes (covering the `@defer` / subscription tail) or, via
+            // the guard's `Drop`, if the client hangs mid-stream. Must wrap after body-size
+            // handling so the inner body's exact size hint stays readable above. The router
+            // span (if stashed) is carried into the body so it stays open until stream close.
+            let request_duration_recording = context
+                .extensions()
+                .with_lock(|lock| lock.remove::<RequestDurationRecording>());
+            let body = match request_duration_recording {
+                Some(recording) => {
+                    let span = context
+                        .extensions()
+                        .with_lock(|lock| lock.remove::<RequestSpanExtension>())
+                        .map(|ext| ext.0);
+                    RequestDurationBody::new(body, recording, span).boxed_unsync()
+                }
+                None => body,
             };
 
             http::Response::from_parts(parts, body).into_response()

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -5096,6 +5096,14 @@ expression: "&schema"
           ],
           "description": "Histogram of server request duration"
         },
+        "http.server.request.time_to_first_response": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/StandardInstrumentExtendedRouterAttributesWithRouterSelector"
+            }
+          ],
+          "description": "Histogram of the time from request start until the primary response is ready to send\n(status, headers, and the first response chunk). Measured inside the router, so this is\nnot a client-observed time to first byte. Opt-in: disabled by default."
+        },
         "http.server.response.body.size": {
           "allOf": [
             {

--- a/apollo-router/src/metrics/mod.rs
+++ b/apollo-router/src/metrics/mod.rs
@@ -720,8 +720,12 @@ pub(crate) mod test_utils {
             // Sort the datapoints so that we can compare them
             serde_metric.data.datapoints.sort();
 
-            // Redact duration metrics;
-            if serde_metric.name.ends_with(".duration") {
+            // Redact duration-style metrics; their sums are wall-clock timings that would
+            // otherwise make snapshots non-deterministic. `time_to_first_response` is also a
+            // wall-clock duration despite its name not ending in `.duration`.
+            if serde_metric.name.ends_with(".duration")
+                || serde_metric.name.ends_with(".time_to_first_response")
+            {
                 serde_metric
                     .data
                     .datapoints

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -116,6 +116,11 @@ pub(crate) struct InstrumentsConfig {
 }
 
 const HTTP_SERVER_REQUEST_DURATION_METRIC: &str = "http.server.request.duration";
+// Named for parity with `http.server.request.duration`. This measures the router-side
+// "response ready" moment (status, headers, first chunk), not a client-observed time to
+// first byte, so it is deliberately not named `..._time_to_first_byte`.
+const HTTP_SERVER_REQUEST_TIME_TO_FIRST_RESPONSE_METRIC: &str =
+    "http.server.request.time_to_first_response";
 const HTTP_SERVER_REQUEST_BODY_SIZE_METRIC: &str = "http.server.request.body.size";
 const HTTP_SERVER_RESPONSE_BODY_SIZE_METRIC: &str = "http.server.response.body.size";
 const HTTP_SERVER_ACTIVE_REQUESTS: &str = "http.server.active_requests";
@@ -198,6 +203,26 @@ impl InstrumentsConfig {
                         .f64_histogram(HTTP_SERVER_REQUEST_DURATION_METRIC)
                         .with_unit("s")
                         .with_description("Duration of HTTP server requests.")
+                        .build(),
+                ),
+            );
+        }
+
+        if self
+            .router
+            .attributes
+            .http_server_request_time_to_first_response
+            .is_enabled()
+        {
+            static_instruments.insert(
+                HTTP_SERVER_REQUEST_TIME_TO_FIRST_RESPONSE_METRIC.to_string(),
+                StaticInstrument::Histogram(
+                    meter
+                        .f64_histogram(HTTP_SERVER_REQUEST_TIME_TO_FIRST_RESPONSE_METRIC)
+                        .with_unit("s")
+                        .with_description(
+                            "Time from HTTP server request start to the first response byte.",
+                        )
                         .build(),
                 ),
             );
@@ -335,6 +360,40 @@ impl InstrumentsConfig {
                     attributes: Vec::new(),
                     selector: None,
                     selectors: match &self.router.attributes.http_server_request_duration {
+                        DefaultedStandardInstrument::Bool(_)
+                        | DefaultedStandardInstrument::Unset => None,
+                        DefaultedStandardInstrument::Extendable { attributes } => {
+                            Some(attributes.clone())
+                        }
+                    },
+                    updated: false,
+                    _phantom: PhantomData,
+                }),
+            });
+        let http_server_request_time_to_first_response = self
+            .router
+            .attributes
+            .http_server_request_time_to_first_response
+            .is_enabled()
+            .then(|| CustomHistogram {
+                inner: Mutex::new(CustomHistogramInner {
+                    increment: Increment::Duration(Instant::now(), "s".to_string()),
+                    condition: Condition::True,
+                    histogram: Some(
+                        static_instruments
+                            .get(HTTP_SERVER_REQUEST_TIME_TO_FIRST_RESPONSE_METRIC)
+                            .expect(
+                                "cannot get static instrument for router; this should not happen",
+                            )
+                            .as_histogram()
+                            .cloned()
+                            .expect(
+                                "cannot convert instrument to histogram for router; this should not happen",
+                            ),
+                    ),
+                    attributes: Vec::new(),
+                    selector: None,
+                    selectors: match &self.router.attributes.http_server_request_time_to_first_response {
                         DefaultedStandardInstrument::Bool(_)
                         | DefaultedStandardInstrument::Unset => None,
                         DefaultedStandardInstrument::Extendable { attributes } => {
@@ -494,6 +553,7 @@ impl InstrumentsConfig {
 
         RouterInstruments {
             http_server_request_duration,
+            http_server_request_time_to_first_response,
             http_server_request_body_size,
             http_server_response_body_size,
             http_server_active_requests,
@@ -1890,7 +1950,7 @@ fn value_to_f64(value: &opentelemetry::Value) -> Option<f64> {
 /// Convert a duration to f64 based on the specified unit.
 /// Supported units: "s" (seconds), "ms" (milliseconds), "us" (microseconds), "ns" (nanoseconds)
 /// Defaults to seconds for any other unit string.
-fn duration_to_f64(duration: std::time::Duration, unit: &str) -> f64 {
+pub(crate) fn duration_to_f64(duration: std::time::Duration, unit: &str) -> f64 {
     match unit {
         "ms" => duration.as_secs_f64() * 1000.0,
         "us" => duration.as_micros() as f64,
@@ -2386,6 +2446,49 @@ where
                 _phantom: PhantomData,
             }),
         }
+    }
+}
+
+impl<A, T, Request, Response, EventResponse> CustomHistogram<Request, Response, EventResponse, A, T>
+where
+    A: Selectors<Request, Response, EventResponse> + Default,
+    T: Selector<Request = Request, Response = Response, EventResponse = EventResponse>,
+{
+    /// Compute the response-time attributes for an `Increment::Duration` histogram and hand
+    /// off the histogram handle, attributes and the request-start `Instant` for *deferred*
+    /// recording — without recording the sample now.
+    ///
+    /// Used by `http.server.request.duration`, which must record the full request lifecycle
+    /// (through stream close / drop) rather than at response-ready. The histogram is taken
+    /// out of `self`, so a subsequent `on_response` / `Drop` becomes a no-op and the sample
+    /// is recorded exactly once by the returned payload.
+    ///
+    /// Returns `None` when the response-level condition fails or the histogram is absent, in
+    /// which case no sample should be recorded.
+    pub(crate) fn take_duration_recording(
+        &self,
+        response: &Response,
+    ) -> Option<(Histogram<f64>, Vec<KeyValue>, Instant, String)> {
+        let mut inner = self.inner.lock();
+        if !inner.condition.evaluate_response(response) {
+            let _ = inner.histogram.take();
+            return None;
+        }
+        let attrs = inner
+            .selectors
+            .as_ref()
+            .map(|s| s.on_response(response))
+            .unwrap_or_default();
+        extend_attributes(&mut inner.attributes, attrs);
+
+        let (start, unit) = match &inner.increment {
+            Increment::Duration(instant, unit) => (*instant, unit.clone()),
+            _ => return None,
+        };
+        let histogram = inner.histogram.take()?;
+        // Mark as updated so the `Drop` impl does not double-record.
+        inner.updated = true;
+        Some((histogram, inner.attributes.clone(), start, unit))
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/config_new/router/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/router/instruments.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::task::Poll;
@@ -10,6 +11,7 @@ use opentelemetry::metrics::Histogram;
 use pin_project_lite::pin_project;
 use schemars::JsonSchema;
 use serde::Deserialize;
+use tokio::time::Instant;
 use tower::BoxError;
 
 use super::selectors::RouterSelector;
@@ -26,6 +28,7 @@ use crate::plugins::telemetry::config_new::instruments::CustomInstruments;
 use crate::plugins::telemetry::config_new::instruments::DefaultedStandardInstrument;
 use crate::plugins::telemetry::config_new::instruments::SubscriptionsTerminatedAttributes;
 use crate::plugins::telemetry::config_new::instruments::SubscriptionsTerminatedCounter;
+use crate::plugins::telemetry::config_new::instruments::duration_to_f64;
 use crate::plugins::telemetry::config_new::router::attributes::RouterAttributes;
 use crate::plugins::telemetry::config_new::router_overhead::RouterOverheadAttributes;
 use crate::plugins::telemetry::otlp::TelemetryDataKind;
@@ -37,6 +40,13 @@ pub(crate) struct RouterInstrumentsConfig {
     /// Histogram of server request duration
     #[serde(rename = "http.server.request.duration")]
     pub(crate) http_server_request_duration:
+        DefaultedStandardInstrument<Extendable<RouterAttributes, RouterSelector>>,
+
+    /// Histogram of the time from request start until the primary response is ready to send
+    /// (status, headers, and the first response chunk). Measured inside the router, so this is
+    /// not a client-observed time to first byte. Opt-in: disabled by default.
+    #[serde(rename = "http.server.request.time_to_first_response")]
+    pub(crate) http_server_request_time_to_first_response:
         DefaultedStandardInstrument<Extendable<RouterAttributes, RouterSelector>>,
 
     /// Counter of active requests
@@ -73,6 +83,14 @@ impl DefaultForLevel for RouterInstrumentsConfig {
     ) {
         self.http_server_request_duration
             .defaults_for_levels(requirement_level, kind);
+        // `http.server.request.time_to_first_response` is opt-in (default off), unlike the
+        // other standard router instruments. Only apply attribute defaults once the user has
+        // explicitly enabled it, so upgrading does not silently add a new histogram. Leaving
+        // it `Unset` keeps `is_enabled()` false and the instrument unbuilt.
+        if self.http_server_request_time_to_first_response.is_enabled() {
+            self.http_server_request_time_to_first_response
+                .defaults_for_levels(requirement_level, kind);
+        }
         self.http_server_active_requests
             .defaults_for_levels(requirement_level, kind);
         self.http_server_request_body_size
@@ -88,6 +106,9 @@ impl DefaultForLevel for RouterInstrumentsConfig {
 
 pub(crate) struct RouterInstruments {
     pub(crate) http_server_request_duration: Option<
+        CustomHistogram<router::Request, router::Response, (), RouterAttributes, RouterSelector>,
+    >,
+    pub(crate) http_server_request_time_to_first_response: Option<
         CustomHistogram<router::Request, router::Response, (), RouterAttributes, RouterSelector>,
     >,
     pub(crate) http_server_active_requests: Option<ActiveRequestsCounter>,
@@ -119,6 +140,11 @@ impl Instrumented for RouterInstruments {
         if let Some(http_server_request_duration) = &self.http_server_request_duration {
             http_server_request_duration.on_request(request);
         }
+        if let Some(http_server_request_time_to_first_response) =
+            &self.http_server_request_time_to_first_response
+        {
+            http_server_request_time_to_first_response.on_request(request);
+        }
         if let Some(http_server_active_requests) = &self.http_server_active_requests {
             http_server_active_requests.on_request(request);
         }
@@ -138,8 +164,27 @@ impl Instrumented for RouterInstruments {
     }
 
     fn on_response(&self, response: &Self::Response) {
-        if let Some(http_server_request_duration) = &self.http_server_request_duration {
-            http_server_request_duration.on_response(response);
+        // `http.server.request.duration` must reflect the FULL request lifecycle — through
+        // the last `@defer` chunk / stream close — not just time-to-first-response. Rather
+        // than record here at response-ready, hand the histogram off to a
+        // `RequestDurationRecording` stashed in the context; the axum layer records it when
+        // the client-facing body stream closes, or on drop if the client hangs mid-stream.
+        if let Some(http_server_request_duration) = &self.http_server_request_duration
+            && let Some((histogram, attributes, start, unit)) =
+                http_server_request_duration.take_duration_recording(response)
+        {
+            let recording = RequestDurationRecording::new(histogram, attributes, start, unit);
+            response
+                .context
+                .extensions()
+                .with_lock(|lock| lock.insert(recording));
+        }
+        // `http.server.request.time_to_first_response` preserves the old time-to-first-byte
+        // signal: same request-start timer, recorded now at response-ready.
+        if let Some(http_server_request_time_to_first_response) =
+            &self.http_server_request_time_to_first_response
+        {
+            http_server_request_time_to_first_response.on_response(response);
         }
         if let Some(http_server_active_requests) = &self.http_server_active_requests {
             http_server_active_requests.on_response(response);
@@ -160,8 +205,15 @@ impl Instrumented for RouterInstruments {
     }
 
     fn on_error(&self, error: &BoxError, ctx: &Context) {
+        // On the error path no response stream is produced, so `take_duration_recording` was
+        // never called: the histogram is still live here and records elapsed-at-error.
         if let Some(http_server_request_duration) = &self.http_server_request_duration {
             http_server_request_duration.on_error(error, ctx);
+        }
+        if let Some(http_server_request_time_to_first_response) =
+            &self.http_server_request_time_to_first_response
+        {
+            http_server_request_time_to_first_response.on_error(error, ctx);
         }
         if let Some(http_server_active_requests) = &self.http_server_active_requests {
             http_server_active_requests.on_error(error, ctx);
@@ -190,6 +242,134 @@ pub(crate) type RouterCustomInstruments = CustomInstruments<
     RouterSelector,
     RouterValue,
 >;
+
+/// Stashed by `RouterInstruments::on_response` so the `http.server.request.duration`
+/// histogram can be recorded when the client-facing response stream closes — covering the
+/// full request lifecycle including any `@defer` / subscription tail — instead of at
+/// response-ready.
+///
+/// Records the elapsed duration **exactly once**: either when the stream completes normally
+/// (via [`Self::record`], driven by [`RequestDurationBody`] on end-of-body) or, failing
+/// that, when this guard is dropped — which covers a stream that is cancelled or a client
+/// that hangs mid-stream. The [`AtomicBool`] guarantees only the first of the two wins.
+pub(crate) struct RequestDurationRecording {
+    histogram: Histogram<f64>,
+    attributes: Vec<opentelemetry::KeyValue>,
+    start: Instant,
+    unit: String,
+    recorded: AtomicBool,
+}
+
+/// Carries an owned clone of the router request `Span` through the context so the axum layer
+/// can attach it to [`RequestDurationBody`], extending the span's lifetime to stream close.
+/// A newtype so it does not collide with other `Span`-typed context extensions.
+pub(crate) struct RequestSpanExtension(pub(crate) tracing::Span);
+
+impl RequestDurationRecording {
+    pub(crate) fn new(
+        histogram: Histogram<f64>,
+        attributes: Vec<opentelemetry::KeyValue>,
+        start: Instant,
+        unit: String,
+    ) -> Self {
+        Self {
+            histogram,
+            attributes,
+            start,
+            unit,
+            recorded: AtomicBool::new(false),
+        }
+    }
+
+    /// Record the elapsed duration since request start, but only on the first call. Safe to
+    /// call from both the normal stream-end path and `Drop`; later calls are no-ops.
+    pub(crate) fn record(&self) {
+        if self
+            .recorded
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            let value = duration_to_f64(self.start.elapsed(), &self.unit);
+            self.histogram.record(value, &self.attributes);
+        }
+    }
+}
+
+/// Record the full-lifecycle request duration if it was not already recorded on normal
+/// stream completion — this is the drop-path safety net for cancelled streams and clients
+/// that hang mid-stream.
+impl Drop for RequestDurationRecording {
+    fn drop(&mut self) {
+        self.record();
+    }
+}
+
+pin_project! {
+    /// `http_body::Body` wrapper that records `http.server.request.duration` when the
+    /// client-facing response body closes. Records on normal end-of-body (`poll_frame`
+    /// returns `Ready(None)`); the contained [`RequestDurationRecording`] guard records on
+    /// `Drop` if the body is cancelled before completion — together yielding exactly one
+    /// sample covering the full request lifecycle.
+    ///
+    /// Delegates `size_hint`/`is_end_stream` to the inner body so content-length and
+    /// streaming semantics are preserved.
+    ///
+    /// Optionally carries an owned clone of the router request `Span`. Holding the clone
+    /// here keeps the span from closing (and thus from being exported) until the body
+    /// finishes streaming or is dropped, so the span covers the full request lifecycle —
+    /// including the `@defer` / subscription tail — rather than ending at response-ready.
+    pub(crate) struct RequestDurationBody<B> {
+        #[pin]
+        inner: B,
+        recording: RequestDurationRecording,
+        // Kept alive (never entered) for the duration of the body so the span's end
+        // timestamp lands at stream close. Never held across `.await` as an `Entered`
+        // guard, so this is `Send`-safe.
+        _span: Option<tracing::Span>,
+    }
+}
+
+impl<B> RequestDurationBody<B> {
+    pub(crate) fn new(
+        inner: B,
+        recording: RequestDurationRecording,
+        span: Option<tracing::Span>,
+    ) -> Self {
+        Self {
+            inner,
+            recording,
+            _span: span,
+        }
+    }
+}
+
+impl<B> http_body::Body for RequestDurationBody<B>
+where
+    B: http_body::Body,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.project();
+        let next = this.inner.poll_frame(cx);
+        if let Poll::Ready(None) = &next {
+            this.recording.record();
+        }
+        next
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
 
 /// Stashed by `RouterInstruments::on_response` when the `http.server.response.body.size`
 /// histogram was not recorded during `on_response` (because compression is pending).
@@ -345,5 +525,105 @@ mod tests {
         }
         .with_metrics()
         .await;
+    }
+
+    mod request_duration {
+        use http_body::Frame;
+        use http_body_util::BodyExt;
+        use http_body_util::StreamBody;
+
+        use super::*;
+
+        fn duration_recording(histogram: Histogram<f64>) -> RequestDurationRecording {
+            RequestDurationRecording::new(histogram, vec![], Instant::now(), "s".to_string())
+        }
+
+        /// A body of `chunk_count` data frames — stands in for a `@defer` / streamed response.
+        fn streamed_body(
+            chunk_count: usize,
+        ) -> StreamBody<impl Stream<Item = Result<Frame<Bytes>, BoxError>>> {
+            let frames = (0..chunk_count)
+                .map(|_| Ok(Frame::data(Bytes::from_static(b"chunk"))))
+                .collect::<Vec<_>>();
+            StreamBody::new(stream::iter(frames))
+        }
+
+        #[tokio::test]
+        async fn records_once_when_body_drains_normally() {
+            async {
+                let meter = crate::metrics::meter_provider().meter("test");
+                let histogram = meter.f64_histogram("test.request.duration").build();
+
+                let body =
+                    RequestDurationBody::new(streamed_body(3), duration_recording(histogram), None);
+
+                // Fully drain the body, like a client reading every `@defer` chunk.
+                let collected = body.collect().await.expect("body should drain");
+                assert_eq!(collected.to_bytes().len(), 15);
+
+                assert_histogram_count!("test.request.duration", 1);
+            }
+            .with_metrics()
+            .await;
+        }
+
+        #[tokio::test]
+        async fn records_elapsed_on_drop_when_stream_is_cancelled() {
+            async {
+                let meter = crate::metrics::meter_provider().meter("test");
+                let histogram = meter.f64_histogram("test.request.duration").build();
+
+                let mut body =
+                    RequestDurationBody::new(streamed_body(3), duration_recording(histogram), None);
+
+                // Pull a single frame then drop mid-stream — emulates a client that hangs.
+                let first = body.frame().await;
+                assert!(first.is_some(), "expected at least one frame");
+                drop(body);
+
+                // Still recorded exactly once, via the drop-path safety net.
+                assert_histogram_count!("test.request.duration", 1);
+            }
+            .with_metrics()
+            .await;
+        }
+
+        #[tokio::test]
+        async fn records_exactly_once_across_normal_end_and_drop() {
+            async {
+                let meter = crate::metrics::meter_provider().meter("test");
+                let histogram = meter.f64_histogram("test.request.duration").build();
+
+                let body =
+                    RequestDurationBody::new(streamed_body(2), duration_recording(histogram), None);
+
+                // Drain normally (records via end-of-body) then drop the guard (no-op).
+                let _ = body.collect().await.expect("body should drain");
+
+                assert_histogram_count!("test.request.duration", 1);
+            }
+            .with_metrics()
+            .await;
+        }
+
+        #[tokio::test]
+        async fn does_not_record_until_body_completes() {
+            async {
+                let meter = crate::metrics::meter_provider().meter("test");
+                let histogram = meter.f64_histogram("test.request.duration").build();
+
+                let mut body =
+                    RequestDurationBody::new(streamed_body(2), duration_recording(histogram), None);
+
+                // Read one frame but do not finish the body: nothing recorded yet.
+                let _ = body.frame().await;
+                // `body` is intentionally kept alive across the assertion below.
+
+                assert_histogram_not_exists!("test.request.duration", f64);
+                drop(body);
+            }
+            .with_metrics()
+            .await;
+        }
     }
 }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -682,6 +682,23 @@ impl PluginPrivate for Telemetry {
                             custom_instruments.on_response(response);
                             custom_events.on_response(response);
 
+                            // If the duration instrument deferred its recording to stream
+                            // close, also carry a clone of the router span so its lifetime
+                            // extends to stream close (Bryn: spans must cover the entire
+                            // request). The clone is held — never entered — by the response
+                            // body wrapper in the axum layer.
+                            if response.context.extensions().with_lock(|lock| {
+                                lock.contains_key::<config_new::router::instruments::RequestDurationRecording>()
+                            }) {
+                                response.context.extensions().with_lock(|lock| {
+                                    lock.insert(
+                                        config_new::router::instruments::RequestSpanExtension(
+                                            span.clone(),
+                                        ),
+                                    )
+                                });
+                            }
+
                             let mut headers: HashMap<String, Vec<String>> =
                                 HashMap::with_capacity(2);
                             if expose_trace_id.enabled {
@@ -2175,6 +2192,7 @@ mod tests {
     use crate::metrics::FutureMetricsExt;
     use crate::plugin::DynPlugin;
     use crate::plugin::PluginInit;
+    use crate::plugin::test::MockRouterService;
     use crate::plugins::demand_control::COST_ACTUAL_KEY;
     use crate::plugins::demand_control::COST_ESTIMATED_KEY;
     use crate::plugins::demand_control::COST_RESULT_KEY;
@@ -2189,6 +2207,7 @@ mod tests {
     use crate::services::SupergraphRequest;
     use crate::services::SupergraphResponse;
     use crate::services::router;
+    use crate::services::router::BoxService;
 
     // Serializes tests that call `plugin.activate()`. `Telemetry::activate()`
     // -> `Activation::commit()` performs two process-wide writes:
@@ -2595,6 +2614,70 @@ mod tests {
             );
             drop(bad_request_router_service);
             crate::plugin::test::await_mock_driver(driver).await;
+        }
+        .with_metrics()
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn router_service_records_time_to_first_response_and_defers_duration() {
+        async {
+            // Enable both the duration and the new time-to-first-response standard
+            // instruments, with everything else off so the assertions are unambiguous.
+            let plugin = create_plugin_with_config(
+                r#"
+telemetry:
+  instrumentation:
+    instruments:
+      default_requirement_level: none
+      router:
+        http.server.request.duration: true
+        http.server.request.time_to_first_response: true
+"#,
+            )
+            .await;
+
+            let mut mock_service = MockRouterService::new();
+            mock_service
+                .expect_call()
+                .times(1)
+                .returning(move |req: RouterRequest| {
+                    Ok(RouterResponse::fake_builder()
+                        .context(req.context)
+                        .status_code(StatusCode::OK)
+                        .header("content-type", "application/json")
+                        .data(json!({"data": {"field": "value"}}))
+                        .build()
+                        .unwrap())
+                });
+            let mut router_service = plugin.router_service(BoxService::new(mock_service));
+            let mut response = router_service
+                .ready()
+                .await
+                .unwrap()
+                .call(RouterRequest::fake_builder().build().unwrap())
+                .await
+                .unwrap();
+
+            // `time_to_first_response` is recorded at response-ready.
+            assert_histogram_count!("http.server.request.time_to_first_response", 1);
+
+            // `http.server.request.duration` is *deferred* to stream close: at this point a
+            // recording guard is stashed in the context and the histogram has not yet
+            // recorded. (In production the axum layer records it on body close/drop.)
+            assert!(
+                response.context.extensions().with_lock(|lock| {
+                    lock.contains_key::<crate::plugins::telemetry::config_new::router::instruments::RequestDurationRecording>()
+                }),
+                "duration recording should be stashed for deferred recording"
+            );
+            assert_histogram_not_exists!("http.server.request.duration", f64);
+
+            // Draining and dropping the response (and its context) fires the guard's Drop,
+            // recording the full-lifecycle duration exactly once.
+            let _ = response.next_response().await;
+            drop(response);
+            assert_histogram_count!("http.server.request.duration", 1);
         }
         .with_metrics()
         .await;

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/instruments.mdx
@@ -23,7 +23,8 @@ OpenTelemetry specifies multiple [standard metric instruments](https://opentelem
 
   * `http.server.active_requests` - The number of active requests in flight.
   * `http.server.request.body.size` - A histogram of request body sizes for requests handled by the router.
-  * `http.server.request.duration` - A histogram of request durations for requests handled by the router.
+  * `http.server.request.duration` - A histogram of request durations for requests handled by the router. This measures the **full** request lifecycle, from request start until the client-facing response stream closes. For `@defer` and subscription responses it therefore includes the streamed tail, not only the time to the first response. If the client disconnects or the stream is cancelled before completion, the duration is recorded using the elapsed time at the moment the stream is dropped. The sample is recorded exactly once per request. See [Duration semantics](#httpserverrequestduration-covers-the-full-request-lifecycle) for the behavior change and how to recover the previous meaning.
+  * `http.server.request.time_to_first_response` - A histogram of the time from request start until the router has the primary response ready to send (status, headers, and the first response chunk). This is **opt-in** (disabled by default). For non-streamed responses it is approximately equal to `http.server.request.duration`; for `@defer` and subscription responses it is shorter, because it excludes the streamed tail. See [Why "time to first response" and not "time to first byte"](#why-time-to-first-response-and-not-time-to-first-byte) for what this metric does and does not measure.
   * `http.server.response.body.size` - A histogram of response body sizes for requests handled by the router.
 
 + In the [subgraph service](#router-request-lifecycle-services):
@@ -64,6 +65,7 @@ telemetry:
         http.server.active_requests: false # (default is true)
         http.server.request.body.size: false # (default is true)
         http.server.request.duration: false # (default is true)
+        http.server.request.time_to_first_response: true # (opt-in, default is false)
         http.server.response.body.size: false # (default is true)
       subgraph:
         http.client.request.body.size: false # (default is true)
@@ -94,6 +96,34 @@ telemetry:
         http.client.request.duration:
           attributes:
             connector.source.name: true
+```
+
+#### `http.server.request.duration` covers the full request lifecycle
+
+Previously, `http.server.request.duration` stopped timing when the primary response was ready to send. It now times the entire request, from request start until the client-facing response stream closes. For a plain (non-streamed) response the two moments are effectively the same, so the metric is unchanged. For `@defer` and subscription responses, the recorded duration is now larger because it includes the time spent streaming deferred chunks or subscription events.
+
+<Note>
+
+This is a behavior change to a widely-used metric. If you have dashboards or alerts built on `http.server.request.duration` for operations that use `@defer` or subscriptions, their values will increase after upgrading, because the streamed tail is now included. To recover the previous "time to the first response" measurement, enable [`http.server.request.time_to_first_response`](#why-time-to-first-response-and-not-time-to-first-byte), which preserves the old semantics.
+
+</Note>
+
+The duration is recorded exactly once per request: when the response stream completes normally, or, if the client disconnects or the stream is cancelled before completion, at the moment the stream is dropped (using the elapsed time at that point). This guarantees a duration is always recorded, including for a client that opens a request and then hangs.
+
+#### Why "time to first response" and not "time to first byte"
+
+`http.server.request.time_to_first_response` measures the time from request start until the router has the **primary response ready to send**: the response status, headers, and the first response chunk. It is measured inside the router, at the point the response becomes ready to hand back to the client transport.
+
+It deliberately does **not** claim to be "time to first byte" (TTFB). The standard [TTFB](https://developer.mozilla.org/en-US/docs/Glossary/Time_to_first_byte) is a client-observed, network-inclusive measurement: the time until the first byte of the response is received by the client. The router cannot measure that. Its measurement ends before response serialization, transport write, and network transit to the client, so it is always smaller than a true client-side TTFB. Naming this metric `time_to_first_response` names exactly what the router observes (the response becoming ready), without implying a client-side or network measurement it does not perform. The name also keeps parity with `http.server.request.duration`, which measures from the same start point to a later moment in the same lifecycle.
+
+This instrument is opt-in. Unlike the other standard router instruments, it stays disabled even when `default_requirement_level` is `required` or `recommended`, so upgrading does not silently add a new histogram to your metrics pipeline. Enable it explicitly when you want the first-response timing:
+
+```yaml title="router.yaml"
+telemetry:
+  instrumentation:
+    instruments:
+      router:
+        http.server.request.time_to_first_response: true
 ```
 
 ### Apollo standard instruments


### PR DESCRIPTION
Closes #9242.
Supersedes #9269, which prototyped this as a separate `stream_duration` custom instrument. Per the direction in that PR's discussion, this fixes the standard metric directly instead.

## What this does

`http.server.request.duration` now measures the **full** request lifecycle, from request start until the client-facing response stream closes, instead of stopping when the primary response is ready. For plain (non-streamed) responses this is unchanged. For `@defer` and subscription responses it now includes the streamed tail. The sample is recorded exactly once per request: on normal stream completion, or, if the client disconnects or the stream is cancelled, at the moment the stream is dropped, so a duration is always recorded.

Adds `http.server.request.time_to_first_response`, an **opt-in** standard instrument that records the previous timing: request start until the router has the primary response ready to send. It is measured inside the router, so it is not a client-observed time to first byte, and it is named accordingly. It is disabled by default so upgrading does not add a new histogram unless you enable it.

## Why

Teams running `@defer` and subscriptions at scale need request-duration telemetry that reflects the full response, including the deferred/streamed tail that the previous response-ready semantics did not cover. Fixing `http.server.request.duration` keeps a single, standard duration signal correct for streamed responses, while `time_to_first_response` preserves the earlier measurement for anyone who wants it.

## Reviewer notes

Two decisions worth an explicit nod:
- **Semantic change to `http.server.request.duration`.** It is a widely-used signal; dashboards and alerts on it for `@defer`/subscription operations will see larger values after upgrading. Called out in the changeset and docs.
- **Metric name and default.** Named `time_to_first_response` (not `time_to_first_byte`) because it measures the router-side response-ready moment, not a client-observed TTFB. Kept opt-in (default off) so it does not silently add cardinality on upgrade, even though the other standard instruments default on.
