### PR TITLE
refactor(batching): move query plan analysis into a layer

### DIFF
--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -5,7 +5,7 @@
 //! - At the router service, a batch query is split apart into multiple requests.
 //! - A single [Batch] structure is created, which is responsible for handling the batch lifecycle.
 //! - Each individual request gets a [BatchQuery] extension.
-//! - After query planning of each individual request, the [PrepareBatchingExecutionLayer] collects
+//! - After query planning of each individual request, the [BatchQueryPlanAnalysisLayer] collects
 //!   the hashes of the plan nodes that will be executed unconditionally as part of the query plan.
 //!   Those query nodes are candidates for being batched up into a single request at the subgraph
 //!   side, as they do not depend on other data being fetched first.

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -5,10 +5,10 @@
 //! - At the router service, a batch query is split apart into multiple requests.
 //! - A single [Batch] structure is created, which is responsible for handling the batch lifecycle.
 //! - Each individual request gets a [BatchQuery] extension.
-//! - After query planning of each individual request, we collect the hashes of the plan nodes that
-//!   will be executed unconditionally as part of the query plan. Those query nodes are candidates
-//!   for being batched up into a single request at the subgraph side, as they do not depend on
-//!   other data being fetched first.
+//! - After query planning of each individual request, the [PrepareBatchingExecutionLayer] collects
+//!   the hashes of the plan nodes that will be executed unconditionally as part of the query plan.
+//!   Those query nodes are candidates for being batched up into a single request at the subgraph
+//!   side, as they do not depend on other data being fetched first.
 //! - [BatchQuery::set_query_hashes] is called with those hashes, to set the expected number of
 //!   subgraph requests. The hashes are also used to track successful and unsuccessful responses to
 //!   each individual subgraph request.
@@ -29,6 +29,8 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
+use futures::future::BoxFuture;
+use http::StatusCode;
 use opentelemetry::Context as otelContext;
 use opentelemetry::trace::TraceContextExt;
 use parking_lot::Mutex as PMutex;
@@ -43,9 +45,11 @@ use tracing::Span;
 use crate::Context;
 use crate::error::FetchError;
 use crate::error::SubgraphBatchingError;
+use crate::graphql;
 use crate::plugins::telemetry::otel::span_ext::OpenTelemetrySpanExt;
 use crate::services::SubgraphRequest;
 use crate::services::SubgraphResponse;
+use crate::services::execution;
 use crate::services::process_batches;
 use crate::services::router;
 use crate::services::router::body::RouterBody;
@@ -484,6 +488,102 @@ pub(crate) async fn assemble_batch(
         request,
         txs,
     })
+}
+
+/// Handle pre-execution batching concerns:
+/// - Inform the [BatchQuery] about the query plan fetch node hashes
+/// - Reject the request if it contains any subscription or defer nodes
+#[derive(Clone)]
+pub(crate) struct PrepareBatchingExecutionLayer {
+    _private: (),
+}
+
+impl PrepareBatchingExecutionLayer {
+    pub(crate) fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl<S> tower::Layer<S> for PrepareBatchingExecutionLayer {
+    type Service = PrepareBatchingExecutionService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        PrepareBatchingExecutionService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PrepareBatchingExecutionService<S> {
+    inner: S,
+}
+
+impl<S> tower::Service<execution::Request> for PrepareBatchingExecutionService<S>
+where
+    S: tower::Service<execution::Request, Response = execution::Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError>,
+{
+    type Response = S::Response;
+    type Error = BoxError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: execution::Request) -> Self::Future {
+        let inner = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, inner);
+
+        Box::pin(async move {
+            let context = &req.context;
+            let plan = &req.query_plan;
+            let variables = &req.supergraph_request.body().variables;
+            let is_deferred = plan.is_deferred(variables);
+            let is_subscription = plan.is_subscription();
+
+            let Some(batching) = context
+                .extensions()
+                .with_lock(|lock| lock.get::<crate::configuration::Batching>().cloned())
+            else {
+                return inner.call(req).await.map_err(Into::into);
+            };
+
+            if batching.enabled && (is_deferred || is_subscription) {
+                let code = if is_deferred {
+                    "BATCHING_DEFER_UNSUPPORTED"
+                } else {
+                    "BATCHING_SUBSCRIPTION_UNSUPPORTED"
+                };
+                let mut response = execution::Response::new_from_graphql_response(
+                        graphql::Response::builder()
+                        .error(crate::error::Error::builder()
+                            .message("Deferred responses and subscriptions aren't supported in batches")
+                            .extension_code(code)
+                            .build())
+                            .build(),
+                        context.clone(),
+                    );
+                *response.response.status_mut() = StatusCode::NOT_ACCEPTABLE;
+                return Ok(response);
+            }
+
+            // Now perform query batch analysis
+            let batch_query_opt = context
+                .extensions()
+                .with_lock(|lock| lock.get::<BatchQuery>().cloned());
+            if let Some(batch_query) = batch_query_opt {
+                let query_hashes = plan.query_hashes(batching, variables)?;
+                batch_query.set_query_hashes(query_hashes).await?;
+                tracing::debug!("batch registered: {}", batch_query);
+            }
+
+            inner.call(req).await.map_err(Into::into)
+        })
+    }
 }
 
 #[cfg(test)]

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -29,8 +29,6 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
-use futures::future::BoxFuture;
-use http::StatusCode;
 use opentelemetry::Context as otelContext;
 use opentelemetry::trace::TraceContextExt;
 use parking_lot::Mutex as PMutex;
@@ -45,16 +43,17 @@ use tracing::Span;
 use crate::Context;
 use crate::error::FetchError;
 use crate::error::SubgraphBatchingError;
-use crate::graphql;
 use crate::plugins::telemetry::otel::span_ext::OpenTelemetrySpanExt;
 use crate::services::SubgraphRequest;
 use crate::services::SubgraphResponse;
-use crate::services::execution;
 use crate::services::process_batches;
 use crate::services::router;
 use crate::services::router::body::RouterBody;
 use crate::services::subgraph::SubgraphRequestId;
 use crate::spec::QueryHash;
+
+mod query_plan_analysis_layer;
+pub(crate) use self::query_plan_analysis_layer::*;
 
 /// A query that is part of a batch.
 /// Note: It's ok to make transient clones of this struct, but *do not* store clones anywhere apart
@@ -488,102 +487,6 @@ pub(crate) async fn assemble_batch(
         request,
         txs,
     })
-}
-
-/// Handle pre-execution batching concerns:
-/// - Inform the [BatchQuery] about the query plan fetch node hashes
-/// - Reject the request if it contains any subscription or defer nodes
-#[derive(Clone)]
-pub(crate) struct PrepareBatchingExecutionLayer {
-    _private: (),
-}
-
-impl PrepareBatchingExecutionLayer {
-    pub(crate) fn new() -> Self {
-        Self { _private: () }
-    }
-}
-
-impl<S> tower::Layer<S> for PrepareBatchingExecutionLayer {
-    type Service = PrepareBatchingExecutionService<S>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        PrepareBatchingExecutionService { inner }
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct PrepareBatchingExecutionService<S> {
-    inner: S,
-}
-
-impl<S> tower::Service<execution::Request> for PrepareBatchingExecutionService<S>
-where
-    S: tower::Service<execution::Request, Response = execution::Response> + Clone + Send + 'static,
-    S::Future: Send + 'static,
-    S::Error: Into<BoxError>,
-{
-    type Response = S::Response;
-    type Error = BoxError;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(Into::into)
-    }
-
-    fn call(&mut self, req: execution::Request) -> Self::Future {
-        let inner = self.inner.clone();
-        let mut inner = std::mem::replace(&mut self.inner, inner);
-
-        Box::pin(async move {
-            let context = &req.context;
-            let plan = &req.query_plan;
-            let variables = &req.supergraph_request.body().variables;
-            let is_deferred = plan.is_deferred(variables);
-            let is_subscription = plan.is_subscription();
-
-            let Some(batching) = context
-                .extensions()
-                .with_lock(|lock| lock.get::<crate::configuration::Batching>().cloned())
-            else {
-                return inner.call(req).await.map_err(Into::into);
-            };
-
-            if batching.enabled && (is_deferred || is_subscription) {
-                let code = if is_deferred {
-                    "BATCHING_DEFER_UNSUPPORTED"
-                } else {
-                    "BATCHING_SUBSCRIPTION_UNSUPPORTED"
-                };
-                let mut response = execution::Response::new_from_graphql_response(
-                        graphql::Response::builder()
-                        .error(crate::error::Error::builder()
-                            .message("Deferred responses and subscriptions aren't supported in batches")
-                            .extension_code(code)
-                            .build())
-                            .build(),
-                        context.clone(),
-                    );
-                *response.response.status_mut() = StatusCode::NOT_ACCEPTABLE;
-                return Ok(response);
-            }
-
-            // Now perform query batch analysis
-            let batch_query_opt = context
-                .extensions()
-                .with_lock(|lock| lock.get::<BatchQuery>().cloned());
-            if let Some(batch_query) = batch_query_opt {
-                let query_hashes = plan.query_hashes(batching, variables)?;
-                batch_query.set_query_hashes(query_hashes).await?;
-                tracing::debug!("batch registered: {}", batch_query);
-            }
-
-            inner.call(req).await.map_err(Into::into)
-        })
-    }
 }
 
 #[cfg(test)]

--- a/apollo-router/src/batching/query_plan_analysis_layer.rs
+++ b/apollo-router/src/batching/query_plan_analysis_layer.rs
@@ -1,0 +1,105 @@
+use futures::future::BoxFuture;
+use http::StatusCode;
+use tower::BoxError;
+
+use crate::batching::BatchQuery;
+use crate::graphql;
+use crate::services::execution;
+
+/// Analyze the query plan for a batch query.
+///
+/// This informs the [`BatchQuery`] about the query plan fetch node hashes.
+///
+/// It also reject the request if it contains any subscription or defer nodes, which is not
+/// supported in batch requests.
+#[derive(Clone)]
+pub(crate) struct BatchQueryPlanAnalysisLayer {
+    _private: (),
+}
+
+impl BatchQueryPlanAnalysisLayer {
+    pub(crate) fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl<S> tower::Layer<S> for BatchQueryPlanAnalysisLayer {
+    type Service = BatchQueryPlanAnalysisService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        BatchQueryPlanAnalysisService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct BatchQueryPlanAnalysisService<S> {
+    inner: S,
+}
+
+impl<S> tower::Service<execution::Request> for BatchQueryPlanAnalysisService<S>
+where
+    S: tower::Service<execution::Request, Response = execution::Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<BoxError>,
+{
+    type Response = S::Response;
+    type Error = BoxError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: execution::Request) -> Self::Future {
+        let inner = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, inner);
+
+        Box::pin(async move {
+            let plan = &req.query_plan;
+            let variables = &req.supergraph_request.body().variables;
+            let is_deferred = plan.is_deferred(variables);
+            let is_subscription = plan.is_subscription();
+
+            let Some(batching) = req.context
+                .extensions()
+                .with_lock(|lock| lock.get::<crate::configuration::Batching>().cloned())
+            else {
+                return inner.call(req).await.map_err(Into::into);
+            };
+
+            if batching.enabled && (is_deferred || is_subscription) {
+                let code = if is_deferred {
+                    "BATCHING_DEFER_UNSUPPORTED"
+                } else {
+                    "BATCHING_SUBSCRIPTION_UNSUPPORTED"
+                };
+                let mut response = execution::Response::new_from_graphql_response(
+                        graphql::Response::builder()
+                        .error(crate::error::Error::builder()
+                            .message("Deferred responses and subscriptions aren't supported in batches")
+                            .extension_code(code)
+                            .build())
+                            .build(),
+                        req.context,
+                    );
+                *response.response.status_mut() = StatusCode::NOT_ACCEPTABLE;
+                return Ok(response);
+            }
+
+            // Now perform query batch analysis
+            let batch_query_opt = req.context
+                .extensions()
+                .with_lock(|lock| lock.get::<BatchQuery>().cloned());
+            if let Some(batch_query) = batch_query_opt {
+                let query_hashes = plan.query_hashes(batching, variables)?;
+                batch_query.set_query_hashes(query_hashes).await?;
+                tracing::debug!("batch registered: {}", batch_query);
+            }
+
+            inner.call(req).await.map_err(Into::into)
+        })
+    }
+}

--- a/apollo-router/src/batching/query_plan_analysis_layer.rs
+++ b/apollo-router/src/batching/query_plan_analysis_layer.rs
@@ -42,7 +42,7 @@ where
     S::Future: Send + 'static,
     S::Error: Into<BoxError>,
 {
-    type Response = S::Response;
+    type Response = execution::Response;
     type Error = BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -63,7 +63,8 @@ where
             let is_deferred = plan.is_deferred(variables);
             let is_subscription = plan.is_subscription();
 
-            let Some(batching) = req.context
+            let Some(batching) = req
+                .context
                 .extensions()
                 .with_lock(|lock| lock.get::<crate::configuration::Batching>().cloned())
             else {
@@ -90,7 +91,8 @@ where
             }
 
             // Now perform query batch analysis
-            let batch_query_opt = req.context
+            let batch_query_opt = req
+                .context
                 .extensions()
                 .with_lock(|lock| lock.get::<BatchQuery>().cloned());
             if let Some(batch_query) = batch_query_opt {
@@ -101,5 +103,227 @@ where
 
             inner.call(req).await.map_err(Into::into)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr as _;
+    use std::sync::Arc;
+
+    use tower::Service as _;
+    use tower::ServiceBuilder;
+    use tower::ServiceExt as _;
+
+    use super::BatchQueryPlanAnalysisLayer;
+    use crate::Configuration;
+    use crate::Context;
+    use crate::batching::Batch;
+    use crate::batching::BatchQuery;
+    use crate::compute_job::ComputeJobType;
+    use crate::graphql;
+    use crate::query_planner::QueryPlan;
+    use crate::query_planner::QueryPlannerService;
+    use crate::services::QueryPlannerContent;
+    use crate::services::QueryPlannerRequest;
+    use crate::services::execution;
+    use crate::spec::Query;
+    use crate::spec::Schema;
+
+    async fn plan_query(
+        query: &str,
+        schema: Arc<Schema>,
+        configuration: Arc<Configuration>,
+    ) -> Arc<QueryPlan> {
+        let document = Query::parse_document(query, None, &schema, &configuration).unwrap();
+
+        let QueryPlannerContent::Plan {
+            plan: query_plan, ..
+        } = QueryPlannerService::for_test(schema, configuration)
+            .unwrap()
+            .oneshot(
+                QueryPlannerRequest::builder()
+                    .query(query)
+                    .document(document)
+                    .metadata(crate::plugins::authorization::CacheKeyMetadata::default())
+                    .plan_options(crate::services::PlanOptions::default())
+                    .variables(serde_json_bytes::Map::new())
+                    .compute_job_type(ComputeJobType::QueryPlanning)
+                    .build(),
+            )
+            .await
+            .unwrap()
+            .content
+            .unwrap()
+        else {
+            panic!("unexpected query planner output");
+        };
+
+        query_plan
+    }
+
+    #[tokio::test]
+    async fn reject_defer_query_plans() {
+        let (mock, handle) = tower_test::mock::pair::<execution::Request, execution::Response>();
+
+        let mut service = ServiceBuilder::new()
+            .layer(BatchQueryPlanAnalysisLayer::new())
+            .service(mock);
+
+        // Setup is 70% of the work!
+
+        let configuration = Arc::new(
+            Configuration::from_str(
+                r#"
+            batching:
+                enabled: true
+                mode: batch_http_link
+                subgraph:
+                    all:
+                        enabled: true
+        "#,
+            )
+            .unwrap(),
+        );
+
+        let schema = Arc::new(
+            Schema::parse(
+                include_str!("../../tests/fixtures/batching/schema.graphql"),
+                &configuration,
+            )
+            .unwrap(),
+        );
+
+        let query = r#"
+          {
+            entryA(count: 1) { index }
+            ... @defer {
+              entryB(count: 1) { index }
+            }
+          }
+        "#;
+
+        let query_plan = plan_query(query, schema, configuration.clone()).await;
+
+        let batch = Arc::new(Batch::spawn_handler(1));
+        let batch_query = Batch::query_for_index(batch, 0).unwrap();
+
+        let context = Context::new();
+        context.extensions().with_lock(|lock| {
+            lock.insert(configuration.batching.clone());
+            lock.insert(batch_query);
+        });
+
+        let request = execution::Request::builder()
+            .supergraph_request(http::Request::new(
+                graphql::Request::fake_builder().query(query).build(),
+            ))
+            .context(context)
+            .query_plan(query_plan)
+            .build();
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .unwrap()
+            .next_response()
+            .await
+            .unwrap();
+        assert!(response.contains_error_code("BATCHING_DEFER_UNSUPPORTED"));
+
+        crate::plugin::test::assert_no_mock_calls(handle).await;
+    }
+
+    #[tokio::test]
+    async fn analyze_query_plan_nodes() {
+        let (mock, mut handle) =
+            tower_test::mock::pair::<execution::Request, execution::Response>();
+        let driver = tokio::task::spawn(async move {
+            let (request, responder) = handle.next_request().await.unwrap();
+
+            request.context.extensions().with_lock(|lock| {
+                let batch_query = lock.get::<BatchQuery>().unwrap();
+                assert_eq!(
+                    batch_query
+                        .remaining
+                        .load(std::sync::atomic::Ordering::Relaxed),
+                    2,
+                    "both subgraph requests should be identified as batch-able"
+                );
+            });
+
+            // Succeed the request
+            responder.send_response(
+                execution::Response::builder()
+                    .data(serde_json_bytes::json!({
+                        "entryA": [{ "index": 20 }],
+                        "entryB": [{ "index": 30 }],
+                    }))
+                    .context(request.context)
+                    .build()
+                    .unwrap(),
+            );
+        });
+
+        let mut service = ServiceBuilder::new()
+            .layer(BatchQueryPlanAnalysisLayer::new())
+            .service(mock);
+
+        // Setup is 70% of the work!
+
+        let configuration = Arc::new(
+            Configuration::from_str(
+                r#"
+            batching:
+                enabled: true
+                mode: batch_http_link
+                subgraph:
+                    all:
+                        enabled: true
+        "#,
+            )
+            .unwrap(),
+        );
+
+        let schema = Arc::new(
+            Schema::parse(
+                include_str!("../../tests/fixtures/batching/schema.graphql"),
+                &configuration,
+            )
+            .unwrap(),
+        );
+
+        let query = r#"
+          {
+            entryA(count: 1) { index }
+            entryB(count: 1) { index }
+          }
+        "#;
+
+        let query_plan = plan_query(query, schema, configuration.clone()).await;
+
+        let batch = Arc::new(Batch::spawn_handler(1));
+        let batch_query = Batch::query_for_index(batch, 0).unwrap();
+
+        let context = Context::new();
+        context.extensions().with_lock(|lock| {
+            lock.insert(configuration.batching.clone());
+            lock.insert(batch_query);
+        });
+
+        let request = execution::Request::builder()
+            .supergraph_request(http::Request::new(
+                graphql::Request::fake_builder().query(query).build(),
+            ))
+            .context(context)
+            .query_plan(query_plan)
+            .build();
+
+        let _response = service.ready().await.unwrap().call(request).await.unwrap();
+
+        crate::plugin::test::await_mock_driver(driver).await;
     }
 }

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -21,7 +21,7 @@ use tracing_futures::Instrument;
 
 use crate::Configuration;
 use crate::Context;
-use crate::batching::PrepareBatchingExecutionLayer;
+use crate::batching::BatchQueryPlanAnalysisLayer;
 use crate::configuration::PersistedQueriesPrewarmQueryPlanCache;
 use crate::configuration::mode::Mode;
 use crate::error::CacheResolverError;
@@ -575,7 +575,7 @@ impl PluggableSupergraphServiceBuilder {
             .map(|t| t.config.apollo.clone());
 
         let execution_service: execution::BoxCloneService = ServiceBuilder::new()
-            .layer(PrepareBatchingExecutionLayer::new())
+            .layer(BatchQueryPlanAnalysisLayer::new())
             .layer(SubscriptionExecutionLayer::new(
                 configuration.notify.clone(),
             ))

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -21,8 +21,7 @@ use tracing_futures::Instrument;
 
 use crate::Configuration;
 use crate::Context;
-use crate::batching::BatchQuery;
-use crate::configuration::Batching;
+use crate::batching::PrepareBatchingExecutionLayer;
 use crate::configuration::PersistedQueriesPrewarmQueryPlanCache;
 use crate::configuration::mode::Mode;
 use crate::error::CacheResolverError;
@@ -242,44 +241,6 @@ async fn service_call(
 
             let is_deferred = plan.is_deferred(&variables);
             let is_subscription = plan.is_subscription();
-
-            if let Some(batching) = context
-                .extensions()
-                .with_lock(|lock| lock.get::<Batching>().cloned())
-            {
-                if batching.enabled && (is_deferred || is_subscription) {
-                    let message = if is_deferred {
-                        "BATCHING_DEFER_UNSUPPORTED"
-                    } else {
-                        "BATCHING_SUBSCRIPTION_UNSUPPORTED"
-                    };
-                    let mut response = SupergraphResponse::new_from_graphql_response(
-                            graphql::Response::builder()
-                                .errors(vec![crate::error::Error::builder()
-                                    .message(String::from(
-                                        "Deferred responses and subscriptions aren't supported in batches",
-                                    ))
-                                    .extension_code(message)
-                                    .build()])
-                                .build(),
-                            context.clone(),
-                        );
-                    *response.response.status_mut() = StatusCode::NOT_ACCEPTABLE;
-                    return Ok(response);
-                }
-                // Now perform query batch analysis
-                let batch_query_opt = context
-                    .extensions()
-                    .with_lock(|lock| lock.get::<BatchQuery>().cloned());
-                if let Some(batch_query) = batch_query_opt {
-                    let query_hashes = plan.query_hashes(batching, &variables)?;
-                    batch_query
-                        .set_query_hashes(query_hashes)
-                        .await
-                        .map_err(|e| CacheResolverError::BatchingError(e.to_string()))?;
-                    tracing::debug!("batch registered: {}", batch_query);
-                }
-            }
 
             let ClientRequestAccepts {
                 multipart_defer: accepts_multipart_defer,
@@ -614,6 +575,7 @@ impl PluggableSupergraphServiceBuilder {
             .map(|t| t.config.apollo.clone());
 
         let execution_service: execution::BoxCloneService = ServiceBuilder::new()
+            .layer(PrepareBatchingExecutionLayer::new())
             .layer(SubscriptionExecutionLayer::new(
                 configuration.notify.clone(),
             ))

--- a/apollo-router/src/services/supergraph/tests.rs
+++ b/apollo-router/src/services/supergraph/tests.rs
@@ -1351,6 +1351,90 @@ async fn subscription_without_header() {
     insta::assert_json_snapshot!(res);
 }
 
+/// Requests without the correct `Accept` header should not reach the batching execution layer.
+#[tokio::test]
+async fn batching_defer_unsupported_and_incorrect_header() {
+    let configuration: Configuration = serde_json::from_value(serde_json::json!({
+        "include_subgraph_errors": { "all": true },
+        "batching": {
+            "enabled": true,
+            "mode": "batch_http_link",
+        },
+    }))
+    .unwrap();
+    let batching = configuration.batching.clone();
+
+    let service = TestHarness::builder()
+        .configuration(Arc::new(configuration))
+        .schema(SCHEMA)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let context = Context::new();
+    context.extensions().with_lock(|lock| {
+        lock.insert(batching);
+    });
+
+    let request = supergraph::Request::fake_builder()
+        .query("query { currentUser { id ...@defer { name } } }")
+        .context(context)
+        .build()
+        .unwrap();
+
+    let mut stream = service.oneshot(request).await.unwrap();
+    let res = stream.next_response().await.unwrap();
+
+    assert!(
+        res.contains_error_code("DEFER_BAD_HEADER"),
+        "expected DEFER_BAD_HEADER, got: {res:?}"
+    );
+}
+
+/// Requests with invalid variables do not reach the execution service, so batching + defer +
+/// invalid variable raises a variable error instead of a batching + defer error.
+#[tokio::test]
+async fn batching_defer_unsupported_and_incorrect_variable() {
+    let configuration: Configuration = serde_json::from_value(serde_json::json!({
+        "include_subgraph_errors": { "all": true },
+        "batching": {
+            "enabled": true,
+            "mode": "batch_http_link",
+        },
+    }))
+    .unwrap();
+    let batching = configuration.batching.clone();
+
+    let service = TestHarness::builder()
+        .configuration(Arc::new(configuration))
+        .schema(SCHEMA)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let context = defer_context();
+    // XXX(@goto-bus-stop): not ideal but this implies that the `Accept` header was passed in
+    // correctly; the router service is normally responsible for populating this context value
+    context.extensions().with_lock(|lock| {
+        lock.insert(batching);
+    });
+
+    let request = supergraph::Request::fake_builder()
+        .query("query($skip: Boolean!) { currentUser { id ...@defer { name @skip(if: $skip) } } }")
+        .variable("skip", "not-a-boolean")
+        .context(context)
+        .build()
+        .unwrap();
+
+    let mut stream = service.oneshot(request).await.unwrap();
+    let res = stream.next_response().await.unwrap();
+
+    assert!(
+        res.contains_error_code("VALIDATION_INVALID_TYPE_VARIABLE"),
+        "expected VALIDATION_INVALID_TYPE_VARIABLE, got: {res:?}"
+    );
+}
+
 #[tokio::test]
 async fn root_typename_with_defer_and_empty_first_response() {
     let subgraphs = MockedSubgraphs([


### PR DESCRIPTION
Batching does two things after query planning, but before execution:
- Reject the subrequest if its query plan contains a defer or subscription node, as the batching response format is a flat JSON array and doesn't support streaming responses
- Compute query hashes based on the query plan, which `BatchQuery` then uses to track subgraph batches

This previously happened inline at the supergraph service. We can instead do it as a layer on the execution service.

There's an ordering change here. Client `Accept` header verification for plans that use `@defer` or subscriptions now happens _before_ the batching check, so in practice you'll probably hit _that one_ instead of the batching-specific error. Also, variable validation happens before the batching check, so if you sent invalid variables _and_ a `@defer` query, you'll get an error about your variables instead of the `BATCHING_DEFER_UNSUPPORTED` error.
There are new tests in the supergraph service for this.

<!-- start metadata -->

<!-- [ROUTER-1873] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1873]: https://apollographql.atlassian.net/browse/ROUTER-1873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ