### PR TITLE
ci: add retry/timeout to flaky network steps in mise install and check_helm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,16 @@ commands:
             - run:
                 name: Install mise
                 command: |
-                  curl https://mise.jdx.dev/install.sh | sh
+                  # Download to a file first (rather than `curl | sh`) so a retried/interrupted
+                  # download can't half-execute a partially-streamed install script. The install
+                  # script itself has no built-in retry, and a stalled TCP connection here would
+                  # otherwise hang until CircleCI's no-output timeout kills the whole step instead
+                  # of failing fast and retrying.
+                  curl --proto '=https' --tlsv1.2 -fsSL \
+                    --connect-timeout 10 --max-time 60 \
+                    --retry 5 --retry-connrefused \
+                    -o /tmp/mise-install.sh https://mise.jdx.dev/install.sh
+                  sh /tmp/mise-install.sh
                   mise activate bash >> "$BASH_ENV"
                   for i in 1 2 3; do
                     if mise install --yes --quiet; then
@@ -324,7 +333,11 @@ commands:
           name: Validate helm manifests
           command: |
             # Create list of kube versions
-            CURRENT_KUBE_VERSIONS=$(curl -s -L https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml \
+            # raw.githubusercontent.com occasionally returns transient 5xx/429 responses or has
+            # DNS/connect blips under load, so retry with backoff instead of failing on the first hiccup.
+            CURRENT_KUBE_VERSIONS=$(curl -s -L --fail --retry 5 --retry-connrefused \
+              --connect-timeout 10 --max-time 60 \
+              https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml \
               | yq -o json '.' \
               | jq --raw-output '.schedules[] | select((now | strftime("%Y-%m-%dT00:00:00Z")) as $date | .releaseDate < $date and .endOfLifeDate > $date) | select(.previousPatches != null) | .previousPatches[].release')
 
@@ -346,7 +359,13 @@ commands:
               fi
 
               # Sometimes the database has not been updated with schema details. If that happens, just skip the kubeconform checks until the database is updated"
-              if ! curl --head --silent --output /dev/null  --fail "https://github.com/yannh/kubernetes-json-schema/tree/master/v${kube_version}"; then
+              # Retry transient network errors here too so a blip against github.com doesn't get
+              # misread as "schema not yet available" and silently skip validation. A real 404
+              # (schema genuinely not published yet) is not retried here since --retry only
+              # retries on transient errors (5xx/429/timeouts/connection resets), not 404s.
+              if ! curl --head --silent --output /dev/null --fail --retry 5 --retry-connrefused \
+                --connect-timeout 10 --max-time 30 \
+                "https://github.com/yannh/kubernetes-json-schema/tree/master/v${kube_version}"; then
                 echo "Skipping validation for kubernetes version: ${kube_version} until the schema database is updated."
                 continue
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,32 @@ commands:
                     --connect-timeout 10 --max-time 60 \
                     --retry 5 --retry-connrefused \
                     -o /tmp/mise-install.sh https://mise.jdx.dev/install.sh
-                  sh /tmp/mise-install.sh
+
+                  # The install script itself fetches the mise binary and checksums with
+                  # bare `curl` calls that have no timeout or retry of their own (and no env
+                  # var to configure them), so a stall there hangs with zero output until
+                  # CircleCI's 10-minute no-output timeout kills the step outright (as
+                  # happened on build 393704: https://circleci.com/gh/apollographql/router/393704).
+                  # Bound each attempt ourselves and retry -- this step also runs on macOS,
+                  # which has no `timeout` binary, so use a portable background-watcher kill
+                  # instead of relying on one.
+                  for i in 1 2 3; do
+                    sh /tmp/mise-install.sh &
+                    script_pid=$!
+                    ( sleep 120; kill -9 "$script_pid" 2>/dev/null ) &
+                    watcher_pid=$!
+                    if wait "$script_pid" 2>/dev/null; then
+                      kill "$watcher_pid" 2>/dev/null
+                      break
+                    fi
+                    kill "$watcher_pid" 2>/dev/null
+                    if [ $i -eq 3 ]; then
+                      echo "mise install script failed or timed out after 3 attempts"
+                      exit 1
+                    fi
+                    echo "mise install script failed or timed out (attempt $i/3), retrying in $((i*5))s..."
+                    sleep $((i*5))
+                  done
                   mise activate bash >> "$BASH_ENV"
                   for i in 1 2 3; do
                     if mise install --yes --quiet; then
@@ -271,6 +296,10 @@ commands:
                     echo "mise install failed (attempt $i/3), retrying in $((i*5))s..."
                     sleep $((i*5))
                   done
+                # Backstop: our own watcher above bounds the install script's runtime, but
+                # keep this well below CircleCI's 10-minute default so any other silent
+                # stall in this step (e.g. `mise install`) fails fast too.
+                no_output_timeout: 5m
       - when:
           condition:
             or:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,10 +296,6 @@ commands:
                     echo "mise install failed (attempt $i/3), retrying in $((i*5))s..."
                     sleep $((i*5))
                   done
-                # Backstop: our own watcher above bounds the install script's runtime, but
-                # keep this well below CircleCI's 10-minute default so any other silent
-                # stall in this step (e.g. `mise install`) fails fast too.
-                no_output_timeout: 5m
       - when:
           condition:
             or:


### PR DESCRIPTION
## Summary
Two CircleCI jobs flaked on transient network errors this week, confirmed via same-commit rerun (fail then immediate pass with zero code changes):
- `lint-amd_linux_build`: "Install mise" step timed out (2026-07-02/03, 2026-07-08)
- `check_helm-amd_linux_helm`: gave up after repeated attempts against `raw.githubusercontent.com` (2026-07-06 x2, 2026-07-09)

## Root causes
- **mise install**: the tool-version install (`mise install --yes --quiet`) already had a correct 3-attempt retry with backoff — that part was fine. The actual gap was the line above it: `curl https://mise.jdx.dev/install.sh | sh`, which downloads and runs the **installer itself** with no timeout, no retry, piped straight into `sh`. A stalled connection had no bound, hanging until CircleCI's no-output timeout killed the step.
- **check_helm**: two `curl` calls with zero retry — fetching the current Kubernetes release schedule, and checking whether a k8s-schema entry exists for validation. Neither had `--retry`, `--fail`, or a timeout.

## Fix
- mise: download the installer to a file first with `--connect-timeout 10 --max-time 60 --retry 5 --retry-connrefused -fsSL`, then execute it — bounds the hang and avoids the `curl | sh` anti-pattern where a retried/interrupted transfer could dribble a partially-streamed script into a live shell.
- check_helm: added `--retry 5 --retry-connrefused` with connect/max timeouts to both curl calls. The schema-existence check deliberately keeps plain `--retry` (not `--retry-all-errors`) since a 404 there is a legitimate "schema not published yet, skip" signal — `--retry` only retries curl's transient-error class (5xx/429/timeouts/connection resets), so it won't misread a real 404 as a network blip.

## Caveats
- This smooths over transient blips, not a sustained GitHub outage or rate-limiting window — if `raw.githubusercontent.com` degrades for an extended period, bounded retries will still eventually give up.
- Could not run this against real CircleCI to confirm; validated the YAML parses correctly and re-read the full diff for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)