### PR TITLE
ci: include unstripped binary in -debug images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -726,25 +726,33 @@ jobs:
 
                   BASE_VERSION=$(cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[0].version')
                   ARTIFACT_FILENAME="router-v${BASE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+                  DEBUG_ARTIFACT_FILENAME="router-v${BASE_VERSION}-x86_64-unknown-linux-gnu-debug.tar.gz"
                   ARTIFACT_URL="https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/artifacts/${ARTIFACT_FILENAME}"
+                  DEBUG_ARTIFACT_URL="https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/artifacts/${DEBUG_ARTIFACT_FILENAME}"
                   VERSION="v$(echo "${BASE_VERSION}" | tr "+" "-")"
                   ROUTER_TAG=ghcr.io/apollographql/nightly/router
 
-                  # Validate local artifact exists and calculate its checksum as a safety net
-                  if [ ! -f "artifacts/${ARTIFACT_FILENAME}" ]; then
-                    echo "Error: Local artifact not found: artifacts/${ARTIFACT_FILENAME}"
-                    exit 1
-                  fi
+                  # Validate local artifacts exist and calculate checksums as a safety net
+                  for FILENAME in "${ARTIFACT_FILENAME}" "${DEBUG_ARTIFACT_FILENAME}"; do
+                    if [ ! -f "artifacts/${FILENAME}" ]; then
+                      echo "Error: Local artifact not found: artifacts/${FILENAME}"
+                      exit 1
+                    fi
+                  done
                   LOCAL_ARTIFACT_SHA256SUM=$(sha256sum "artifacts/${ARTIFACT_FILENAME}" | cut -d' ' -f1)
+                  LOCAL_DEBUG_ARTIFACT_SHA256SUM=$(sha256sum "artifacts/${DEBUG_ARTIFACT_FILENAME}" | cut -d' ' -f1)
                   echo "Local artifact checksum: ${LOCAL_ARTIFACT_SHA256SUM}"
+                  echo "Local debug artifact checksum: ${LOCAL_DEBUG_ARTIFACT_SHA256SUM}"
 
-                  # Download the artifact and calculate its checksum
-                  echo "Downloading artifact to calculate checksum..."
+                  # Download each artifact and calculate its checksum
+                  echo "Downloading artifacts to calculate checksums..."
                   curl -sSL -H "Circle-Token: ${CIRCLE_TOKEN}" -o "router-artifact.tar.gz" "${ARTIFACT_URL}"
-
-                  # Calculate checksum of the tarball (not the binary inside)
                   ARTIFACT_URL_SHA256SUM=$(sha256sum "router-artifact.tar.gz" | cut -d' ' -f1)
                   rm -f router-artifact.tar.gz
+
+                  curl -sSL -H "Circle-Token: ${CIRCLE_TOKEN}" -o "router-debug-artifact.tar.gz" "${DEBUG_ARTIFACT_URL}"
+                  DEBUG_ARTIFACT_URL_SHA256SUM=$(sha256sum "router-debug-artifact.tar.gz" | cut -d' ' -f1)
+                  rm -f router-debug-artifact.tar.gz
 
                   # Compare local vs remote artifact checksums
                   if [ "${LOCAL_ARTIFACT_SHA256SUM}" != "${ARTIFACT_URL_SHA256SUM}" ]; then
@@ -753,14 +761,25 @@ jobs:
                     echo "Remote: ${ARTIFACT_URL_SHA256SUM}"
                     exit 1
                   fi
+                  if [ "${LOCAL_DEBUG_ARTIFACT_SHA256SUM}" != "${DEBUG_ARTIFACT_URL_SHA256SUM}" ]; then
+                    echo "Error: Local and remote debug artifact checksums don't match!"
+                    echo "Local:      ${LOCAL_DEBUG_ARTIFACT_SHA256SUM}"
+                    echo "Remote: ${DEBUG_ARTIFACT_URL_SHA256SUM}"
+                    exit 1
+                  fi
                   echo "Local and remote artifact checksums match: ${LOCAL_ARTIFACT_SHA256SUM}"
+                  echo "Local and remote debug artifact checksums match: ${LOCAL_DEBUG_ARTIFACT_SHA256SUM}"
 
                   echo "REPO_URL: ${REPO_URL}"
                   echo "BASE_VERSION: ${BASE_VERSION}"
                   echo "ARTIFACT_FILENAME: ${ARTIFACT_FILENAME}"
+                  echo "DEBUG_ARTIFACT_FILENAME: ${DEBUG_ARTIFACT_FILENAME}"
                   echo "ARTIFACT_URL: ${ARTIFACT_URL}"
+                  echo "DEBUG_ARTIFACT_URL: ${DEBUG_ARTIFACT_URL}"
                   echo "ARTIFACT_URL_SHA256SUM: ${ARTIFACT_URL_SHA256SUM}"
+                  echo "DEBUG_ARTIFACT_URL_SHA256SUM: ${DEBUG_ARTIFACT_URL_SHA256SUM}"
                   echo "LOCAL_ARTIFACT_SHA256SUM: ${LOCAL_ARTIFACT_SHA256SUM}"
+                  echo "LOCAL_DEBUG_ARTIFACT_SHA256SUM: ${LOCAL_DEBUG_ARTIFACT_SHA256SUM}"
                   echo "VERSION: ${VERSION}"
                   echo "ROUTER_TAG: ${ROUTER_TAG}"
 
@@ -772,10 +791,10 @@ jobs:
                   # Note: GH Token owned by apollo-bot2, no expire
                   echo ${GITHUB_OCI_TOKEN} | docker login ghcr.io -u apollo-bot2 --password-stdin
                   # TODO: Can't figure out how to build multi-arch image from ARTIFACT_URL right now. Figure out later...
-                  # Build and push debug image
-                  docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug dockerfiles/.
+                  # Build and push debug image (unstripped binary + heaptrack)
+                  docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${DEBUG_ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${DEBUG_ARTIFACT_URL_SHA256SUM}" --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug dockerfiles/.
                   docker push ${ROUTER_TAG}:${VERSION}-debug
-                  # Build and push release image
+                  # Build and push release image (stripped binary)
                   docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg ROUTER_RELEASE=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} dockerfiles/.
                   docker push ${ROUTER_TAG}:${VERSION}
                   # save containers for analysis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,13 @@ incremental = false
 inherits = "release"
 debug = 1
 
+# Used by `cargo xtask dist` for release artifacts. Keeps line-table debuginfo
+# so package can emit both a stripped tarball and an unstripped -debug tarball
+# from a single build.
+[profile.release-dist]
+inherits = "release"
+debug = 1
+
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -3,6 +3,7 @@ ARG ROUTER_RELEASE=latest
 ARG ARTIFACT_URL=
 ARG CIRCLE_TOKEN=
 ARG ARTIFACT_URL_SHA256SUM=
+ARG DEBUG_IMAGE=false
 # We will use TARGETPLATFORM inside the download_and_validate_router.sh script
 # It is set automatically by Docker when doing a buildx build, see:
 #  https://docs.docker.com/build/building/multi-platform/

--- a/dockerfiles/diy/build_docker_image.sh
+++ b/dockerfiles/diy/build_docker_image.sh
@@ -18,9 +18,10 @@
 # Note: This utility makes assumptions about the existence of files relative
 #       to the directory where it is executed. To work correctly you must
 #       execute in the "repo"/dockerfiles/diy directory.
-# Note: A debug image is an image where heaptrack is installed. The router
-#       is still a release build router, but all memory is being tracked
-#       under heaptrack. (https://github.com/KDE/heaptrack)
+# Note: A debug image is an image where heaptrack is installed and the router
+#       binary retains debuginfo (line tables). Memory is tracked under
+#       heaptrack (https://github.com/KDE/heaptrack). When building from a
+#       released version, the -debug tarball (unstripped binary) is used.
 # Note: When I first wrote this script, I was careful to make sure that various
 #       invalid combinations of parameters were detected. As the functionality
 #       has grown, I've become less careful. So, take care you don't do things
@@ -38,7 +39,7 @@ usage () {
    printf "Usage: build_docker_image.sh [-b [-r <repo>]] [-d] [-m <arch>] [-n <name>] [<release>]\n"
    printf "\t-a build docker image from a build artifact\n"
    printf "\t-b build docker image from the default repo, if not present build from a released version\n"
-   printf "\t-d build debug image, router will run under control of heaptrack\n"
+   printf "\t-d build debug image, unstripped router under heaptrack\n"
    printf "\t-m override machine architecture. valid options are: amd64 or arm64 (DEFAULT: machine architecture)\n"
    printf "\t-n override image name (DEFAULT: router)\n"
    printf "\t-r build docker image from a specified repo, only valid with -b flag\n"

--- a/dockerfiles/download_and_validate_router.sh
+++ b/dockerfiles/download_and_validate_router.sh
@@ -57,33 +57,39 @@ fi
 
 if [ -z "${ARTIFACT_URL}" ]; then
     echo "Downloading Router release: ${ROUTER_RELEASE}"
-    # Download router tarball directly instead of using installer
-    TARBALL_NAME="router-${ROUTER_RELEASE}-${ARCH}.tar.gz"
 
-    # We use the rover-plugin service to download the Router tarball, rather
-    # than the actual executable which is what our usual curl installer does.
-    #
-    # Expanding on that with a couple notes:
-    #
-    #   - There is, as of the time of this writing, NO fixed Apollo-controlled URL
-    #     that lets you download a specific Router release tarball.
-    #   - We currently only have the curl installer which downloads and extracts
-    #     the tarballs.
-    #   - This approach is acceptable and defensive since rover is guaranteed to
-    #     have this in order for it to download the router, and that's not going
-    #     away. They also go through the same Orbiter endpoint/code anyhow.
-    #   - It IS possible to fix orbiter to also serve on the router domain and w
-    #     could do that, but this seemed more than acceptable, and is a well-tested
-    #     and monitored endpoint.
-    #   - The architecture is determined from TARGETPLATFORM, an environment variable
-    #     made available by Docker: https://docs.docker.com/build/building/multi-platform/
-    #     These are usually from `--platform` values passed within CircleCI's config where
-    #     this release process is invoked.
+    if [ "${DEBUG_IMAGE}" = "true" ]; then
+        # Debug images ship the unstripped binary. Rover only serves the
+        # stripped production tarball, so fetch the -debug artifact from GitHub.
+        TARBALL_NAME="router-${ROUTER_RELEASE}-${ARCH}-debug.tar.gz"
+        DOWNLOAD_URL="https://github.com/apollographql/router/releases/download/${ROUTER_RELEASE}/${TARBALL_NAME}"
+    else
+        TARBALL_NAME="router-${ROUTER_RELEASE}-${ARCH}.tar.gz"
+        # We use the rover-plugin service to download the Router tarball, rather
+        # than the actual executable which is what our usual curl installer does.
+        #
+        # Expanding on that with a couple notes:
+        #
+        #   - There is, as of the time of this writing, NO fixed Apollo-controlled URL
+        #     that lets you download a specific Router release tarball.
+        #   - We currently only have the curl installer which downloads and extracts
+        #     the tarballs.
+        #   - This approach is acceptable and defensive since rover is guaranteed to
+        #     have this in order for it to download the router, and that's not going
+        #     away. They also go through the same Orbiter endpoint/code anyhow.
+        #   - It IS possible to fix orbiter to also serve on the router domain and w
+        #     could do that, but this seemed more than acceptable, and is a well-tested
+        #     and monitored endpoint.
+        #   - The architecture is determined from TARGETPLATFORM, an environment variable
+        #     made available by Docker: https://docs.docker.com/build/building/multi-platform/
+        #     These are usually from `--platform` values passed within CircleCI's config where
+        #     this release process is invoked.
+        DOWNLOAD_URL="https://rover.apollo.dev/tar/router/${ARCH}/${ROUTER_RELEASE}"
+    fi
 
     # Download the router tarball from the rover service
-    curl -sSL \
-      "https://rover.apollo.dev/tar/router/${ARCH}/${ROUTER_RELEASE}" \
-        -o "${TARBALL_NAME}"
+
+    curl -sSL "${DOWNLOAD_URL}" -o "${TARBALL_NAME}"
 
     # Download and validate checksum
     curl -sSL \

--- a/xtask/src/commands/dist.rs
+++ b/xtask/src/commands/dist.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use xtask::*;
 
+const RELEASE_DIST_DIR: &str = "release-dist";
+
 #[derive(Debug, clap::Parser)]
 pub struct Dist {
     #[clap(long)]
@@ -13,7 +15,7 @@ pub struct Dist {
 
 impl Dist {
     pub fn run(&self) -> Result<()> {
-        let mut args = vec!["build", "--release"];
+        let mut args = vec!["build", "--profile", "release-dist"];
         if let Some(features) = &self.features {
             args.push("--features");
             args.push(features);
@@ -25,14 +27,17 @@ impl Dist {
                 args.push(target);
                 cargo!(args);
 
-                let bin_path = TARGET_DIR.join(target).join("release").join(RELEASE_BIN);
+                let bin_path = TARGET_DIR
+                    .join(target)
+                    .join(RELEASE_DIST_DIR)
+                    .join(RELEASE_BIN);
 
                 eprintln!("successfully compiled to: {}", &bin_path);
             }
             None => {
                 cargo!(args);
 
-                let bin_path = TARGET_DIR.join("release").join(RELEASE_BIN);
+                let bin_path = TARGET_DIR.join(RELEASE_DIST_DIR).join(RELEASE_BIN);
 
                 eprintln!("successfully compiled to: {}", &bin_path);
             }

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -2,16 +2,21 @@
 mod macos;
 
 use std::fmt;
+use std::fs;
 use std::path::Path;
+use std::process::Command;
 use std::str::FromStr;
 
 use anyhow::Context;
 use anyhow::Result;
+use anyhow::bail;
 use anyhow::ensure;
+use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use xtask::*;
 
 const INCLUDE: &[&str] = &["README.md", "LICENSE", "licenses.html"];
+const RELEASE_DIST_DIR: &str = "release-dist";
 
 pub(crate) const TARGET_X86_64_MUSL_LINUX: &str = "x86_64-unknown-linux-musl";
 pub(crate) const TARGET_X86_64_GNU_LINUX: &str = "x86_64-unknown-linux-gnu";
@@ -36,11 +41,12 @@ pub struct Package {
 
 impl Package {
     pub fn run(&self) -> Result<()> {
+        let target = self.target.clone().unwrap_or_default();
         let release_path = match &self.target {
-            None => TARGET_DIR.join("release").join(RELEASE_BIN),
+            None => TARGET_DIR.join(RELEASE_DIST_DIR).join(RELEASE_BIN),
             Some(target) => TARGET_DIR
                 .join(target.to_string())
-                .join("release")
+                .join(RELEASE_DIST_DIR)
                 .join(RELEASE_BIN),
         };
 
@@ -53,48 +59,114 @@ impl Package {
         #[cfg(target_os = "macos")]
         self.macos.run(&release_path)?;
 
-        let output_path = if !self.output.exists() {
-            if let Some(path) = self.output.parent() {
-                let _ = std::fs::create_dir_all(path);
-            }
-            self.output.to_owned()
-        } else if self.output.is_dir() {
-            self.output.join(format!(
-                "router-v{}-{}.tar.gz",
-                *PKG_VERSION,
-                self.target.clone().unwrap_or_default()
-            ))
-        } else {
-            self.output.to_owned()
-        };
-        eprintln!("Creating tarball: {output_path}");
-        let mut file = flate2::write::GzEncoder::new(
-            std::io::BufWriter::new(
-                std::fs::File::create(&output_path).context("could not create TGZ file")?,
-            ),
-            flate2::Compression::default(),
-        );
-        let mut ar = tar::Builder::new(&mut file);
-        eprintln!("Adding {release_path}...");
-        ar.append_file(
-            Path::new("dist").join(RELEASE_BIN),
-            &mut std::fs::File::open(release_path).context("could not open binary")?,
-        )
-        .context("could not add file to TGZ archive")?;
+        let (output_path, output_is_dir) = self.output_paths()?;
 
-        for path in INCLUDE {
-            eprintln!("Adding {path}...");
-            ar.append_file(
-                Path::new("dist").join(path),
-                &mut std::fs::File::open(PKG_PROJECT_ROOT.join(path))
-                    .context("could not open binary")?,
-            )
-            .context("could not add file to TGZ archive")?;
+        if target.is_linux_gnu() {
+            // Unstripped binary goes in the -debug tarball; a stripped copy goes
+            // in the normal release tarball used by production images.
+            let debug_output = if output_is_dir {
+                self.output
+                    .join(format!("router-v{}-{}-debug.tar.gz", *PKG_VERSION, target))
+            } else {
+                // When a concrete file path is given, derive the debug sibling name.
+                let file_name = output_path
+                    .file_name()
+                    .context("output path has no file name")?;
+                let debug_name = if let Some(stem) = file_name.strip_suffix(".tar.gz") {
+                    format!("{stem}-debug.tar.gz")
+                } else {
+                    format!("{file_name}-debug")
+                };
+                match output_path.parent() {
+                    Some(parent) => parent.join(debug_name),
+                    None => Utf8PathBuf::from(debug_name),
+                }
+            };
+
+            create_tarball(&debug_output, &release_path)?;
+
+            let stripped_path = strip_binary(&release_path)?;
+            create_tarball(&output_path, &stripped_path)?;
+        } else {
+            create_tarball(&output_path, &release_path)?;
         }
 
-        ar.finish().context("could not finish TGZ archive")?;
-
         Ok(())
+    }
+
+    /// Resolve the normal (stripped) output path and whether `--output` was a directory.
+    fn output_paths(&self) -> Result<(Utf8PathBuf, bool)> {
+        let target = self.target.clone().unwrap_or_default();
+        if !self.output.exists() {
+            if let Some(path) = self.output.parent() {
+                let _ = fs::create_dir_all(path);
+            }
+            Ok((self.output.to_owned(), false))
+        } else if self.output.is_dir() {
+            Ok((
+                self.output
+                    .join(format!("router-v{}-{}.tar.gz", *PKG_VERSION, target)),
+                true,
+            ))
+        } else {
+            Ok((self.output.to_owned(), false))
+        }
+    }
+}
+
+fn create_tarball(output_path: &Utf8Path, binary_path: &Utf8Path) -> Result<()> {
+    eprintln!("Creating tarball: {output_path}");
+    let mut file = flate2::write::GzEncoder::new(
+        std::io::BufWriter::new(
+            fs::File::create(output_path).context("could not create TGZ file")?,
+        ),
+        flate2::Compression::default(),
+    );
+    let mut ar = tar::Builder::new(&mut file);
+    eprintln!("Adding {binary_path}...");
+    ar.append_file(
+        Path::new("dist").join(RELEASE_BIN),
+        &mut fs::File::open(binary_path).context("could not open binary")?,
+    )
+    .context("could not add file to TGZ archive")?;
+
+    for path in INCLUDE {
+        eprintln!("Adding {path}...");
+        ar.append_file(
+            Path::new("dist").join(path),
+            &mut fs::File::open(PKG_PROJECT_ROOT.join(path))
+                .context("could not open included file")?,
+        )
+        .context("could not add file to TGZ archive")?;
+    }
+
+    ar.finish().context("could not finish TGZ archive")?;
+    Ok(())
+}
+
+/// Copy `binary_path` and strip debuginfo from the copy, leaving the original intact.
+fn strip_binary(binary_path: &Utf8Path) -> Result<Utf8PathBuf> {
+    let persist_dir = TARGET_DIR.join("xtask-strip");
+    fs::create_dir_all(&persist_dir).context("could not create xtask-strip dir")?;
+    let stripped_path = persist_dir.join(RELEASE_BIN);
+    fs::copy(binary_path, &stripped_path).context("could not copy binary for stripping")?;
+
+    let strip = which::which("strip").context("`strip` not found on PATH")?;
+    let status = Command::new(strip)
+        .arg("--strip-debug")
+        .arg(stripped_path.as_str())
+        .status()
+        .context("failed to run strip")?;
+    if !status.success() {
+        bail!("strip failed with status: {status}");
+    }
+
+    Ok(stripped_path)
+}
+
+impl Target {
+    fn is_linux_gnu(&self) -> bool {
+        matches!(self, Target::GnuLinux | Target::ArmLinux)
     }
 }
 


### PR DESCRIPTION
Its useful to have debug symbols for flamegraphs, which we don't currently include in `-debug` suffixed images.
This PR builds the release binary with symbols included, then uses `strip` to remove them for non-debug images.

<!-- start metadata -->

<!-- [ROUTER-1998] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1998]: https://apollographql.atlassian.net/browse/ROUTER-1998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ