### PR TITLE
ci: detect default branch dynamically instead of hardcoding "dev"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,12 +495,14 @@ jobs:
       - run:
           name: Skip if no source files changed
           command: |
-            # Always run on dev (post-merge); CIRCLE_BRANCH is 'dev' for nightly triggers too
-            if [ "$CIRCLE_BRANCH" = "dev" ]; then
+            # Always run on the default branch (post-merge); nightly triggers also target it
+            git remote set-head origin -a
+            DEFAULT_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | sed 's|^origin/||')
+            if [ "$CIRCLE_BRANCH" = "$DEFAULT_BRANCH" ]; then
               exit 0
             fi
-            git fetch origin dev --depth=100
-            BASE=$(git merge-base HEAD origin/dev 2>/dev/null || git rev-parse HEAD~1)
+            git fetch origin "$DEFAULT_BRANCH" --depth=100
+            BASE=$(git merge-base HEAD "origin/$DEFAULT_BRANCH" 2>/dev/null || git rev-parse HEAD~1)
             CHANGED=$(git diff --name-only "$BASE" HEAD)
             echo "Changed files:"
             echo "$CHANGED"
@@ -535,7 +537,7 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": ":x: CI tests *failed* on `dev` for `${CIRCLE_JOB}` — a merge may have broken the build!\n<${CIRCLE_BUILD_URL}|View failed job>"
+                          "text": ":x: CI tests *failed* on `${CIRCLE_BRANCH}` for `${CIRCLE_JOB}` — a merge may have broken the build!\n<${CIRCLE_BUILD_URL}|View failed job>"
                         }
                       }
                     ]


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-####] -->
---

The `test` job's "skip if no source files changed" optimization hardcoded `"dev"` in three places: the branch comparison, the `git fetch`, and the `git merge-base` call.  Any fork or mirror whose default branch isn't named `dev` gets a failed `git fetch` on every test run.

Replace all three with the same `git remote set-head origin -a` + `origin/HEAD` pattern that the `create_cache_keys` command already uses in this same file.  No external configuration required — behavior on this repo is unchanged.

Also replaced the hardcoded `` `dev` `` string in the Slack failure alert text with `${CIRCLE_BRANCH}` so the message is accurate regardless of the repo's default branch name.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary) — n/a
- [x] Changeset is included for user-facing changes — n/a (CI-only)
- [x] Changes are compatible
- [x] Documentation completed — n/a
- [x] Performance impact assessed and acceptable — adds one fast `git remote set-head` call
- [x] Metrics and logs are added and documented — n/a
- Tests added and passing
    - [x] Unit tests — n/a
    - [x] Integration tests — n/a
    - [x] Manual tests, as necessary — n/a