### PR TITLE
chore(ci): switch /claude-review model to claude-fable-5

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: '--model claude-opus-4-8 --append-system-prompt "Always post a PR comment summarizing your decision, even if you decide to STOP without doing a full review."'
+          claude_args: '--model claude-fable-5 --append-system-prompt "Always post a PR comment summarizing your decision, even if you decide to STOP without doing a full review."'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }} --comment'


### PR DESCRIPTION
switching from opus to fable for reviews because spending ~$20 a pop to save hours of debugging later is a decent deal