### PR TITLE
fix(test): close router-readiness race in test_subscription_callback

### DIFF
--- a/apollo-router/tests/integration/subscriptions/callback.rs
+++ b/apollo-router/tests/integration/subscriptions/callback.rs
@@ -46,6 +46,17 @@ async fn test_subscription_callback() -> Result<(), BoxError> {
     router.start().await;
     router.assert_started().await;
 
+    // See `wait_for_router_ready` doc below — `assert_started` only matches
+    // the `GraphQL endpoint exposed` log line, emitted before the axum
+    // server task is actually polling connections. This test previously
+    // lacked this probe even though its siblings
+    // (`test_subscription_callback_error_payload`,
+    // `test_subscription_callback_pure_error_payload`) gained it after
+    // hitting exactly this race on CI — the initial `execute_query` POST
+    // below is exposed to the identical TOCTOU window.
+    let router_url = format!("http://{}/", router.bind_address());
+    wait_for_router_ready(&router_url, tokio::time::Duration::from_secs(90)).await;
+
     let subscription_query = r#"subscription { userWasCreated(intervalMs: 100, nbEvents: 3) { name reviews { body } } }"#;
 
     // Send subscription request to router


### PR DESCRIPTION
## Summary
- `test_subscription_callback` sends its first request right after `router.assert_started()`, which only matches the "GraphQL endpoint exposed" log line. That line is emitted by axum before the server task is actually polling its listener for connections — a TOCTOU window where a client racing in immediately after can hit a reset connection instead of a real response.
- The two sibling tests in this same file — `test_subscription_callback_error_payload` and `test_subscription_callback_pure_error_payload` — already hit this exact race on CI and were fixed (see `87200d577`, `f4634550f`) by adding a `wait_for_router_ready()` condition-based poll before their first request. `test_subscription_callback` never got the same treatment and was left with the identical open window.

## Fix
Apply the same, already-proven `wait_for_router_ready()` poll (bounded retry against the router's own bind address, not a fixed sleep) to `test_subscription_callback`, matching its siblings.

## Test plan
- [x] `cargo test -p apollo-router --test integration_tests --no-run` compiles clean
- [x] `cargo fmt --check` clean
- [x] Ran `integration::subscriptions::callback::*` (including this newly-patched test) 25x under synthetic CPU stress — 0 failures
- [x] Ran once via `cargo nextest run --profile ci` under stress — all matched tests passed

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)