### PR TITLE
fix(telemetry): avoid deep-hashing responses in extended-ref extraction

### DIFF
--- a/.changesets/fix_extended_refs_fragment_deep_hash.md
+++ b/.changesets/fix_extended_refs_fragment_deep_hash.md
@@ -2,6 +2,6 @@
 
 `extract_enums_from_selection_set` (used when `telemetry.apollo.metrics_reference_mode` is `extended`, the default) deduplicated fragment spreads with a `HashSet` keyed on `&Object`. Because `&T` hashes and compares by value, every fragment spread deep-hashed the entire response subtree, so extraction cost grew with response size and fragment count. Operations with many nested fragments over large responses saw significant added CPU and tail latency.
 
-The set now keys on the response object's pointer identity, which is `O(1)` and sufficient for the deduplication and cycle protection this function needs. Reported reference data is unchanged.
+The set now keys on the response object's address via a small `ByAddress` wrapper, which is `O(1)` and sufficient for the deduplication and cycle protection this function needs. Reported reference data is unchanged.
 
 By [@ebylund](https://github.com/ebylund) in https://github.com/apollographql/router/pull/9840

--- a/.changesets/fix_extended_refs_fragment_deep_hash.md
+++ b/.changesets/fix_extended_refs_fragment_deep_hash.md
@@ -4,4 +4,4 @@
 
 The set now keys on the response object's pointer identity, which is `O(1)` and sufficient for the deduplication and cycle protection this function needs. Reported reference data is unchanged.
 
-By [@ebylund](https://github.com/ebylund) in https://github.com/apollographql/router/pull/XXXX
+By [@ebylund](https://github.com/ebylund) in https://github.com/apollographql/router/pull/9840

--- a/.changesets/fix_extended_refs_fragment_deep_hash.md
+++ b/.changesets/fix_extended_refs_fragment_deep_hash.md
@@ -1,0 +1,7 @@
+### Fix excess CPU and latency from extended metrics reference mode on fragment-heavy operations
+
+`extract_enums_from_selection_set` (used when `telemetry.apollo.metrics_reference_mode` is `extended`, the default) deduplicated fragment spreads with a `HashSet` keyed on `&Object`. Because `&T` hashes and compares by value, every fragment spread deep-hashed the entire response subtree, so extraction cost grew with response size and fragment count. Operations with many nested fragments over large responses saw significant added CPU and tail latency.
+
+The set now keys on the response object's pointer identity, which is `O(1)` and sufficient for the deduplication and cycle protection this function needs. Reported reference data is unchanged.
+
+By [@ebylund](https://github.com/ebylund) in https://github.com/apollographql/router/pull/XXXX

--- a/apollo-router/src/apollo_studio_interop/mod.rs
+++ b/apollo-router/src/apollo_studio_interop/mod.rs
@@ -434,7 +434,13 @@ fn extract_enums_from_selection_set(
     result_set: &mut ReferencedEnums,
 ) {
     let mut stack: Vec<(&[SpecSelection], &Object)> = vec![(selection_set, selection_response)];
-    let mut visited_fragments: HashSet<(&str, &Object)> = HashSet::new();
+    // Key visited fragments by the response object's pointer identity, not by value.
+    // Keying on `&Object` would hash/compare the entire response subtree on every
+    // fragment spread (its `Hash`/`Eq` delegate to the pointee), so extraction cost
+    // would grow with response size. Address identity is sufficient for dedup and
+    // cycle protection here: the pointer is only ever compared, never dereferenced,
+    // and all referents outlive this call.
+    let mut visited_fragments: HashSet<(&str, *const Object)> = HashSet::new();
 
     while let Some((selections, response)) = stack.pop() {
         for selection in selections.iter() {
@@ -465,7 +471,7 @@ fn extract_enums_from_selection_set(
                     stack.push((selection_set, response));
                 }
                 SpecSelection::FragmentSpread { name, .. } => {
-                    let key = (name.as_str(), response);
+                    let key = (name.as_str(), response as *const Object);
                     if visited_fragments.insert(key)
                         && let Some(fragment) = fragments.get(name)
                     {

--- a/apollo-router/src/apollo_studio_interop/mod.rs
+++ b/apollo-router/src/apollo_studio_interop/mod.rs
@@ -426,6 +426,26 @@ fn add_enum_value_to_map(
     }
 }
 
+/// Wraps a `&Object` so a `HashSet` deduplicates by the object's address rather
+/// than its (deep) contents. `Object`'s own `Hash`/`Eq` recurse over the whole
+/// subtree, so keying visited fragments on `&Object` would deep-hash the response
+/// on every fragment spread (the regression this guards against). Keying on the
+/// address is `O(1)`, and the `'a` lifetime ties every key to the borrowed
+/// response tree, so the borrow checker guarantees no key outlives its referent.
+struct ByAddress<'a>(&'a Object);
+
+impl PartialEq for ByAddress<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.0, other.0)
+    }
+}
+impl Eq for ByAddress<'_> {}
+impl std::hash::Hash for ByAddress<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::ptr::hash(self.0, state);
+    }
+}
+
 fn extract_enums_from_selection_set(
     selection_set: &[SpecSelection],
     fragments: &Fragments,
@@ -434,13 +454,12 @@ fn extract_enums_from_selection_set(
     result_set: &mut ReferencedEnums,
 ) {
     let mut stack: Vec<(&[SpecSelection], &Object)> = vec![(selection_set, selection_response)];
-    // Key visited fragments by the response object's pointer identity, not by value.
-    // Keying on `&Object` would hash/compare the entire response subtree on every
-    // fragment spread (its `Hash`/`Eq` delegate to the pointee), so extraction cost
-    // would grow with response size. Address identity is sufficient for dedup and
-    // cycle protection here: the pointer is only ever compared, never dereferenced,
-    // and all referents outlive this call.
-    let mut visited_fragments: HashSet<(&str, *const Object)> = HashSet::new();
+    // Deduplicate visited fragments by the response object's address, not its
+    // contents. `Object`'s `Hash`/`Eq` recurse over the whole subtree, so keying on
+    // `&Object` would deep-hash the response on every fragment spread and make
+    // extraction cost grow with response size. `ByAddress` keys on the address
+    // (`O(1)`); its `'a` lifetime keeps every key tied to the borrowed response tree.
+    let mut visited_fragments: HashSet<(&str, ByAddress<'_>)> = HashSet::new();
 
     while let Some((selections, response)) = stack.pop() {
         for selection in selections.iter() {
@@ -471,7 +490,7 @@ fn extract_enums_from_selection_set(
                     stack.push((selection_set, response));
                 }
                 SpecSelection::FragmentSpread { name, .. } => {
-                    let key = (name.as_str(), response as *const Object);
+                    let key = (name.as_str(), ByAddress(response));
                     if visited_fragments.insert(key)
                         && let Some(fragment) = fragments.get(name)
                     {


### PR DESCRIPTION
## What / why

`extract_enums_from_selection_set` (used when `telemetry.apollo.metrics_reference_mode` is `extended`, which is the default) deduplicates fragment spreads with a `HashSet` keyed on the response object. The key was `&Object`, and `&T` implements `Hash`/`Eq` by delegating to the pointee, so every fragment spread deep-hashed the entire response subtree. Extraction cost grew with response size times fragment count; operations with many nested fragments over large responses saw substantial added CPU and tail latency.

This keys the set on the response object's address via a small `ByAddress(&Object)` wrapper, which is `O(1)` and sufficient for the deduplication and cycle protection this function needs. It removes the deep hash introduced when the key was changed to `&Object` in an earlier commit of #9473.

## Reasoning record

**Intent.** Restore pre-2.16 CPU and latency for extended metrics reference mode without changing reported data.

**What changed.** `apollo_studio_interop/mod.rs`: a `ByAddress<'a>(&'a Object)` newtype whose `Hash`/`Eq` use `std::ptr::eq` / `std::ptr::hash`, and `visited_fragments` re-typed to `HashSet<(&str, ByAddress<'_>)>`. Changeset added. No `unsafe`, no raw pointer.

**Roads not taken.**
- `Arc` / `Arc::ptr_eq` (the first suggestion in review). Not feasible here: the response nodes are `serde_json_bytes` maps held inline in one owned tree, not individually `Arc`-backed, so `ptr_eq` would need an upstream `serde_json_bytes` change or a per-node `Arc` allocation that defeats the perf goal.
- A raw `*const Object` (the initial version of this fix). Works and is O(1), but carries no lifetime, so a future change that freed a referent mid-traversal would compile and silently corrupt. `ByAddress` gets the same identity while the `'a` binding makes that a compile error instead.
- Bounding or memoizing traversal. Unnecessary once per-spread cost is `O(1)` again.

**Hard parts / why this is subtle.** `&T` hashes and compares by value (it delegates to the pointee) while address identity does not. The two look interchangeable at the call site but have very different cost. `ByAddress` compares with `std::ptr::eq` and hashes with `std::ptr::hash`, and its referents are only ever compared, never dereferenced.

**Least confidence.** Output is identical because `ReferencedEnums` is a set. Verified locally: the full `apollo_studio_interop` suite passes at the CI toolchain (1.96.1), including the two fragment-dedup snapshot tests, with no snapshot changes; `cargo xtask lint` is clean. This is not backed by a committed benchmark (the repo has no perf test for this path); the authoritative signal is the reporter's flame graphs and the ~2x prod CPU on the ticket. A quick local gut check keying the dedup on `&Object` vs `ByAddress` over a large response confirmed the expected algorithmic gap (deep hash per spread vs constant cost).

**Blast radius.** Limited to extended-reference enum extraction on the usage-reporting path. No change to routing, response handling, or reported data. This only removes cost.

**Documentation.** No docs change: behavior, configuration, and reported data are unchanged.

Fixes ROUTER-2005.
