### PR TITLE
chore: rename misleading `*Layer` types

### DIFF
--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -699,7 +699,7 @@ mod test {
     use crate::services::RouterResponse;
     use crate::services::SupergraphRequest;
     use crate::services::connector::request_service::Request as ConnectorRequest;
-    use crate::services::layers::persisted_queries::PersistedQueryLayer;
+    use crate::services::layers::persisted_queries::PersistedQueryExpander;
     use crate::services::layers::query_analysis::QueryAnalysis;
     use crate::services::router;
     use crate::services::router::service::RouterCreator;
@@ -836,7 +836,11 @@ mod test {
 
         RouterCreator::new(
             query_analysis,
-            Arc::new(PersistedQueryLayer::new(&Default::default()).await.unwrap()),
+            Arc::new(
+                PersistedQueryExpander::new(&Default::default())
+                    .await
+                    .unwrap(),
+            ),
             Arc::new(supergraph_creator),
             Arc::new(Configuration::default()),
         )

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -700,7 +700,7 @@ mod test {
     use crate::services::SupergraphRequest;
     use crate::services::connector::request_service::Request as ConnectorRequest;
     use crate::services::layers::persisted_queries::PersistedQueryLayer;
-    use crate::services::layers::query_analysis::QueryAnalysisLayer;
+    use crate::services::layers::query_analysis::QueryAnalysis;
     use crate::services::router;
     use crate::services::router::service::RouterCreator;
     use crate::spec::Schema;
@@ -791,8 +791,7 @@ mod test {
 
         let config = Arc::new(config);
         let schema = Arc::new(Schema::parse(schema, &config).unwrap());
-        let query_analysis =
-            Arc::new(QueryAnalysisLayer::new(schema.clone(), config.clone()).await);
+        let query_analysis = Arc::new(QueryAnalysis::new(schema.clone(), config.clone()).await);
 
         let qp_arc = QueryPlannerService::create_planner(&schema, &config).unwrap();
         let subgraph_schemas = crate::query_planner::build_subgraph_schemas(&qp_arc);

--- a/apollo-router/src/query_planner/warmup.rs
+++ b/apollo-router/src/query_planner/warmup.rs
@@ -14,7 +14,7 @@ use crate::plugins::telemetry::utils::Timer;
 use crate::query_planner::InMemoryQueryPlanCache;
 use crate::services::CachingRequest;
 use crate::services::PlanOptions;
-use crate::services::layers::query_analysis::QueryAnalysisLayer;
+use crate::services::layers::query_analysis::QueryAnalysis;
 
 pub(crate) type BoxCloneService =
     tower::util::BoxCloneService<WarmupRequest, (), CacheResolverError>;
@@ -39,11 +39,11 @@ pub(crate) struct WarmupRequest {
 /// different request/response type.
 #[derive(Clone)]
 pub(crate) struct WarmupParseQueryLayer {
-    query_analysis: Arc<QueryAnalysisLayer>,
+    query_analysis: Arc<QueryAnalysis>,
 }
 
 impl WarmupParseQueryLayer {
-    pub(crate) fn new(query_analysis: Arc<QueryAnalysisLayer>) -> Self {
+    pub(crate) fn new(query_analysis: Arc<QueryAnalysis>) -> Self {
         Self { query_analysis }
     }
 }
@@ -61,7 +61,7 @@ impl<S> tower::Layer<S> for WarmupParseQueryLayer {
 
 #[derive(Clone)]
 pub(crate) struct WarmupParseQueryService<S> {
-    query_analysis: Arc<QueryAnalysisLayer>,
+    query_analysis: Arc<QueryAnalysis>,
     inner: S,
 }
 
@@ -246,7 +246,7 @@ mod tests {
     use crate::services::CachingRequest;
     use crate::services::QueryPlannerContent;
     use crate::services::layers::query_analysis::ParsedDocument;
-    use crate::services::layers::query_analysis::QueryAnalysisLayer;
+    use crate::services::layers::query_analysis::QueryAnalysis;
     use crate::spec::Schema;
     use crate::spec::SchemaHash;
 
@@ -413,7 +413,7 @@ mod tests {
             Schema::parse(include_str!("testdata/schema.graphql"), &configuration).unwrap(),
         );
 
-        let query_analysis = Arc::new(QueryAnalysisLayer::new(schema, configuration).await);
+        let query_analysis = Arc::new(QueryAnalysis::new(schema, configuration).await);
 
         let mut service = ServiceBuilder::new()
             .layer(WarmupParseQueryLayer::new(query_analysis))

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -42,7 +42,7 @@ use crate::services::apollo_graph_reference;
 use crate::services::apollo_key;
 use crate::services::http::HttpClientServiceFactory;
 use crate::services::layers::persisted_queries::PersistedQueryLayer;
-use crate::services::layers::query_analysis::QueryAnalysisLayer;
+use crate::services::layers::query_analysis::QueryAnalysis;
 use crate::services::router;
 use crate::services::router::pipeline_handle::PipelineRef;
 use crate::services::router::service::RouterCreator;
@@ -268,15 +268,15 @@ impl YamlRouterFactory {
         license: Arc<LicenseState>,
     ) -> Result<RouterCreator, BoxError> {
         // Instantiate the parser here so we can use it to warm up the planner below
-        let query_analysis_layer =
-            Arc::new(QueryAnalysisLayer::new(schema.clone(), configuration.clone()).await);
+        let query_analysis =
+            Arc::new(QueryAnalysis::new(schema.clone(), configuration.clone()).await);
         let persisted_query_layer = Arc::new(PersistedQueryLayer::new(&configuration).await?);
 
         let (supergraph_creator, warmup) = self
             .inner_create_supergraph(
                 configuration.clone(),
                 schema,
-                query_analysis_layer.clone(),
+                query_analysis.clone(),
                 initial_telemetry_plugin,
                 extra_plugins,
                 license,
@@ -296,7 +296,7 @@ impl YamlRouterFactory {
         .await;
 
         RouterCreator::new(
-            query_analysis_layer,
+            query_analysis,
             persisted_query_layer,
             Arc::new(supergraph_creator),
             configuration,
@@ -309,7 +309,7 @@ impl YamlRouterFactory {
         &mut self,
         configuration: Arc<Configuration>,
         schema: Arc<Schema>,
-        query_analysis: Arc<QueryAnalysisLayer>,
+        query_analysis: Arc<QueryAnalysis>,
         initial_telemetry_plugin: Option<Box<dyn DynPlugin>>,
         extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
         license: Arc<LicenseState>,

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -41,7 +41,7 @@ use crate::services::SupergraphCreator;
 use crate::services::apollo_graph_reference;
 use crate::services::apollo_key;
 use crate::services::http::HttpClientServiceFactory;
-use crate::services::layers::persisted_queries::PersistedQueryLayer;
+use crate::services::layers::persisted_queries::PersistedQueryExpander;
 use crate::services::layers::query_analysis::QueryAnalysis;
 use crate::services::router;
 use crate::services::router::pipeline_handle::PipelineRef;
@@ -270,7 +270,7 @@ impl YamlRouterFactory {
         // Instantiate the parser here so we can use it to warm up the planner below
         let query_analysis =
             Arc::new(QueryAnalysis::new(schema.clone(), configuration.clone()).await);
-        let persisted_query_layer = Arc::new(PersistedQueryLayer::new(&configuration).await?);
+        let persisted_queries = Arc::new(PersistedQueryExpander::new(&configuration).await?);
 
         let (supergraph_creator, warmup) = self
             .inner_create_supergraph(
@@ -286,7 +286,7 @@ impl YamlRouterFactory {
 
         SupergraphCreator::warm_up_query_planner(
             warmup,
-            &persisted_query_layer,
+            &persisted_queries,
             previous_router.map(|previous| previous.previous_cache()),
             configuration.supergraph.query_planning.warmed_up_queries,
             &configuration
@@ -297,7 +297,7 @@ impl YamlRouterFactory {
 
         RouterCreator::new(
             query_analysis,
-            persisted_query_layer,
+            persisted_queries,
             Arc::new(supergraph_creator),
             configuration,
         )

--- a/apollo-router/src/services/layers/apq/mod.rs
+++ b/apollo-router/src/services/layers/apq/mod.rs
@@ -50,14 +50,16 @@ impl PersistedQuery {
     }
 }
 
-/// A layer-like type implementing Automatic Persisted Queries.
+/// Implements caching and expansion of [Automatic Persisted Queries][apq].
+///
+/// [apq]: https://www.apollographql.com/docs/apollo-server/performance/apq
 #[derive(Clone)]
-pub(crate) struct APQLayer {
+pub(crate) struct APQExpander {
     /// set to None if APQ is disabled
     cache: Option<DeduplicatingCache<String, String>>,
 }
 
-impl APQLayer {
+impl APQExpander {
     pub(crate) fn activate(&self) {
         if let Some(cache) = &self.cache {
             cache.activate();
@@ -65,7 +67,7 @@ impl APQLayer {
     }
 }
 
-impl APQLayer {
+impl APQExpander {
     pub(crate) fn with_cache(cache: DeduplicatingCache<String, String>) -> Self {
         Self { cache: Some(cache) }
     }

--- a/apollo-router/src/services/layers/persisted_queries/mod.rs
+++ b/apollo-router/src/services/layers/persisted_queries/mod.rs
@@ -269,7 +269,7 @@ impl PersistedQueryLayer {
 
             match doc_opt {
                 None => {
-                    // For some reason, QueryAnalysisLayer didn't give us a document?
+                    // For some reason, QueryAnalysis didn't give us a document?
                     return Err(supergraph_err(
                         graphql_err(
                             "MISSING_PARSED_OPERATION",
@@ -510,7 +510,7 @@ mod tests {
     use crate::graphql;
     use crate::metrics::FutureMetricsExt;
     use crate::services::layers::persisted_queries::freeform_graphql_behavior::FreeformGraphQLBehavior;
-    use crate::services::layers::query_analysis::QueryAnalysisLayer;
+    use crate::services::layers::query_analysis::QueryAnalysis;
     use crate::spec::Schema;
     use crate::test_harness::mocks::persisted_queries::*;
 
@@ -848,7 +848,7 @@ mod tests {
 
     async fn run_first_two_layers(
         pq_layer: &PersistedQueryLayer,
-        query_analysis_layer: &QueryAnalysisLayer,
+        query_analysis: &QueryAnalysis,
         body: &str,
         skip_enforcement: bool,
     ) -> SupergraphRequest {
@@ -875,7 +875,7 @@ mod tests {
         let updated_request = pq_layer
             .supergraph_request(incoming_request)
             .expect("pq layer returned error response instead of returning a request");
-        query_analysis_layer
+        query_analysis
             .supergraph_request(updated_request)
             .await
             .expect("QA layer returned error response instead of returning a request")
@@ -883,13 +883,13 @@ mod tests {
 
     async fn denied_by_safelist(
         pq_layer: &PersistedQueryLayer,
-        query_analysis_layer: &QueryAnalysisLayer,
+        query_analysis: &QueryAnalysis,
         body: &str,
         log_unknown: bool,
         counter_value: u64,
     ) {
         let request_with_analyzed_query =
-            run_first_two_layers(pq_layer, query_analysis_layer, body, false).await;
+            run_first_two_layers(pq_layer, query_analysis, body, false).await;
 
         let mut supergraph_response = pq_layer
             .supergraph_request_with_analyzed_query(request_with_analyzed_query)
@@ -922,14 +922,14 @@ mod tests {
 
     async fn allowed_by_safelist(
         pq_layer: &PersistedQueryLayer,
-        query_analysis_layer: &QueryAnalysisLayer,
+        query_analysis: &QueryAnalysis,
         body: &str,
         log_unknown: bool,
         skip_enforcement: bool,
         counter_value: u64,
     ) {
         let request_with_analyzed_query =
-            run_first_two_layers(pq_layer, query_analysis_layer, body, skip_enforcement).await;
+            run_first_two_layers(pq_layer, query_analysis, body, skip_enforcement).await;
 
         pq_layer
             .supergraph_request_with_analyzed_query(request_with_analyzed_query)
@@ -992,12 +992,12 @@ mod tests {
 
             let schema = Arc::new(Schema::parse(include_str!("../../../testdata/supergraph.graphql"), &Default::default()).unwrap());
 
-            let query_analysis_layer = QueryAnalysisLayer::new(schema, Arc::new(config)).await;
+            let query_analysis = QueryAnalysis::new(schema, Arc::new(config)).await;
 
             // A random query is blocked.
             denied_by_safelist(
                 &pq_layer,
-                &query_analysis_layer,
+                &query_analysis,
                 "query SomeQuery { me { id } }",
                 log_unknown,
                 1,
@@ -1006,7 +1006,7 @@ mod tests {
             // But it is allowed with skip_enforcement set.
             allowed_by_safelist(
                 &pq_layer,
-                &query_analysis_layer,
+                &query_analysis,
                 "query SomeQuery { me { id } }",
                 log_unknown,
                 true,
@@ -1016,7 +1016,7 @@ mod tests {
             // The exact string from the manifest is allowed.
             allowed_by_safelist(
                 &pq_layer,
-                &query_analysis_layer,
+                &query_analysis,
                 "fragment A on Query { me { id } }    query SomeOp { ...A ...B }    fragment,,, B on Query{me{name,username}  } # yeah",
                 log_unknown,
                 false,
@@ -1027,7 +1027,7 @@ mod tests {
             // Reordering definitions and reformatting a bit matches.
             allowed_by_safelist(
                 &pq_layer,
-                &query_analysis_layer,
+                &query_analysis,
                 "#comment\n  fragment, B on Query  , { me{name    username} }    query SomeOp {  ...A ...B }  fragment    \nA on Query { me{ id} }",
                 log_unknown,
                 false,
@@ -1038,7 +1038,7 @@ mod tests {
             // Reordering fields does not match!
             denied_by_safelist(
                 &pq_layer,
-                &query_analysis_layer,
+                &query_analysis,
                 "fragment A on Query { me { id } }    query SomeOp { ...A ...B }    fragment,,, B on Query{me{username,name}  } # yeah",
                 log_unknown,
                 2,
@@ -1049,7 +1049,7 @@ mod tests {
             // introspection is enabled.
             allowed_by_safelist(
                 &pq_layer,
-                &query_analysis_layer,
+                &query_analysis,
                 r#"fragment F on Query { __typename foo: __schema { __typename } } query Q { __type(name: "foo") { name } ...F }"#,
                 log_unknown,
                 false,
@@ -1063,7 +1063,7 @@ mod tests {
             // (https://github.com/apollographql/apollo-rs/issues/613)
             allowed_by_safelist(
                 &pq_layer,
-                &query_analysis_layer,
+                &query_analysis,
                 r#"fragment F on Query { __typename foo: __schema { __typename } } query Q { __type(name: "foo") { name } ...F ...F }"#,
                 log_unknown,
                 false,
@@ -1076,7 +1076,7 @@ mod tests {
             // But adding any top-level non-introspection field is enough to make it not count as introspection.
             denied_by_safelist(
                 &pq_layer,
-                &query_analysis_layer,
+                &query_analysis,
                 r#"fragment F on Query { __typename foo: __schema { __typename } me { id } } query Q { __type(name: "foo") { name } ...F }"#,
                 log_unknown,
                 3,

--- a/apollo-router/src/services/layers/persisted_queries/mod.rs
+++ b/apollo-router/src/services/layers/persisted_queries/mod.rs
@@ -50,12 +50,12 @@ pub(crate) struct RequestPersistedQueryId {
 ///
 /// This type actually consists of two conceptual layers that must both be applied at the supergraph
 /// service stage, at different points:
-/// - [PersistedQueryLayer::supergraph_request] must be done *before* the GraphQL request is parsed
+/// - [PersistedQueryExpander::supergraph_request] must be done *before* the GraphQL request is parsed
 ///   and validated.
-/// - [PersistedQueryLayer::supergraph_request_with_analyzed_query] must be done *after* the
+/// - [PersistedQueryExpander::supergraph_request_with_analyzed_query] must be done *after* the
 ///   GraphQL request is parsed and validated.
 #[derive(Debug)]
-pub(crate) struct PersistedQueryLayer {
+pub(crate) struct PersistedQueryExpander {
     /// Manages polling uplink for persisted queries and caches the current
     /// value of the manifest and projected safelist. None if the layer is disabled.
     pub(crate) manifest_poller: Option<PersistedQueryManifestPoller>,
@@ -70,8 +70,8 @@ fn skip_enforcement(request: &SupergraphRequest) -> bool {
         .unwrap_or(false)
 }
 
-impl PersistedQueryLayer {
-    /// Create a new [`PersistedQueryLayer`] from CLI options, YAML configuration,
+impl PersistedQueryExpander {
+    /// Create a new [`PersistedQueryExpander`] from CLI options, YAML configuration,
     /// and optionally, an existing persisted query manifest poller.
     pub(crate) async fn new(configuration: &Configuration) -> Result<Self, BoxError> {
         if configuration.persisted_queries.enabled {
@@ -95,7 +95,7 @@ impl PersistedQueryLayer {
     /// 1) resolving a persisted query ID to a query body
     /// 2) rejecting free-form GraphQL requests if they are never allowed by configuration.
     ///    Matching against safelists is done later in
-    ///    [`PersistedQueryLayer::supergraph_request_with_analyzed_query`].
+    ///    [`PersistedQueryExpander::supergraph_request_with_analyzed_query`].
     ///
     /// This functions similarly to a checkpoint service, short-circuiting the pipeline on error
     /// (using an `Err()` return value).
@@ -229,7 +229,7 @@ impl PersistedQueryLayer {
     /// Handles post-GraphQL-parsing work for requests using the persisted queries feature,
     /// in particular safelisting.
     ///
-    /// Any request that was expanded by the [`PersistedQueryLayer::supergraph_request`] call is
+    /// Any request that was expanded by the [`PersistedQueryExpander::supergraph_request`] call is
     /// passed through immediately. Free-form GraphQL is matched against safelists and rejected or
     /// passed through based on router configuration.
     ///
@@ -517,7 +517,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn disabled_pq_layer_has_no_poller() {
         let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(PersistedQueries::builder().enabled(false).build())
                 .uplink(uplink_config)
@@ -532,7 +532,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn enabled_pq_layer_has_poller() {
         let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(PersistedQueries::builder().enabled(true).build())
                 .uplink(uplink_config)
@@ -571,7 +571,7 @@ mod tests {
 
         let (_mock_guard, uplink_config) = mock_pq_uplink(&manifest).await;
 
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(PersistedQueries::builder().enabled(true).build())
                 .uplink(uplink_config)
@@ -598,7 +598,7 @@ mod tests {
         let (id, _body, manifest) = fake_manifest();
         let (_mock_guard, uplink_config) = mock_pq_uplink(&manifest).await;
 
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(PersistedQueries::builder().enabled(true).build())
                 .uplink(uplink_config)
@@ -642,7 +642,7 @@ mod tests {
         ]);
         let (_mock_guard, uplink_config) = mock_pq_uplink(&manifest).await;
 
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(PersistedQueries::builder().enabled(true).build())
                 .uplink(uplink_config)
@@ -707,7 +707,7 @@ mod tests {
 
         let (_mock_guard, uplink_config) = mock_pq_uplink(&manifest).await;
 
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(PersistedQueries::builder().enabled(true).build())
                 .apq(Apq::fake_builder().enabled(true).build())
@@ -739,7 +739,7 @@ mod tests {
 
         let (_mock_guard, uplink_config) = mock_pq_uplink(&manifest).await;
 
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(PersistedQueries::builder().enabled(true).build())
                 .apq(Apq::fake_builder().enabled(false).build())
@@ -777,7 +777,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn enabled_apq_configuration_tracked_in_pq_layer() {
         let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .apq(Apq::fake_builder().enabled(true).build())
                 .persisted_query(PersistedQueries::builder().enabled(true).build())
@@ -798,7 +798,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn disabled_apq_configuration_tracked_in_pq_layer() {
         let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .apq(Apq::fake_builder().enabled(false).build())
                 .uplink(uplink_config)
@@ -820,7 +820,7 @@ mod tests {
     async fn enabled_safelist_configuration_tracked_in_pq_layer() {
         let safelist_config = PersistedQueriesSafelist::builder().enabled(true).build();
         let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(
                     PersistedQueries::builder()
@@ -847,7 +847,7 @@ mod tests {
     }
 
     async fn run_first_two_layers(
-        pq_layer: &PersistedQueryLayer,
+        pq_layer: &PersistedQueryExpander,
         query_analysis: &QueryAnalysis,
         body: &str,
         skip_enforcement: bool,
@@ -882,7 +882,7 @@ mod tests {
     }
 
     async fn denied_by_safelist(
-        pq_layer: &PersistedQueryLayer,
+        pq_layer: &PersistedQueryExpander,
         query_analysis: &QueryAnalysis,
         body: &str,
         log_unknown: bool,
@@ -921,7 +921,7 @@ mod tests {
     }
 
     async fn allowed_by_safelist(
-        pq_layer: &PersistedQueryLayer,
+        pq_layer: &PersistedQueryExpander,
         query_analysis: &QueryAnalysis,
         body: &str,
         log_unknown: bool,
@@ -988,7 +988,7 @@ mod tests {
                 .build()
                 .unwrap();
 
-            let pq_layer = PersistedQueryLayer::new(&config).await.unwrap();
+            let pq_layer = PersistedQueryExpander::new(&config).await.unwrap();
 
             let schema = Arc::new(Schema::parse(include_str!("../../../testdata/supergraph.graphql"), &Default::default()).unwrap());
 
@@ -1108,7 +1108,7 @@ mod tests {
         let (_mock_guard, uplink_config) = mock_pq_uplink(&manifest).await;
 
         let safelist_config = PersistedQueriesSafelist::builder().enabled(true).build();
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(
                     PersistedQueries::builder()
@@ -1173,7 +1173,7 @@ mod tests {
     async fn require_id_disabled_by_default_with_safelisting_enabled_in_pq_layer() {
         let safelist_config = PersistedQueriesSafelist::builder().enabled(true).build();
         let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(
                     PersistedQueries::builder()
@@ -1206,7 +1206,7 @@ mod tests {
             .require_id(true)
             .build();
         let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(
                     PersistedQueries::builder()
@@ -1237,7 +1237,7 @@ mod tests {
             .require_id(true)
             .build();
         let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(
                     PersistedQueries::builder()
@@ -1290,7 +1290,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn safelisting_disabled_by_default_in_pq_layer() {
         let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(PersistedQueries::builder().enabled(true).build())
                 .apq(Apq::fake_builder().enabled(false).build())
@@ -1315,7 +1315,7 @@ mod tests {
     async fn disabled_safelist_configuration_tracked_in_pq_layer() {
         let (_mock_guard, uplink_config) = mock_empty_pq_uplink().await;
         let safelist_config = PersistedQueriesSafelist::builder().enabled(false).build();
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(
                     PersistedQueries::builder()
@@ -1344,7 +1344,7 @@ mod tests {
     async fn can_pass_different_body_from_published_pq_id_with_apq_enabled() {
         let (id, _body, manifest) = fake_manifest();
         let (_mock_guard, uplink_config) = mock_pq_uplink(&manifest).await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(PersistedQueries::builder().enabled(true).build())
                 .apq(Apq::fake_builder().enabled(true).build())
@@ -1370,7 +1370,7 @@ mod tests {
     async fn cannot_pass_different_body_as_published_pq_id_with_apq_disabled() {
         let (id, _body, manifest) = fake_manifest();
         let (_mock_guard, uplink_config) = mock_pq_uplink(&manifest).await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(PersistedQueries::builder().enabled(true).build())
                 .apq(Apq::fake_builder().enabled(false).build())
@@ -1403,7 +1403,7 @@ mod tests {
     async fn cannot_pass_same_body_as_published_pq_id_with_apq_disabled() {
         let (id, body, manifest) = fake_manifest();
         let (_mock_guard, uplink_config) = mock_pq_uplink(&manifest).await;
-        let pq_layer = PersistedQueryLayer::new(
+        let pq_layer = PersistedQueryExpander::new(
             &Configuration::fake_builder()
                 .persisted_query(PersistedQueries::builder().enabled(true).build())
                 .apq(Apq::fake_builder().enabled(false).build())

--- a/apollo-router/src/services/layers/persisted_queries/tower_compat.rs
+++ b/apollo-router/src/services/layers/persisted_queries/tower_compat.rs
@@ -11,16 +11,16 @@ use futures::future::BoxFuture;
 use tower::BoxError;
 use tower::Service;
 
-use super::PersistedQueryLayer;
+use super::PersistedQueryExpander;
 use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
 
 pub(crate) struct ExpandIdsLayer {
-    wrapped: Arc<PersistedQueryLayer>,
+    wrapped: Arc<PersistedQueryExpander>,
 }
 
 impl ExpandIdsLayer {
-    pub(crate) fn new(wrapped: Arc<PersistedQueryLayer>) -> Self {
+    pub(crate) fn new(wrapped: Arc<PersistedQueryExpander>) -> Self {
         Self { wrapped }
     }
 }
@@ -39,7 +39,7 @@ impl<S> tower::Layer<S> for ExpandIdsLayer {
 #[derive(Clone)]
 pub(crate) struct ExpandIdsService<S> {
     inner: S,
-    wrapped: Arc<PersistedQueryLayer>,
+    wrapped: Arc<PersistedQueryExpander>,
 }
 
 impl<S> Service<SupergraphRequest> for ExpandIdsService<S>
@@ -72,11 +72,11 @@ where
 }
 
 pub(crate) struct EnforceSafelistLayer {
-    wrapped: Arc<PersistedQueryLayer>,
+    wrapped: Arc<PersistedQueryExpander>,
 }
 
 impl EnforceSafelistLayer {
-    pub(crate) fn new(wrapped: Arc<PersistedQueryLayer>) -> Self {
+    pub(crate) fn new(wrapped: Arc<PersistedQueryExpander>) -> Self {
         Self { wrapped }
     }
 }
@@ -95,7 +95,7 @@ impl<S> tower::Layer<S> for EnforceSafelistLayer {
 #[derive(Clone)]
 pub(crate) struct EnforceSafelistService<S> {
     inner: S,
-    wrapped: Arc<PersistedQueryLayer>,
+    wrapped: Arc<PersistedQueryExpander>,
 }
 
 impl<S> Service<SupergraphRequest> for EnforceSafelistService<S>

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -69,10 +69,10 @@ pub(crate) fn recursive_selections_check_enabled() -> bool {
 
 /// A layer-like type that handles several aspects of query parsing and analysis.
 ///
-/// The supergraph layer implementation is in [QueryAnalysisLayer::supergraph_request].
+/// The supergraph layer implementation is in [QueryAnalysis::supergraph_request].
 #[derive(Clone)]
 #[allow(clippy::type_complexity)]
-pub(crate) struct QueryAnalysisLayer {
+pub(crate) struct QueryAnalysis {
     pub(crate) schema: Arc<Schema>,
     configuration: Arc<Configuration>,
     cache: Arc<Mutex<LruCache<QueryAnalysisKey, Result<(Context, ParsedDocument), SpecError>>>>,
@@ -86,7 +86,7 @@ struct QueryAnalysisKey {
     operation_name: Option<String>,
 }
 
-impl QueryAnalysisLayer {
+impl QueryAnalysis {
     pub(crate) async fn new(schema: Arc<Schema>, configuration: Arc<Configuration>) -> Self {
         let enable_authorization_directives =
             AuthorizationPlugin::enable_directives(&configuration, &schema).unwrap_or(false);
@@ -512,7 +512,7 @@ mod tests {
     use apollo_compiler::ExecutableDocument;
     use apollo_compiler::Schema;
 
-    use super::QueryAnalysisLayer;
+    use super::QueryAnalysis;
 
     fn parse(
         schema_sdl: &str,
@@ -528,7 +528,7 @@ mod tests {
     fn count_recursive_selections_simple_query() {
         let doc = parse(SCHEMA, "query { a { b { c } } }");
         let op = doc.operations.get(None).unwrap();
-        let count = QueryAnalysisLayer::count_recursive_selections(
+        let count = QueryAnalysis::count_recursive_selections(
             &doc,
             &mut HashMap::new(),
             &op.selection_set,
@@ -543,7 +543,7 @@ mod tests {
     fn count_recursive_selections_exceeds_limit() {
         let doc = parse(SCHEMA, "query { a { b { c } } }");
         let op = doc.operations.get(None).unwrap();
-        let count = QueryAnalysisLayer::count_recursive_selections(
+        let count = QueryAnalysis::count_recursive_selections(
             &doc,
             &mut HashMap::new(),
             &op.selection_set,
@@ -557,7 +557,7 @@ mod tests {
     fn count_recursive_selections_exactly_at_limit() {
         let doc = parse(SCHEMA, "query { a { b { c } } }");
         let op = doc.operations.get(None).unwrap();
-        let count = QueryAnalysisLayer::count_recursive_selections(
+        let count = QueryAnalysis::count_recursive_selections(
             &doc,
             &mut HashMap::new(),
             &op.selection_set,
@@ -575,7 +575,7 @@ mod tests {
         let op = doc.operations.get(None).unwrap();
 
         // Under a generous limit: a(1) + spread(2) + b(3) + c(4) = 4
-        let count = QueryAnalysisLayer::count_recursive_selections(
+        let count = QueryAnalysis::count_recursive_selections(
             &doc,
             &mut HashMap::new(),
             &op.selection_set,
@@ -585,7 +585,7 @@ mod tests {
         assert_eq!(count, Some(4));
 
         // With a tight limit that the fragment exceeds
-        let count = QueryAnalysisLayer::count_recursive_selections(
+        let count = QueryAnalysis::count_recursive_selections(
             &doc,
             &mut HashMap::new(),
             &op.selection_set,
@@ -602,7 +602,7 @@ mod tests {
         let doc = parse(schema, query);
         let op = doc.operations.get(None).unwrap();
         // a(1) + inline_fragment(2) + b(3) = 3
-        let count = QueryAnalysisLayer::count_recursive_selections(
+        let count = QueryAnalysis::count_recursive_selections(
             &doc,
             &mut HashMap::new(),
             &op.selection_set,
@@ -620,7 +620,7 @@ mod tests {
         let op = doc.operations.get(None).unwrap();
 
         // a(1) + spread(2) + b(3) + a2(4) + spread(5) + b_cached(6) = 6
-        let count = QueryAnalysisLayer::count_recursive_selections(
+        let count = QueryAnalysis::count_recursive_selections(
             &doc,
             &mut HashMap::new(),
             &op.selection_set,
@@ -634,7 +634,7 @@ mod tests {
     fn count_recursive_selections_limit_zero_always_exceeds() {
         let doc = parse("type Query { a: String }", "query { a }");
         let op = doc.operations.get(None).unwrap();
-        let count = QueryAnalysisLayer::count_recursive_selections(
+        let count = QueryAnalysis::count_recursive_selections(
             &doc,
             &mut HashMap::new(),
             &op.selection_set,

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -66,7 +66,7 @@ use crate::services::RouterResponse;
 use crate::services::SupergraphCreator;
 use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
-use crate::services::layers::apq::APQLayer;
+use crate::services::layers::apq::APQExpander;
 use crate::services::layers::content_negotiation;
 use crate::services::layers::content_negotiation::GRAPHQL_JSON_RESPONSE_HEADER_VALUE;
 use crate::services::layers::persisted_queries::EnforceSafelistLayer;
@@ -99,21 +99,21 @@ pub(crate) struct RouterService {
 impl RouterService {
     fn new(
         supergraph_service: supergraph::BoxCloneService,
-        apq_layer: APQLayer,
+        apq_expander: APQExpander,
         persisted_query_layer: Arc<PersistedQueryLayer>,
         query_analysis: Arc<QueryAnalysis>,
         batching: Batching,
     ) -> Self {
         // Some of the layers in the stack are wrapping previous implementations that are called
         // layers, but are not tower layers at all.
-        let apq_layer = Arc::new(apq_layer);
+        let apq_expander = Arc::new(apq_expander);
 
         let service = ServiceBuilder::new()
             .layer(DisplayRouterRequestLayer)
             .layer(BatchingLayer::new(batching))
             .layer(RouterToSupergraphRequestLayer)
             .layer(ExpandIdsLayer::new(persisted_query_layer.clone()))
-            .layer(APQCachingLayer::new(apq_layer))
+            .layer(APQCachingLayer::new(apq_expander))
             .layer(ParseQueryLayer::new(query_analysis))
             .layer(EnforceSafelistLayer::new(persisted_query_layer))
             .service(supergraph_service)
@@ -675,22 +675,22 @@ impl RouterCreator {
         configuration: Arc<Configuration>,
     ) -> Result<Self, BoxError> {
         let static_page = StaticPageLayer::new(&configuration);
-        let apq_layer = if configuration.apq.enabled {
-            APQLayer::with_cache(
+        let apq_expander = if configuration.apq.enabled {
+            APQExpander::with_cache(
                 DeduplicatingCache::from_configuration(&configuration.apq.router.cache, "APQ")
                     .await?,
             )
         } else {
-            APQLayer::disabled()
+            APQExpander::disabled()
         };
         // There is a problem here.
         // APQ isn't a plugin and so cannot participate in plugin lifecycle events.
         // After telemetry `activate` NO part of the pipeline can fail as globals have been interacted with.
-        // However, the APQLayer uses DeduplicatingCache which is fallible. So if this fails on hot reload the router will be
+        // However, the APQExpander uses DeduplicatingCache which is fallible. So if this fails on hot reload the router will be
         // left in an inconsistent state and all metrics will likely stop working.
         // Fixing this will require a larger refactor to bring APQ into the router lifecycle.
         // For now just call activate to make the gauges work on the happy path.
-        apq_layer.activate();
+        apq_expander.activate();
 
         // Create a handle that will help us keep track of this pipeline.
         // A metric is exposed that allows the use to see if pipelines are being hung onto.
@@ -706,7 +706,7 @@ impl RouterCreator {
         let router_service = content_negotiation::RouterContentNegotiationLayer::default().layer(
             RouterService::new(
                 supergraph_creator.make(),
-                apq_layer,
+                apq_expander,
                 persisted_query_layer,
                 query_analysis,
                 configuration.batching.clone(),

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -72,7 +72,7 @@ use crate::services::layers::content_negotiation::GRAPHQL_JSON_RESPONSE_HEADER_V
 use crate::services::layers::persisted_queries::EnforceSafelistLayer;
 use crate::services::layers::persisted_queries::ExpandIdsLayer;
 use crate::services::layers::persisted_queries::PersistedQueryLayer;
-use crate::services::layers::query_analysis::QueryAnalysisLayer;
+use crate::services::layers::query_analysis::QueryAnalysis;
 use crate::services::layers::static_page::StaticPageLayer;
 use crate::services::router;
 use crate::services::router::batching::BatchingLayer;
@@ -101,7 +101,7 @@ impl RouterService {
         supergraph_service: supergraph::BoxCloneService,
         apq_layer: APQLayer,
         persisted_query_layer: Arc<PersistedQueryLayer>,
-        query_analysis_layer: Arc<QueryAnalysisLayer>,
+        query_analysis: Arc<QueryAnalysis>,
         batching: Batching,
     ) -> Self {
         // Some of the layers in the stack are wrapping previous implementations that are called
@@ -114,7 +114,7 @@ impl RouterService {
             .layer(RouterToSupergraphRequestLayer)
             .layer(ExpandIdsLayer::new(persisted_query_layer.clone()))
             .layer(APQCachingLayer::new(apq_layer))
-            .layer(ParseQueryLayer::new(query_analysis_layer))
+            .layer(ParseQueryLayer::new(query_analysis))
             .layer(EnforceSafelistLayer::new(persisted_query_layer))
             .service(supergraph_service)
             .boxed_clone();
@@ -669,7 +669,7 @@ impl RouterFactory for RouterCreator {
 
 impl RouterCreator {
     pub(crate) async fn new(
-        query_analysis_layer: Arc<QueryAnalysisLayer>,
+        query_analysis: Arc<QueryAnalysis>,
         persisted_query_layer: Arc<PersistedQueryLayer>,
         supergraph_creator: Arc<SupergraphCreator>,
         configuration: Arc<Configuration>,
@@ -708,7 +708,7 @@ impl RouterCreator {
                 supergraph_creator.make(),
                 apq_layer,
                 persisted_query_layer,
-                query_analysis_layer,
+                query_analysis,
                 configuration.batching.clone(),
             ),
         );

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -71,7 +71,7 @@ use crate::services::layers::content_negotiation;
 use crate::services::layers::content_negotiation::GRAPHQL_JSON_RESPONSE_HEADER_VALUE;
 use crate::services::layers::persisted_queries::EnforceSafelistLayer;
 use crate::services::layers::persisted_queries::ExpandIdsLayer;
-use crate::services::layers::persisted_queries::PersistedQueryLayer;
+use crate::services::layers::persisted_queries::PersistedQueryExpander;
 use crate::services::layers::query_analysis::QueryAnalysis;
 use crate::services::layers::static_page::StaticPageLayer;
 use crate::services::router;
@@ -100,7 +100,7 @@ impl RouterService {
     fn new(
         supergraph_service: supergraph::BoxCloneService,
         apq_expander: APQExpander,
-        persisted_query_layer: Arc<PersistedQueryLayer>,
+        persisted_queries: Arc<PersistedQueryExpander>,
         query_analysis: Arc<QueryAnalysis>,
         batching: Batching,
     ) -> Self {
@@ -112,10 +112,10 @@ impl RouterService {
             .layer(DisplayRouterRequestLayer)
             .layer(BatchingLayer::new(batching))
             .layer(RouterToSupergraphRequestLayer)
-            .layer(ExpandIdsLayer::new(persisted_query_layer.clone()))
+            .layer(ExpandIdsLayer::new(persisted_queries.clone()))
             .layer(APQCachingLayer::new(apq_expander))
             .layer(ParseQueryLayer::new(query_analysis))
-            .layer(EnforceSafelistLayer::new(persisted_query_layer))
+            .layer(EnforceSafelistLayer::new(persisted_queries))
             .service(supergraph_service)
             .boxed_clone();
 
@@ -157,7 +157,7 @@ pub(crate) async fn from_supergraph_mock_with_configuration(
 
     RouterCreator::new(
         query_analysis,
-        Arc::new(PersistedQueryLayer::new(&configuration).await.unwrap()),
+        Arc::new(PersistedQueryExpander::new(&configuration).await.unwrap()),
         Arc::new(supergraph_creator),
         configuration,
     )
@@ -199,7 +199,11 @@ pub(crate) async fn empty() -> impl Service<
 
     RouterCreator::new(
         query_analysis,
-        Arc::new(PersistedQueryLayer::new(&Default::default()).await.unwrap()),
+        Arc::new(
+            PersistedQueryExpander::new(&Default::default())
+                .await
+                .unwrap(),
+        ),
         Arc::new(supergraph_creator),
         Arc::new(Configuration::default()),
     )
@@ -670,7 +674,7 @@ impl RouterFactory for RouterCreator {
 impl RouterCreator {
     pub(crate) async fn new(
         query_analysis: Arc<QueryAnalysis>,
-        persisted_query_layer: Arc<PersistedQueryLayer>,
+        persisted_queries: Arc<PersistedQueryExpander>,
         supergraph_creator: Arc<SupergraphCreator>,
         configuration: Arc<Configuration>,
     ) -> Result<Self, BoxError> {
@@ -707,7 +711,7 @@ impl RouterCreator {
             RouterService::new(
                 supergraph_creator.make(),
                 apq_expander,
-                persisted_query_layer,
+                persisted_queries,
                 query_analysis,
                 configuration.batching.clone(),
             ),

--- a/apollo-router/src/services/router/tower_compat.rs
+++ b/apollo-router/src/services/router/tower_compat.rs
@@ -12,7 +12,7 @@ use tower::Service;
 use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
 use crate::services::layers::apq::APQLayer;
-use crate::services::layers::query_analysis::QueryAnalysisLayer;
+use crate::services::layers::query_analysis::QueryAnalysis;
 
 pub(crate) struct APQCachingLayer {
     wrapped: Arc<APQLayer>,
@@ -75,11 +75,11 @@ where
 }
 
 pub(crate) struct ParseQueryLayer {
-    wrapped: Arc<QueryAnalysisLayer>,
+    wrapped: Arc<QueryAnalysis>,
 }
 
 impl ParseQueryLayer {
-    pub(crate) fn new(wrapped: Arc<QueryAnalysisLayer>) -> Self {
+    pub(crate) fn new(wrapped: Arc<QueryAnalysis>) -> Self {
         Self { wrapped }
     }
 }
@@ -98,7 +98,7 @@ impl<S> tower::Layer<S> for ParseQueryLayer {
 #[derive(Clone)]
 pub(crate) struct ParseQueryService<S> {
     inner: S,
-    wrapped: Arc<QueryAnalysisLayer>,
+    wrapped: Arc<QueryAnalysis>,
 }
 
 impl<S> Service<SupergraphRequest> for ParseQueryService<S>

--- a/apollo-router/src/services/router/tower_compat.rs
+++ b/apollo-router/src/services/router/tower_compat.rs
@@ -11,15 +11,15 @@ use tower::Service;
 
 use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
-use crate::services::layers::apq::APQLayer;
+use crate::services::layers::apq::APQExpander;
 use crate::services::layers::query_analysis::QueryAnalysis;
 
 pub(crate) struct APQCachingLayer {
-    wrapped: Arc<APQLayer>,
+    wrapped: Arc<APQExpander>,
 }
 
 impl APQCachingLayer {
-    pub(crate) fn new(wrapped: Arc<APQLayer>) -> Self {
+    pub(crate) fn new(wrapped: Arc<APQExpander>) -> Self {
         Self { wrapped }
     }
 }
@@ -38,7 +38,7 @@ impl<S> tower::Layer<S> for APQCachingLayer {
 #[derive(Clone)]
 pub(crate) struct APQCachingService<S> {
     inner: S,
-    wrapped: Arc<APQLayer>,
+    wrapped: Arc<APQExpander>,
 }
 
 impl<S> Service<SupergraphRequest> for APQCachingService<S>

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -60,7 +60,7 @@ use crate::services::fetch_service::FetchService;
 use crate::services::http::HttpClientServiceFactory;
 use crate::services::layers::allow_only_http_post_mutations::AllowOnlyHttpPostMutationsLayer;
 use crate::services::layers::content_negotiation;
-use crate::services::layers::persisted_queries::PersistedQueryLayer;
+use crate::services::layers::persisted_queries::PersistedQueryExpander;
 use crate::services::layers::query_analysis::QueryAnalysis;
 use crate::services::query_planner;
 use crate::services::router::ClientRequestAccepts;
@@ -725,7 +725,7 @@ impl SupergraphCreator {
 
     pub(crate) async fn warm_up_query_planner(
         warmup_query_planner_service: warmup::BoxCloneService,
-        persisted_query_layer: &PersistedQueryLayer,
+        persisted_queries: &PersistedQueryExpander,
         previous_cache: Option<InMemoryQueryPlanCache>,
         max_cached_queries: Option<usize>,
         experimental_pql_prewarm: &PersistedQueriesPrewarmQueryPlanCache,
@@ -733,7 +733,7 @@ impl SupergraphCreator {
         let requests = warmup::queries_to_warm_up(
             previous_cache,
             max_cached_queries,
-            persisted_query_layer.all_operations(),
+            persisted_queries.all_operations(),
             experimental_pql_prewarm,
         )
         .await;

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -61,7 +61,7 @@ use crate::services::http::HttpClientServiceFactory;
 use crate::services::layers::allow_only_http_post_mutations::AllowOnlyHttpPostMutationsLayer;
 use crate::services::layers::content_negotiation;
 use crate::services::layers::persisted_queries::PersistedQueryLayer;
-use crate::services::layers::query_analysis::QueryAnalysisLayer;
+use crate::services::layers::query_analysis::QueryAnalysis;
 use crate::services::query_planner;
 use crate::services::router::ClientRequestAccepts;
 use crate::services::subgraph;
@@ -477,7 +477,7 @@ pub(crate) struct PluggableSupergraphServiceBuilder {
     schema: Arc<Schema>,
     subgraph_schemas: Arc<SubgraphSchemas>,
     /// Only for warmup. XXX(@goto-bus-stop): We should delete this when the factories are refactored!
-    query_analysis: Arc<QueryAnalysisLayer>,
+    query_analysis: Arc<QueryAnalysis>,
 }
 
 impl PluggableSupergraphServiceBuilder {
@@ -485,7 +485,7 @@ impl PluggableSupergraphServiceBuilder {
         query_planner_service: query_planner::BoxCloneService,
         schema: Arc<Schema>,
         subgraph_schemas: Arc<SubgraphSchemas>,
-        query_analysis: Arc<QueryAnalysisLayer>,
+        query_analysis: Arc<QueryAnalysis>,
     ) -> Self {
         Self {
             plugins: Arc::new(Default::default()),

--- a/apollo-router/src/services/supergraph/tests.rs
+++ b/apollo-router/src/services/supergraph/tests.rs
@@ -3757,7 +3757,7 @@ async fn test_cache_warmup() {
     use crate::services::QueryPlannerContent;
     use crate::services::QueryPlannerResponse;
     use crate::services::layers::persisted_queries::PersistedQueryLayer;
-    use crate::services::layers::query_analysis::QueryAnalysisLayer;
+    use crate::services::layers::query_analysis::QueryAnalysis;
     use crate::services::query_planner;
     use crate::services::supergraph::service::SupergraphCreator;
 
@@ -3772,7 +3772,7 @@ async fn test_cache_warmup() {
 
     // We have to do a bunch of setup here...
     let query_analysis =
-        Arc::new(QueryAnalysisLayer::new(schema.clone(), Arc::new(configuration.clone())).await);
+        Arc::new(QueryAnalysis::new(schema.clone(), Arc::new(configuration.clone())).await);
     let pq_layer = PersistedQueryLayer::new(&configuration).await.unwrap();
 
     /// Return an empty plan that doesn't require any subgraph requests to fulfill.

--- a/apollo-router/src/services/supergraph/tests.rs
+++ b/apollo-router/src/services/supergraph/tests.rs
@@ -3756,7 +3756,7 @@ async fn test_cache_warmup() {
     use crate::services::PluggableSupergraphServiceBuilder;
     use crate::services::QueryPlannerContent;
     use crate::services::QueryPlannerResponse;
-    use crate::services::layers::persisted_queries::PersistedQueryLayer;
+    use crate::services::layers::persisted_queries::PersistedQueryExpander;
     use crate::services::layers::query_analysis::QueryAnalysis;
     use crate::services::query_planner;
     use crate::services::supergraph::service::SupergraphCreator;
@@ -3773,7 +3773,7 @@ async fn test_cache_warmup() {
     // We have to do a bunch of setup here...
     let query_analysis =
         Arc::new(QueryAnalysis::new(schema.clone(), Arc::new(configuration.clone())).await);
-    let pq_layer = PersistedQueryLayer::new(&configuration).await.unwrap();
+    let pq_layer = PersistedQueryExpander::new(&configuration).await.unwrap();
 
     /// Return an empty plan that doesn't require any subgraph requests to fulfill.
     fn empty_query_plan() -> QueryPlannerResponse {

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -31,7 +31,7 @@ use crate::router_factory::RouterFactory;
 use crate::router_factory::YamlRouterFactory;
 use crate::services::SupergraphCreator;
 use crate::services::execution;
-use crate::services::layers::persisted_queries::PersistedQueryLayer;
+use crate::services::layers::persisted_queries::PersistedQueryExpander;
 use crate::services::layers::query_analysis::QueryAnalysis;
 use crate::services::router;
 use crate::services::router::service::RouterCreator;
@@ -398,7 +398,7 @@ impl<'a> TestHarness<'a> {
         let (config, _schema, query_analysis, supergraph_creator) = self.build_common().await?;
         let router_creator = RouterCreator::new(
             query_analysis,
-            Arc::new(PersistedQueryLayer::new(&config).await.unwrap()),
+            Arc::new(PersistedQueryExpander::new(&config).await.unwrap()),
             Arc::new(supergraph_creator),
             config.clone(),
         )
@@ -426,7 +426,7 @@ impl<'a> TestHarness<'a> {
         let (config, _schema, query_analysis, supergraph_creator) = self.build_common().await?;
         let router_creator = RouterCreator::new(
             query_analysis,
-            Arc::new(PersistedQueryLayer::new(&config).await.unwrap()),
+            Arc::new(PersistedQueryExpander::new(&config).await.unwrap()),
             Arc::new(supergraph_creator),
             config.clone(),
         )

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -32,7 +32,7 @@ use crate::router_factory::YamlRouterFactory;
 use crate::services::SupergraphCreator;
 use crate::services::execution;
 use crate::services::layers::persisted_queries::PersistedQueryLayer;
-use crate::services::layers::query_analysis::QueryAnalysisLayer;
+use crate::services::layers::query_analysis::QueryAnalysis;
 use crate::services::router;
 use crate::services::router::service::RouterCreator;
 use crate::services::subgraph;
@@ -308,7 +308,7 @@ impl<'a> TestHarness<'a> {
         (
             Arc<Configuration>,
             Arc<Schema>,
-            Arc<QueryAnalysisLayer>,
+            Arc<QueryAnalysis>,
             SupergraphCreator,
         ),
         BoxError,
@@ -339,8 +339,7 @@ impl<'a> TestHarness<'a> {
             limits: Default::default(),
         }));
 
-        let query_analysis =
-            Arc::new(QueryAnalysisLayer::new(schema.clone(), config.clone()).await);
+        let query_analysis = Arc::new(QueryAnalysis::new(schema.clone(), config.clone()).await);
 
         let (supergraph_creator, _warmup) = YamlRouterFactory
             .inner_create_supergraph(


### PR DESCRIPTION
Several types are called Layer in the router but are not actually tower layers at all. Here I rename them:

- `services::layers::apq::APQLayer` -> `APQExpander` (APQCache would also be a good name, but we should follow up and just convert this into a real layer, it should be easy.)
- `services::layers::persisted_queries::PersistedQueryLayer` -> `PersistedQueryExpander` (It also does filtering of non-allowlisted requests, but the main thing is expansion. We should follow up and convert this into two real layers.)
- `services::layers::query_analysis::QueryAnalysisLayer` -> `QueryAnalysis`


<!-- start metadata -->

<!-- [ROUTER-1995] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

Naming change only, no functionality, so no tests.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
It's not a layer.

[ROUTER-1995]: https://apollographql.atlassian.net/browse/ROUTER-1995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ