### PR TITLE
fix(coprocessor): honor HTTP/2 keep-alive over Unix domain sockets

### DIFF
--- a/.changesets/fix_uds_coprocessor_http2_keepalive.md
+++ b/.changesets/fix_uds_coprocessor_http2_keepalive.md
@@ -1,0 +1,9 @@
+### HTTP/2 keep-alive now works for coprocessors over a Unix domain socket ([Issue #ISSUE_NUMBER](https://github.com/apollographql/router/issues/ISSUE_NUMBER))
+
+`experimental_http2_keep_alive_interval` (and its companion timeout) were only applied to the TCP client, so they were silently ignored for coprocessors and subgraphs reached over a `unix://` URL. Against a hung-but-open peer — one whose socket stays open with no `EOF` to detect, e.g. during a long stop-the-world pause — the router would wait indefinitely instead of tearing the connection down.
+
+The Unix-socket client now receives the same keep-alive configuration as the TCP client, so unanswered pings trip the keep-alive timeout and the connection is closed after roughly `interval + timeout`.
+
+Because a Unix socket has no TLS/ALPN for the client to negotiate HTTP/2, keep-alive over a socket only takes effect when HTTP/2 is forced on. A coprocessor configured with keep-alive against a `unix://` URL while `experimental_http2` is not `http2only` is now rejected at startup with an actionable error, rather than accepted with keep-alive silently doing nothing.
+
+By [@theJC](https://github.com/theJC) in https://github.com/apollographql/router/pull/PULL_NUMBER

--- a/.changesets/fix_uds_coprocessor_http2_keepalive.md
+++ b/.changesets/fix_uds_coprocessor_http2_keepalive.md
@@ -1,4 +1,4 @@
-### HTTP/2 keep-alive now works for coprocessors over a Unix domain socket ([Issue #ISSUE_NUMBER](https://github.com/apollographql/router/issues/ISSUE_NUMBER))
+### HTTP/2 keep-alive now works for coprocessors over a Unix domain socket ([PR #9785](https://github.com/apollographql/router/pull/9785))
 
 `experimental_http2_keep_alive_interval` (and its companion timeout) were only applied to the TCP client, so they were silently ignored for coprocessors and subgraphs reached over a `unix://` URL. Against a hung-but-open peer — one whose socket stays open with no `EOF` to detect, e.g. during a long stop-the-world pause — the router would wait indefinitely instead of tearing the connection down.
 
@@ -6,4 +6,4 @@ The Unix-socket client now receives the same keep-alive configuration as the TCP
 
 Because a Unix socket has no TLS/ALPN for the client to negotiate HTTP/2, keep-alive over a socket only takes effect when HTTP/2 is forced on. A coprocessor configured with keep-alive against a `unix://` URL while `experimental_http2` is not `http2only` is now rejected at startup with an actionable error, rather than accepted with keep-alive silently doing nothing.
 
-By [@theJC](https://github.com/theJC) in https://github.com/apollographql/router/pull/PULL_NUMBER
+By [@theJC](https://github.com/theJC) in https://github.com/apollographql/router/pull/9785

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -41,6 +41,7 @@ use crate::plugin::PluginPrivate;
 use crate::plugins::telemetry::config_new::conditions::Condition;
 use crate::plugins::telemetry::config_new::router::selectors::RouterSelector;
 use crate::plugins::telemetry::config_new::subgraph::selectors::SubgraphSelector;
+use crate::plugins::traffic_shaping::Http2Config;
 use crate::services;
 use crate::services::PATH_QUERY_PARAM;
 use crate::services::PipelineStep;
@@ -268,6 +269,25 @@ impl PluginPrivate for CoprocessorPlugin<HTTPClientService> {
         if let Some(ref url) = init.config.subgraph.all.response.url {
             validate_coprocessor_url(url, "coprocessor.subgraph.all.response.url")?;
         }
+
+        // HTTP/2 keep-alive only takes effect over a Unix socket when HTTP/2 is forced on, so reject
+        // the combination that would silently give no keep-alive (see validate_uds_keep_alive).
+        let mut all_urls: Vec<&str> = vec![init.config.url.as_str()];
+        all_urls.extend(
+            [
+                init.config.router.request.url.as_deref(),
+                init.config.router.response.url.as_deref(),
+                init.config.supergraph.request.url.as_deref(),
+                init.config.supergraph.response.url.as_deref(),
+                init.config.execution.request.url.as_deref(),
+                init.config.execution.response.url.as_deref(),
+                init.config.subgraph.all.request.url.as_deref(),
+                init.config.subgraph.all.response.url.as_deref(),
+            ]
+            .into_iter()
+            .flatten(),
+        );
+        validate_uds_keep_alive(&client_config, &all_urls)?;
 
         // Use shared HttpClientService infrastructure instead of duplicated client creation
         let tls_root_store =
@@ -710,6 +730,31 @@ pub(crate) fn validate_coprocessor_url(url: &str, config_path: &str) -> Result<(
         // Validate HTTP/HTTPS URLs can be parsed
         url.parse::<http::Uri>()
             .map_err(|e| format!("{config_path}: invalid URL '{url}': {e}"))?;
+    }
+    Ok(())
+}
+
+/// Reject an HTTP/2 keep-alive configuration that would be silently inert over a Unix socket.
+///
+/// HTTP/2 keep-alive pings are an h2-only feature. Over a Unix socket the client only speaks
+/// HTTP/2 when it is forced on (`http2only`): unlike TCP there is no TLS/ALPN over UDS for the
+/// client to negotiate h2, so `enable`/`disable` fall back to HTTP/1.1 and the keep-alive pings
+/// never fire. Accepting such a config would leave an operator believing a hung coprocessor over
+/// the socket would be detected when it would not, so fail loudly at startup instead.
+pub(crate) fn validate_uds_keep_alive(client: &Client, urls: &[&str]) -> Result<(), BoxError> {
+    let keep_alive_configured = client.experimental_http2_keep_alive_interval.is_some();
+    let http2_only = matches!(client.experimental_http2, Some(Http2Config::Http2Only));
+    let uses_unix_socket = urls.iter().any(|url| url.starts_with("unix://"));
+
+    if keep_alive_configured && !http2_only && uses_unix_socket {
+        return Err(
+            "coprocessor.client.experimental_http2_keep_alive_interval is set for a Unix-socket \
+             coprocessor URL, but coprocessor.client.experimental_http2 is not `http2only`. Unix \
+             sockets have no TLS/ALPN to negotiate HTTP/2, so the connection falls back to \
+             HTTP/1.1 and the HTTP/2 keep-alive pings never fire (a hung coprocessor would not be \
+             detected). Set `experimental_http2: http2only` to use keep-alive over the socket."
+                .into(),
+        );
     }
     Ok(())
 }

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -6926,6 +6926,115 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[rstest::rstest]
+    // Default HTTP/2 (`enable`) over a Unix socket resolves to HTTP/1.1, so keep-alive is inert.
+    #[case::default_http2(serde_json::json!({
+        "coprocessor": {
+            "url": "unix:///var/run/coprocessor.sock",
+            "client": { "experimental_http2_keep_alive_interval": "30s" }
+        }
+    }))]
+    // `enable` explicitly — same outcome as the default.
+    #[case::enable_http2(serde_json::json!({
+        "coprocessor": {
+            "url": "unix:///var/run/coprocessor.sock",
+            "client": {
+                "experimental_http2": "enable",
+                "experimental_http2_keep_alive_interval": "30s"
+            }
+        }
+    }))]
+    // `disable` can never carry HTTP/2 keep-alive at all.
+    #[case::disable_http2(serde_json::json!({
+        "coprocessor": {
+            "url": "unix:///var/run/coprocessor.sock",
+            "client": {
+                "experimental_http2": "disable",
+                "experimental_http2_keep_alive_interval": "30s"
+            }
+        }
+    }))]
+    // The unix:// URL is a per-stage override rather than the top-level url.
+    #[case::stage_override(serde_json::json!({
+        "coprocessor": {
+            "url": "http://localhost:8081",
+            "client": { "experimental_http2_keep_alive_interval": "30s" },
+            "router": { "request": { "url": "unix:///var/run/coprocessor.sock" } }
+        }
+    }))]
+    #[tokio::test]
+    async fn test_unix_socket_keep_alive_without_http2only_rejected(
+        #[case] config: serde_json::Value,
+    ) {
+        let result = crate::TestHarness::builder()
+            .configuration_json(config)
+            .unwrap()
+            .build_router()
+            .await;
+
+        assert!(
+            result.is_err(),
+            "UDS keep-alive without http2only should be rejected"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("http2only"),
+            "Error should point the operator at experimental_http2: http2only: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_unix_socket_keep_alive_with_http2only_accepted() {
+        // http2only forces HTTP/2 prior knowledge over the socket, so keep-alive is effective.
+        let config = serde_json::json!({
+            "coprocessor": {
+                "url": "unix:///var/run/coprocessor.sock",
+                "client": {
+                    "experimental_http2": "http2only",
+                    "experimental_http2_keep_alive_interval": "30s"
+                }
+            }
+        });
+
+        let result = crate::TestHarness::builder()
+            .configuration_json(config)
+            .unwrap()
+            .build_router()
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "UDS keep-alive with http2only should load: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tcp_keep_alive_without_http2only_accepted() {
+        // Guard against a false positive: over TCP, `enable` can still negotiate HTTP/2 via ALPN,
+        // so keep-alive with the default HTTP/2 config must remain valid for non-UDS URLs.
+        let config = serde_json::json!({
+            "coprocessor": {
+                "url": "http://localhost:8081",
+                "client": { "experimental_http2_keep_alive_interval": "30s" }
+            }
+        });
+
+        let result = crate::TestHarness::builder()
+            .configuration_json(config)
+            .unwrap()
+            .build_router()
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "TCP keep-alive without http2only should load: {:?}",
+            result.err()
+        );
+    }
+
     #[tokio::test]
     async fn test_invalid_http_url_rejected() {
         let config = serde_json::json!({

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -305,16 +305,32 @@ impl HttpClientService {
 
         #[cfg(unix)]
         let unix_client = {
+            let mut unix_client_builder =
+                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new());
             // NOTE: pool_timer is intentionally not set; see comment on client_builder above.
-            let unix_client_inner =
-                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                    .pool_idle_timeout(pool_idle_timeout)
-                    .http2_only(http2 == Http2Config::Http2Only)
-                    .build(ConnectionTimingConnector::new(
-                        UnixConnector,
-                        service_target,
-                        "unix",
-                    ));
+            unix_client_builder
+                .pool_idle_timeout(pool_idle_timeout)
+                .http2_only(http2 == Http2Config::Http2Only);
+            // Apply the same http2 keep-alive configuration as the TCP client above. Without it,
+            // experimental_http2_keep_alive_* was silently ignored for Unix domain sockets: a dead
+            // coprocessor peer is still detected promptly via EOF, but a hung-but-open peer (e.g.
+            // long GC pause, deadlock) went undetected, so idle pooled UDS connections were never
+            // pinged and stale connections were only discovered when a request rode them.
+            if let Some(interval) = http2_keep_alive_interval {
+                unix_client_builder
+                    // WARN: http2 keep-alive requires a timer; don't remove this
+                    .timer(TokioTimer::new())
+                    .http2_keep_alive_interval(Some(interval))
+                    .http2_keep_alive_timeout(http2_keep_alive_timeout)
+                    // Send pings even when the connection is idle in the pool, so stale
+                    // connections are detected before a request is made on them
+                    .http2_keep_alive_while_idle(true);
+            }
+            let unix_client_inner = unix_client_builder.build(ConnectionTimingConnector::new(
+                UnixConnector,
+                service_target,
+                "unix",
+            ));
 
             ServiceBuilder::new()
                 .layer(DecompressionLayer::new())

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -1120,6 +1120,99 @@ mod h2c_keep_alive {
     }
 }
 
+#[cfg(unix)]
+mod h2c_keep_alive_unix {
+    use std::future::pending;
+    use std::time::Duration;
+
+    use tokio::net::UnixListener;
+
+    use super::*;
+    use crate::configuration::shared::Client;
+
+    /// Accept one Unix-socket connection, complete the HTTP/2 server handshake so the client
+    /// considers the connection established and sends its request, then FREEZE: hold the
+    /// connection open but never poll it again. Incoming frames — the request HEADERS and, more
+    /// importantly, the client's keep-alive PINGs — are therefore never read or ACKed. This
+    /// models a coprocessor whose event loop has stalled (e.g. a stop-the-world GC pause) while
+    /// the socket stays open, so no FIN/EOF is delivered to the client to signal the peer is gone.
+    async fn serve_hung_after_handshake(listener: UnixListener) {
+        let (stream, _) = listener.accept().await.expect("accept unix connection");
+        let _conn = h2::server::handshake(stream)
+            .await
+            .expect("h2 server handshake");
+        // Deliberately never poll `_conn`: the connection is left open and completely
+        // unresponsive, holding the socket fd so the client sees no EOF.
+        pending::<()>().await;
+    }
+
+    /// Regression test for HTTP/2 keep-alive over Unix domain sockets.
+    ///
+    /// The `unix://` client used to be built without any keep-alive configuration, so
+    /// `experimental_http2_keep_alive_*` was silently ignored for Unix-socket transports (only the
+    /// TCP client honored it). Against a hung-but-open peer — one that never closes the socket, so
+    /// there is no EOF to detect — the client would then wait indefinitely for a response.
+    ///
+    /// With keep-alive applied to the UDS client, the unanswered pings trip the keep-alive timeout
+    /// and the client tears the connection down after roughly interval + timeout, so the request
+    /// fails promptly instead of hanging. The `no_keep_alive` case guards the regression property:
+    /// it confirms that without keep-alive the very same hung server leaves the request pending,
+    /// i.e. keep-alive is what causes the teardown (not some other client-side timeout).
+    #[rstest]
+    #[case::keep_alive_detects_hang(
+        Some((Duration::from_millis(100), Duration::from_millis(100))),
+        true
+    )]
+    #[case::no_keep_alive_hangs(None, false)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_keep_alive_tears_down_hung_unix_socket_connection(
+        #[case] keep_alive: Option<(Duration, Duration)>,
+        #[case] expect_torn_down: bool,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hung.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        tokio::spawn(serve_hung_after_handshake(listener));
+
+        let client_config = match keep_alive {
+            Some((interval, timeout)) => Client::builder()
+                .experimental_http2(Http2Config::Http2Only)
+                .experimental_http2_keep_alive_interval(interval)
+                .experimental_http2_keep_alive_timeout(timeout)
+                .build(),
+            None => Client::builder()
+                .experimental_http2(Http2Config::Http2Only)
+                .build(),
+        };
+        let service = HttpClientService::from_client_config(client_config).unwrap();
+
+        let uri: Uri = hyperlocal::Uri::new(path.to_str().unwrap(), "/").into();
+
+        // Bound the wait well above interval + timeout but far below any real hang: with keep-alive
+        // the request resolves (as an error) inside this window; without it, the request is still
+        // pending when the window elapses.
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(3),
+            try_send_request(service, uri, r#"{"query":"{ me }"}"#),
+        )
+        .await;
+
+        if expect_torn_down {
+            let result = outcome
+                .expect("keep-alive should tear down the hung connection, but the request hung past the timeout");
+            assert!(
+                result.is_err(),
+                "expected the request to fail once the hung connection was torn down, got success"
+            );
+        } else {
+            assert!(
+                outcome.is_err(),
+                "without keep-alive the request should still be hanging on the unresponsive peer, but it resolved"
+            );
+        }
+    }
+}
+
 mod compressed_req_res {
     use super::*;
 


### PR DESCRIPTION
## Problem

HTTP/2 keep-alive (`experimental_http2_keep_alive_interval` / `_timeout`) was applied only to the TCP client in `HttpClientService`. The Unix-socket client was built with just `pool_idle_timeout` + `http2_only`, so keep-alive was **silently ignored** for coprocessors (and subgraphs/connectors) reached over a `unix://` URL.

Over a Unix socket a *dead* peer is detected promptly via EOF, but a **hung-but-open** peer — one whose socket stays open with no EOF, e.g. during a stop-the-world pause or an event-loop stall — went undetected. Idle/in-flight pooled h2 connections were never pinged, so the router would wait on the stalled peer (up to the downstream timeout) instead of tearing the connection down.

## Fix

`apollo-router/src/services/http/service.rs`: apply the same keep-alive block (timer + interval + timeout + `keep_alive_while_idle`) to the Unix-socket client as the TCP client, so `experimental_http2_keep_alive_*` is honored on both transports.

## Guardrail

HTTP/2 keep-alive is an h2-only feature, and a Unix socket has **no TLS/ALPN** for the client to negotiate h2 — so `hyper-util`'s auto mode falls back to HTTP/1.1 unless HTTP/2 is forced on. That means keep-alive over a socket is only effective with `experimental_http2: http2only`.

`apollo-router/src/plugins/coprocessor/mod.rs`: reject at config load when keep-alive is set for a `unix://` coprocessor URL (top-level or any per-stage override) while `experimental_http2` is not `http2only`, with an actionable error. Previously that combination was accepted and did nothing. TCP keep-alive with the default HTTP/2 config stays valid (ALPN can still negotiate h2 there).

## Tests

- `services::http::tests::h2c_keep_alive_unix` — a Unix-socket server that completes the h2 handshake then freezes (never acks pings, socket held open), modeling a stalled peer. Asserts keep-alive tears the connection down; the no-keep-alive case confirms the teardown is caused by keep-alive.
- `plugins::coprocessor::test::tests` — config-load coverage: reject for default/`enable`/`disable` + `unix://` (incl. a per-stage override), accept for `http2only` + `unix://`, and a TCP false-positive guard.

All new tests pass; `cargo fmt` and `cargo clippy` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Scope & follow-up

The keep-alive fix in `service.rs` applies to **every** client that talks over a Unix socket — coprocessor, subgraph, and connector — since they share `HttpClientService`.

The new config-load validation that **rejects** keep-alive + `unix://` + non-`http2only` is currently **coprocessor-only**, because that plugin is where the URL and client config are validated together. Subgraph and connector configurations can express the same inert combination and are not yet guarded. Extending equivalent validation to subgraph/connector `unix://` URLs is a sensible follow-up (separate config-validation sites); happy to do it here or in a follow-up PR depending on reviewer preference.
