### PR TITLE
perf(query-planner): reduce allocations and hash-based node comparison in query planner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
 name = "apollo-federation"
 version = "2.16.0"
 dependencies = [
+ "ahash",
  "apollo-compiler",
  "apollo-federation",
  "apollo-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
+ahash = "0.8.11"
 apollo-compiler = "1.32.0"
 apollo-parser = "0.8.6"
 apollo-smith = "0.15.2"

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -22,6 +22,7 @@ correctness = []
 connect-migrate = ["dep:clap", "dep:apollo-parser", "time/formatting"]
 
 [dependencies]
+ahash.workspace = true
 apollo-compiler.workspace = true
 apollo-parser = { workspace = true, optional = true }
 clap = { version = "4", features = ["derive"], optional = true }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -1,4 +1,6 @@
 use std::fmt::Write as _;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::iter;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -176,6 +178,11 @@ pub(crate) struct FetchDependencyGraphNode {
     /// As query plan execution runs, it accumulates fetch data into a response object. This is the
     /// path at which to merge in the data for this particular fetch.
     merge_at: Option<Vec<FetchDataPathElement>>,
+    /// Precomputed hash of (subgraph_name, merge_at, defer_ref) for fast-reject in merge key
+    /// comparisons. Two nodes with different hashes cannot share a merge key, avoiding expensive
+    /// deep Vec<FetchDataPathElement> equality checks.
+    #[serde(skip)]
+    merge_key_hash: u64,
     /// The fetch ID generation, if one is necessary (used when handling `@defer`).
     ///
     /// This can be treated as an Option using `OnceLock::get()`.
@@ -191,6 +198,18 @@ pub(crate) struct FetchDependencyGraphNode {
     /// If true, then we skip an expensive computation during `is_useless()`. (This partially
     /// caches that computation.)
     is_known_useful: bool,
+}
+
+fn compute_merge_key_hash(
+    subgraph_name: &str,
+    merge_at: &Option<Vec<FetchDataPathElement>>,
+    defer_ref: &Option<DeferRef>,
+) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    subgraph_name.hash(&mut hasher);
+    merge_at.hash(&mut hasher);
+    defer_ref.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// Safely generate IDs for fetch dependency nodes without mutable access.
@@ -610,10 +629,9 @@ impl FetchDependencyGraphNodePath {
 
         let mut res: IndexSet<Name> = self
             .possible_types
-            .clone()
-            .into_iter()
+            .iter()
             .map(|pt| {
-                let field = CompositeTypeDefinitionPosition::try_from(self.schema.get_type(&pt)?)?
+                let field = CompositeTypeDefinitionPosition::try_from(self.schema.get_type(pt)?)?
                     .field(element.name().clone())?
                     .get(self.schema.schema())?;
                 let typ = self
@@ -784,6 +802,7 @@ impl FetchDependencyGraph {
             .schema_by_source(&subgraph_name)?
             .clone();
         self.on_modification();
+        let merge_key_hash = compute_merge_key_hash(&subgraph_name, &merge_at, &defer_ref);
         Ok(self.graph.add_node(Arc::new(FetchDependencyGraphNode {
             subgraph_name,
             root_kind,
@@ -794,6 +813,7 @@ impl FetchDependencyGraph {
                 .then(|| Arc::new(FetchInputs::empty(self.supergraph_schema.clone()))),
             input_rewrites: Default::default(),
             merge_at,
+            merge_key_hash,
             id: OnceLock::new(),
             defer_ref,
             cached_cost: None,
@@ -1602,8 +1622,8 @@ impl FetchDependencyGraph {
             // the `merge_sibling_in` would shrink `children_nodes` dynamically. I found it easier
             // to reason about it the other way around by incrementing `i` when it's merged into
             // `j` without modifying `children_nodes`.
-            for (i, i_node_index) in children_nodes.iter().cloned().enumerate() {
-                for (_j, j_node_index) in children_nodes.iter().cloned().enumerate().skip(i + 1) {
+            for (i, i_node_index) in children_nodes.iter().copied().enumerate() {
+                for (_j, j_node_index) in children_nodes.iter().copied().enumerate().skip(i + 1) {
                     if self.can_merge_sibling_in(j_node_index, i_node_index)? {
                         // Merge node `i` into node `j`.
                         // In theory, we can merge in any direction. But, we merge i into j,
@@ -2290,8 +2310,10 @@ impl FetchDependencyGraph {
             return Ok(false);
         };
 
-        // we compare the subgraph names last because on average it improves performance
-        Ok(node.merge_at == sibling.merge_at
+        // Hash check rejects mismatched merge keys without deep Vec comparison.
+        // We compare the subgraph names last because on average it improves performance.
+        Ok(node.merge_key_hash == sibling.merge_key_hash
+            && node.merge_at == sibling.merge_at
             && own_parent_id == sibling_parent_id
             && node.defer_ref == sibling.defer_ref
             && node.subgraph_name == sibling.subgraph_name)
@@ -2323,9 +2345,11 @@ impl FetchDependencyGraph {
             return Ok(false);
         };
 
-        // we compare the subgraph names last because on average it improves performance
+        // Hash check rejects mismatched merge keys without deep Vec comparison.
+        // We compare the subgraph names last because on average it improves performance.
         Ok(grand_child_parent_relation.path_in_parent.is_some()
             && grand_child_parent_parent_relation.path_in_parent.is_some()
+            && child.merge_key_hash == grand_child.merge_key_hash
             && child.merge_at == grand_child.merge_at
             && child_inputs.contains(grand_child_inputs)
             && node.defer_ref == grand_child.defer_ref
@@ -3147,23 +3171,16 @@ impl FetchDependencyGraphNode {
     }
 
     // PORT_NOTE: In JS version, this value is memoized on the node struct.
-    fn subgraph_and_merge_at_key(&self) -> Option<String> {
-        // PORT_NOTE: In JS version, this hash value is defined as below.
-        // ```
-        // hasInputs ? `${toValidGraphQLName(subgraphName)}-${mergeAt?.join('::') ?? ''}` : undefined,
-        // ```
-        // TODO: We could use a numeric hash key in Rust, instead of a string key as done in JS.
+    // Uses a numeric hash instead of the JS string key to avoid per-node
+    // string allocation + formatting. Hash collisions are safe because the
+    // caller (merge_fetches_with_same_subgraph_and_merge_at) does a full
+    // equality check via has_equal_inputs within each bucket.
+    fn subgraph_and_merge_at_key(&self) -> Option<u64> {
         self.inputs.as_ref()?;
-        let subgraph_name = &self.subgraph_name;
-        let merge_at_str = match self.merge_at {
-            Some(ref merge_at) => merge_at
-                .iter()
-                .map(|m| m.to_string())
-                .collect::<Vec<_>>()
-                .join("::"),
-            None => "".to_string(),
-        };
-        Some(format!("{subgraph_name}-{merge_at_str}"))
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.subgraph_name.hash(&mut hasher);
+        self.merge_at.hash(&mut hasher);
+        Some(hasher.finish())
     }
 
     fn add_context_renamer(&mut self, renamer: FetchDataKeyRenamer) {

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -178,11 +178,6 @@ pub(crate) struct FetchDependencyGraphNode {
     /// As query plan execution runs, it accumulates fetch data into a response object. This is the
     /// path at which to merge in the data for this particular fetch.
     merge_at: Option<Vec<FetchDataPathElement>>,
-    /// Precomputed hash of (subgraph_name, merge_at, defer_ref) for fast-reject in merge key
-    /// comparisons. Two nodes with different hashes cannot share a merge key, avoiding expensive
-    /// deep Vec<FetchDataPathElement> equality checks.
-    #[serde(skip)]
-    merge_key_hash: u64,
     /// The fetch ID generation, if one is necessary (used when handling `@defer`).
     ///
     /// This can be treated as an Option using `OnceLock::get()`.
@@ -198,18 +193,6 @@ pub(crate) struct FetchDependencyGraphNode {
     /// If true, then we skip an expensive computation during `is_useless()`. (This partially
     /// caches that computation.)
     is_known_useful: bool,
-}
-
-fn compute_merge_key_hash(
-    subgraph_name: &str,
-    merge_at: &Option<Vec<FetchDataPathElement>>,
-    defer_ref: &Option<DeferRef>,
-) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    subgraph_name.hash(&mut hasher);
-    merge_at.hash(&mut hasher);
-    defer_ref.hash(&mut hasher);
-    hasher.finish()
 }
 
 /// Safely generate IDs for fetch dependency nodes without mutable access.
@@ -802,7 +785,6 @@ impl FetchDependencyGraph {
             .schema_by_source(&subgraph_name)?
             .clone();
         self.on_modification();
-        let merge_key_hash = compute_merge_key_hash(&subgraph_name, &merge_at, &defer_ref);
         Ok(self.graph.add_node(Arc::new(FetchDependencyGraphNode {
             subgraph_name,
             root_kind,
@@ -813,7 +795,6 @@ impl FetchDependencyGraph {
                 .then(|| Arc::new(FetchInputs::empty(self.supergraph_schema.clone()))),
             input_rewrites: Default::default(),
             merge_at,
-            merge_key_hash,
             id: OnceLock::new(),
             defer_ref,
             cached_cost: None,
@@ -2310,10 +2291,8 @@ impl FetchDependencyGraph {
             return Ok(false);
         };
 
-        // Hash check rejects mismatched merge keys without deep Vec comparison.
-        // We compare the subgraph names last because on average it improves performance.
-        Ok(node.merge_key_hash == sibling.merge_key_hash
-            && node.merge_at == sibling.merge_at
+        // we compare the subgraph names last because on average it improves performance
+        Ok(node.merge_at == sibling.merge_at
             && own_parent_id == sibling_parent_id
             && node.defer_ref == sibling.defer_ref
             && node.subgraph_name == sibling.subgraph_name)
@@ -2345,11 +2324,9 @@ impl FetchDependencyGraph {
             return Ok(false);
         };
 
-        // Hash check rejects mismatched merge keys without deep Vec comparison.
-        // We compare the subgraph names last because on average it improves performance.
+        // we compare the subgraph names last because on average it improves performance
         Ok(grand_child_parent_relation.path_in_parent.is_some()
             && grand_child_parent_parent_relation.path_in_parent.is_some()
-            && child.merge_key_hash == grand_child.merge_key_hash
             && child.merge_at == grand_child.merge_at
             && child_inputs.contains(grand_child_inputs)
             && node.defer_ref == grand_child.defer_ref

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -178,6 +178,11 @@ pub(crate) struct FetchDependencyGraphNode {
     /// As query plan execution runs, it accumulates fetch data into a response object. This is the
     /// path at which to merge in the data for this particular fetch.
     merge_at: Option<Vec<FetchDataPathElement>>,
+    /// Precomputed hash of (subgraph_name, merge_at, defer_ref) for fast-reject in
+    /// `can_merge_sibling_in`. Not used in `can_merge_grand_child_in` because that
+    /// method compares fields from mixed nodes (child vs parent).
+    #[serde(skip)]
+    merge_key_hash: u64,
     /// The fetch ID generation, if one is necessary (used when handling `@defer`).
     ///
     /// This can be treated as an Option using `OnceLock::get()`.
@@ -193,6 +198,18 @@ pub(crate) struct FetchDependencyGraphNode {
     /// If true, then we skip an expensive computation during `is_useless()`. (This partially
     /// caches that computation.)
     is_known_useful: bool,
+}
+
+fn compute_merge_key_hash(
+    subgraph_name: &str,
+    merge_at: &Option<Vec<FetchDataPathElement>>,
+    defer_ref: &Option<DeferRef>,
+) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    subgraph_name.hash(&mut hasher);
+    merge_at.hash(&mut hasher);
+    defer_ref.hash(&mut hasher);
+    hasher.finish()
 }
 
 /// Safely generate IDs for fetch dependency nodes without mutable access.
@@ -785,6 +802,7 @@ impl FetchDependencyGraph {
             .schema_by_source(&subgraph_name)?
             .clone();
         self.on_modification();
+        let merge_key_hash = compute_merge_key_hash(&subgraph_name, &merge_at, &defer_ref);
         Ok(self.graph.add_node(Arc::new(FetchDependencyGraphNode {
             subgraph_name,
             root_kind,
@@ -795,6 +813,7 @@ impl FetchDependencyGraph {
                 .then(|| Arc::new(FetchInputs::empty(self.supergraph_schema.clone()))),
             input_rewrites: Default::default(),
             merge_at,
+            merge_key_hash,
             id: OnceLock::new(),
             defer_ref,
             cached_cost: None,
@@ -2291,8 +2310,10 @@ impl FetchDependencyGraph {
             return Ok(false);
         };
 
-        // we compare the subgraph names last because on average it improves performance
-        Ok(node.merge_at == sibling.merge_at
+        // Hash check rejects mismatched merge keys without deep Vec comparison.
+        // We compare the subgraph names last because on average it improves performance.
+        Ok(node.merge_key_hash == sibling.merge_key_hash
+            && node.merge_at == sibling.merge_at
             && own_parent_id == sibling_parent_id
             && node.defer_ref == sibling.defer_ref
             && node.subgraph_name == sibling.subgraph_name)

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -205,7 +205,7 @@ fn compute_merge_key_hash(
     merge_at: &Option<Vec<FetchDataPathElement>>,
     defer_ref: &Option<DeferRef>,
 ) -> u64 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let mut hasher = ahash::AHasher::default();
     subgraph_name.hash(&mut hasher);
     merge_at.hash(&mut hasher);
     defer_ref.hash(&mut hasher);
@@ -3175,7 +3175,7 @@ impl FetchDependencyGraphNode {
     // equality check via has_equal_inputs within each bucket.
     fn subgraph_and_merge_at_key(&self) -> Option<u64> {
         self.inputs.as_ref()?;
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        let mut hasher = ahash::AHasher::default();
         self.subgraph_name.hash(&mut hasher);
         self.merge_at.hash(&mut hasher);
         Some(hasher.finish())

--- a/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
@@ -462,12 +462,8 @@ fn flat_wrap_nodes(
     let mut nodes = Vec::new();
     for node in [first, second].into_iter().chain(iter) {
         match (kind, node) {
-            (NodeKind::Parallel, PlanNode::Parallel(inner)) => {
-                nodes.extend(inner.nodes.iter().cloned())
-            }
-            (NodeKind::Sequence, PlanNode::Sequence(inner)) => {
-                nodes.extend(inner.nodes.iter().cloned())
-            }
+            (NodeKind::Parallel, PlanNode::Parallel(inner)) => nodes.extend(inner.nodes),
+            (NodeKind::Sequence, PlanNode::Sequence(inner)) => nodes.extend(inner.nodes),
             (_, node) => nodes.push(node),
         }
     }

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -285,7 +285,7 @@ time = { version = "0.3.36", features = ["serde"] }
 similar.workspace = true
 console = "0.16.0"
 bytesize = { version = "1.3.0", features = ["serde"] }
-ahash = "0.8.11"
+ahash.workspace = true
 itoa = "1.0.9"
 ryu = "1.0.15"
 apollo-environment-detector = "0.1.0"


### PR DESCRIPTION
Node comparisons:
- When comparing potential merge candidate in `can_merge_sibling_in`, this change compares hashes of the nodes instead of a deep data comparison. Note that this does not affect the check for merging grandchild nodes, as that caused the planner to miss merge opportunities in a previous commit

Allocation savings:
- Converts `subgraph_and_merge_at_key` from string formatting to numeric hash
- `.iter()` instead of `.clone().into_iter()` on `possible_types`
- `.copied()` instead of `.cloned()` on Copy-type NodeIndex
- Move owned Vec<PlanNode> instead of cloning in flat_wrap_nodes

<!-- start metadata -->

<!-- [FED-1071] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [X] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[FED-1071]: https://apollographql.atlassian.net/browse/FED-1071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ