### PR TITLE
fix(diagnostics): correct ECharts dimension types in flamegraph renderer

### DIFF
--- a/.changesets/fix_bryn_flamegraph_renderer_dimension_types.md
+++ b/.changesets/fix_bryn_flamegraph_renderer_dimension_types.md
@@ -1,0 +1,7 @@
+### Fix flamegraph rendering in diagnostics memory profiler ([PR #9837](https://github.com/apollographql/router/pull/9837))
+
+The memory profiler's flamegraph visualization could fail to render function names. Without explicit dimension types on the ECharts custom series, ECharts inferred the `name` and `percentage` dimensions as numeric since they weren't referenced in `encode`, causing the renderer to cast function names to `NaN`.
+
+This is now fixed by explicitly declaring the dimension types so `name` is kept as a string.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/9837

--- a/apollo-router/src/plugins/diagnostics/resources/flamegraph-renderer.js
+++ b/apollo-router/src/plugins/diagnostics/resources/flamegraph-renderer.js
@@ -162,6 +162,17 @@ function renderFlameGraph(containerId, flameData) {
         series: [{
             type: 'custom',
             renderItem: renderFlameItem,
+            // Dimensions 3 (label) and 4 (percentage) aren't covered by `encode`,
+            // so without an explicit type ECharts defaults them to numeric and
+            // `api.value(3)` in renderFlameItem casts the function name to NaN.
+            // `name` must stay 'ordinal' so it's kept as a string, not parsed as a number.
+            dimensions: [
+                { name: 'level', type: 'number' },
+                { name: 'start', type: 'number' },
+                { name: 'end', type: 'number' },
+                { name: 'name', type: 'ordinal' },
+                { name: 'percentage', type: 'number' }
+            ],
             encode: {
                 x: [1, 2],
                 y: 0


### PR DESCRIPTION
## Summary
- Explicitly declare dimension types for the flamegraph's ECharts custom series so `name` stays a string and `percentage` stays numeric.
- Without this, ECharts inferred both dimensions as numeric (since they aren't referenced in `encode`), causing `api.value(3)` in `renderFlameItem` to cast the function name to `NaN` and break rendering.

## Test plan
- [ ] Load a memory profile flamegraph in the router diagnostics UI and confirm function names render correctly