### PR TITLE
refactor: extract introspection from the query planner

### DIFF
--- a/.changesets/fix_renee_router_1951_introspection_service.md
+++ b/.changesets/fix_renee_router_1951_introspection_service.md
@@ -1,0 +1,7 @@
+### Resolve introspection queries before query planning ([PR #9756](https://github.com/apollographql/router/pull/9756))
+
+GraphQL queries requesting the `__schema` or `__type` introspection fields are now executed inside the supergraph service. Previously, such queries were executed inside the query planner service. This change is visible in the spans reported by Router telemetry: introspection queries no longer emit a query planner span.
+
+GraphQL queries requesting _only_ `__typename` are now treated the same way as any other (non-introspection) query. Previously, `__typename` could be resolved at several different locations in the Router, depending on if an alias was used or if it was requested along with other fields. Now, `__typename` is always resolved in the same way. This change is also visible in the spans reported by Router telemetry: queries that only request `__typename` will progress to the execution span instead of being short-circuited inside the query planner span.
+
+By [@goto-bus-stop](https://github.com/goto-bus-stop) in https://github.com/apollographql/router/pull/9756

--- a/apollo-router/src/batching/query_plan_analysis_layer.rs
+++ b/apollo-router/src/batching/query_plan_analysis_layer.rs
@@ -147,7 +147,6 @@ mod tests {
                     .document(document)
                     .metadata(crate::plugins::authorization::CacheKeyMetadata::default())
                     .plan_options(crate::services::PlanOptions::default())
-                    .variables(serde_json_bytes::Map::new())
                     .compute_job_type(ComputeJobType::QueryPlanning)
                     .build(),
             )

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -108,11 +108,11 @@ pub(crate) fn introspection_service(
 ///
 /// That is:
 /// - The operation is a query operation, AND:
-///   - The operation has schema introspection fields (__schema or __type), OR:
-///   - The operation does not have explicit root fields (...which implies __typename).
+/// - The operation has schema introspection fields (__schema or __type)
+///
+/// Notably, { __typename } is not considered an introspection query.
 pub(crate) fn is_introspection_query(document: &ParsedDocument) -> bool {
-    document.operation.is_query()
-        && (document.has_schema_introspection || !document.has_explicit_root_fields)
+    document.operation.is_query() && document.has_schema_introspection
 }
 
 /// Terminal service for GraphQL introspection queries that always returns an error saying

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -24,11 +24,28 @@ use crate::spec::QueryHash;
 
 const DEFAULT_INTROSPECTION_CACHE_CAPACITY: NonZeroUsize = NonZeroUsize::new(5).unwrap();
 
+/// Request type for [IntrospectionService].
+pub(crate) struct IntrospectionRequest {
+    /// The GraphQL schema to introspect.
+    pub(crate) schema: Arc<spec::Schema>,
+    /// Document representing the introspection operation to execute.
+    pub(crate) document: ParsedDocument,
+    /// JSON variable values used to execute the query.
+    pub(crate) variables: Object,
+}
+
+/// In-memory cache storage for introspection.
+pub(crate) type IntrospectionCache = Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>;
+
+/// A terminal service that handles (partial) execution of introspection.
+pub(crate) type IntrospectionService =
+    BoxCloneService<IntrospectionRequest, graphql::Response, ComputeBackPressureError>;
+
 #[derive(Clone)]
 enum Mode {
     Disabled,
     Enabled {
-        storage: Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>,
+        storage: IntrospectionCache,
         max_depth: MaxDepth,
     },
 }
@@ -58,23 +75,6 @@ fn introspection_mode(configuration: &Configuration) -> Mode {
         Mode::Disabled
     }
 }
-
-/// Request type for [IntrospectionService].
-pub(crate) struct IntrospectionRequest {
-    /// The GraphQL schema to introspect.
-    pub(crate) schema: Arc<spec::Schema>,
-    /// Document representing the introspection operation to execute.
-    pub(crate) document: ParsedDocument,
-    /// JSON variable values used to execute the query.
-    pub(crate) variables: Object,
-}
-
-/// In-memory cache storage for introspection.
-pub(crate) type IntrospectionCache = Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>;
-
-/// A terminal service that handles (partial) execution of introspection.
-pub(crate) type IntrospectionService =
-    BoxCloneService<IntrospectionRequest, graphql::Response, ComputeBackPressureError>;
 
 /// Returns a terminal service that does cached, partial execution of introspection.
 ///
@@ -246,12 +246,12 @@ impl std::fmt::Display for IntrospectionCacheKey {
 #[derive(Clone)]
 struct IntrospectionCacheService<S> {
     inner: S,
-    cache: Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>,
+    cache: IntrospectionCache,
 }
 
 /// In-memory caching layer for introspection requests. It uses a fixed cache size.
 impl<S> IntrospectionCacheService<S> {
-    fn new(inner: S, cache: Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>) -> Self {
+    fn new(inner: S, cache: IntrospectionCache) -> Self {
         Self { inner, cache }
     }
 }
@@ -259,11 +259,11 @@ impl<S> IntrospectionCacheService<S> {
 ///
 /// A stopgap solution until Apollo Platform provides apollo-cache-memory!
 struct IntrospectionCacheLayer {
-    cache: Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>,
+    cache: IntrospectionCache,
 }
 
 impl IntrospectionCacheLayer {
-    fn new(cache: Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>) -> Self {
+    fn new(cache: IntrospectionCache) -> Self {
         Self { cache }
     }
 }

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -425,6 +425,7 @@ mod tests {
 
     use super::IntrospectionCacheLayer;
     use super::IntrospectionRequest;
+    use super::RejectMixedIntrospectionLayer;
     use super::introspection_service;
     use crate::Configuration;
     use crate::cache::storage::CacheStorage;
@@ -494,6 +495,75 @@ mod tests {
             .unwrap();
 
         drop(service);
+        crate::plugin::test::await_mock_driver(driver).await;
+    }
+
+    #[tokio::test]
+    async fn test_reject_mixed_introspection() {
+        let (mock, mut handle) =
+            tower_test::mock::pair::<IntrospectionRequest, graphql::Response>();
+
+        // We expect one introspection request to go through, and the mixed request not to reach the
+        // inner service.
+        let driver = tokio::task::spawn(async move {
+            let (_request, responder) = handle.next_request().await.unwrap();
+            responder.send_response(
+                graphql::Response::builder()
+                    .data(serde_json_bytes::json!({
+                        "__schema": {
+                            "queryType": {
+                                "name": "Query",
+                            },
+                        },
+                    }))
+                    .build(),
+            );
+        });
+
+        let config = Configuration::default();
+        let schema =
+            Arc::new(Schema::parse(include_str!("testdata/supergraph.graphql"), &config).unwrap());
+
+        let introspection_query = r#"{ __schema { queryType { name } } }"#;
+        let introspection_document =
+            Query::parse_document(introspection_query, None, &schema, &config).unwrap();
+
+        let mixed_query = r#"{
+            __schema { queryType { name } }
+            me { id }
+        }"#;
+        let mixed_document = Query::parse_document(mixed_query, None, &schema, &config).unwrap();
+
+        let mut service = ServiceBuilder::new()
+            .layer(RejectMixedIntrospectionLayer::new())
+            .service(mock);
+
+        let mixed_response = service
+            .ready()
+            .await
+            .unwrap()
+            .call(IntrospectionRequest {
+                schema: schema.clone(),
+                document: mixed_document,
+                variables: Default::default(),
+            })
+            .await
+            .unwrap();
+        assert!(mixed_response.contains_error_code("MIXED_INTROSPECTION"));
+
+        let introspection_response = service
+            .ready()
+            .await
+            .unwrap()
+            .call(IntrospectionRequest {
+                schema,
+                document: introspection_document,
+                variables: Default::default(),
+            })
+            .await
+            .unwrap();
+        assert!(introspection_response.errors.is_empty());
+
         crate::plugin::test::await_mock_driver(driver).await;
     }
 

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -46,7 +46,6 @@ fn introspection_mode(configuration: &Configuration) -> Mode {
             DEFAULT_INTROSPECTION_CACHE_CAPACITY,
             "introspection",
         ));
-        storage.activate();
         Mode::Enabled {
             storage,
             max_depth: if configuration.limits.router.introspection_max_depth {
@@ -70,6 +69,9 @@ pub(crate) struct IntrospectionRequest {
     pub(crate) variables: Object,
 }
 
+/// In-memory cache storage for introspection.
+pub(crate) type IntrospectionCache = Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>;
+
 /// A terminal service that handles (partial) execution of introspection.
 pub(crate) type IntrospectionService =
     BoxCloneService<IntrospectionRequest, graphql::Response, ComputeBackPressureError>;
@@ -78,17 +80,27 @@ pub(crate) type IntrospectionService =
 ///
 /// If introspection is disabled in config, always returns an error response.
 /// If a query contains both introspection and concrete fields, returns an error response.
-pub(crate) fn introspection_service(configuration: &Configuration) -> IntrospectionService {
+///
+/// Returns the cache object separately for telemetry activation.
+pub(crate) fn introspection_service(
+    configuration: &Configuration,
+) -> (IntrospectionService, Option<IntrospectionCache>) {
+    let builder = ServiceBuilder::new().layer(RejectMixedIntrospectionLayer::new());
+
     match introspection_mode(configuration) {
-        Mode::Enabled { storage, max_depth } => ServiceBuilder::new()
-            .layer(RejectMixedIntrospectionLayer::new())
-            .layer(IntrospectionCacheLayer::new(storage.clone()))
-            .service(IntrospectionExecutionService::new(max_depth.clone()))
-            .boxed_clone(),
-        Mode::Disabled => ServiceBuilder::new()
-            .layer(RejectMixedIntrospectionLayer::new())
-            .service(IntrospectionDisabledService::new())
-            .boxed_clone(),
+        Mode::Enabled { storage, max_depth } => (
+            builder
+                .layer(IntrospectionCacheLayer::new(storage.clone()))
+                .service(IntrospectionExecutionService::new(max_depth))
+                .boxed_clone(),
+            Some(storage),
+        ),
+        Mode::Disabled => (
+            builder
+                .service(IntrospectionDisabledService::new())
+                .boxed_clone(),
+            None,
+        ),
     }
 }
 
@@ -129,7 +141,7 @@ impl tower::Service<IntrospectionRequest> for IntrospectionDisabledService {
         std::task::Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: IntrospectionRequest) -> Self::Future {
+    fn call(&mut self, _req: IntrospectionRequest) -> Self::Future {
         let error = graphql::Error::builder()
             .message(String::from("introspection has been disabled"))
             .extension_code("INTROSPECTION_DISABLED")
@@ -346,7 +358,7 @@ impl tower::Service<IntrospectionRequest> for IntrospectionExecutionService {
     }
 
     fn call(&mut self, req: IntrospectionRequest) -> Self::Future {
-        let max_depth = self.max_depth.clone();
+        let max_depth = self.max_depth;
 
         Box::pin(async move {
             // Don't go through the heavy-duty compute job pool just to return "Query".
@@ -417,6 +429,7 @@ mod tests {
 
     use super::IntrospectionCacheLayer;
     use super::IntrospectionRequest;
+    use super::introspection_service;
     use crate::Configuration;
     use crate::cache::storage::CacheStorage;
     use crate::graphql;
@@ -486,5 +499,61 @@ mod tests {
 
         drop(service);
         crate::plugin::test::await_mock_driver(driver).await;
+    }
+
+    #[tokio::test]
+    async fn test_single_aliased_root_typename() {
+        let mut config = Configuration::default();
+        config.supergraph.introspection = true;
+        let schema =
+            Arc::new(Schema::parse(include_str!("testdata/supergraph.graphql"), &config).unwrap());
+        let query = "{ x: __typename }";
+        let document = Query::parse_document(query, None, &schema, &config).unwrap();
+
+        let (service, _cache) = introspection_service(&config);
+        let response = service
+            .oneshot(IntrospectionRequest {
+                schema,
+                document,
+                variables: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.data,
+            Some(serde_json_bytes::json!({
+                "x": "Query",
+            })),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_two_root_typenames() {
+        let mut config = Configuration::default();
+        config.supergraph.introspection = true;
+
+        let schema =
+            Arc::new(Schema::parse(include_str!("testdata/supergraph.graphql"), &config).unwrap());
+        let query = "{ x: __typename __typename }";
+        let document = Query::parse_document(query, None, &schema, &config).unwrap();
+
+        let (service, _cache) = introspection_service(&config);
+        let response = service
+            .oneshot(IntrospectionRequest {
+                schema,
+                document,
+                variables: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.data,
+            Some(serde_json_bytes::json!({
+                "x": "Query",
+                "__typename": "Query",
+            })),
+        );
     }
 }

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -104,7 +104,8 @@ pub(crate) fn introspection_service(
     }
 }
 
-/// Returns if the document contains an introspection query.
+/// Returns if the document contains an introspection query. If this function returns true, it is
+/// appropriate to use the introspection service to resolve the query.
 ///
 /// That is:
 /// - The operation is a query operation, AND:
@@ -112,7 +113,12 @@ pub(crate) fn introspection_service(
 ///
 /// Notably, { __typename } is not considered an introspection query.
 pub(crate) fn is_introspection_query(document: &ParsedDocument) -> bool {
-    document.operation.is_query() && document.has_schema_introspection
+    let operation = &document.operation;
+
+    operation.is_query()
+        && operation
+            .root_fields(&document.executable)
+            .any(|field| matches!(field.name.as_str(), "__schema" | "__type"))
 }
 
 /// Terminal service for GraphQL introspection queries that always returns an error saying
@@ -194,7 +200,15 @@ where
     }
 
     fn call(&mut self, req: IntrospectionRequest) -> Self::Future {
-        if req.document.has_schema_introspection && req.document.has_explicit_root_fields {
+        let operation = &req.document.operation;
+
+        // We should only receive an IntrospectionRequest if the operation was already determined to
+        // contain introspection fields. So, we only have to check if it contains any
+        // _non-introspection_ fields to decide if it's a mixed operation.
+        if operation
+            .root_fields(&req.document.executable)
+            .any(|field| !matches!(field.name.as_str(), "__typename" | "__schema" | "__type"))
+        {
             let error = graphql::Error::builder()
                 .message(
                     "\

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -1,11 +1,15 @@
+//! Implements GraphQL schema introspection.
+use std::future::Ready;
 use std::num::NonZeroUsize;
-use std::ops::ControlFlow;
 use std::sync::Arc;
 
-use apollo_compiler::executable::Selection;
-use serde_json_bytes::json;
+use futures::future::BoxFuture;
+use futures::future::Either;
 use sha2::Digest;
 use sha2::Sha256;
+use tower::ServiceBuilder;
+use tower::ServiceExt as _;
+use tower::util::BoxCloneService;
 
 use crate::Configuration;
 use crate::cache::storage::CacheStorage;
@@ -14,20 +18,17 @@ use crate::compute_job::ComputeBackPressureError;
 use crate::compute_job::ComputeJobType;
 use crate::graphql;
 use crate::json_ext::Object;
-use crate::query_planner::QueryKey;
 use crate::services::layers::query_analysis::ParsedDocument;
 use crate::spec;
+use crate::spec::QueryHash;
 
 const DEFAULT_INTROSPECTION_CACHE_CAPACITY: NonZeroUsize = NonZeroUsize::new(5).unwrap();
-
-#[derive(Clone)]
-pub(crate) struct IntrospectionCache(Mode);
 
 #[derive(Clone)]
 enum Mode {
     Disabled,
     Enabled {
-        storage: Arc<CacheStorage<String, graphql::Response>>,
+        storage: Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>,
         max_depth: MaxDepth,
     },
 }
@@ -38,228 +39,452 @@ enum MaxDepth {
     Ignore,
 }
 
-impl IntrospectionCache {
-    pub(crate) fn new(configuration: &Configuration) -> Self {
-        if configuration.supergraph.introspection {
-            let storage = Arc::new(CacheStorage::new_in_memory(
-                DEFAULT_INTROSPECTION_CACHE_CAPACITY,
-                "introspection",
-            ));
-            Self(Mode::Enabled {
-                storage,
-                max_depth: if configuration.limits.router.introspection_max_depth {
-                    MaxDepth::Check
-                } else {
-                    MaxDepth::Ignore
-                },
-            })
-        } else {
-            Self(Mode::Disabled)
+/// Determine the introspection mode based on YAML configuration.
+fn introspection_mode(configuration: &Configuration) -> Mode {
+    if configuration.supergraph.introspection {
+        let storage = Arc::new(CacheStorage::new_in_memory(
+            DEFAULT_INTROSPECTION_CACHE_CAPACITY,
+            "introspection",
+        ));
+        storage.activate();
+        Mode::Enabled {
+            storage,
+            max_depth: if configuration.limits.router.introspection_max_depth {
+                MaxDepth::Check
+            } else {
+                MaxDepth::Ignore
+            },
         }
+    } else {
+        Mode::Disabled
+    }
+}
+
+/// Request type for [IntrospectionService].
+pub(crate) struct IntrospectionRequest {
+    /// The GraphQL schema to introspect.
+    pub(crate) schema: Arc<spec::Schema>,
+    /// Document representing the introspection operation to execute.
+    pub(crate) document: ParsedDocument,
+    /// JSON variable values used to execute the query.
+    pub(crate) variables: Object,
+}
+
+/// A terminal service that handles (partial) execution of introspection.
+pub(crate) type IntrospectionService =
+    BoxCloneService<IntrospectionRequest, graphql::Response, ComputeBackPressureError>;
+
+/// Returns a terminal service that does cached, partial execution of introspection.
+///
+/// If introspection is disabled in config, always returns an error response.
+/// If a query contains both introspection and concrete fields, returns an error response.
+pub(crate) fn introspection_service(configuration: &Configuration) -> IntrospectionService {
+    match introspection_mode(configuration) {
+        Mode::Enabled { storage, max_depth } => ServiceBuilder::new()
+            .layer(RejectMixedIntrospectionLayer::new())
+            .layer(IntrospectionCacheLayer::new(storage.clone()))
+            .service(IntrospectionExecutionService::new(max_depth.clone()))
+            .boxed_clone(),
+        Mode::Disabled => ServiceBuilder::new()
+            .layer(RejectMixedIntrospectionLayer::new())
+            .service(IntrospectionDisabledService::new())
+            .boxed_clone(),
+    }
+}
+
+/// Returns if the document contains an introspection query.
+///
+/// That is:
+/// - The operation is a query operation, AND:
+///   - The operation has schema introspection fields (__schema or __type), OR:
+///   - The operation does not have explicit root fields (...which implies __typename).
+pub(crate) fn is_introspection_query(document: &ParsedDocument) -> bool {
+    document.operation.is_query()
+        && (document.has_schema_introspection || !document.has_explicit_root_fields)
+}
+
+/// Terminal service for GraphQL introspection queries that always returns an error saying
+/// introspection is disabled.
+#[derive(Clone)]
+struct IntrospectionDisabledService {
+    _private: (),
+}
+
+impl IntrospectionDisabledService {
+    fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl tower::Service<IntrospectionRequest> for IntrospectionDisabledService {
+    // Actually Infallible, but this matches the IntrospectionExecutionService.
+    type Error = ComputeBackPressureError;
+    type Response = graphql::Response;
+    type Future = Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
     }
 
-    pub(crate) fn activate(&self) {
-        if let Mode::Enabled { storage, .. } = &self.0 {
-            storage.activate();
-        }
-    }
-
-    /// If `request` is a query with only introspection fields,
-    /// execute it and return a (cached) response
-    pub(crate) async fn maybe_execute(
-        &self,
-        schema: &Arc<spec::Schema>,
-        key: &QueryKey,
-        doc: &ParsedDocument,
-        variables: Object,
-    ) -> ControlFlow<Result<graphql::Response, ComputeBackPressureError>, ()> {
-        Self::maybe_lone_root_typename(schema, doc)?;
-        if doc.operation.is_query() {
-            if doc.has_schema_introspection {
-                if doc.has_explicit_root_fields {
-                    ControlFlow::Break(Ok(Self::mixed_fields_error()))?;
-                } else {
-                    ControlFlow::Break(
-                        self.cached_introspection(schema, key, doc, variables).await,
-                    )?
-                }
-            } else if !doc.has_explicit_root_fields {
-                // Root __typename only
-
-                // No list field so depth is already known to be zero:
-                let max_depth = MaxDepth::Ignore;
-
-                // Probably a small query, execute it without caching:
-                ControlFlow::Break(Ok(Self::execute_introspection(
-                    max_depth, schema, doc, variables,
-                )))?
-            }
-        }
-        ControlFlow::Continue(())
-    }
-
-    /// A `{ __typename }` query is often used as a ping or health check.
-    /// Handle it without touching the cache.
-    ///
-    /// This fast path only applies if no fragment or directive is used,
-    /// so that we don’t have to deal with `@skip` or `@include` here.
-    fn maybe_lone_root_typename(
-        schema: &Arc<spec::Schema>,
-        doc: &ParsedDocument,
-    ) -> ControlFlow<Result<graphql::Response, ComputeBackPressureError>, ()> {
-        if doc.operation.selection_set.selections.len() == 1
-            && let Selection::Field(field) = &doc.operation.selection_set.selections[0]
-            && field.name == "__typename"
-            && field.directives.is_empty()
-        {
-            // `{ alias: __typename }` is much less common so handling it here is not essential
-            // but easier than a conditional to reject it
-            let key = field.response_key().as_str();
-            let object_type_name = schema
-                .api_schema()
-                .root_operation(doc.operation.operation_type)
-                .expect("validation should have caught undefined root operation")
-                .as_str();
-            let data = json!({key: object_type_name});
-            ControlFlow::Break(Ok(graphql::Response::builder().data(data).build()))?
-        }
-        ControlFlow::Continue(())
-    }
-
-    fn mixed_fields_error() -> graphql::Response {
+    fn call(&mut self, req: IntrospectionRequest) -> Self::Future {
         let error = graphql::Error::builder()
-            .message(
-                "\
-                Mixed queries with both schema introspection and concrete fields \
-                are not supported yet: https://github.com/apollographql/router/issues/2789\
-            ",
-            )
-            .extension_code("MIXED_INTROSPECTION")
+            .message(String::from("introspection has been disabled"))
+            .extension_code("INTROSPECTION_DISABLED")
             .build();
-        graphql::Response::builder().error(error).build()
+        std::future::ready(Ok(graphql::Response::builder().error(error).build()))
+    }
+}
+
+/// Short-circuits requests that contain both introspection and concrete fields, responding with GraphQL errors.
+struct RejectMixedIntrospectionLayer {
+    _private: (),
+}
+impl RejectMixedIntrospectionLayer {
+    fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl<S> tower::Layer<S> for RejectMixedIntrospectionLayer {
+    type Service = RejectMixedIntrospectionService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RejectMixedIntrospectionService { inner }
+    }
+}
+
+/// Short-circuits requests that contain both introspection and concrete fields, responding with GraphQL errors.
+#[derive(Clone)]
+struct RejectMixedIntrospectionService<S> {
+    inner: S,
+}
+
+impl<S> tower::Service<IntrospectionRequest> for RejectMixedIntrospectionService<S>
+where
+    S: tower::Service<IntrospectionRequest, Response = graphql::Response>,
+{
+    type Response = graphql::Response;
+    type Error = S::Error;
+    type Future = Either<
+        S::Future,
+        // Rejection
+        Ready<Result<Self::Response, Self::Error>>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
     }
 
-    fn introspection_cache_key(query: &str, variables: Object) -> Option<String> {
-        if let Ok(variable_key) = serde_json::to_string(&variables) {
-            let mut hasher = Sha256::new();
-            hasher.update(variable_key);
-            Some(format!("{query}:{:x}", hasher.finalize()))
-        } else {
-            tracing::warn!(
-                "Failed to serialize variables for introspection cache key, skipping cache: {:?}",
-                variables
-            );
-            None
-        }
-    }
-
-    async fn cached_introspection(
-        &self,
-        schema: &Arc<spec::Schema>,
-        key: &QueryKey,
-        doc: &ParsedDocument,
-        variables: Object,
-    ) -> Result<graphql::Response, ComputeBackPressureError> {
-        let (storage, max_depth) = match &self.0 {
-            Mode::Enabled { storage, max_depth } => (storage, *max_depth),
-            Mode::Disabled => {
-                let error = graphql::Error::builder()
-                    .message(String::from("introspection has been disabled"))
-                    .extension_code("INTROSPECTION_DISABLED")
-                    .build();
-                return Ok(graphql::Response::builder().error(error).build());
-            }
-        };
-
-        let cache_key = Self::introspection_cache_key(&key.filtered_query, variables.clone());
-        if let Some(cache_key) = &cache_key
-            && let Some(response) = storage.get(cache_key, |_| unreachable!()).await
-        {
-            return Ok(response);
-        }
-
-        let schema = schema.clone();
-        let doc = doc.clone();
-        let response = compute_job::execute(ComputeJobType::Introspection, move |_| {
-            Self::execute_introspection(max_depth, &schema, &doc, variables)
-        })?
-        // `expect()` propagates any panic that potentially happens in the closure, but:
-        //
-        // * We try to avoid such panics in the first place and consider them bugs
-        // * The panic handler in `apollo-router/src/executable.rs` exits the process
-        //   so this error case should never be reached.
-        .await;
-
-        if let Some(cache_key) = cache_key {
-            storage.insert(cache_key, response.clone()).await;
-        }
-        Ok(response)
-    }
-
-    fn execute_introspection(
-        max_depth: MaxDepth,
-        schema: &spec::Schema,
-        doc: &ParsedDocument,
-        variables: Object,
-    ) -> graphql::Response {
-        let api_schema = schema.api_schema();
-        let operation = &doc.operation;
-        let max_depth_result = match max_depth {
-            MaxDepth::Check => {
-                apollo_compiler::introspection::check_max_depth(&doc.executable, operation)
-            }
-            MaxDepth::Ignore => Ok(()),
-        };
-        let result = max_depth_result
-            .and_then(|()| {
-                apollo_compiler::request::coerce_variable_values(api_schema, operation, &variables)
-            })
-            .and_then(|variable_values| {
-                apollo_compiler::introspection::partial_execute(
-                    api_schema,
-                    &schema.implementers_map,
-                    &doc.executable,
-                    operation,
-                    &variable_values,
+    fn call(&mut self, req: IntrospectionRequest) -> Self::Future {
+        if req.document.has_schema_introspection && req.document.has_explicit_root_fields {
+            let error = graphql::Error::builder()
+                .message(
+                    "\
+                    Mixed queries with both schema introspection and concrete fields \
+                    are not supported yet: https://github.com/apollographql/router/issues/2789\
+                ",
                 )
-            });
-        match result {
-            Ok(response) => response.into(),
-            Err(e) => {
-                let error = e.to_graphql_error(&doc.executable.sources);
-                graphql::Response::builder().error(error).build()
+                .extension_code("MIXED_INTROSPECTION")
+                .build();
+            Either::Right(std::future::ready(Ok(graphql::Response::builder()
+                .error(error)
+                .build())))
+        } else {
+            Either::Left(self.inner.call(req))
+        }
+    }
+}
+
+impl IntrospectionRequest {
+    fn is_root_typename_only(&self) -> bool {
+        // `has_schema_introspection` is about __type and __schema,
+        // so if we don't have either of those AND we don't have explicit root fields, we can
+        // assume that we only have `__typename` which is covered by neither.
+        !self.document.has_schema_introspection && !self.document.has_explicit_root_fields
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub(crate) struct IntrospectionCacheKey {
+    /// Hash of the GraphQL query against a specific schema.
+    operation: Arc<QueryHash>,
+    /// Hash of the variables used to execute the introspection query.
+    variables: sha2::digest::Output<Sha256>,
+}
+
+impl std::fmt::Display for IntrospectionCacheKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "introspect:{}:variables:{:x}",
+            self.operation, self.variables
+        )
+    }
+}
+
+/// In-memory caching service for introspection requests.
+///
+/// A stopgap solution until Apollo Platform provides apollo-cache-memory!
+#[derive(Clone)]
+struct IntrospectionCacheService<S> {
+    inner: S,
+    cache: Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>,
+}
+
+/// In-memory caching layer for introspection requests. It uses a fixed cache size.
+impl<S> IntrospectionCacheService<S> {
+    fn new(inner: S, cache: Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>) -> Self {
+        Self { inner, cache }
+    }
+}
+
+///
+/// A stopgap solution until Apollo Platform provides apollo-cache-memory!
+struct IntrospectionCacheLayer {
+    cache: Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>,
+}
+
+impl IntrospectionCacheLayer {
+    fn new(cache: Arc<CacheStorage<IntrospectionCacheKey, graphql::Response>>) -> Self {
+        Self { cache }
+    }
+}
+
+impl<S> tower::Layer<S> for IntrospectionCacheLayer {
+    type Service = IntrospectionCacheService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        IntrospectionCacheService::new(inner, self.cache.clone())
+    }
+}
+
+impl<S> tower::Service<IntrospectionRequest> for IntrospectionCacheService<S>
+where
+    S: tower::Service<IntrospectionRequest, Response = graphql::Response> + Clone + Send + 'static,
+    S::Error: Send,
+    S::Future: Send + 'static,
+{
+    type Response = graphql::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        // This should indicate _cache_ readiness--we don't have that concept right now though.
+        // We might not use the inner service so we ready it only on cache misses.
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: IntrospectionRequest) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let cache = self.cache.clone();
+
+        Box::pin(async move {
+            let cache_key = if let Ok(variable_key) = serde_json::to_string(&req.variables) {
+                let mut hasher = Sha256::new();
+                hasher.update(variable_key);
+                IntrospectionCacheKey {
+                    operation: req.document.hash.clone(),
+                    variables: hasher.finalize(),
+                }
+            } else {
+                tracing::warn!(
+                    "Failed to serialize variables for introspection cache key, skipping cache: {:?}",
+                    req.variables
+                );
+
+                return inner.ready().await?.call(req).await;
+            };
+
+            if let Some(response) = cache.get(&cache_key, |_| unreachable!()).await {
+                return Ok(response);
             }
+
+            let response = inner.ready().await?.call(req).await?;
+            cache.insert(cache_key, response.clone()).await;
+
+            Ok(response)
+        })
+    }
+}
+
+/// Terminal service for executing GraphQL introspection queries against a schema.
+///
+/// Only the introspection parts of the input GraphQL query are executed. Non-introspection parts
+/// are silently ignored.
+///
+/// When the introspection depth limit is exceeded, returns an error response.
+#[derive(Clone)]
+struct IntrospectionExecutionService {
+    max_depth: MaxDepth,
+}
+
+impl IntrospectionExecutionService {
+    fn new(max_depth: MaxDepth) -> Self {
+        Self { max_depth }
+    }
+}
+
+impl tower::Service<IntrospectionRequest> for IntrospectionExecutionService {
+    type Response = graphql::Response;
+    type Error = ComputeBackPressureError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: IntrospectionRequest) -> Self::Future {
+        let max_depth = self.max_depth.clone();
+
+        Box::pin(async move {
+            // Don't go through the heavy-duty compute job pool just to return "Query".
+            let response = if req.is_root_typename_only() {
+                execute_introspection(
+                    // No list field so depth is already known to be zero:
+                    MaxDepth::Ignore,
+                    &req.schema,
+                    &req.document,
+                    req.variables,
+                )
+            } else {
+                compute_job::execute(ComputeJobType::Introspection, move |_| {
+                    execute_introspection(max_depth, &req.schema, &req.document, req.variables)
+                })?
+                .await
+            };
+
+            Ok(response)
+        })
+    }
+}
+
+fn execute_introspection(
+    max_depth: MaxDepth,
+    schema: &spec::Schema,
+    doc: &ParsedDocument,
+    variables: Object,
+) -> graphql::Response {
+    let api_schema = schema.api_schema();
+    let operation = &doc.operation;
+    let max_depth_result = match max_depth {
+        MaxDepth::Check => {
+            apollo_compiler::introspection::check_max_depth(&doc.executable, operation)
+        }
+        MaxDepth::Ignore => Ok(()),
+    };
+    let result = max_depth_result
+        .and_then(|()| {
+            apollo_compiler::request::coerce_variable_values(api_schema, operation, &variables)
+        })
+        .and_then(|variable_values| {
+            apollo_compiler::introspection::partial_execute(
+                api_schema,
+                &schema.implementers_map,
+                &doc.executable,
+                operation,
+                &variable_values,
+            )
+        });
+    match result {
+        Ok(response) => response.into(),
+        Err(e) => {
+            let error = e.to_graphql_error(&doc.executable.sources);
+            graphql::Response::builder().error(error).build()
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use serde_json_bytes::json;
+    use std::num::NonZeroUsize;
+    use std::sync::Arc;
 
-    use crate::introspection::IntrospectionCache;
+    use tower::Service as _;
+    use tower::ServiceBuilder;
+    use tower::ServiceExt as _;
 
-    #[test]
-    fn test_variable_normalization_key() {
-        let variables = json!({
-            "e": true,
-            "a": "John Doe",
-            "b": 30,
-            "f": null,
-            "d": {
-                "b": 1,
-                "a": 2,
-            },
-            "c": [1, "Hello", { "d": "World","a": 3 }],
+    use super::IntrospectionCacheLayer;
+    use super::IntrospectionRequest;
+    use crate::Configuration;
+    use crate::cache::storage::CacheStorage;
+    use crate::graphql;
+    use crate::spec::Query;
+    use crate::spec::Schema;
+
+    #[tokio::test]
+    async fn introspection_cache_hit() {
+        let (mock, mut handle) =
+            tower_test::mock::pair::<IntrospectionRequest, graphql::Response>();
+        let driver = tokio::task::spawn(async move {
+            let (_request, responder) = handle.next_request().await.unwrap();
+            responder.send_response(
+                graphql::Response::builder()
+                    .data(serde_json_bytes::json!({
+                        "__schema": {
+                            "queryType": {
+                                "name": "Query",
+                            },
+                        },
+                    }))
+                    .build(),
+            );
         });
-        let key = IntrospectionCache::introspection_cache_key(
-            "query { __typename }",
-            variables.as_object().unwrap().clone(),
-        )
-        .unwrap();
-        assert_eq!(
-            key,
-            "query { __typename }:618d257f0ab1069a2374274c8c6e56f6b6528a839045647cedcfd147bc5dd9cf"
-        );
+
+        let config = Configuration::default();
+        let schema =
+            Arc::new(Schema::parse(include_str!("testdata/supergraph.graphql"), &config).unwrap());
+        let query = "{ __schema { queryType { name } } }";
+
+        let cache = Arc::new(CacheStorage::new_in_memory(
+            NonZeroUsize::new(5).unwrap(),
+            "introspection",
+        ));
+        let mut service = ServiceBuilder::new()
+            .layer(IntrospectionCacheLayer::new(cache))
+            .service(mock);
+
+        // We should be able to call the mock service twice with the same query, despite only handling
+        // one request.
+
+        let document = Query::parse_document(query, None, &schema, &config).unwrap();
+        service
+            .ready()
+            .await
+            .unwrap()
+            .call(IntrospectionRequest {
+                schema: schema.clone(),
+                document,
+                variables: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let document = Query::parse_document(query, None, &schema, &config).unwrap();
+        service
+            .ready()
+            .await
+            .unwrap()
+            .call(IntrospectionRequest {
+                schema: schema.clone(),
+                document,
+                variables: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        drop(service);
+        crate::plugin::test::await_mock_driver(driver).await;
     }
 }

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -7,6 +7,7 @@ use futures::future::BoxFuture;
 use futures::future::Either;
 use sha2::Digest;
 use sha2::Sha256;
+use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::ServiceExt as _;
 use tower::util::BoxCloneService;
@@ -14,7 +15,6 @@ use tower::util::BoxCloneService;
 use crate::Configuration;
 use crate::cache::storage::CacheStorage;
 use crate::compute_job;
-use crate::compute_job::ComputeBackPressureError;
 use crate::compute_job::ComputeJobType;
 use crate::graphql;
 use crate::json_ext::Object;
@@ -39,7 +39,7 @@ pub(crate) type IntrospectionCache = Arc<CacheStorage<IntrospectionCacheKey, gra
 
 /// A terminal service that handles (partial) execution of introspection.
 pub(crate) type IntrospectionService =
-    BoxCloneService<IntrospectionRequest, graphql::Response, ComputeBackPressureError>;
+    BoxCloneService<IntrospectionRequest, graphql::Response, BoxError>;
 
 #[derive(Clone)]
 enum Mode {
@@ -85,7 +85,9 @@ fn introspection_mode(configuration: &Configuration) -> Mode {
 pub(crate) fn introspection_service(
     configuration: &Configuration,
 ) -> (IntrospectionService, Option<IntrospectionCache>) {
-    let builder = ServiceBuilder::new().layer(RejectMixedIntrospectionLayer::new());
+    let builder = ServiceBuilder::new()
+        .load_shed()
+        .layer(RejectMixedIntrospectionLayer::new());
 
     match introspection_mode(configuration) {
         Mode::Enabled { storage, max_depth } => (
@@ -136,7 +138,7 @@ impl IntrospectionDisabledService {
 
 impl tower::Service<IntrospectionRequest> for IntrospectionDisabledService {
     // Actually Infallible, but this matches the IntrospectionExecutionService.
-    type Error = ComputeBackPressureError;
+    type Error = BoxError;
     type Response = graphql::Response;
     type Future = Ready<Result<Self::Response, Self::Error>>;
 
@@ -352,7 +354,7 @@ impl IntrospectionExecutionService {
 
 impl tower::Service<IntrospectionRequest> for IntrospectionExecutionService {
     type Response = graphql::Response;
-    type Error = ComputeBackPressureError;
+    type Error = BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -213,15 +213,6 @@ where
     }
 }
 
-impl IntrospectionRequest {
-    fn is_root_typename_only(&self) -> bool {
-        // `has_schema_introspection` is about __type and __schema,
-        // so if we don't have either of those AND we don't have explicit root fields, we can
-        // assume that we only have `__typename` which is covered by neither.
-        !self.document.has_schema_introspection && !self.document.has_explicit_root_fields
-    }
-}
-
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) struct IntrospectionCacheKey {
     /// Hash of the GraphQL query against a specific schema.
@@ -361,23 +352,12 @@ impl tower::Service<IntrospectionRequest> for IntrospectionExecutionService {
         let max_depth = self.max_depth;
 
         Box::pin(async move {
-            // Don't go through the heavy-duty compute job pool just to return "Query".
-            let response = if req.is_root_typename_only() {
-                execute_introspection(
-                    // No list field so depth is already known to be zero:
-                    MaxDepth::Ignore,
-                    &req.schema,
-                    &req.document,
-                    req.variables,
-                )
-            } else {
+            Ok(
                 compute_job::execute(ComputeJobType::Introspection, move |_| {
                     execute_introspection(max_depth, &req.schema, &req.document, req.variables)
                 })?
-                .await
-            };
-
-            Ok(response)
+                .await,
+            )
         })
     }
 }

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -854,13 +854,7 @@ mod tests {
         let schema_arc: Arc<crate::spec::Schema> = schema.into();
         let qp_arc = QueryPlannerService::create_planner(&schema_arc, &config).unwrap();
         let subgraph_schemas = crate::query_planner::build_subgraph_schemas(&qp_arc);
-        let mut planner = QueryPlannerService::new(
-            schema_arc,
-            config.clone(),
-            qp_arc,
-            Arc::new(crate::introspection::IntrospectionCache::new(&config)),
-        )
-        .unwrap();
+        let mut planner = QueryPlannerService::new(schema_arc, config.clone(), qp_arc).unwrap();
 
         let ctx = Context::new();
         ctx.extensions()
@@ -874,7 +868,6 @@ mod tests {
                 CacheKeyMetadata::default(),
                 PlanOptions::default(),
                 ComputeJobType::QueryPlanning,
-                variables.clone(),
             ))
             .await
             .unwrap();

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -795,14 +795,9 @@ mod test {
 
         let qp_arc = QueryPlannerService::create_planner(&schema, &config).unwrap();
         let subgraph_schemas = crate::query_planner::build_subgraph_schemas(&qp_arc);
-        let planner = QueryPlannerService::new(
-            schema.clone(),
-            config.clone(),
-            qp_arc,
-            Arc::new(crate::introspection::IntrospectionCache::new(&config)),
-        )
-        .unwrap()
-        .boxed_clone();
+        let planner = QueryPlannerService::new(schema.clone(), config.clone(), qp_arc)
+            .unwrap()
+            .boxed_clone();
 
         let mut builder = PluggableSupergraphServiceBuilder::new(
             planner,

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -302,7 +302,6 @@ where
             query,
             operation_name,
             context,
-            variables,
         } = request;
 
         if self.enable_authorization_directives {
@@ -347,7 +346,6 @@ where
             .metadata(metadata.clone())
             .plan_options(plan_options.clone())
             .compute_job_type(compute_job_type)
-            .variables(variables)
             .build();
 
         // Check the cache first
@@ -395,22 +393,9 @@ where
                 match res {
                     Ok(QueryPlannerResponse { content, errors }) => {
                         if let Some(content) = content.clone() {
-                            let can_cache = match &content {
-                                // Already cached in an introspection-specific, small-size,
-                                // in-memory-only cache.
-                                QueryPlannerContent::CachedIntrospectionResponse { .. } => false,
-                                _ => true,
-                            };
-
-                            if can_cache {
-                                tokio::spawn(async move {
-                                    entry.insert(Ok(content)).await;
-                                });
-                            } else {
-                                tokio::spawn(async move {
-                                    entry.send(Ok(Ok(content))).await;
-                                });
-                            }
+                            tokio::spawn(async move {
+                                entry.insert(Ok(content)).await;
+                            });
                         }
 
                         // This will be overridden by the Rust usage reporting implementation
@@ -722,11 +707,7 @@ impl ValueType for Result<QueryPlannerContent, Arc<QueryPlannerError>> {
     fn estimated_size(&self) -> Option<usize> {
         match self {
             Ok(QueryPlannerContent::Plan { plan }) => Some(plan.estimated_size()),
-            Ok(QueryPlannerContent::Response { response })
-            | Ok(QueryPlannerContent::CachedIntrospectionResponse { response }) => {
-                Some(estimate_size(response))
-            }
-            Ok(QueryPlannerContent::IntrospectionDisabled) => None,
+            Ok(QueryPlannerContent::Response { response }) => Some(estimate_size(response)),
             Err(e) => Some(estimate_size(e)),
         }
     }
@@ -757,7 +738,6 @@ mod tests {
     use crate::apollo_studio_interop::UsageReporting;
     use crate::configuration::QueryPlanning;
     use crate::configuration::Supergraph;
-    use crate::json_ext::Object;
     use crate::query_planner::QueryPlan;
     use crate::spec::Query;
     use crate::spec::Schema;
@@ -967,8 +947,7 @@ mod tests {
                     .call(query_planner::CachingRequest::new(
                         "query Me { me { username } }".to_string(),
                         Some("".into()),
-                        context.clone(),
-                        Default::default()
+                        context.clone()
                     ))
                     .await
                     .is_err()
@@ -992,8 +971,7 @@ mod tests {
                 .call(query_planner::CachingRequest::new(
                     "query Me { me { name { first } } }".to_string(),
                     Some("".into()),
-                    context.clone(),
-                    Default::default()
+                    context.clone()
                 ))
                 .await
                 .is_err()
@@ -1055,7 +1033,6 @@ mod tests {
                 "query Me { me { name { first } } }".to_string(),
                 Some("".into()),
                 context.clone(),
-                Default::default(),
             ))
             .await;
 
@@ -1130,7 +1107,6 @@ mod tests {
                 "query Me { me { name { first } } }".to_string(),
                 Some("".into()),
                 context.clone(),
-                Default::default(),
             ))
             .with_memory_tracking("planning_task")
             .await;
@@ -1246,7 +1222,6 @@ mod tests {
                     "query Me { me { name { first } } }".to_string(),
                     Some("".into()),
                     context.clone(),
-                    Default::default(),
                 ))
                 .await
         });
@@ -1329,7 +1304,6 @@ mod tests {
                 "query Me { me { name { first } } }".to_string(),
                 Some("".into()),
                 context.clone(),
-                Default::default(),
             ))
             .await;
 
@@ -1405,7 +1379,6 @@ mod tests {
                 "query Me { me { name { first } } }".to_string(),
                 Some("".into()),
                 context.clone(),
-                Default::default(),
             ))
             .with_memory_tracking("planning_task")
             .await;
@@ -1481,7 +1454,6 @@ mod tests {
                 "query Me { me { name { first } } }".to_string(),
                 Some("".into()),
                 context.clone(),
-                Default::default(),
             ))
             .with_memory_tracking("planning_task")
             .await;
@@ -1558,7 +1530,6 @@ mod tests {
                 "query Me { me { name { first } } }".to_string(),
                 Some("".into()),
                 context.clone(),
-                Default::default(),
             ))
             .with_memory_tracking("planning_task")
             .await;
@@ -1638,7 +1609,6 @@ mod tests {
                 "query Me { me { name { first } } }".to_string(),
                 Some("".into()),
                 context.clone(),
-                Default::default(),
             ))
             .with_memory_tracking("planning_task")
             .await;
@@ -1717,7 +1687,6 @@ mod tests {
                 "query Me { me { name { first } } }".to_string(),
                 Some("".into()),
                 context.clone(),
-                Default::default(),
             ))
             .with_memory_tracking("planning_task")
             .await;
@@ -1795,7 +1764,6 @@ mod tests {
                     "query Me { me { name { first } } }".to_string(),
                     Some("".into()),
                     context.clone(),
-                    Default::default(),
                 ))
                 .await;
 
@@ -1872,7 +1840,6 @@ mod tests {
                     "query Me { me { username } }".to_string(),
                     Some("".into()),
                     context.clone(),
-                    Default::default(),
                 ))
                 .await
                 .unwrap();
@@ -1882,103 +1849,6 @@ mod tests {
                     .with_lock(|lock| lock.contains_key::<Arc<UsageReporting>>())
             );
         }
-    }
-
-    #[test(tokio::test)]
-    async fn test_introspection_cache() {
-        let mut delegate = MockMyQueryPlanner::new();
-        delegate
-            .expect_clone()
-            // This is the main point of the test: if introspection queries are not cached, then the delegate
-            // will be called twice when we send the same request twice
-            .times(2)
-            .returning(|| {
-                let mut planner = MockMyQueryPlanner::new();
-                planner.expect_sync_call().returning(|_| {
-                    let qp_content = QueryPlannerContent::CachedIntrospectionResponse {
-                        response: Box::new(
-                            crate::graphql::Response::builder()
-                                .data(Object::new())
-                                .build(),
-                        ),
-                    };
-
-                    Ok(QueryPlannerResponse::builder().content(qp_content).build())
-                });
-                planner
-            });
-
-        let configuration = Default::default();
-        let schema = include_str!("testdata/schema.graphql");
-        let schema = Arc::new(Schema::parse(schema, &configuration).unwrap());
-
-        let mut planner = CachingQueryPlanner::for_test(
-            delegate,
-            schema.clone(),
-            Default::default(),
-            &configuration,
-        )
-        .await
-        .unwrap();
-
-        let configuration = Configuration::default();
-
-        let doc1 = Query::parse_document(
-            "{
-              __schema {
-                  types {
-                  name
-                }
-              }
-            }",
-            None,
-            &schema,
-            &configuration,
-        )
-        .unwrap();
-
-        let context = Context::new();
-        context
-            .extensions()
-            .with_lock(|lock| lock.insert::<ParsedDocument>(doc1));
-
-        assert!(
-            planner
-                .call(query_planner::CachingRequest::new(
-                    "{
-                    __schema {
-                        types {
-                        name
-                      }
-                    }
-                  }"
-                    .to_string(),
-                    Some("".into()),
-                    context.clone(),
-                    Default::default()
-                ))
-                .await
-                .is_ok()
-        );
-
-        assert!(
-            planner
-                .call(query_planner::CachingRequest::new(
-                    "{
-                        __schema {
-                            types {
-                            name
-                          }
-                        }
-                      }"
-                    .to_string(),
-                    Some("".into()),
-                    context.clone(),
-                    Default::default()
-                ))
-                .await
-                .is_ok()
-        );
     }
 
     // Expect that if we call the CQP twice, the second call will return cached data
@@ -1992,7 +1862,7 @@ mod tests {
                 // Don't allow the delegate to be called more than once
                 .times(1)
                 .returning(|_| {
-                    let qp_content = QueryPlannerContent::CachedIntrospectionResponse {
+                    let qp_content = QueryPlannerContent::Response {
                         response: Box::new(
                             crate::graphql::Response::builder()
                                 .data(json!(r#"{"data":{"me":{"name":"Ada Lovelace"}}}%"#))
@@ -2040,7 +1910,6 @@ mod tests {
                 .to_string(),
                 None,
                 context.clone(),
-                Default::default(),
             ))
             .await
             .unwrap();
@@ -2055,7 +1924,6 @@ mod tests {
                 .to_string(),
                 None,
                 context.clone(),
-                Default::default(),
             ))
             .await
             .unwrap();
@@ -2115,7 +1983,6 @@ mod tests {
                 .to_string(),
                 None,
                 context.clone(),
-                Default::default(),
             ))
             .await;
 
@@ -2129,7 +1996,6 @@ mod tests {
                 .to_string(),
                 None,
                 context.clone(),
-                Default::default(),
             ))
             .await;
 

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -722,7 +722,6 @@ mod tests {
     use bytesize::ByteSize;
     use mockall::mock;
     use parking_lot::Mutex;
-    use serde_json_bytes::json;
     use test_log::test;
     use tower::Service;
     use tracing::Subscriber;
@@ -1854,33 +1853,27 @@ mod tests {
     // Expect that if we call the CQP twice, the second call will return cached data
     #[test(tokio::test)]
     async fn test_cache_works() {
-        let mut delegate = MockMyQueryPlanner::new();
-        delegate.expect_clone().times(2).returning(|| {
-            let mut planner = MockMyQueryPlanner::new();
-            planner
-                .expect_sync_call()
-                // Don't allow the delegate to be called more than once
-                .times(1)
-                .returning(|_| {
-                    let qp_content = QueryPlannerContent::Response {
-                        response: Box::new(
-                            crate::graphql::Response::builder()
-                                .data(json!(r#"{"data":{"me":{"name":"Ada Lovelace"}}}%"#))
-                                .build(),
-                        ),
-                    };
+        let (mock, mut handle) =
+            tower_test::mock::pair::<QueryPlannerRequest, QueryPlannerResponse>();
+        let driver = tokio::task::spawn(async move {
+            let (_request, responder) = handle
+                .next_request()
+                .await
+                .expect("should receive one request");
 
-                    Ok(QueryPlannerResponse::builder().content(qp_content).build())
-                });
-            planner
+            let content = QueryPlannerContent::Plan {
+                plan: Arc::new(QueryPlan::fake_new(None, None)),
+            };
+
+            responder.send_response(QueryPlannerResponse::builder().content(content).build());
         });
 
         let configuration = Default::default();
         let schema = include_str!("../testdata/starstuff@current.graphql");
         let schema = Arc::new(Schema::parse(schema, &configuration).unwrap());
 
-        let mut planner = CachingQueryPlanner::for_test(
-            delegate,
+        let mut service = CachingQueryPlanner::for_test(
+            mock.map_err(|err| panic!("tower-test errored: {err}")),
             schema.clone(),
             Default::default(),
             &configuration,
@@ -1888,45 +1881,39 @@ mod tests {
         .await
         .unwrap();
 
-        let doc = Query::parse_document(
-            "query ExampleQuery { me { name } }",
-            None,
-            &schema,
-            &configuration,
-        )
-        .unwrap();
+        let query = "query ExampleQuery { me { name } }";
+        let doc = Query::parse_document(query, None, &schema, &configuration).unwrap();
         let context = Context::new();
         context
             .extensions()
             .with_lock(|lock| lock.insert::<ParsedDocument>(doc));
 
-        let _ = planner
+        let _ = service
+            .ready()
+            .await
+            .unwrap()
             .call(query_planner::CachingRequest::new(
-                "query ExampleQuery {
-                  me {
-                    name
-                  }
-                }"
-                .to_string(),
+                query.to_string(),
                 None,
                 context.clone(),
             ))
             .await
             .unwrap();
 
-        let _ = planner
+        let _ = service
+            .ready()
+            .await
+            .unwrap()
             .call(query_planner::CachingRequest::new(
-                "query ExampleQuery {
-                  me {
-                    name
-                  }
-                }"
-                .to_string(),
+                query.to_string(),
                 None,
                 context.clone(),
             ))
             .await
             .unwrap();
+
+        drop(service);
+        crate::plugin::test::await_mock_driver(driver).await;
     }
 
     #[test(tokio::test)]
@@ -1974,6 +1961,9 @@ mod tests {
             .with_lock(|lock| lock.insert::<ParsedDocument>(doc));
 
         let r = planner
+            .ready()
+            .await
+            .unwrap()
             .call(query_planner::CachingRequest::new(
                 "query ExampleQuery {
                   me {
@@ -1987,6 +1977,9 @@ mod tests {
             .await;
 
         let r2 = planner
+            .ready()
+            .await
+            .unwrap()
             .call(query_planner::CachingRequest::new(
                 "query ExampleQuery {
                   me {

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -31,11 +31,6 @@ use crate::error::QueryPlannerError;
 use crate::error::ServiceBuildError;
 use crate::error::ValidationErrors;
 use crate::graphql;
-use crate::introspection::IntrospectionRequest;
-use crate::introspection::IntrospectionService;
-use crate::introspection::introspection_service;
-use crate::introspection::is_introspection_query;
-use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::metrics::meter_provider;
 use crate::plugins::authorization;
@@ -95,7 +90,6 @@ pub(crate) struct QueryPlannerService {
     authorization_config: Arc<authorization::Conf>,
     _federation_instrument: ObservableGauge<u64>,
     signature_normalization_algorithm: ApolloSignatureNormalizationAlgorithm,
-    introspection: IntrospectionService,
 }
 
 fn federation_version_instrument(federation_version: Option<i64>) -> ObservableGauge<u64> {
@@ -222,18 +216,15 @@ impl QueryPlannerService {
         schema: Arc<Schema>,
         configuration: Arc<Configuration>,
     ) -> Result<Self, ServiceBuildError> {
-        let introspection = introspection_service(&configuration);
         let planner = Self::create_planner(&schema, &configuration)?;
-        let introspection = Arc::new(IntrospectionCache::new(&configuration));
 
-        Self::new(schema, configuration, planner, introspection)
+        Self::new(schema, configuration, planner)
     }
 
     pub(crate) fn new(
         schema: Arc<Schema>,
         configuration: Arc<Configuration>,
         planner: Arc<QueryPlanner>,
-        introspection: IntrospectionService,
     ) -> Result<Self, ServiceBuildError> {
         let enable_authorization_directives =
             AuthorizationPlugin::enable_directives(&configuration, &schema)?;
@@ -251,7 +242,6 @@ impl QueryPlannerService {
             configuration,
             _federation_instrument: federation_instrument,
             signature_normalization_algorithm,
-            introspection,
         })
     }
 
@@ -397,7 +387,6 @@ impl Service<QueryPlannerRequest> for QueryPlannerService {
             metadata,
             plan_options,
             compute_job_type,
-            variables,
         } = req;
 
         let this = self.clone();
@@ -444,7 +433,6 @@ impl Service<QueryPlannerRequest> for QueryPlannerService {
                     },
                     doc,
                     compute_job_type,
-                    variables,
                 )
                 .await;
 
@@ -476,7 +464,6 @@ impl QueryPlannerService {
         mut key: QueryKey,
         mut doc: ParsedDocument,
         compute_job_type: ComputeJobType,
-        variables: Object,
     ) -> Result<QueryPlannerContent, MaybeBackPressureError<QueryPlannerError>> {
         let mut query_metrics = Default::default();
         let mut selections = self
@@ -487,25 +474,6 @@ impl QueryPlannerService {
                 &mut query_metrics,
             )
             .await?;
-
-        // TODO(@goto-bus-stop): this is not a query planning concern
-        if is_introspection_query(&doc) {
-            let request = IntrospectionRequest {
-                schema: self.schema.clone(),
-                document: doc,
-                variables,
-            };
-
-            let response = self.introspection
-                .ready()
-                .await?
-                .call(request)
-                .await?;
-
-            return Ok(QueryPlannerContent::CachedIntrospectionResponse {
-                response: Box::new(response),
-            });
-        }
 
         // TODO(@goto-bus-stop): this is not a query planning concern
         let filter_res = if self.enable_authorization_directives {
@@ -713,8 +681,7 @@ mod tests {
 
     #[test(tokio::test)]
     async fn noop_query_should_produce_empty_plan() {
-        let mut config = Configuration::default();
-        config.supergraph.introspection = true;
+        let config = Configuration::default();
         let config = Arc::new(config);
 
         let schema = Arc::new(Schema::parse(EXAMPLE_SCHEMA, &config).unwrap());
@@ -799,87 +766,8 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn test_single_aliased_root_typename() {
-        let config = Arc::new(Configuration::default());
-        let schema = Arc::new(Schema::parse(EXAMPLE_SCHEMA, &config).unwrap());
-
-        let mut service = QueryPlannerService::for_test(schema.clone(), config.clone()).unwrap();
-
-        let query = "{ x: __typename }";
-        let document = Query::parse_document(query, None, &schema, &config).unwrap();
-
-        let response = service
-            .ready()
-            .await
-            .unwrap()
-            .call(
-                QueryPlannerRequest::builder()
-                    .query(query)
-                    .and_operation_name(document.operation.name.as_deref())
-                    .document(document)
-                    .compute_job_type(ComputeJobType::QueryPlanning)
-                    .metadata(CacheKeyMetadata::default())
-                    .plan_options(PlanOptions::default())
-                    .build(),
-            )
-            .await
-            .unwrap();
-
-        if let QueryPlannerContent::CachedIntrospectionResponse { response } =
-            response.content.expect("successful response")
-        {
-            assert_eq!(
-                r#"{"data":{"x":"Query"}}"#,
-                serde_json::to_string(&response).unwrap()
-            )
-        } else {
-            panic!();
-        }
-    }
-
-    #[test(tokio::test)]
-    async fn test_two_root_typenames() {
-        let config = Arc::new(Configuration::default());
-        let schema = Arc::new(Schema::parse(EXAMPLE_SCHEMA, &config).unwrap());
-
-        let mut service = QueryPlannerService::for_test(schema.clone(), config.clone()).unwrap();
-
-        let query = "{ x: __typename __typename }";
-        let document = Query::parse_document(query, None, &schema, &config).unwrap();
-
-        let response = service
-            .ready()
-            .await
-            .unwrap()
-            .call(
-                QueryPlannerRequest::builder()
-                    .query(query)
-                    .and_operation_name(document.operation.name.as_deref())
-                    .document(document)
-                    .compute_job_type(ComputeJobType::QueryPlanning)
-                    .metadata(CacheKeyMetadata::default())
-                    .plan_options(PlanOptions::default())
-                    .build(),
-            )
-            .await
-            .unwrap();
-
-        if let QueryPlannerContent::CachedIntrospectionResponse { response } =
-            response.content.expect("successful response")
-        {
-            assert_eq!(
-                r#"{"data":{"x":"Query","__typename":"Query"}}"#,
-                serde_json::to_string(&response).unwrap()
-            )
-        } else {
-            panic!();
-        }
-    }
-
-    #[test(tokio::test)]
     async fn test_subselections() {
-        let mut configuration: Configuration = Default::default();
-        configuration.supergraph.introspection = true;
+        let configuration: Configuration = Default::default();
         let configuration = Arc::new(configuration);
 
         let schema = Schema::parse(EXAMPLE_SCHEMA, &configuration).unwrap();
@@ -1138,8 +1026,7 @@ mod tests {
             }
         }
 
-        let mut configuration: Configuration = Default::default();
-        configuration.supergraph.introspection = true;
+        let configuration: Configuration = Default::default();
         let configuration = Arc::new(configuration);
 
         let doc = Query::parse_document(query, None, &planner.schema, &configuration).unwrap();
@@ -1155,7 +1042,6 @@ mod tests {
                 },
                 doc,
                 ComputeJobType::QueryPlanning,
-                Default::default(),
             )
             .await
             .unwrap();

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -1,7 +1,6 @@
 //! Calls out to the apollo-federation crate
 
 use std::fmt::Debug;
-use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::task::Poll;
@@ -32,7 +31,10 @@ use crate::error::QueryPlannerError;
 use crate::error::ServiceBuildError;
 use crate::error::ValidationErrors;
 use crate::graphql;
-use crate::introspection::IntrospectionCache;
+use crate::introspection::IntrospectionRequest;
+use crate::introspection::IntrospectionService;
+use crate::introspection::introspection_service;
+use crate::introspection::is_introspection_query;
 use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::metrics::meter_provider;
@@ -93,7 +95,7 @@ pub(crate) struct QueryPlannerService {
     authorization_config: Arc<authorization::Conf>,
     _federation_instrument: ObservableGauge<u64>,
     signature_normalization_algorithm: ApolloSignatureNormalizationAlgorithm,
-    introspection: Arc<IntrospectionCache>,
+    introspection: IntrospectionService,
 }
 
 fn federation_version_instrument(federation_version: Option<i64>) -> ObservableGauge<u64> {
@@ -220,6 +222,7 @@ impl QueryPlannerService {
         schema: Arc<Schema>,
         configuration: Arc<Configuration>,
     ) -> Result<Self, ServiceBuildError> {
+        let introspection = introspection_service(&configuration);
         let planner = Self::create_planner(&schema, &configuration)?;
         let introspection = Arc::new(IntrospectionCache::new(&configuration));
 
@@ -230,7 +233,7 @@ impl QueryPlannerService {
         schema: Arc<Schema>,
         configuration: Arc<Configuration>,
         planner: Arc<QueryPlanner>,
-        introspection: Arc<IntrospectionCache>,
+        introspection: IntrospectionService,
     ) -> Result<Self, ServiceBuildError> {
         let enable_authorization_directives =
             AuthorizationPlugin::enable_directives(&configuration, &schema)?;
@@ -485,17 +488,23 @@ impl QueryPlannerService {
             )
             .await?;
 
-        match self
-            .introspection
-            .maybe_execute(&self.schema, &key, &doc, variables)
-            .await
-        {
-            ControlFlow::Continue(()) => (),
-            ControlFlow::Break(result) => {
-                return Ok(QueryPlannerContent::CachedIntrospectionResponse {
-                    response: Box::new(result.map_err(MaybeBackPressureError::TemporaryError)?),
-                });
-            }
+        // TODO(@goto-bus-stop): this is not a query planning concern
+        if is_introspection_query(&doc) {
+            let request = IntrospectionRequest {
+                schema: self.schema.clone(),
+                document: doc,
+                variables,
+            };
+
+            let response = self.introspection
+                .ready()
+                .await?
+                .call(request)
+                .await?;
+
+            return Ok(QueryPlannerContent::CachedIntrospectionResponse {
+                response: Box::new(response),
+            });
         }
 
         // TODO(@goto-bus-stop): this is not a query planning concern

--- a/apollo-router/src/query_planner/warmup.rs
+++ b/apollo-router/src/query_planner/warmup.rs
@@ -126,7 +126,6 @@ where
                     query: req.query,
                     operation_name: req.operation_name,
                     context,
-                    variables: Default::default(),
                 })
                 .await
         })

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -23,7 +23,6 @@ use crate::configuration::APOLLO_PLUGIN_PREFIX;
 use crate::configuration::Configuration;
 use crate::configuration::ConfigurationError;
 use crate::configuration::TlsClient;
-use crate::introspection::IntrospectionCache;
 use crate::plugin::DynPlugin;
 use crate::plugin::Handler;
 use crate::plugin::PluginFactory;
@@ -315,21 +314,15 @@ impl YamlRouterFactory {
         license: Arc<LicenseState>,
         previous_router: Option<&crate::services::router::service::RouterCreator>,
     ) -> Result<(SupergraphCreator, warmup::BoxCloneService), BoxError> {
-        let introspection = Arc::new(IntrospectionCache::new(&configuration));
-
         let (query_planner_service, subgraph_schemas) = {
             let _span = tracing::info_span!("query_planner_creation").entered();
 
             let planner = QueryPlannerService::create_planner(&schema, &configuration)?;
             let subgraph_schemas = crate::query_planner::build_subgraph_schemas(&planner);
 
-            let query_planner_service = QueryPlannerService::new(
-                schema.clone(),
-                configuration.clone(),
-                planner.clone(),
-                introspection.clone(),
-            )?
-            .boxed_clone();
+            let query_planner_service =
+                QueryPlannerService::new(schema.clone(), configuration.clone(), planner.clone())?
+                    .boxed_clone();
 
             (query_planner_service, subgraph_schemas)
         };
@@ -370,9 +363,6 @@ impl YamlRouterFactory {
 
             // Final creation after this line we must NOT fail to go live with the new router from this point as some plugins may interact with globals.
             let pair = builder.with_plugins(plugins).build().await?;
-
-            // Only now can we build telemetry instruments
-            introspection.activate();
 
             Ok(pair)
         }

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -433,10 +433,6 @@ pub(crate) struct ParsedDocumentInner {
     pub(crate) executable: Arc<Valid<ExecutableDocument>>,
     pub(crate) hash: Arc<QueryHash>,
     pub(crate) operation: Node<Operation>,
-    /// `__schema` or `__type`
-    pub(crate) has_schema_introspection: bool,
-    /// Non-meta fields explicitly defined in the schema
-    pub(crate) has_explicit_root_fields: bool,
 }
 
 impl ParsedDocumentInner {
@@ -447,22 +443,11 @@ impl ParsedDocumentInner {
         hash: Arc<QueryHash>,
     ) -> Result<Arc<Self>, SpecError> {
         let operation = get_operation(&executable, operation_name)?;
-        let mut has_schema_introspection = false;
-        let mut has_explicit_root_fields = false;
-        for field in operation.root_fields(&executable) {
-            match field.name.as_str() {
-                "__typename" => {} // turns out we have no conditional on `has_root_typename`
-                "__schema" | "__type" if operation.is_query() => has_schema_introspection = true,
-                _ => has_explicit_root_fields = true,
-            }
-        }
         Ok(Arc::new(Self {
             ast,
             executable,
             hash,
             operation,
-            has_schema_introspection,
-            has_explicit_root_fields,
         }))
     }
 }

--- a/apollo-router/src/services/query_planner.rs
+++ b/apollo-router/src/services/query_planner.rs
@@ -5,9 +5,6 @@ use std::sync::Arc;
 use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json_bytes::ByteString;
-use serde_json_bytes::Map as JsonMap;
-use serde_json_bytes::Value;
 use static_assertions::assert_impl_all;
 
 use super::layers::query_analysis::ParsedDocument;
@@ -17,7 +14,6 @@ use crate::compute_job::MaybeBackPressureError;
 use crate::error::CacheResolverError;
 use crate::error::QueryPlannerError;
 use crate::graphql;
-use crate::json_ext::Object;
 use crate::query_planner::QueryPlan;
 
 /// Options for planning a query
@@ -39,8 +35,6 @@ pub(crate) struct Request {
     pub(crate) metadata: crate::plugins::authorization::CacheKeyMetadata,
     pub(crate) plan_options: PlanOptions,
     pub(crate) compute_job_type: ComputeJobType,
-    /// Only for introspection queries.
-    pub(crate) variables: Object,
 }
 
 #[buildstructor::buildstructor]
@@ -56,8 +50,6 @@ impl Request {
         metadata: crate::plugins::authorization::CacheKeyMetadata,
         plan_options: PlanOptions,
         compute_job_type: ComputeJobType,
-        // Skip the `Object` type alias in order to use buildstructor’s map special-casing
-        variables: JsonMap<ByteString, Value>,
     ) -> Request {
         Self {
             query,
@@ -66,7 +58,6 @@ impl Request {
             metadata,
             plan_options,
             compute_job_type,
-            variables,
         }
     }
 }
@@ -78,8 +69,6 @@ pub(crate) struct CachingRequest {
     pub(crate) query: String,
     pub(crate) operation_name: Option<String>,
     pub(crate) context: Context,
-    /// Only for introspection queries.
-    pub(crate) variables: Object,
 }
 
 #[buildstructor::buildstructor]
@@ -92,14 +81,11 @@ impl CachingRequest {
         query: String,
         operation_name: Option<String>,
         context: Context,
-        // Skip the `Object` type alias in order to use buildstructor’s map special-casing
-        variables: JsonMap<ByteString, Value>,
     ) -> CachingRequest {
         Self {
             query,
             operation_name,
             context,
-            variables,
         }
     }
 }
@@ -117,8 +103,6 @@ pub(crate) struct Response {
 pub(crate) enum QueryPlannerContent {
     Plan { plan: Arc<QueryPlan> },
     Response { response: Box<graphql::Response> },
-    CachedIntrospectionResponse { response: Box<graphql::Response> },
-    IntrospectionDisabled,
 }
 
 #[buildstructor::buildstructor]

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -190,6 +190,7 @@ async fn service_call(
         // It's unfortunate that we are _executing_ these queries here rather than in the execution
         // service, but it's basically the only way we can do it right now.
         let result = introspection_service
+            // This has a load shed layer on it, so it will definitely be ready.
             .ready()
             .await?
             .call(introspection::IntrospectionRequest {

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -16,12 +16,14 @@ use tower::BoxError;
 use tower::Layer;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
+use tower::load_shed::error::Overloaded;
 use tower_service::Service;
 use tracing_futures::Instrument;
 
 use crate::Configuration;
 use crate::Context;
 use crate::batching::BatchQueryPlanAnalysisLayer;
+use crate::compute_job::ComputeBackPressureError;
 use crate::configuration::PersistedQueriesPrewarmQueryPlanCache;
 use crate::configuration::mode::Mode;
 use crate::error::CacheResolverError;
@@ -183,6 +185,10 @@ async fn service_call(
         .with_lock(|extensions| extensions.get::<ParsedDocument>().cloned())
         && introspection::is_introspection_query(&document)
     {
+        // Introspection queries are currently short-circuited: we don't support query planning
+        // them, and we don't support mixed introspection/non-introspection queries.
+        // It's unfortunate that we are _executing_ these queries here rather than in the execution
+        // service, but it's basically the only way we can do it right now.
         let result = introspection_service
             .ready()
             .await?
@@ -197,12 +203,25 @@ async fn service_call(
             Ok(response) => Ok(SupergraphResponse::new_from_graphql_response(
                 response, context,
             )),
-            Err(backpressure) => Ok(SupergraphResponse::error_builder()
-                .status_code(StatusCode::SERVICE_UNAVAILABLE)
-                .context(context)
-                .error(backpressure.to_graphql_error())
-                .build()
-                .unwrap()),
+            Err(error) => {
+                // There are two types of backpressure errors currently: one from tower and one from
+                // the compute job pool. Handle both of them the same way.
+                let backpressure = error
+                    .downcast_ref::<Overloaded>()
+                    .map(|_| &ComputeBackPressureError)
+                    .or_else(|| error.downcast_ref::<ComputeBackPressureError>());
+
+                if let Some(backpressure) = backpressure {
+                    Ok(SupergraphResponse::error_builder()
+                        .status_code(StatusCode::SERVICE_UNAVAILABLE)
+                        .context(context)
+                        .error(backpressure.to_graphql_error())
+                        .build()
+                        .unwrap())
+                } else {
+                    Err(error)
+                }
+            }
         };
     }
 

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -28,7 +28,8 @@ use crate::configuration::mode::Mode;
 use crate::error::CacheResolverError;
 use crate::graphql;
 use crate::graphql::IntoGraphQLErrors;
-use crate::json_ext::Object;
+use crate::introspection;
+use crate::introspection::IntrospectionService;
 use crate::layers::DEFAULT_BUFFER_SIZE;
 use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 use crate::plugin::DynPlugin;
@@ -61,6 +62,7 @@ use crate::services::http::HttpClientServiceFactory;
 use crate::services::layers::allow_only_http_post_mutations::AllowOnlyHttpPostMutationsLayer;
 use crate::services::layers::content_negotiation;
 use crate::services::layers::persisted_queries::PersistedQueryExpander;
+use crate::services::layers::query_analysis::ParsedDocument;
 use crate::services::layers::query_analysis::QueryAnalysis;
 use crate::services::query_planner;
 use crate::services::router::ClientRequestAccepts;
@@ -79,6 +81,7 @@ pub(crate) type Plugins = IndexMap<String, Box<dyn DynPlugin>>;
 pub(crate) struct SupergraphService {
     query_planner_service: query_planner::CacheBoxCloneService,
     execution_service: execution::BoxCloneService,
+    introspection_service: IntrospectionService,
     schema: Arc<Schema>,
     strict_variable_validation: Mode,
 }
@@ -89,12 +92,14 @@ impl SupergraphService {
     pub(crate) fn new(
         query_planner_service: query_planner::CacheBoxCloneService,
         execution_service: execution::BoxCloneService,
+        introspection_service: IntrospectionService,
         schema: Arc<Schema>,
         strict_variable_validation: Mode,
     ) -> Self {
         SupergraphService {
             query_planner_service,
             execution_service,
+            introspection_service,
             schema,
             strict_variable_validation,
         }
@@ -121,18 +126,24 @@ impl Service<SupergraphRequest> for SupergraphService {
         }
 
         // Consume our cloned services and allow ownership to be transferred to the async block.
-        let planning_clone = self.query_planner_service.clone();
-        let planning = std::mem::replace(&mut self.query_planner_service, planning_clone);
+        let query_planner_service = self.query_planner_service.clone();
+        let query_planner_service =
+            std::mem::replace(&mut self.query_planner_service, query_planner_service);
 
-        let execution_clone = self.execution_service.clone();
-        let execution = std::mem::replace(&mut self.execution_service, execution_clone);
+        let execution_service = self.execution_service.clone();
+        let execution_service = std::mem::replace(&mut self.execution_service, execution_service);
+
+        // We won't do a readiness dance here because we didn't ready the service: we don't know if
+        // we'll need it.
+        let introspection_service = self.introspection_service.clone();
 
         let schema = self.schema.clone();
 
         let context_cloned = req.context.clone();
         let fut = service_call(
-            planning,
-            execution,
+            query_planner_service,
+            execution_service,
+            introspection_service,
             schema,
             req,
             self.strict_variable_validation,
@@ -159,6 +170,7 @@ impl Service<SupergraphRequest> for SupergraphService {
 async fn service_call(
     planning: query_planner::CacheBoxCloneService,
     mut execution_service: execution::BoxCloneService,
+    mut introspection_service: IntrospectionService,
     schema: Arc<Schema>,
     req: SupergraphRequest,
     strict_variable_validation: Mode,
@@ -166,6 +178,34 @@ async fn service_call(
     let context = req.context;
     let body = req.supergraph_request.body();
     let variables = body.variables.clone();
+
+    if let Some(document) = context
+        .extensions()
+        .with_lock(|extensions| extensions.get::<ParsedDocument>().cloned())
+        && introspection::is_introspection_query(&document)
+    {
+        let result = introspection_service
+            .ready()
+            .await?
+            .call(introspection::IntrospectionRequest {
+                schema,
+                document,
+                variables,
+            })
+            .await;
+
+        return match result {
+            Ok(response) => Ok(SupergraphResponse::new_from_graphql_response(
+                response, context,
+            )),
+            Err(backpressure) => Ok(SupergraphResponse::error_builder()
+                .status_code(StatusCode::SERVICE_UNAVAILABLE)
+                .context(context)
+                .error(backpressure.to_graphql_error())
+                .build()
+                .unwrap()),
+        };
+    }
 
     let QueryPlannerResponse { content, errors } = match plan_query(
         planning,
@@ -180,7 +220,6 @@ async fn service_call(
             .query
             .clone()
             .unwrap_or_default(),
-        variables.clone(),
     )
     .await
     {
@@ -214,26 +253,9 @@ async fn service_call(
     }
 
     match content {
-        Some(QueryPlannerContent::Response { response })
-        | Some(QueryPlannerContent::CachedIntrospectionResponse { response }) => Ok(
+        Some(QueryPlannerContent::Response { response }) => Ok(
             SupergraphResponse::new_from_graphql_response(*response, context),
         ),
-        Some(QueryPlannerContent::IntrospectionDisabled) => {
-            let mut response = SupergraphResponse::new_from_graphql_response(
-                graphql::Response::builder()
-                    .errors(vec![
-                        crate::error::Error::builder()
-                            .message(String::from("introspection has been disabled"))
-                            .extension_code("INTROSPECTION_DISABLED")
-                            .build(),
-                    ])
-                    .build(),
-                context,
-            );
-            *response.response.status_mut() = StatusCode::BAD_REQUEST;
-            Ok(response)
-        }
-
         Some(QueryPlannerContent::Plan { plan }) => {
             let query_metrics = plan.query_metrics;
             context.extensions().with_lock(|lock| {
@@ -441,7 +463,6 @@ async fn plan_query(
     operation_name: Option<String>,
     context: Context,
     query_str: String,
-    variables: Object,
 ) -> Result<QueryPlannerResponse, CacheResolverError> {
     let qpr = planning
         .call(
@@ -449,7 +470,6 @@ async fn plan_query(
                 .query(query_str)
                 .and_operation_name(operation_name)
                 .context(context.clone())
-                .variables(variables)
                 .build(),
         )
         .instrument(tracing::info_span!(
@@ -561,6 +581,9 @@ impl PluggableSupergraphServiceBuilder {
         )?
         .boxed_clone();
 
+        let (introspection_service, introspection_cache) =
+            introspection::introspection_service(&configuration);
+
         // Activate the telemetry plugin.
         // We must NOT fail to go live with the new router from this point as the telemetry plugin activate interacts with globals.
         for (_, plugin) in self.plugins.iter() {
@@ -570,6 +593,9 @@ impl PluggableSupergraphServiceBuilder {
         // We need a non-fallible hook so that once we know we are going live with a pipeline we do final initialization.
         // For now just shoe-horn something in, but if we ever reintroduce the query planner hook in plugins and activate then this can be made clean.
         query_plan_cache.activate();
+        if let Some(introspection_cache) = introspection_cache {
+            introspection_cache.activate();
+        }
 
         let subscription_plugin_conf = self
             .plugins
@@ -636,6 +662,7 @@ impl PluggableSupergraphServiceBuilder {
         let supergraph_service = SupergraphService::builder()
             .query_planner_service(query_planner_service.clone())
             .execution_service(execution_service)
+            .introspection_service(introspection_service)
             .schema(schema.clone())
             .strict_variable_validation(configuration.supergraph.strict_variable_validation)
             .build();

--- a/apollo-router/tests/integration/telemetry/metrics.rs
+++ b/apollo-router/tests/integration/telemetry/metrics.rs
@@ -537,18 +537,22 @@ async fn test_gauges_on_reload() {
     router
         .assert_metrics_contains(r#"apollo_router_cache_storage_estimated_size{kind="query planner",type="memory",otel_scope_name="apollo/router"} "#, None)
         .await;
+
+    // APQ cache should contain the persisted query
     router
         .assert_metrics_contains(
             r#"apollo_router_cache_size{kind="APQ",type="memory",otel_scope_name="apollo/router"} 1"#,
             None,
         )
         .await;
+    // Query plan cache should contain the regular query + the persisted query
     router
         .assert_metrics_contains(
-            r#"apollo_router_cache_size{kind="query planner",type="memory",otel_scope_name="apollo/router"} 1"#,
+            r#"apollo_router_cache_size{kind="query planner",type="memory",otel_scope_name="apollo/router"} 2"#,
             None,
         )
         .await;
+    // Introspection cache should contain the introspection query
     router
         .assert_metrics_contains(
             r#"apollo_router_cache_size{kind="introspection",type="memory",otel_scope_name="apollo/router"} 1"#,


### PR DESCRIPTION
Replaces the IntrospectionCache structure by a stack of tower services,
depending on the mode.

This new introspection service is called from the `SupergraphService`,
instead of inside the `QueryPlannerService`.

The `SupergraphService` is already an "orchestrator" service, calling into
multiple inner services to produce its result. This seems like a fine
place to do introspection, too. We could put introspection orchestration
in a separate layer in the future, but as it stands this doesn't seem
bad to me.

The `QueryPlannerService` now doesn't need to know about variables
anymore. It also does not need to special-case introspection responses
to prevent double-caching.

The `introspection_service` function returns both the service and
the cache object, so we can do telemetry activation for it inside the
supergraph service factory, together with all other telemetry
activation.

Some tests are moved from the query planner service to the introspection
service, but we're still mostly relying on the introspection integration
tests.

### Removal of `{ __typename }` fast path
We used to have special-casing for the `{ __typename }` query. The
documented reason for this was performance: comments claimed this
is a common query for pings or health checks. I think that's fair, but there
was a secret, more important reason: `{ __typename }` produces an empty
query plan, and we did not support empty query plans. Removing the
optimization actually caused errors.

After #9738, we do support empty query plans. This means that the
optimization is no longer _required_ to make the router work. I prefer not
having this optimization, because it caused `__typename` to be resolved
differently depending on if there are _other fields_ in the query. Now,
`{ __typename }` goes through the query planner like any other query, and
is resolved in the execution service the same way as when you write
`{ __typename otherField }`.

### Introspection service behaviours

- We always reject mixed GraphQL queries that contain schema introspection
  AND regular fields.
- When introspection is disabled, we reject all introspection-only
  requests with a GraphQL error.
- When introspection is enabled, we apply a cache layer (currently
  specific to introspection) to an introspection execution service, which
  executes introspection on the compute job pool.

### Why so many layers?
In the Apollo Platform crates, we'll be working on generic tower
caching layers. The aim is to replace `IntrospectionCacheLayer` by
an apollo-cache-memory layer when it becomes available.
By already splitting the introspection service into layers now,
this will become trivial to adopt.


<!-- [ROUTER-1951] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

Changeset is probably advisable, coming up later.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

[ROUTER-1951]: https://apollographql.atlassian.net/browse/ROUTER-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ