### PR TITLE
test(coprocessor): assert traceparent parent-id on the wire

### DIFF
--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -399,15 +399,9 @@ pub(crate) fn externalize_header_map(
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
-
     use http::Response;
-    use parking_lot::Mutex;
     use tower::service_fn;
     use tracing_futures::WithSubscriber;
-    use tracing_subscriber::Registry;
-    use tracing_subscriber::filter::LevelFilter;
-    use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::*;
     use crate::assert_snapshot_subscriber;
@@ -541,77 +535,6 @@ mod test {
                 .await;
         }
         .with_subscriber(assert_snapshot_subscriber!())
-        .await;
-    }
-
-    /// Regression test for ROUTER-1948: `client.call()` in `Externalizable::call` must execute
-    /// inside the `http_req_span` scope, not inside the surrounding `external_plugin` span.
-    ///
-    /// `HttpClientService::call` synchronously captures `Span::current()` to inject the
-    /// W3C `traceparent` header.  The `in_scope` call ensures the right span is active at that
-    /// moment, so the injected parent-id belongs to the HTTP client span rather than the outer
-    /// coprocessor span.
-    #[tokio::test]
-    async fn coprocessor_client_call_executes_in_http_req_span_scope() {
-        // Minimal subscriber: Registry tracks span IDs; LevelFilter enables INFO spans.
-        let subscriber = Registry::default().with(LevelFilter::INFO);
-
-        let captured_span_id: Arc<Mutex<Option<tracing::Id>>> = Arc::new(Mutex::new(None));
-        let captured_clone = captured_span_id.clone();
-
-        async {
-            // Simulate the enclosing span that wraps the entire coprocessor call.
-            let external_plugin = tracing::info_span!("external_plugin");
-            let external_plugin_id = external_plugin.id();
-            assert!(
-                external_plugin_id.is_some(),
-                "test requires external_plugin span to be enabled and have an id"
-            );
-            let _enter = external_plugin.enter();
-
-            let service = service_fn(move |req: HttpRequest| {
-                // Capture which span is *current* when client.call() runs synchronously.
-                // The fix (in_scope) means this should be http_req_span, not external_plugin.
-                *captured_clone.lock() = tracing::Span::current().id();
-                async move {
-                    Ok::<_, BoxError>(HttpResponse {
-                        http_response: Response::builder()
-                            .status(200)
-                            .body(router::body::from_bytes(
-                                serde_json::to_vec(&serde_json::json!({
-                                    "version": EXTERNALIZABLE_VERSION,
-                                    "stage": "RouterRequest",
-                                    "control": "continue",
-                                    "id": "test-id",
-                                }))
-                                .unwrap(),
-                            ))
-                            .unwrap(),
-                        context: req.context,
-                    })
-                }
-            });
-
-            let externalizable = Externalizable::<String>::router_builder()
-                .stage(PipelineStep::RouterRequest)
-                .id("test-id".to_string())
-                .build();
-
-            let _ = externalizable
-                .call(service, "http://example.com/test", Context::new())
-                .await;
-
-            let captured = captured_span_id.lock().take();
-            assert!(
-                captured.is_some(),
-                "client.call() must execute within a span"
-            );
-            assert_ne!(
-                captured, external_plugin_id,
-                "client.call() must run in http_req_span scope, not external_plugin scope"
-            );
-        }
-        .with_subscriber(subscriber)
         .await;
     }
 }

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -4,6 +4,9 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use insta::assert_yaml_snapshot;
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceResponse;
+use prost::Message;
 use serde_json::json;
 use tower::BoxError;
 use wiremock::Mock;
@@ -13,7 +16,9 @@ use wiremock::matchers::method;
 use wiremock::matchers::path;
 
 use crate::integration::IntegrationTest;
+use crate::integration::ValueExt;
 use crate::integration::common::Query;
+use crate::integration::common::Telemetry;
 use crate::integration::common::graph_os_enabled;
 use crate::integration::common::redact_cache_debug_query_hash;
 
@@ -102,6 +107,130 @@ async fn test_coprocessor_limit_payload() -> Result<(), BoxError> {
 
     router.graceful_shutdown().await;
     Ok(())
+}
+
+/// Regression test for ROUTER-1948: the coprocessor's server span must be parented under the
+/// router's outbound HTTP CLIENT span (the `http_request` span), not the surrounding
+/// `external_plugin` span.
+///
+/// The router injects a W3C `traceparent` into the coprocessor request; its parent-id must point
+/// at that outbound HTTP span.  We assert this end-to-end: capture the `traceparent` the mock
+/// coprocessor actually receives, then look up the router's own exported spans (via a mock OTLP
+/// collector) and confirm the span whose id equals that parent-id is the CLIENT span for the
+/// coprocessor call.  Its exported OTel name follows the HTTP convention `POST <url>` (the
+/// `http_request` tracing span carries `otel.name = "POST <url>"`).
+///
+/// On the pre-fix code the parent-id is `external_plugin`'s span id, so this fails.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_coprocessor_trace_context_parented_under_http_request_span() -> Result<(), BoxError> {
+    if !graph_os_enabled() {
+        return Ok(());
+    }
+
+    // Mock coprocessor: capture the `traceparent` it receives, echo the payload back as `continue`.
+    let captured_traceparent: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured = captured_traceparent.clone();
+    let coprocessor = wiremock::MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(move |req: &wiremock::Request| {
+            if let Some(traceparent) = req.headers.get("traceparent") {
+                *captured.lock().unwrap() = traceparent.to_str().ok().map(str::to_string);
+            }
+            let mut body: serde_json::Value = serde_json::from_slice(&req.body)
+                .unwrap_or_else(|_| json!({"version": 1, "stage": "RouterRequest"}));
+            body["control"] = json!("continue");
+            ResponseTemplate::new(200).set_body_json(body)
+        })
+        .mount(&coprocessor)
+        .await;
+
+    // Mock OTLP collector: accept and retain the router's exported spans.
+    let otlp = wiremock::MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/traces"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            ExportTraceServiceResponse::default().encode_to_vec(),
+            "application/x-protobuf",
+        ))
+        .mount(&otlp)
+        .await;
+
+    let config = include_str!("fixtures/coprocessor_trace_context_propagation.router.yaml")
+        .replace("<coprocessor-address>", &coprocessor.uri())
+        .replace("<otel-collector-endpoint>", &otlp.uri());
+
+    let mut router = IntegrationTest::builder()
+        .config(config)
+        .telemetry(Telemetry::Otlp {
+            endpoint: Some(format!("{}/v1/traces", otlp.uri())),
+        })
+        // Disable keep-alive so the router isn't held open at shutdown (see module note).
+        .reqwest_client(no_keepalive_reqwest_client())
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let (_trace_id, response) = router.execute_default_query().await;
+    assert_eq!(response.status(), 200);
+
+    // Spans arrive asynchronously via the batch processor, so poll (10s / 50ms) until the
+    // http_request span the coprocessor was parented under has been exported.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let parent_span_name = loop {
+        // Clone the captured value out and drop the lock before awaiting.
+        let traceparent = captured_traceparent.lock().unwrap().clone();
+        if let Some(traceparent) = traceparent {
+            // traceparent: version "-" trace-id "-" parent-id "-" flags
+            let parent_id = traceparent
+                .split('-')
+                .nth(2)
+                .unwrap_or_default()
+                .to_string();
+            if let Some(name) = exported_span_name_by_id(&otlp, &parent_id).await {
+                break Some(name);
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            break None;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    router.graceful_shutdown().await;
+
+    assert!(
+        captured_traceparent.lock().unwrap().is_some(),
+        "coprocessor must have received a traceparent header"
+    );
+    // The coprocessor's outbound HTTP CLIENT span is exported as `POST <coprocessor-url>`.
+    // On the pre-fix code the parent-id resolves to the `external_plugin` span instead.
+    assert_eq!(
+        parent_span_name,
+        Some(format!("POST {}", coprocessor.uri())),
+        "coprocessor's parent span must be the outbound HTTP CLIENT span, not external_plugin"
+    );
+    Ok(())
+}
+
+/// Decode the spans the router exported to the mock OTLP collector and return the `name` of the
+/// span whose `spanId` matches `span_id` (16 lowercase hex), if present.
+async fn exported_span_name_by_id(otlp: &wiremock::MockServer, span_id: &str) -> Option<String> {
+    let requests = otlp.received_requests().await?;
+    let spans = serde_json::Value::Array(
+        requests
+            .iter()
+            .filter(|r| r.url.path().ends_with("/v1/traces"))
+            .filter_map(|r| ExportTraceServiceRequest::decode(r.body.as_slice()).ok())
+            .filter_map(|trace| serde_json::to_value(trace).ok())
+            .collect(),
+    );
+    spans
+        .select_path(&format!("$..spans..[?(@.spanId == '{span_id}')].name"))
+        .ok()?
+        .first()
+        .and_then(|v| v.as_string())
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/apollo-router/tests/integration/fixtures/coprocessor_trace_context_propagation.router.yaml
+++ b/apollo-router/tests/integration/fixtures/coprocessor_trace_context_propagation.router.yaml
@@ -1,0 +1,22 @@
+coprocessor:
+  url: "<coprocessor-address>"
+  router:
+    request:
+      body: true
+telemetry:
+  exporters:
+    tracing:
+      propagation:
+        trace_context: true
+      common:
+        service_name: router
+        # Force every trace to sample regardless of the inbound request, so the
+        # coprocessor's outbound http_request span is always exported.
+        sampler: 1.0
+        parent_based_sampler: false
+      otlp:
+        enabled: true
+        protocol: http
+        endpoint: <otel-collector-endpoint>
+        batch_processor:
+          scheduled_delay: 10ms


### PR DESCRIPTION
Draft / proposed regression test for #9724.

The current unit test doesn't exercise the real injection path — its `service_fn` mock only checks which span is current, so it never runs `HttpClientService::call`'s actual `get_text_map_propagator` / `prepare_context` / `HeaderInjector` code. Reverting the fix leaves it green.

This replaces it with an end-to-end integration test: a real router with a coprocessor + OTLP tracing export, a mock coprocessor, and a mock OTLP collector. It captures the `traceparent` the coprocessor actually receives, looks up the router's own exported span whose id equals that parent-id, and asserts it's the outbound HTTP CLIENT span (`POST <url>`) — not `external_plugin`.

Verified locally: fails on the pre-fix code (parent resolves to `external_plugin`), passes on the fix. No production changes. No global-state or nextest serialization needed — it's a separate test binary (process-isolated under both `cargo test` and nextest), and the router installs the propagator itself via real config rather than the test poking global state.
