### PR TITLE
build: install flamegraph in debug images

### DIFF
--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -1,3 +1,6 @@
+# Must be declared before any FROM so it can be used in FROM stage selection.
+ARG DEBUG_IMAGE=false
+
 FROM debian:bookworm-slim AS downloader
 ARG ROUTER_RELEASE=latest
 ARG ARTIFACT_URL=
@@ -20,6 +23,17 @@ WORKDIR /
 COPY download_and_validate_router.sh /tmp/download_and_validate_router.sh
 RUN chmod +x /tmp/download_and_validate_router.sh && /tmp/download_and_validate_router.sh
 
+# Use a multi-stage build to install the debug tools if DEBUG_IMAGE is true
+FROM rust:slim-bookworm AS install-debug-tools-true
+# We use the rust addr2line to avoid this error/perf issue https://github.com/iced-rs/iced/issues/2394
+RUN cargo install addr2line --locked --features="bin"
+RUN cargo install flamegraph --locked
+
+FROM rust:slim-bookworm AS install-debug-tools-false
+# Do nothing
+
+FROM install-debug-tools-${DEBUG_IMAGE} AS install-debug-tools
+
 FROM debian:bookworm-slim AS distro
 ARG DEBUG_IMAGE=false
 ARG REPO_URL=https://github.com/apollographql/router
@@ -38,13 +52,17 @@ RUN \
   && apt-get install -y \
     ca-certificates
 
-# If debug image, install heaptrack and make a data directory
+# If debug image, install perf and heaptrack and make a data directory
 RUN \
   if [ "${DEBUG_IMAGE}" = "true" ]; then \
-    apt-get install -y heaptrack && \
+    apt-get install -y linux-perf heaptrack && \
     mkdir data && \
     chown router data; \
   fi
+
+# Copy the debug tools from the install-debug-tools stage if DEBUG_IMAGE was true.
+COPY --from=install-debug-tools /usr/local/cargo/bin/flamegraph* /usr/bin/
+COPY --from=install-debug-tools /usr/local/cargo/bin/addr2line* /usr/bin/
 
 # Clean up apt lists
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Having these tools in `-debug` images will make running performance comparisons easier.

<!-- start metadata -->

<!-- [ROUTER-1998] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1998]: https://apollographql.atlassian.net/browse/ROUTER-1998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ