### PR TITLE
fix(ci): retry scoop install of mise, extend Windows timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,8 +281,19 @@ commands:
                   iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
             - run:
                 name: Install mise
+                no_output_timeout: 20m
                 command: |
-                  scoop install mise@${MISE_VERSION#v}
+                  for i in 1 2 3; do
+                    if scoop install mise@${MISE_VERSION#v}; then
+                      break
+                    fi
+                    if [ $i -eq 3 ]; then
+                      echo "scoop install mise failed after 3 attempts"
+                      exit 1
+                    fi
+                    echo "scoop install mise failed (attempt $i/3), retrying in $((i*5))s..."
+                    sleep $((i*5))
+                  done
                   for i in 1 2 3; do
                     if mise install --yes --quiet; then
                       break


### PR DESCRIPTION
## Summary
- `test-windows_test` failed on `dev` on 2026-07-13 (job 394003) and 2026-07-16 (job 394875) in the "Install mise" step with `Too long with no output (exceeded 10m0s): context deadline exceeded`.
- The step's `scoop install mise@${MISE_VERSION#v}` downloads from GitHub releases and occasionally stalled long enough to hit CircleCI's default 10-minute no-output timeout. The existing 3-attempt retry loop only wrapped `mise install --yes --quiet`, not the `scoop install` call, so a stalled download killed the job before any retry ever ran.
- Fix: wrap `scoop install mise@...` in the same retry-with-backoff pattern already used for `mise install --yes --quiet`, and set `no_output_timeout: 20m` on the step for headroom.

Fixes ROUTER-2001.

## Test plan
- [ ] YAML validated to parse (`ruby -ryaml`) — done locally
- [ ] Confirm subsequent Windows nightly/merge CI runs no longer hit the "Install mise" timeout

<!-- ROUTER-2001 -->