### PR TITLE
ci: label prep + reconcile PRs; widen state filter

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -357,13 +357,14 @@ jobs:
           >  - Version bumps (see _Files Changed_ for the true reality)
           >  - That it targets the right release branch (\`$VERSION\` in this case!)
           >
-          > Opened automatically by the \`test-release-prep\` workflow.
+          > Opened automatically by the \`release-prep\` workflow.
           EOF
           )
           gh pr create \
             --repo "$GITHUB_REPOSITORY" \
             --base "$VERSION" \
             --head "$PREP_BRANCH" \
+            --label release-prep \
             --title "prep release: v$VERSION" \
             --body "$BODY"
 

--- a/xtask/src/commands/release/reconcile.rs
+++ b/xtask/src/commands/release/reconcile.rs
@@ -252,7 +252,7 @@ impl Reconcile {
                 origin = self.common.origin
             );
             eprintln!(
-                "  gh pr create --repo {repo} -B {dev} -H {reconcile_branch} --title ... --body ...",
+                "  gh pr create --repo {repo} -B {dev} -H {reconcile_branch} --label release-reconcile --title ... --body ...",
                 repo = self.common.repo
             );
             if !self.no_auto_merge {
@@ -301,6 +301,8 @@ impl Reconcile {
             dev.as_str(),
             "-H",
             reconcile_branch.as_str(),
+            "--label",
+            "release-reconcile",
             "--title",
             pr_title.as_str(),
             "--body",

--- a/xtask/src/commands/release/state.rs
+++ b/xtask/src/commands/release/state.rs
@@ -214,24 +214,19 @@ fn list_tags() -> Result<Vec<Version>> {
 
 /// List open release-related PRs in the target repo via `gh pr list --search ...`.
 ///
-/// Scoped to `label:release` rather than every open PR.  Two reasons:
+/// Scoped to the three release-cycle labels rather than every open PR.  Two reasons:
 ///
 ///   1. `mergeStateStatus` is an expensive GraphQL field — GitHub's backend
 ///      times out (HTTP 502) when asked to compute it for ~80+ PRs at once,
 ///      which is the steady state on apollographql/router.
-///   2. The detector only cares about release-cycle PRs.  Release PRs get
-///      `--label release` at create time (see `test-release-new.yml`), so
-///      this filter is sufficient for line attribution.
+///   2. The detector only cares about release-cycle PRs.  Each PR type gets
+///      its label at create time:
+///        - Release PRs → `release` (in `release/new.rs`)
+///        - Prep PRs → `release-prep` (in `release-prep.yml`)
+///        - Reconcile PRs → `release-reconcile` (in `release/reconcile.rs`)
 ///
-/// Prep PRs (head `prep-<X.Y.Z>`) and reconcile PRs (head `reconcile-v<X.Y.Z>`)
-/// are not currently labeled and so won't appear here.  That's a known gap:
-/// `release status` still surfaces them when the release PR is open (the
-/// attribution code in `build_line_state` matches by head ref name on the
-/// returned PR set), but a reconcile PR with no release PR open on the same
-/// version line won't be detected by `check_no_existing_reconcile`.  Worst
-/// case the local branch-create fails when re-running reconcile against the
-/// same version.  TODO: add `--label reconcile` / `--label prep` at PR-open
-/// time and combine results from multiple label-filtered queries.
+/// GitHub search's `label:a,b,c` syntax matches any of the labels (OR), so a
+/// single query covers all three.
 fn list_open_prs(repo: &str) -> Result<Vec<PrSummary>> {
     if !xtask::gh::available() {
         return Err(anyhow!(
@@ -244,7 +239,7 @@ fn list_open_prs(repo: &str) -> Result<Vec<PrSummary>> {
         "pr",
         "list",
         "--search",
-        "is:pr is:open label:release",
+        "is:pr is:open label:release,release-prep,release-reconcile",
         "--limit",
         "30",
         "--json",


### PR DESCRIPTION
Prep PRs (opened by \`release-prep.yml\`) and reconcile PRs (opened by \`cargo xtask release reconcile\`) were being created without labels, so the release-state detector's \`label:release\` filter missed them.

## Changes

- \`release-prep.yml\` — adds \`--label release-prep\` to its \`gh pr create\` call.
- \`xtask/src/commands/release/reconcile.rs\` — adds \`--label release-reconcile\`.
- \`xtask/src/commands/release/state.rs\` — widens the search to \`label:release,release-prep,release-reconcile\` (GitHub's comma-OR).  Doc comment rewritten to reflect the new state; removes the now-satisfied TODO.

Both \`release-prep\` and \`release-reconcile\` already exist on the repo, color \`#9C31D4\` (matches the existing \`release\` label so they read as a family).

## Why

Closes the state-detector edge case where a reconcile PR could exist without being visible to \`check_no_existing_reconcile\` — meaning a re-run of \`cargo xtask release reconcile\` against the same version could fail at branch-create time instead of showing a clean "already exists" message.

Also worth batching in before the upcoming \`dev-v2.10.x\` tooling backport so LTS picks it up in the same trip.