### PR TITLE
fix(rhai): clone scope under the lock instead of holding it for the whole callback

### DIFF
--- a/.changesets/breaking_router_1877_rhai_scope_lock_contention.md
+++ b/.changesets/breaking_router_1877_rhai_scope_lock_contention.md
@@ -1,0 +1,13 @@
+### Stop holding the Rhai `scope` lock for the duration of non-curried callbacks  ([PR #9825](https://github.com/apollographql/router/pull/9825))
+
+Non-curried Rhai callbacks (`Fn("name")`, as opposed to closures) ran against a single `Scope` shared across every stage and every subgraph for the life of the router's Rhai instance, guarded by one mutex. That mutex was held for the callback's *entire* execution, serializing every concurrent non-curried callback against every other one - including sibling subgraph requests fanning out from the same client request.
+
+The router now holds that lock only long enough to clone the scope, then runs the callback against the private clone. Non-curried callbacks that read module-level constants (`apollo_sdl`, `Router.APOLLO_SDL`, etc.) are unaffected.
+
+> **Warning**
+>
+> Global variable mutations in non-curried callbacks (`Fn("name")`) no longer persist across invocations. Each call runs against a private clone of the scope, so a callback's writes to a global are discarded when it returns. Only the router's own `apollo_sdl` / `apollo_start` constants and whatever the script's top-level statements populated at startup are guaranteed visible to later calls. Scripts that relied on a named function mutating a global and reading that mutation in a subsequent callback — an undocumented and untested pattern — will need to be updated (for example, by using curried closures, which remain unaffected).
+
+Closures remain unaffected and are still the recommended pattern for avoiding this lock (see [the Rhai docs](https://www.apollographql.com/docs/graphos/routing/customization/rhai#curried-vs-non-curried-callback-function)); this change reduces the cost of the alternative rather than replacing the recommendation.
+
+By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9825

--- a/.changesets/fix_rohan_b99_router_1876_rhai_scope_lock.md
+++ b/.changesets/fix_rohan_b99_router_1876_rhai_scope_lock.md
@@ -1,0 +1,9 @@
+### Stop holding the Rhai `scope` lock for the duration of non-curried callbacks ([ROUTER-1876](https://apollographql.atlassian.net/browse/ROUTER-1876))
+
+Non-curried Rhai callbacks (`Fn("name")`, as opposed to closures) ran against a single `Scope` shared across every stage and every subgraph for the life of the router's Rhai instance, guarded by one mutex. That mutex was held for the callback's *entire* execution, serializing every concurrent non-curried callback against every other one -- including sibling subgraph requests fanning out from the same client request.
+
+The router now holds that lock only long enough to clone the scope, then runs the callback against the private clone. Non-curried callbacks that read module-level constants (`apollo_sdl`, `Router.APOLLO_SDL`, etc.) are unaffected. Scripts relying on a named function's mutation of a global variable persisting into the *next* callback invocation -- an undocumented and untested pattern -- will no longer see that mutation persist; each call now sees a fresh copy of the scope as it stood after the script's own top-level initialization.
+
+Closures remain unaffected and are still the recommended pattern for avoiding this lock (see [the Rhai docs](/graphos/routing/customization/rhai#curried-vs-non-curried-callback-functions)); this change reduces the cost of the alternative rather than replacing the recommendation.
+
+By [@rohan-b99](https://github.com/rohan-b99)

--- a/.changesets/fix_rohan_b99_router_1876_rhai_scope_lock.md
+++ b/.changesets/fix_rohan_b99_router_1876_rhai_scope_lock.md
@@ -1,9 +1,0 @@
-### Stop holding the Rhai `scope` lock for the duration of non-curried callbacks ([ROUTER-1876](https://apollographql.atlassian.net/browse/ROUTER-1876))
-
-Non-curried Rhai callbacks (`Fn("name")`, as opposed to closures) ran against a single `Scope` shared across every stage and every subgraph for the life of the router's Rhai instance, guarded by one mutex. That mutex was held for the callback's *entire* execution, serializing every concurrent non-curried callback against every other one -- including sibling subgraph requests fanning out from the same client request.
-
-The router now holds that lock only long enough to clone the scope, then runs the callback against the private clone. Non-curried callbacks that read module-level constants (`apollo_sdl`, `Router.APOLLO_SDL`, etc.) are unaffected. Scripts relying on a named function's mutation of a global variable persisting into the *next* callback invocation -- an undocumented and untested pattern -- will no longer see that mutation persist; each call now sees a fresh copy of the scope as it stood after the script's own top-level initialization.
-
-Closures remain unaffected and are still the recommended pattern for avoiding this lock (see [the Rhai docs](/graphos/routing/customization/rhai#curried-vs-non-curried-callback-functions)); this change reduces the cost of the alternative rather than replacing the recommendation.
-
-By [@rohan-b99](https://github.com/rohan-b99)

--- a/.changesets/fix_rohan_b99_router_1876_rhai_spawn_blocking.md
+++ b/.changesets/fix_rohan_b99_router_1876_rhai_spawn_blocking.md
@@ -1,7 +1,7 @@
-### Run Rhai script hooks on the blocking thread pool ([ROUTER-1876](https://apollographql.atlassian.net/browse/ROUTER-1876))
+### Run Rhai script hooks on the blocking thread pool ([PR #9815](https://github.com/apollographql/router/pull/9815))
 
 Rhai request and response hooks were evaluated inline on the Tokio async executor thread. A script with a loop, regex, or other CPU-bound work held that thread for the duration of its evaluation, delaying every other in-flight request scheduled on it.
 
 Rhai script evaluation now runs via `tokio::task::spawn_blocking`, so it executes on Tokio's dedicated blocking thread pool instead of an async executor thread.
 
-By [@rohan-b99](https://github.com/rohan-b99)
+By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9815

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -35,5 +35,9 @@ name = "rhai_string_interning"
 harness = false
 
 [[bench]]
+name = "rhai_scope_lock"
+harness = false
+
+[[bench]]
 name = "query_plan_cache_concurrency"
 harness = false

--- a/apollo-router-benchmarks/benches/rhai_scope_lock.rs
+++ b/apollo-router-benchmarks/benches/rhai_scope_lock.rs
@@ -5,23 +5,28 @@
 //!   - Curried (closure) callbacks: `FnPtr::call`, no shared state touched.
 //!   - Non-curried (named function / `Fn("name")`) callbacks: `Engine::call_fn` against a
 //!     single `Arc<Mutex<Scope<'static>>>` shared by every clone of the plugin's `RhaiService`
-//!     for the lifetime of the router's Rhai instance (until the next hot-reload).
+//!     for the lifetime of the router's Rhai instance (until the next hot-reload). `execute()`
+//!     clones the scope under the lock and calls against the private clone, so the lock is
+//!     only ever held for the clone, not the call.
 //!
 //! This benchmark isolates that difference: it does not touch the string interner lock
-//! (disabled via `set_max_strings_interned(0)` in both configurations, matching the
+//! (disabled via `set_max_strings_interned(0)` in every configuration, matching the
 //! recommended `intern_strings: false` setting — see `rhai_string_interning.rs`), so any
 //! throughput gap observed here is attributable to the `scope` mutex alone.
 //!
-//! Two configurations:
-//!   - `non_curried` — one shared `Arc<Mutex<Scope>>`, `Engine::call_fn` locks it on every call,
-//!     exactly mirroring `execute()`'s non-curried branch.
+//! Three configurations:
 //!   - `curried` — a curried `FnPtr` (closure capturing a bound value, matching the docs'
 //!     own curried example), `FnPtr::call` touches no shared scope at all.
+//!   - `non_curried_cloned` — one shared `Arc<Mutex<Scope>>`, locked only to `Scope::clone()`
+//!     it, then `Engine::call_fn` against the owned clone. Mirrors `execute()`'s current
+//!     non-curried branch.
+//!   - `non_curried_locked` — the pre-fix shape: the same shared `Arc<Mutex<Scope>>` held
+//!     for the full `call_fn`. Kept as a baseline to show the size of the improvement.
 //!
 //! Two variants:
 //!   - `sequential` — single thread, measures raw per-call cost with no contention.
 //!   - `concurrent_N` — N OS threads sharing one `Arc<Engine>` (+ one shared `Arc<Mutex<Scope>>`
-//!     for the non-curried case), surfacing scope-mutex serialization under concurrent load —
+//!     for the non-curried cases), surfacing scope-mutex serialization under concurrent load —
 //!     the scenario that matters for a router handling concurrent requests, or fanning out to
 //!     multiple subgraphs within a single request.
 //!
@@ -49,6 +54,8 @@ use rhai::AST;
 // How many OS threads share the engine (and, for non-curried, the scope mutex) in the
 // concurrent variant. Matches rhai_string_interning.rs.
 const CONCURRENCY: usize = 8;
+
+const ARG: &str = "a=1;b=2;c=3";
 
 // A script body representative of typical request-callback work (cookie/header parsing,
 // map building, string ops) -- deliberately modest, not a worst case, since this is meant to
@@ -108,7 +115,73 @@ fn get_curried_fnptr(engine: &Engine, ast: &AST) -> FnPtr {
     fnptr
 }
 
-const ARG: &str = "a=1;b=2;c=3";
+/// One non-curried call, current (post-fix) shape: lock only to clone the scope.
+fn call_non_curried_cloned(engine: &Engine, ast: &AST, scope: &Mutex<Scope<'static>>) {
+    let mut scope = scope.lock().unwrap().clone();
+    let _: Dynamic = engine
+        .call_fn(&mut scope, ast, "process_request", (ARG.to_string(),))
+        .expect("call_fn ok");
+}
+
+/// One non-curried call, pre-fix shape: lock held for the whole call_fn. Baseline only.
+fn call_non_curried_locked(engine: &Engine, ast: &AST, scope: &Mutex<Scope<'static>>) {
+    let mut guard = scope.lock().unwrap();
+    let _: Dynamic = engine
+        .call_fn(&mut guard, ast, "process_request", (ARG.to_string(),))
+        .expect("call_fn ok");
+}
+
+fn bench_variant(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    label: &'static str,
+    call: fn(&Engine, &AST, &Mutex<Scope<'static>>),
+) {
+    let engine = Arc::new(make_engine());
+    let ast = Arc::new(engine.compile(non_curried_script()).expect("compiles"));
+
+    // Sequential: one call at a time, still through the same lock/clone/call_fn path.
+    {
+        let engine = engine.clone();
+        let ast = ast.clone();
+        let scope = Arc::new(Mutex::new(Scope::new()));
+        group.bench_with_input(BenchmarkId::new("sequential", label), label, |b, _| {
+            b.iter(|| call(&engine, &ast, &scope));
+        });
+    }
+
+    // Concurrent: CONCURRENCY threads sharing one Arc<Mutex<Scope>>, exactly mirroring
+    // every request-time invocation of a non-curried callback in execute().
+    {
+        let engine = engine.clone();
+        let ast = ast.clone();
+        group.bench_with_input(
+            BenchmarkId::new(format!("concurrent_{CONCURRENCY}"), label),
+            label,
+            |b, _| {
+                b.iter_custom(|iters| {
+                    let per_thread = (iters as usize).max(1).div_ceil(CONCURRENCY);
+                    let engine = engine.clone();
+                    let ast = ast.clone();
+                    let scope = Arc::new(Mutex::new(Scope::new()));
+                    let start = Instant::now();
+                    std::thread::scope(|s| {
+                        for _ in 0..CONCURRENCY {
+                            let engine = engine.clone();
+                            let ast = ast.clone();
+                            let scope = scope.clone();
+                            s.spawn(move || {
+                                for _ in 0..per_thread {
+                                    call(&engine, &ast, &scope);
+                                }
+                            });
+                        }
+                    });
+                    start.elapsed()
+                });
+            },
+        );
+    }
+}
 
 fn rhai_scope_lock_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("rhai_scope_lock");
@@ -117,71 +190,8 @@ fn rhai_scope_lock_benchmark(c: &mut Criterion) {
         .sample_size(200)
         .throughput(Throughput::Elements(1));
 
-    // ---------------- non_curried: shared Arc<Mutex<Scope>>, locked every call ----------------
-    {
-        let engine = Arc::new(make_engine());
-        let ast = Arc::new(engine.compile(non_curried_script()).expect("compiles"));
-
-        // Sequential: one call at a time, still through the same lock/call_fn path.
-        {
-            let engine = engine.clone();
-            let ast = ast.clone();
-            let scope = Arc::new(Mutex::new(Scope::new()));
-            group.bench_with_input(
-                BenchmarkId::new("sequential", "non_curried"),
-                "non_curried",
-                |b, _| {
-                    b.iter(|| {
-                        let mut guard = scope.lock().unwrap();
-                        let _: Dynamic = engine
-                            .call_fn(&mut guard, &ast, "process_request", (ARG.to_string(),))
-                            .expect("call_fn ok");
-                    });
-                },
-            );
-        }
-
-        // Concurrent: CONCURRENCY threads sharing one Arc<Mutex<Scope>>, exactly mirroring
-        // every request-time invocation of a non-curried callback in execute().
-        {
-            let engine = engine.clone();
-            let ast = ast.clone();
-            group.bench_with_input(
-                BenchmarkId::new(format!("concurrent_{CONCURRENCY}"), "non_curried"),
-                "non_curried",
-                |b, _| {
-                    b.iter_custom(|iters| {
-                        let per_thread = (iters as usize).max(1).div_ceil(CONCURRENCY);
-                        let engine = engine.clone();
-                        let ast = ast.clone();
-                        let scope = Arc::new(Mutex::new(Scope::new()));
-                        let start = Instant::now();
-                        std::thread::scope(|s| {
-                            for _ in 0..CONCURRENCY {
-                                let engine = engine.clone();
-                                let ast = ast.clone();
-                                let scope = scope.clone();
-                                s.spawn(move || {
-                                    for _ in 0..per_thread {
-                                        let mut guard = scope.lock().unwrap();
-                                        let _: Dynamic = engine
-                                            .call_fn(
-                                                &mut guard,
-                                                &ast,
-                                                "process_request",
-                                                (ARG.to_string(),),
-                                            )
-                                            .expect("call_fn ok");
-                                    }
-                                });
-                            }
-                        });
-                        start.elapsed()
-                    });
-                },
-            );
-        }
-    }
+    bench_variant(&mut group, "non_curried_locked", call_non_curried_locked);
+    bench_variant(&mut group, "non_curried_cloned", call_non_curried_cloned);
 
     // ---------------- curried: no shared scope, FnPtr::call ----------------
     {

--- a/apollo-router-benchmarks/benches/rhai_scope_lock.rs
+++ b/apollo-router-benchmarks/benches/rhai_scope_lock.rs
@@ -1,0 +1,250 @@
+//! Benchmark: Rhai `scope` mutex — direct engine, no router stack.
+//!
+//! The router's Rhai plugin (`apollo-router/src/plugins/rhai/mod.rs::execute`) dispatches
+//! every registered callback one of two ways:
+//!   - Curried (closure) callbacks: `FnPtr::call`, no shared state touched.
+//!   - Non-curried (named function / `Fn("name")`) callbacks: `Engine::call_fn` against a
+//!     single `Arc<Mutex<Scope<'static>>>` shared by every clone of the plugin's `RhaiService`
+//!     for the lifetime of the router's Rhai instance (until the next hot-reload).
+//!
+//! This benchmark isolates that difference: it does not touch the string interner lock
+//! (disabled via `set_max_strings_interned(0)` in both configurations, matching the
+//! recommended `intern_strings: false` setting — see `rhai_string_interning.rs`), so any
+//! throughput gap observed here is attributable to the `scope` mutex alone.
+//!
+//! Two configurations:
+//!   - `non_curried` — one shared `Arc<Mutex<Scope>>`, `Engine::call_fn` locks it on every call,
+//!     exactly mirroring `execute()`'s non-curried branch.
+//!   - `curried` — a curried `FnPtr` (closure capturing a bound value, matching the docs'
+//!     own curried example), `FnPtr::call` touches no shared scope at all.
+//!
+//! Two variants:
+//!   - `sequential` — single thread, measures raw per-call cost with no contention.
+//!   - `concurrent_N` — N OS threads sharing one `Arc<Engine>` (+ one shared `Arc<Mutex<Scope>>`
+//!     for the non-curried case), surfacing scope-mutex serialization under concurrent load —
+//!     the scenario that matters for a router handling concurrent requests, or fanning out to
+//!     multiple subgraphs within a single request.
+//!
+//! Run with:
+//! ```
+//! cargo bench -p apollo-router-benchmarks --bench rhai_scope_lock
+//! ```
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use std::time::Instant;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use rhai::Dynamic;
+use rhai::Engine;
+use rhai::FnPtr;
+use rhai::Scope;
+use rhai::AST;
+
+// How many OS threads share the engine (and, for non-curried, the scope mutex) in the
+// concurrent variant. Matches rhai_string_interning.rs.
+const CONCURRENCY: usize = 8;
+
+// A script body representative of typical request-callback work (cookie/header parsing,
+// map building, string ops) -- deliberately modest, not a worst case, since this is meant to
+// model the router's own documented "sweet spot" for Rhai (simple header/context tweaks).
+fn body() -> &'static str {
+    r#"
+        let out = #{};
+        let cookies = request.split(";");
+        for cookie in cookies {
+            let kv = cookie.split("=");
+            out[kv[0]] = kv[1];
+        }
+        out.len()
+    "#
+}
+
+fn non_curried_script() -> String {
+    format!("fn process_request(request) {{ {} }}", body())
+}
+
+// Mirrors the docs' own curried example (index.mdx "Curried vs. non-curried callback
+// functions"): a local value is captured by the closure, so Rhai actually curries it.
+fn curried_maker_script() -> String {
+    format!(
+        r#"
+        fn make_handler() {{
+            let bound_marker = "closure-captured";
+            let handler = |request| {{
+                let marker = bound_marker;
+                {}
+            }};
+            handler
+        }}
+        "#,
+        body()
+    )
+}
+
+fn make_engine() -> Engine {
+    let mut engine = Engine::new();
+    // Isolate the scope-mutex effect from the (separately documented / benchmarked) string
+    // interner lock -- see rhai_string_interning.rs.
+    engine.set_max_strings_interned(0);
+    engine
+}
+
+fn get_curried_fnptr(engine: &Engine, ast: &AST) -> FnPtr {
+    let mut scope = Scope::new();
+    let result: Dynamic = engine
+        .call_fn(&mut scope, ast, "make_handler", ())
+        .expect("make_handler failed");
+    let fnptr = result.try_cast::<FnPtr>().expect("not a FnPtr");
+    assert!(
+        fnptr.is_curried(),
+        "expected a curried FnPtr (closure with captured var)"
+    );
+    fnptr
+}
+
+const ARG: &str = "a=1;b=2;c=3";
+
+fn rhai_scope_lock_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rhai_scope_lock");
+    group
+        .measurement_time(Duration::from_secs(20))
+        .sample_size(200)
+        .throughput(Throughput::Elements(1));
+
+    // ---------------- non_curried: shared Arc<Mutex<Scope>>, locked every call ----------------
+    {
+        let engine = Arc::new(make_engine());
+        let ast = Arc::new(engine.compile(non_curried_script()).expect("compiles"));
+
+        // Sequential: one call at a time, still through the same lock/call_fn path.
+        {
+            let engine = engine.clone();
+            let ast = ast.clone();
+            let scope = Arc::new(Mutex::new(Scope::new()));
+            group.bench_with_input(
+                BenchmarkId::new("sequential", "non_curried"),
+                "non_curried",
+                |b, _| {
+                    b.iter(|| {
+                        let mut guard = scope.lock().unwrap();
+                        let _: Dynamic = engine
+                            .call_fn(&mut guard, &ast, "process_request", (ARG.to_string(),))
+                            .expect("call_fn ok");
+                    });
+                },
+            );
+        }
+
+        // Concurrent: CONCURRENCY threads sharing one Arc<Mutex<Scope>>, exactly mirroring
+        // every request-time invocation of a non-curried callback in execute().
+        {
+            let engine = engine.clone();
+            let ast = ast.clone();
+            group.bench_with_input(
+                BenchmarkId::new(format!("concurrent_{CONCURRENCY}"), "non_curried"),
+                "non_curried",
+                |b, _| {
+                    b.iter_custom(|iters| {
+                        let per_thread = (iters as usize).max(1).div_ceil(CONCURRENCY);
+                        let engine = engine.clone();
+                        let ast = ast.clone();
+                        let scope = Arc::new(Mutex::new(Scope::new()));
+                        let start = Instant::now();
+                        std::thread::scope(|s| {
+                            for _ in 0..CONCURRENCY {
+                                let engine = engine.clone();
+                                let ast = ast.clone();
+                                let scope = scope.clone();
+                                s.spawn(move || {
+                                    for _ in 0..per_thread {
+                                        let mut guard = scope.lock().unwrap();
+                                        let _: Dynamic = engine
+                                            .call_fn(
+                                                &mut guard,
+                                                &ast,
+                                                "process_request",
+                                                (ARG.to_string(),),
+                                            )
+                                            .expect("call_fn ok");
+                                    }
+                                });
+                            }
+                        });
+                        start.elapsed()
+                    });
+                },
+            );
+        }
+    }
+
+    // ---------------- curried: no shared scope, FnPtr::call ----------------
+    {
+        let engine = Arc::new(make_engine());
+        let ast = Arc::new(engine.compile(curried_maker_script()).expect("compiles"));
+        let fnptr = get_curried_fnptr(&engine, &ast);
+
+        // Sequential
+        {
+            let engine = engine.clone();
+            let ast = ast.clone();
+            let fnptr = fnptr.clone();
+            group.bench_with_input(
+                BenchmarkId::new("sequential", "curried"),
+                "curried",
+                |b, _| {
+                    b.iter(|| {
+                        let _: Dynamic = fnptr
+                            .call(&engine, &ast, (ARG.to_string(),))
+                            .expect("curried call ok");
+                    });
+                },
+            );
+        }
+
+        // Concurrent: CONCURRENCY threads, no shared mutable state at all.
+        {
+            let engine = engine.clone();
+            let ast = ast.clone();
+            let fnptr = fnptr.clone();
+            group.bench_with_input(
+                BenchmarkId::new(format!("concurrent_{CONCURRENCY}"), "curried"),
+                "curried",
+                |b, _| {
+                    b.iter_custom(|iters| {
+                        let per_thread = (iters as usize).max(1).div_ceil(CONCURRENCY);
+                        let engine = engine.clone();
+                        let ast = ast.clone();
+                        let fnptr = fnptr.clone();
+                        let start = Instant::now();
+                        std::thread::scope(|s| {
+                            for _ in 0..CONCURRENCY {
+                                let engine = engine.clone();
+                                let ast = ast.clone();
+                                let fnptr = fnptr.clone();
+                                s.spawn(move || {
+                                    for _ in 0..per_thread {
+                                        let _: Dynamic = fnptr
+                                            .call(&engine, &ast, (ARG.to_string(),))
+                                            .expect("curried call ok");
+                                    }
+                                });
+                            }
+                        });
+                        start.elapsed()
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, rhai_scope_lock_benchmark);
+criterion_main!(benches);

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -811,6 +811,16 @@ fn process_error(error: Box<EvalAltResult>) -> ErrorDetails {
 /// The script runs on Tokio's blocking thread pool via `spawn_blocking`, so it never occupies
 /// an async executor thread for the duration of its evaluation.
 ///
+/// Non-curried callbacks (`Fn("name")`) need a `Scope` to call into, since Rhai's `call_fn`
+/// takes one by mutable reference. Rather than holding `rhai_service.scope`'s mutex for the
+/// call's full duration -- which would serialize every non-curried callback across every
+/// concurrent request and every subgraph in a fan-out -- we hold it only long enough to clone
+/// the scope, then run the call against the private clone. This is cheap: under Rhai's `sync`
+/// feature, `Scope`'s `Dynamic` entries are `Arc`-backed, so cloning is O(number of globals),
+/// not O(their size). The trade-off is that a callback's writes to a global no longer persist
+/// to the next call -- only the router's own `apollo_sdl`/`apollo_start` constants and whatever
+/// the script's top-level statements populated at startup are guaranteed visible.
+///
 /// Emits a metric recording the time spent executing the Rhai script.
 async fn execute(
     rhai_service: &RhaiService,
@@ -826,10 +836,10 @@ async fn execute(
         let result = if callback.is_curried() {
             callback.call(&rhai_service.engine, &rhai_service.ast, args)
         } else {
-            let mut guard = rhai_service.scope.lock();
+            let mut scope = rhai_service.scope.lock().clone();
             rhai_service
                 .engine
-                .call_fn(&mut guard, &rhai_service.ast, callback.fn_name(), args)
+                .call_fn(&mut scope, &rhai_service.ast, callback.fn_name(), args)
         };
 
         (result, start.elapsed())

--- a/docs/source/routing/customization/rhai/index.mdx
+++ b/docs/source/routing/customization/rhai/index.mdx
@@ -325,7 +325,7 @@ Each hook in your Rhai script's [main file](#main-file) is passed a `service` ob
     
 <Note>
 
-**About Currying and performance**: Rhai language supports [currying](https://rhai.rs/book/language/fn-curry.html), a technique that binds values into a function to produce a closure, and this has a performance impact in the router: curried (closure-based) callbacks are invoked **without acquiring the global `scope` mutex**, whereas non-curried callbacks briefly lock the `scope` to clone it before each call. The clone is cheap (proportional to the number of global variables in your script, not their size), so non-curried callbacks no longer serialize for their full execution time, but closure-based callbacks still avoid the lock entirely and are the recommended default.
+**About Currying and performance**: Rhai language supports [currying](https://rhai.rs/book/language/fn-curry.html), a technique that binds values into a function to produce a closure, and this has a performance impact in the router: curried (closure-based) callbacks execute **without acquiring the global `scope` mutex**, whereas non-curried callbacks briefly lock the `scope` to clone it before each call. The clone is efficient (proportional to the number of global variables in your script, not their size), so non-curried callbacks no longer serialize for their full execution time, but closure-based callbacks still avoid the lock entirely and are the recommended default.
 
 See [Curried vs. non-curried callback functions](https://www.apollographql.com/docs/graphos/routing/customization/rhai#curried-vs-non-curried-callback-functions) for examples.
 

--- a/docs/source/routing/customization/rhai/index.mdx
+++ b/docs/source/routing/customization/rhai/index.mdx
@@ -325,7 +325,7 @@ Each hook in your Rhai script's [main file](#main-file) is passed a `service` ob
     
 <Note>
 
-**About Currying and performance**: Rhai language supports [currying](https://rhai.rs/book/language/fn-curry.html), a technique that binds values into a function to produce a closure, and this has a direct performance impact in the router: curried (closure-based) callbacks are invoked **without acquiring the global `scope` mutex**, whereas non-curried callbacks lock the `scope` on every call, serializing execution across all concurrent requests. For this reason, closure-based callbacks are the recommended default.
+**About Currying and performance**: Rhai language supports [currying](https://rhai.rs/book/language/fn-curry.html), a technique that binds values into a function to produce a closure, and this has a performance impact in the router: curried (closure-based) callbacks are invoked **without acquiring the global `scope` mutex**, whereas non-curried callbacks briefly lock the `scope` to clone it before each call. The clone is cheap (proportional to the number of global variables in your script, not their size), so non-curried callbacks no longer serialize for their full execution time, but closure-based callbacks still avoid the lock entirely and are the recommended default.
 
 See [Curried vs. non-curried callback functions](https://www.apollographql.com/docs/graphos/routing/customization/rhai#curried-vs-non-curried-callback-functions) for examples.
 
@@ -355,11 +355,11 @@ fn process_request(request) {
 
 ### Curried vs. non-curried callback functions
 
-Non-curried (function pointer), locks `scope` on every call:
+Non-curried (function pointer), briefly locks `scope` to clone it on every call:
 
 ```rhai
 fn process_request(request) {
-    // accesses scope on every invocation
+    // accesses a private clone of scope on every invocation
 }
 
 router.add_request_handler(process_request);


### PR DESCRIPTION
Non-curried Rhai callbacks held the shared scope mutex for their entire
execution, serializing every concurrent request (and every subgraph in a
fan-out) using a non-curried callback. Benchmarking showed throughput at
8-way concurrency actually regressing 41% below the single-threaded number.

Hold the lock only long enough to clone the scope, then run call_fn against
the private clone. The clone is cheap (Arc-backed under Rhai's sync feature),
and post-fix concurrent throughput is now ~4x higher than the locked baseline
at the same concurrency. Updates the docs describing the old locking
behavior and extends the rhai_scope_lock benchmark to compare all three
variants (curried, cloned, and the old locked baseline).

<!-- start metadata -->

<!-- [ROUTER-1877] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary


**Notes**

- Question: should we keep the benchmark in-repo?
- Change this to target dev-v3.x after #9815 is merged

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1877]: https://apollographql.atlassian.net/browse/ROUTER-1877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ