### PR TITLE
fix: avoid deep-hashing the response subtree during reference extraction

### DIFF
--- a/.changesets/fix_extended_reference_hashing.md
+++ b/.changesets/fix_extended_reference_hashing.md
@@ -1,0 +1,5 @@
+### Fix a performance regression in extended reference reporting ([PR #9473](https://github.com/apollographql/router/pull/9473))
+
+With `telemetry.apollo.metrics_reference_mode: extended`, fragment-spread deduplication in `extract_enums_from_selection_set` keyed a `HashSet` on `&Object`, which hashes the whole response subtree on every spread. Extraction cost grew with response size and fragment count. The set now keys on the object's pointer identity.
+
+By [@sethrperkins](https://github.com/sethrperkins) in https://github.com/apollographql/router/pull/9820

--- a/apollo-router/src/apollo_studio_interop/mod.rs
+++ b/apollo-router/src/apollo_studio_interop/mod.rs
@@ -434,7 +434,8 @@ fn extract_enums_from_selection_set(
     result_set: &mut ReferencedEnums,
 ) {
     let mut stack: Vec<(&[SpecSelection], &Object)> = vec![(selection_set, selection_response)];
-    let mut visited_fragments: HashSet<(&str, &Object)> = HashSet::new();
+    // Key by pointer to avoid deep-hashing the response subtree on every spread.
+    let mut visited_fragments: HashSet<(&str, *const Object)> = HashSet::new();
 
     while let Some((selections, response)) = stack.pop() {
         for selection in selections.iter() {
@@ -465,7 +466,7 @@ fn extract_enums_from_selection_set(
                     stack.push((selection_set, response));
                 }
                 SpecSelection::FragmentSpread { name, .. } => {
-                    let key = (name.as_str(), response);
+                    let key = (name.as_str(), response as *const Object);
                     if visited_fragments.insert(key)
                         && let Some(fragment) = fragments.get(name)
                     {


### PR DESCRIPTION
`extract_enums_from_selection_set` dedupes visited fragment spreads with a
`HashSet<(&str, &Object)>`. Hashing `&Object` hashes the pointed-to value, so
every fragment spread deep-hashes the whole response subtree. With
`metrics_reference_mode: extended`, extraction cost scales with response size
times fragment-spread count, and operations with many fragments over large
responses regress noticeably.

Keying on the object's pointer (`*const Object`) dedupes on identity, which is
all this needs, and restores O(1) insertion.

Introduced in #9473.

<!-- start metadata -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

- Documentation, metrics, and logs: no impact. This is an internal fix with no configuration or behavior change.
- Tests: the existing `apollo_studio_interop` unit tests exercise fragment-spread deduplication and pass unchanged. The change only swaps the dedup key from value to identity and preserves output, so no new test was added.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
