### PR TITLE
fix(connectors): don't panic on empty/slash-less relative URI templates

### DIFF
--- a/.changesets/fix_connectors_empty_relative_path_panic.md
+++ b/.changesets/fix_connectors_empty_relative_path_panic.md
@@ -1,0 +1,7 @@
+### Fix a panic building connector request URIs with an empty or slash-less relative path ([PR #9790](https://github.com/apollographql/router/pull/9790))
+
+Connector request URIs with an empty path and query (no `sourcePath`, `connectPath`, or query params) or with a `connectPath` template lacking a leading `/` could panic the router when built against `http` crate versions 1.4.2 and later, which tightened `PathAndQuery` validation to reject an empty string and require a leading `/` on relative paths.
+
+Connector URI construction now explicitly normalizes these cases (empty becomes `/`, a slash-less relative path gets a leading `/` added) instead of relying on validation behavior that newer `http` versions no longer provide.
+
+By [@aaronArinder](https://github.com/aaronArinder) in https://github.com/apollographql/router/pull/9790

--- a/apollo-federation/src/connectors/models/http_json_transport.rs
+++ b/apollo-federation/src/connectors/models/http_json_transport.rs
@@ -224,7 +224,7 @@ impl HttpJsonTransport {
         let query = query.into_string();
 
         uri_parts.path_and_query = Some(match (path.is_empty(), query.is_empty()) {
-            (true, true) => PathAndQuery::from_static(""),
+            (true, true) => PathAndQuery::from_static("/"),
             (true, false) => PathAndQuery::try_from(format!("?{query}"))?,
             (false, true) => PathAndQuery::try_from(path)?,
             (false, false) => PathAndQuery::try_from(format!("{path}?{query}"))?,

--- a/apollo-federation/src/connectors/string_template.rs
+++ b/apollo-federation/src/connectors/string_template.rs
@@ -195,8 +195,19 @@ impl StringTemplate {
         let uri = if result.contains("://") {
             Uri::from_str(result.as_ref())
         } else {
-            // Explicitly set this as a relative URI so it doesn't get confused for a domain name
-            PathAndQuery::from_str(result.as_ref()).map(Uri::from)
+            // Explicitly set this as a relative URI so it doesn't get confused for a domain name.
+            // `PathAndQuery` rejects an empty string and requires a leading `/` (or `?` for a
+            // query-only value); normalize here rather than relying on the caller to have
+            // written a template that already starts with `/`.
+            let relative = result.as_ref();
+            let relative = if relative.is_empty() {
+                "/".to_string()
+            } else if relative.starts_with('/') || relative.starts_with('?') {
+                relative.to_string()
+            } else {
+                format!("/{relative}")
+            };
+            PathAndQuery::from_str(&relative).map(Uri::from)
         }
         .map_err(|err| Error {
             message: format!("Invalid URI: {err}"),


### PR DESCRIPTION
## Summary
- `http` 1.4.2 tightened `PathAndQuery` validation: it now rejects an empty string outright and requires a leading `/` on any non-empty, non-query-only relative path. `http` 1.4.0 (currently locked/shipped) silently normalized both — an empty string became `"/"`, and a slash-less relative path like `"hello"` was accepted as-is and correctly joined later by `make_uri`'s own slash-handling logic.
- This surfaced as the `test_updated_cargo_deps` nightly job panicking on every run once dependency resolution picked up `http` 1.4.2 (see companion PR retiring that job) — but it's a real latent bug independent of that job: any router instance that happens to resolve `http` 1.4.2+ (e.g. via `cargo update`, or once `Cargo.toml`'s `http = "1.4.0"` range naturally advances) will panic building connector request URIs for the empty-path/empty-query case or any connect template lacking a leading `/`.
- Two call sites needed fixing:
  - `http_json_transport.rs`: `PathAndQuery::from_static("")` panicked for the empty-path/empty-query case. Now uses `PathAndQuery::from_static("/")` directly — exactly what 1.4.0 already normalized `""` to internally (verified: `PathAndQuery::from_static("").as_str() == "/"` under 1.4.0).
  - `string_template.rs`: `interpolate_uri`'s relative-URI branch passed the raw interpolated string straight to `PathAndQuery::from_str`, which is what actually broke on an empty connect/source template and on a connect template without a leading slash (e.g. `"hello"` instead of `"/hello"`). Now normalizes before parsing.

## Verification
- Bumped `Cargo.lock`'s `http` to 1.4.2 locally and confirmed the original panics reproduce without this fix.
- With the fix applied (still on `http` 1.4.2): `cargo test -p apollo-federation --lib connectors::` → 1512 passed, 0 failed (including the previously-panicking `test_make_uri` and `test_interpolate_uri` cases). `cargo test -p apollo-router --lib plugins::connectors::` → 107 passed, 0 failed.
- Reverted `Cargo.lock` back to the committed `http = "1.4.0"` and re-ran the same test modules — all still pass, confirming no behavior change under the currently-shipped dependency version.
- `cargo fmt -p apollo-federation --check` clean.

## Test plan
- [x] Existing `test_make_uri` and `test_interpolate_uri` suites pass under both `http` 1.4.0 (current) and 1.4.2 (future)
- [x] `apollo-router`'s `plugins::connectors::` suite passes under both
- [ ] Changeset to follow in a subsequent commit on this branch, referencing this PR number