### PR TITLE
ci: retire test_updated_cargo_deps (backport of #9789 to dev-v2.10.x)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,9 +113,6 @@ parameters:
   quick_nightly:
     type: boolean
     default: false
-  test_updated_cargo_deps:
-    type: boolean
-    default: false
 
 # These are common environment variables that we want to set on on all jobs.
 # While these could conceivably be set on the CircleCI project settings'
@@ -498,90 +495,6 @@ jobs:
           platform: << parameters.platform >>
       - do_coverage
 
-  test_updated:
-    environment:
-      <<: *common_job_environment
-    parameters:
-      platform:
-        type: executor
-        default: amd_linux_test
-      from_test_updated_cargo_deps_workflow:
-        type: boolean
-        default: false
-    executor: << parameters.platform >>
-    steps:
-      - checkout
-      - setup_environment:
-          platform: << parameters.platform >>
-      - run:
-          name: Update all Rust dependencies
-          command: |
-            rm Cargo.lock
-            cargo fetch
-      - xtask_test:
-          variant: "updated"
-
-      - when:
-          condition:
-            equal:
-              [true, << parameters.from_test_updated_cargo_deps_workflow >>]
-          steps:
-            - slack/notify:
-                event: fail
-                custom: |
-                  {
-                    "blocks": [
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": ":x: The `test_updated_cargo_deps` workflow has **failed** for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`!"
-                        }
-                      },
-                      {
-                        "type": "actions",
-                        "elements": [
-                          {
-                            "type": "button",
-                            "action_id": "success_tagged_deploy_view",
-                            "text": {
-                              "type": "plain_text",
-                              "text": "View Job"
-                            },
-                            "url": "${CIRCLE_BUILD_URL}"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-            - slack/notify:
-                event: pass
-                custom: |
-                  {
-                    "blocks": [
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": ":white_check_mark: The `test_updated_cargo_deps` workflow has passed for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`."
-                        }
-                      },
-                      {
-                        "type": "actions",
-                        "elements": [
-                          {
-                            "type": "button",
-                            "action_id": "success_tagged_deploy_view",
-                            "text": {
-                              "type": "plain_text",
-                              "text": "View Job"
-                            },
-                            "url": "${CIRCLE_BUILD_URL}"
-                          }
-                        ]
-                      }
-                    ]
-                  }
   pre_verify_release:
     environment:
       <<: *common_job_environment
@@ -949,19 +862,12 @@ jobs:
                   helm push ${CHART} oci://ghcr.io/apollographql/helm-charts
 
 workflows:
-  test_updated_cargo_deps:
-    when: << pipeline.parameters.test_updated_cargo_deps >>
-    jobs:
-      - test_updated:
-          platform: amd_linux_test
-          from_test_updated_cargo_deps_workflow: true
   ci_checks:
     when:
       not:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
-          - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
       - lint:
           matrix:
@@ -1070,7 +976,6 @@ workflows:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
-          - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
       - pre_verify_release:
           matrix:
@@ -1148,7 +1053,6 @@ workflows:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
-          - << pipeline.parameters.test_updated_cargo_deps >>
     jobs:
       - secops/gitleaks:
           context:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
- `test_updated_cargo_deps` wiped `Cargo.lock` and ran `cargo fetch` before testing, as a canary for upstream dependency breakage ahead of an actual `cargo update`.
- This was retired on `dev` via #9789 (merged 2026-07-10) after failing every night for weeks — first on a `rhai_codegen` 3.2.0 incompatibility, then on an unrelated `http`-crate panic — with no one acting on the alerts. It only ever covered one platform (`amd_linux_test`); the nightly workflow's cross-platform test matrix already covers what's actually shipped.
- That retirement was never backported to `dev-v2.10.x`, so this branch kept running the job nightly and kept failing (visible in `#ii-router-ci-notifications` through 2026-07-16).
- This PR mirrors #9789 exactly for `dev-v2.10.x`: removes the `test_updated` job, the `test_updated_cargo_deps` workflow and pipeline parameter, and its references in the `ci_checks`/`release`/`security-scans` exclusion lists. Not a cherry-pick (the two configs had diverged enough to conflict) — hand-applied the same diff shape and diffed against `dev-v2.10.x` to confirm it's pure deletions.

Fixes ROUTER-1930.

## Follow-up (not in this repo)
Per #9789, the CircleCI Project Settings scheduled trigger that sets `test_updated_cargo_deps=true` nightly needs to be disabled/deleted for this branch too, if that was only done for `dev`.

## Test plan
- [x] YAML validated to parse (`ruby -ryaml`)
- [x] `git diff` against `dev-v2.10.x` confirms pure deletions, no unintended changes
- [ ] Confirm nightly pipeline on `dev-v2.10.x` still runs cleanly without this workflow after merge

<!-- ROUTER-1930 -->