### PR TITLE
Remove deprecated `apollo.router.session.count.active` metric

### DIFF
--- a/.changesets/breaking_zach_router_1765_remove_session_count_active.md
+++ b/.changesets/breaking_zach_router_1765_remove_session_count_active.md
@@ -1,0 +1,7 @@
+### Remove deprecated `apollo.router.session.count.active` metric
+
+The `apollo.router.session.count.active` up/down counter — deprecated throughout 2.x — has been removed. It measured the number of in-flight GraphQL requests, duplicating the OpenTelemetry-compliant `http.server.active_requests` metric and causing confusion in dashboards that displayed both.
+
+If your dashboards or alerts reference `apollo.router.session.count.active` (exported as `apollo_router_session_count_active` in Prometheus), switch to [`http.server.active_requests`](https://www.apollographql.com/docs/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/instruments#opentelemetry-standard-instruments), which follows OpenTelemetry semantic conventions and measures the same value.
+
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/ROUTER-1765

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -200,13 +200,6 @@ impl HttpServerFactory for AxumHttpServerFactory {
                 configuration.supergraph.path
             );
 
-            tracing::warn!(
-                "The `apollo.router.session.count.active` metric is deprecated and may be \
-                 removed in a future release. Switch to the OpenTelemetry-compliant \
-                 `http.server.active_requests` metric instead. See \
-                 https://www.apollographql.com/docs/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments#session"
-            );
-
             // serve extra routers
 
             let listeners_and_routers =
@@ -407,13 +400,6 @@ async fn handle_graphql<RF: RouterFactory>(
     Extension(service_factory): Extension<RF>,
     http_request: Request<axum::body::Body>,
 ) -> impl IntoResponse {
-    let _guard = i64_up_down_counter_with_unit!(
-        "apollo.router.session.count.active",
-        "Amount of in-flight sessions (deprecated, use `http.server.active_requests` instead)",
-        "{session}",
-        1
-    );
-
     let HandlerOptions {
         early_cancel,
         experimental_log_on_broken_pipe,

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -88,16 +88,6 @@ You can attach custom attributes using [router selectors](/router/configuration/
 - `apollo.router.graphql_error` - counts GraphQL errors in responses. Also counts errors which occur during the response validation phase, which are represented in client responses as `extensions.valueCompletion` instead of actual GraphQL errors. Attributes:
   - `code`: error code, including `RESPONSE_VALIDATION_FAILED` in the case of a value completion error.
 
-## Session
-
-- `apollo.router.session.count.active` - Number of in-flight GraphQL requests. **Deprecated**: use `http.server.active_requests` instead.
-
-<Note>
-
-`apollo.router.session.count.active` is a legacy Apollo-specific metric. Apollo recommends using [`http.server.active_requests`](/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/instruments#opentelemetry-standard-instruments) instead, which follows OpenTelemetry semantic conventions and is the standard way to measure in-flight HTTP requests. `apollo.router.session.count.active` might be removed in a future release.
-
-</Note>
-
 ## Cache
 
 - `apollo.router.cache.size` — Number of entries in the cache

--- a/examples/telemetry/metric-rename.router.yaml
+++ b/examples/telemetry/metric-rename.router.yaml
@@ -48,10 +48,10 @@ telemetry:
             # Only these attributes will be preserved on the renamed metric
 
           # Example 5: Rename with custom description and unit
-          - name: apollo.router.session.count.active
-            rename: custom.active.sessions
-            description: "Number of active GraphQL sessions"
-            unit: "{session}"
+          - name: apollo.router.opened.subscriptions
+            rename: custom.active.subscriptions
+            description: "Number of currently open subscriptions"
+            unit: "{subscription}"
 
       # OTLP exporter - receives renamed metrics
       otlp:


### PR DESCRIPTION
The `apollo.router.session.count.active` up/down counter — deprecated throughout 2.x — has been removed. It measured the number of in-flight GraphQL requests, duplicating the OpenTelemetry-compliant `http.server.active_requests` metric and causing confusion in dashboards that displayed both.

If your dashboards or alerts reference `apollo.router.session.count.active` (exported as `apollo_router_session_count_active` in Prometheus), switch to [`http.server.active_requests`](https://www.apollographql.com/docs/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/instruments#opentelemetry-standard-instruments), which follows OpenTelemetry semantic conventions and measures the same value.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
