### PR TITLE
fix(ci): bump Windows resource class to fix page-file mmap failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ executors:
   windows_build: &windows_build_executor
     machine:
       image: "windows-server-2019-vs2019:2024.02.21"
-    resource_class: windows.medium
+    resource_class: windows.xlarge
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows
@@ -90,7 +90,7 @@ executors:
   windows_test: &windows_test_executor
     machine:
       image: "windows-server-2019-vs2019:2024.02.21"
-    resource_class: windows.medium
+    resource_class: windows.xlarge
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows


### PR DESCRIPTION
## Summary
- `test-windows_test`/`build_release-windows_build` nightlies on `dev` failed on 2026-07-09 (job 393535) and 2026-07-10 (job 393727) with `error[E0786]` / `failed to mmap file ...: The paging file is too small (os error 1455)` while linking extra test/example binaries (`router-fuzz`, `hello-world`).
- This is distinct from ROUTER-1928 (Windows CI OOM from `CARGO_BUILD_JOBS=4` on a downsized 15GB runner, fixed via `CARGO_BUILD_JOBS: 2` in #9664) — that fix addresses build parallelism; this is a page-file/virtual-memory limit tied to available RAM, unaffected by `CARGO_BUILD_JOBS`.
- Fix: bump `windows_build`/`windows_test` resource class from `windows.medium` (4 vCPU/15GB) to `windows.xlarge` (8 vCPU/30GB) — the alternative option ROUTER-1928 already identified but didn't apply at the time.

Fixes ROUTER-2000.

## Test plan
- [ ] YAML validated to parse (`ruby -ryaml`) — done locally
- [ ] Confirm next few nightly `test-windows_test`/`build_release-windows_build` runs on `dev` no longer show E0786/os error 1455

<!-- ROUTER-2000 -->