### PR TITLE
ci: don't fire "merge may have broken the build" alert on nightly test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,7 +525,10 @@ jobs:
       #       - fuzz_build
       - when:
           condition:
-            equal: ["dev", "<< pipeline.git.branch >>"]
+            and:
+              - equal: ["dev", "<< pipeline.git.branch >>"]
+              - not:
+                  equal: [true, << parameters.nightly >>]
           steps:
             - slack/notify:
                 event: fail


### PR DESCRIPTION
## Summary
- The `test` job's failure-notify step (added in the `#ii-router-ci-notifications` Slack integration) fires whenever a test run fails on the `dev` branch, with no check for whether the run was nightly-triggered.
- Since nightly test runs also target `dev`, a nightly failure fires **two** Slack alerts back-to-back: the generic "a merge may have broken the build!" message and the separate nightly-specific one — misattributing a scheduled/nightly failure to a fresh merge when no new commit had actually landed.
- Confirmed this in practice while investigating `#ii-router-ci-notifications`: the 2026-07-03 and 2026-07-09 "merge may have broken the build" alerts for `test-amd_linux_test`/`test-windows_test` both landed against commits that had been HEAD of `dev` for many hours with no new merge in between — they were nightly reruns, not merge-triggered failures.
- Fix: add `not: equal: [true, << parameters.nightly >>]` to the generic alert's condition so it only fires for genuinely merge-triggered (non-nightly) failures.

## Test plan
- [ ] YAML validated to parse correctly (`ruby -ryaml` / equivalent) — done locally
- [ ] Confirm on the next real merge-triggered `test` failure on `dev` that the generic alert still fires
- [ ] Confirm on the next nightly `test` failure on `dev` that only the nightly-specific alert fires, not the generic one