### PR TITLE
ci: retire test_updated_cargo_deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,9 +111,6 @@ parameters:
   quick_nightly:
     type: boolean
     default: false
-  test_updated_cargo_deps:
-    type: boolean
-    default: false
 
 # These are common environment variables that we want to set on on all jobs.
 # While these could conceivably be set on the CircleCI project settings'
@@ -604,90 +601,6 @@ jobs:
                       }
                     ]
                   }
-  test_updated:
-    environment:
-      <<: *common_job_environment
-    parameters:
-      platform:
-        type: executor
-        default: amd_linux_test
-      from_test_updated_cargo_deps_workflow:
-        type: boolean
-        default: false
-    executor: << parameters.platform >>
-    steps:
-      - checkout
-      - setup_environment:
-          platform: << parameters.platform >>
-      - run:
-          name: Update all Rust dependencies
-          command: |
-            rm Cargo.lock
-            cargo fetch
-      - xtask_test:
-          variant: "updated"
-
-      - when:
-          condition:
-            equal:
-              [true, << parameters.from_test_updated_cargo_deps_workflow >>]
-          steps:
-            - slack/notify:
-                event: fail
-                custom: |
-                  {
-                    "blocks": [
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": ":x: The `test_updated_cargo_deps` workflow has *failed* for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`!"
-                        }
-                      },
-                      {
-                        "type": "actions",
-                        "elements": [
-                          {
-                            "type": "button",
-                            "action_id": "success_tagged_deploy_view",
-                            "text": {
-                              "type": "plain_text",
-                              "text": "View Job"
-                            },
-                            "url": "${CIRCLE_BUILD_URL}"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-            - slack/notify:
-                event: pass
-                custom: |
-                  {
-                    "blocks": [
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": ":white_check_mark: The `test_updated_cargo_deps` workflow has passed for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`."
-                        }
-                      },
-                      {
-                        "type": "actions",
-                        "elements": [
-                          {
-                            "type": "button",
-                            "action_id": "success_tagged_deploy_view",
-                            "text": {
-                              "type": "plain_text",
-                              "text": "View Job"
-                            },
-                            "url": "${CIRCLE_BUILD_URL}"
-                          }
-                        ]
-                      }
-                    ]
-                  }
   pre_verify_release:
     environment:
       <<: *common_job_environment
@@ -1066,19 +979,12 @@ jobs:
                   cargo xtask release notes "$VERSION_WITHOUT_LEADING_V" || true
 
 workflows:
-  test_updated_cargo_deps:
-    when: << pipeline.parameters.test_updated_cargo_deps >>
-    jobs:
-      - test_updated:
-          platform: amd_linux_test
-          from_test_updated_cargo_deps_workflow: true
   ci_checks:
     when:
       not:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
-          - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
       - fmt_check:
           matrix:
@@ -1182,7 +1088,6 @@ workflows:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
-          - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
       - pre_verify_release:
           matrix:
@@ -1260,7 +1165,6 @@ workflows:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
-          - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
       - secops/gitleaks:
           context:


### PR DESCRIPTION
## Summary
- `test_updated_cargo_deps` wiped `Cargo.lock` and ran `cargo fetch` before testing — a canary meant to catch upstream dependency breakage before an actual `cargo update` landed.
- In practice it had failed on every single nightly run for weeks: since 2026-07-03 it panicked on the exact same `http` 1.4.2 issue every night (see companion PR fixing that in `http_json_transport.rs`), and nobody had acted on any of the Slack alerts.
- It only ever ran on one platform (`amd_linux_test`) — the existing `nightly` workflow's `test` job matrix already covers `[macos_test, windows_test, amd_linux_test, arm_linux_test]` against the real, locked dependency set we actually ship. This job never contributed to that cross-platform coverage.
- Decision: stop preemptively validating against not-yet-adopted dependency versions, and just test what we actually use.

## Changes
- Removed the `test_updated` job (including its dedicated Slack notify blocks).
- Removed the `test_updated_cargo_deps` workflow and pipeline parameter.
- Removed the now-dead `test_updated_cargo_deps` references from the `ci_checks`/`release`/`security-scans` workflow exclusion lists.

## Follow-up (not in this repo)
The CircleCI Project Settings scheduled trigger that sets `test_updated_cargo_deps=true` nightly needs to be disabled/deleted in the CircleCI web UI, or it'll fire a workflow with nothing left to run.

## Test plan
- [x] `.circleci/config.yml` parses as valid YAML
- [x] Verified no remaining references to `test_updated_cargo_deps` / `test_updated` in the config
- [ ] Confirm nightly pipeline still runs cleanly without this workflow after merge