### PR TITLE
fix(connectors): don't copy resolvable keys onto non-entity v0.4 connectors

### DIFF
--- a/.changesets/fix_connectors_v04_query_field_resolvable_key.md
+++ b/.changesets/fix_connectors_v04_query_field_resolvable_key.md
@@ -4,4 +4,4 @@ Under `connect/v0.4`, when a `@key` entity had **both** a type-level reference-r
 
 `connect/v0.3` was never affected, so bumping only the `@link` from `v0.3` to `v0.4` could break a previously working schema. Expansion now only copies keys for `@interfaceObject` types, and always as `resolvable: false`, matching the `v0.3` behavior.
 
-By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/PR_NUMBER
+By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/9853

--- a/.changesets/fix_connectors_v04_query_field_resolvable_key.md
+++ b/.changesets/fix_connectors_v04_query_field_resolvable_key.md
@@ -1,0 +1,7 @@
+### Fix `connect/v0.4` routing entity resolution through a non-entity `Query` connector (RH-1401)
+
+Under `connect/v0.4`, when a `@key` entity had **both** a type-level reference-resolver `@connect` (mapping from `$this`) **and** a separate `Query` field `@connect` returning that same type (mapping from `$args`, with `entity` unset), connector expansion copied the entity's declared `@key` onto the `Query`-field connector's generated subgraph as **resolvable**. That gave the query planner a second, spurious entity path, so it could resolve entity references through the `Query`-field connector — where `$args` is empty during entity resolution — sending a request with the query parameters stripped and surfacing an upstream error (e.g. a `400` reported as `CONNECTOR_FETCH`).
+
+`connect/v0.3` was never affected, so bumping only the `@link` from `v0.3` to `v0.4` could break a previously working schema. Expansion now only copies keys for `@interfaceObject` types, and always as `resolvable: false`, matching the `v0.3` behavior.
+
+By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/PR_NUMBER

--- a/apollo-federation/src/connectors/expand/mod.rs
+++ b/apollo-federation/src/connectors/expand/mod.rs
@@ -729,6 +729,16 @@ mod helpers {
                 .iter()
                 .any(|d| d.name == self.interface_object_name);
 
+            // Only copy keys for `@interfaceObject` types, and always as
+            // `resolvable: false`. Copying a declared `@key` onto a non-entity
+            // connector's output type (e.g. a `Query` field connector mapping
+            // from `$args`) as resolvable would give the query planner a second,
+            // spurious entity path and let it route reference resolution through
+            // the wrong connector. See RH-1401.
+            if !is_interface_object {
+                return Ok(());
+            }
+
             let pos = ObjectTypeDefinitionPosition {
                 type_name: original_output_type.name.clone(),
             };
@@ -742,21 +752,18 @@ mod helpers {
                     .argument_by_name("fields", self.original_schema.schema())
                     .map_err(|_| internal_error!("@key(fields:) argument missing"))?;
 
-                let mut arguments = vec![Node::new(Argument {
-                    name: name!("fields"),
-                    value: key_fields.clone(),
-                })];
-
-                if is_interface_object {
-                    arguments.push(Node::new(Argument {
-                        name: name!("resolvable"),
-                        value: Node::new(Value::Boolean(false)),
-                    }));
-                }
-
                 let key = Directive {
                     name: key.name.clone(),
-                    arguments,
+                    arguments: vec![
+                        Node::new(Argument {
+                            name: name!("fields"),
+                            value: key_fields.clone(),
+                        }),
+                        Node::new(Argument {
+                            name: name!("resolvable"),
+                            value: Node::new(Value::Boolean(false)),
+                        }),
+                    ],
                 };
                 pos.insert_directive(to_schema, Component::new(key))?;
             }

--- a/apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_entity_true_v04.graphql
+++ b/apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_entity_true_v04.graphql
@@ -1,0 +1,76 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "v1", http: {baseURL: "http://127.0.0.1"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: CONNECTORS)
+{
+  """
+  The intended way to make a `Query` field a reference resolver: `entity: true`.
+  This yields an `Explicit` entity resolver whose key is derived from `$args`, so
+  a resolvable `@key` on `Tractor` is correct here — the connector genuinely can
+  resolve the entity by its key. Contrast with `entity_query_field_v04`, where
+  `entity` is unset and no resolvable key should be emitted. See RH-1401.
+  """
+  tractor(id: ID!): Tractor @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {GET: "/tractors?id={$args.id}"}, selection: "id name", entity: true})
+}
+
+type Tractor
+  @join__type(graph: CONNECTORS, key: "id")
+{
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_v03.graphql
+++ b/apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_v03.graphql
@@ -1,0 +1,76 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "v1", http: {baseURL: "http://127.0.0.1"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: CONNECTORS)
+{
+  """
+  A non-entity Query connector that returns the entity type directly, mapping
+  from `$args` with `entity` unset (defaults to false). This must NOT become a
+  resolvable entity path for `Tractor` — otherwise the planner may route
+  reference resolution through here, where `$args` is empty. See RH-1401.
+  """
+  tractor(id: ID!): Tractor @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {GET: "/tractors?id={$args.id}"}, selection: "id name"})
+}
+
+type Tractor
+  @join__type(graph: CONNECTORS, key: "id")
+  @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {GET: "/tractors/{$this.id}"}, selection: "id name"})
+{
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_v04.graphql
+++ b/apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_v04.graphql
@@ -1,0 +1,76 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "v1", http: {baseURL: "http://127.0.0.1"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: CONNECTORS)
+{
+  """
+  A non-entity Query connector that returns the entity type directly, mapping
+  from `$args` with `entity` unset (defaults to false). This must NOT become a
+  resolvable entity path for `Tractor` — otherwise the planner may route
+  reference resolution through here, where `$args` is empty. See RH-1401.
+  """
+  tractor(id: ID!): Tractor @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {GET: "/tractors?id={$args.id}"}, selection: "id name"})
+}
+
+type Tractor
+  @join__type(graph: CONNECTORS, key: "id")
+  @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "v1", http: {GET: "/tractors/{$this.id}"}, selection: "id name"})
+{
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/api@entity_query_field_entity_true_v04.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/api@entity_query_field_entity_true_v04.graphql.snap
@@ -1,0 +1,22 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: api_schema
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_entity_true_v04.graphql
+---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type Query {
+  """
+  The intended way to make a `Query` field a reference resolver: `entity: true`.
+  This yields an `Explicit` entity resolver whose key is derived from `$args`, so
+  a resolvable `@key` on `Tractor` is correct here — the connector genuinely can
+  resolve the entity by its key. Contrast with `entity_query_field_v04`, where
+  `entity` is unset and no resolvable key should be emitted. See RH-1401.
+  """
+  tractor(id: ID!): Tractor
+}
+
+type Tractor {
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/api@entity_query_field_v03.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/api@entity_query_field_v03.graphql.snap
@@ -1,0 +1,21 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: api_schema
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_v03.graphql
+---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type Query {
+  """
+  A non-entity Query connector that returns the entity type directly, mapping
+  from `$args` with `entity` unset (defaults to false). This must NOT become a
+  resolvable entity path for `Tractor` — otherwise the planner may route
+  reference resolution through here, where `$args` is empty. See RH-1401.
+  """
+  tractor(id: ID!): Tractor
+}
+
+type Tractor {
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/api@entity_query_field_v04.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/api@entity_query_field_v04.graphql.snap
@@ -1,0 +1,21 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: api_schema
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_v04.graphql
+---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type Query {
+  """
+  A non-entity Query connector that returns the entity type directly, mapping
+  from `$args` with `entity` unset (defaults to false). This must NOT become a
+  resolvable entity path for `Tractor` — otherwise the planner may route
+  reference resolution through here, where `$args` is empty. See RH-1401.
+  """
+  tractor(id: ID!): Tractor
+}
+
+type Tractor {
+  id: ID!
+  name: String
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@entity_query_field_entity_true_v04.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@entity_query_field_entity_true_v04.graphql.snap
@@ -1,0 +1,216 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: connectors.by_service_name
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_entity_true_v04.graphql
+---
+{
+    "connectors_Query_tractor_0": Connector {
+        id: ConnectId {
+            subgraph_name: "connectors",
+            source_name: Some(
+                "v1",
+            ),
+            named: None,
+            directive: Field(
+                ObjectOrInterfaceFieldDirectivePosition {
+                    field: Object(Query.tractor),
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            ),
+        },
+        transport: Some(
+            HttpJsonTransport {
+                source_template: Some(
+                    StringTemplate {
+                        parts: [
+                            Constant(
+                                Constant {
+                                    value: "http://127.0.0.1",
+                                    location: 0..16,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                connect_template: StringTemplate {
+                    parts: [
+                        Constant(
+                            Constant {
+                                value: "/tractors?id=",
+                                location: 0..13,
+                            },
+                        ),
+                        Expression(
+                            Expression {
+                                expression: JSONSelection {
+                                    inner: Value(
+                                        WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Var(
+                                                            WithRange {
+                                                                node: $args,
+                                                                range: Some(
+                                                                    0..5,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "id",
+                                                                        ),
+                                                                        range: Some(
+                                                                            6..8,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            8..8,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    5..8,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            0..8,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..8,
+                                            ),
+                                        },
+                                    ),
+                                    spec: V0_4,
+                                },
+                                location: 14..22,
+                            },
+                        ),
+                    ],
+                },
+                method: Get,
+                headers: [],
+                body: None,
+                source_path: None,
+                source_query_params: None,
+                connect_path: None,
+                connect_query_params: None,
+            },
+        ),
+        selection: JSONSelection {
+            inner: Named(
+                SubSelection {
+                    selections: [
+                        NamedSelection {
+                            prefix: None,
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "id",
+                                                    ),
+                                                    range: Some(
+                                                        0..2,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        2..2,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    0..2,
+                                ),
+                            },
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "name",
+                                                    ),
+                                                    range: Some(
+                                                        3..7,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        7..7,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    3..7,
+                                ),
+                            },
+                        },
+                    ],
+                    range: Some(
+                        0..7,
+                    ),
+                },
+            ),
+            spec: V0_4,
+        },
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            Explicit,
+        ),
+        spec: V0_4,
+        schema_subtypes_map: {
+            "_Entity": {
+                "Tractor",
+            },
+        },
+        request_headers: {},
+        response_headers: {},
+        request_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
+        response_variable_keys: {},
+        batch_settings: None,
+        error_settings: ConnectorErrorsSettings {
+            message: None,
+            source_extensions: None,
+            connect_extensions: None,
+            connect_is_success: None,
+        },
+        label: Label(
+            "connectors.v1 http: GET /tractors?id={$args.id}",
+        ),
+    },
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@entity_query_field_v03.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@entity_query_field_v03.graphql.snap
@@ -1,0 +1,423 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: connectors.by_service_name
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_v03.graphql
+---
+{
+    "connectors_Query_tractor_0": Connector {
+        id: ConnectId {
+            subgraph_name: "connectors",
+            source_name: Some(
+                "v1",
+            ),
+            named: None,
+            directive: Field(
+                ObjectOrInterfaceFieldDirectivePosition {
+                    field: Object(Query.tractor),
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            ),
+        },
+        transport: Some(
+            HttpJsonTransport {
+                source_template: Some(
+                    StringTemplate {
+                        parts: [
+                            Constant(
+                                Constant {
+                                    value: "http://127.0.0.1",
+                                    location: 0..16,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                connect_template: StringTemplate {
+                    parts: [
+                        Constant(
+                            Constant {
+                                value: "/tractors?id=",
+                                location: 0..13,
+                            },
+                        ),
+                        Expression(
+                            Expression {
+                                expression: JSONSelection {
+                                    inner: Value(
+                                        WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Var(
+                                                            WithRange {
+                                                                node: $args,
+                                                                range: Some(
+                                                                    0..5,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "id",
+                                                                        ),
+                                                                        range: Some(
+                                                                            6..8,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            8..8,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    5..8,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            0..8,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..8,
+                                            ),
+                                        },
+                                    ),
+                                    spec: V0_3,
+                                },
+                                location: 14..22,
+                            },
+                        ),
+                    ],
+                },
+                method: Get,
+                headers: [],
+                body: None,
+                source_path: None,
+                source_query_params: None,
+                connect_path: None,
+                connect_query_params: None,
+            },
+        ),
+        selection: JSONSelection {
+            inner: Named(
+                SubSelection {
+                    selections: [
+                        NamedSelection {
+                            prefix: None,
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "id",
+                                                    ),
+                                                    range: Some(
+                                                        0..2,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        2..2,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    0..2,
+                                ),
+                            },
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "name",
+                                                    ),
+                                                    range: Some(
+                                                        3..7,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        7..7,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    3..7,
+                                ),
+                            },
+                        },
+                    ],
+                    range: Some(
+                        0..7,
+                    ),
+                },
+            ),
+            spec: V0_3,
+        },
+        config: None,
+        max_requests: None,
+        entity_resolver: None,
+        spec: V0_3,
+        schema_subtypes_map: {
+            "_Entity": {
+                "Tractor",
+            },
+        },
+        request_headers: {},
+        response_headers: {},
+        request_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
+        response_variable_keys: {},
+        batch_settings: None,
+        error_settings: ConnectorErrorsSettings {
+            message: None,
+            source_extensions: None,
+            connect_extensions: None,
+            connect_is_success: None,
+        },
+        label: Label(
+            "connectors.v1 http: GET /tractors?id={$args.id}",
+        ),
+    },
+    "connectors_Tractor_0": Connector {
+        id: ConnectId {
+            subgraph_name: "connectors",
+            source_name: Some(
+                "v1",
+            ),
+            named: None,
+            directive: Type(
+                ObjectTypeDefinitionDirectivePosition {
+                    type_name: "Tractor",
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            ),
+        },
+        transport: Some(
+            HttpJsonTransport {
+                source_template: Some(
+                    StringTemplate {
+                        parts: [
+                            Constant(
+                                Constant {
+                                    value: "http://127.0.0.1",
+                                    location: 0..16,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                connect_template: StringTemplate {
+                    parts: [
+                        Constant(
+                            Constant {
+                                value: "/tractors/",
+                                location: 0..10,
+                            },
+                        ),
+                        Expression(
+                            Expression {
+                                expression: JSONSelection {
+                                    inner: Value(
+                                        WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Var(
+                                                            WithRange {
+                                                                node: $this,
+                                                                range: Some(
+                                                                    0..5,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "id",
+                                                                        ),
+                                                                        range: Some(
+                                                                            6..8,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            8..8,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    5..8,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            0..8,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..8,
+                                            ),
+                                        },
+                                    ),
+                                    spec: V0_3,
+                                },
+                                location: 11..19,
+                            },
+                        ),
+                    ],
+                },
+                method: Get,
+                headers: [],
+                body: None,
+                source_path: None,
+                source_query_params: None,
+                connect_path: None,
+                connect_query_params: None,
+            },
+        ),
+        selection: JSONSelection {
+            inner: Named(
+                SubSelection {
+                    selections: [
+                        NamedSelection {
+                            prefix: None,
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "id",
+                                                    ),
+                                                    range: Some(
+                                                        0..2,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        2..2,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    0..2,
+                                ),
+                            },
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "name",
+                                                    ),
+                                                    range: Some(
+                                                        3..7,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        7..7,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    3..7,
+                                ),
+                            },
+                        },
+                    ],
+                    range: Some(
+                        0..7,
+                    ),
+                },
+            ),
+            spec: V0_3,
+        },
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            TypeSingle,
+        ),
+        spec: V0_3,
+        schema_subtypes_map: {
+            "_Entity": {
+                "Tractor",
+            },
+        },
+        request_headers: {},
+        response_headers: {},
+        request_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
+        response_variable_keys: {},
+        batch_settings: None,
+        error_settings: ConnectorErrorsSettings {
+            message: None,
+            source_extensions: None,
+            connect_extensions: None,
+            connect_is_success: None,
+        },
+        label: Label(
+            "connectors.v1 http: GET /tractors/{$this.id}",
+        ),
+    },
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/connectors@entity_query_field_v04.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/connectors@entity_query_field_v04.graphql.snap
@@ -1,0 +1,423 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: connectors.by_service_name
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_v04.graphql
+---
+{
+    "connectors_Query_tractor_0": Connector {
+        id: ConnectId {
+            subgraph_name: "connectors",
+            source_name: Some(
+                "v1",
+            ),
+            named: None,
+            directive: Field(
+                ObjectOrInterfaceFieldDirectivePosition {
+                    field: Object(Query.tractor),
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            ),
+        },
+        transport: Some(
+            HttpJsonTransport {
+                source_template: Some(
+                    StringTemplate {
+                        parts: [
+                            Constant(
+                                Constant {
+                                    value: "http://127.0.0.1",
+                                    location: 0..16,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                connect_template: StringTemplate {
+                    parts: [
+                        Constant(
+                            Constant {
+                                value: "/tractors?id=",
+                                location: 0..13,
+                            },
+                        ),
+                        Expression(
+                            Expression {
+                                expression: JSONSelection {
+                                    inner: Value(
+                                        WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Var(
+                                                            WithRange {
+                                                                node: $args,
+                                                                range: Some(
+                                                                    0..5,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "id",
+                                                                        ),
+                                                                        range: Some(
+                                                                            6..8,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            8..8,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    5..8,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            0..8,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..8,
+                                            ),
+                                        },
+                                    ),
+                                    spec: V0_4,
+                                },
+                                location: 14..22,
+                            },
+                        ),
+                    ],
+                },
+                method: Get,
+                headers: [],
+                body: None,
+                source_path: None,
+                source_query_params: None,
+                connect_path: None,
+                connect_query_params: None,
+            },
+        ),
+        selection: JSONSelection {
+            inner: Named(
+                SubSelection {
+                    selections: [
+                        NamedSelection {
+                            prefix: None,
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "id",
+                                                    ),
+                                                    range: Some(
+                                                        0..2,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        2..2,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    0..2,
+                                ),
+                            },
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "name",
+                                                    ),
+                                                    range: Some(
+                                                        3..7,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        7..7,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    3..7,
+                                ),
+                            },
+                        },
+                    ],
+                    range: Some(
+                        0..7,
+                    ),
+                },
+            ),
+            spec: V0_4,
+        },
+        config: None,
+        max_requests: None,
+        entity_resolver: None,
+        spec: V0_4,
+        schema_subtypes_map: {
+            "_Entity": {
+                "Tractor",
+            },
+        },
+        request_headers: {},
+        response_headers: {},
+        request_variable_keys: {
+            $args: {
+                "id",
+            },
+        },
+        response_variable_keys: {},
+        batch_settings: None,
+        error_settings: ConnectorErrorsSettings {
+            message: None,
+            source_extensions: None,
+            connect_extensions: None,
+            connect_is_success: None,
+        },
+        label: Label(
+            "connectors.v1 http: GET /tractors?id={$args.id}",
+        ),
+    },
+    "connectors_Tractor_0": Connector {
+        id: ConnectId {
+            subgraph_name: "connectors",
+            source_name: Some(
+                "v1",
+            ),
+            named: None,
+            directive: Type(
+                ObjectTypeDefinitionDirectivePosition {
+                    type_name: "Tractor",
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            ),
+        },
+        transport: Some(
+            HttpJsonTransport {
+                source_template: Some(
+                    StringTemplate {
+                        parts: [
+                            Constant(
+                                Constant {
+                                    value: "http://127.0.0.1",
+                                    location: 0..16,
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                connect_template: StringTemplate {
+                    parts: [
+                        Constant(
+                            Constant {
+                                value: "/tractors/",
+                                location: 0..10,
+                            },
+                        ),
+                        Expression(
+                            Expression {
+                                expression: JSONSelection {
+                                    inner: Value(
+                                        WithRange {
+                                            node: Path(
+                                                PathSelection {
+                                                    path: WithRange {
+                                                        node: Var(
+                                                            WithRange {
+                                                                node: $this,
+                                                                range: Some(
+                                                                    0..5,
+                                                                ),
+                                                            },
+                                                            WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "id",
+                                                                        ),
+                                                                        range: Some(
+                                                                            6..8,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            8..8,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    5..8,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        range: Some(
+                                                            0..8,
+                                                        ),
+                                                    },
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..8,
+                                            ),
+                                        },
+                                    ),
+                                    spec: V0_4,
+                                },
+                                location: 11..19,
+                            },
+                        ),
+                    ],
+                },
+                method: Get,
+                headers: [],
+                body: None,
+                source_path: None,
+                source_query_params: None,
+                connect_path: None,
+                connect_query_params: None,
+            },
+        ),
+        selection: JSONSelection {
+            inner: Named(
+                SubSelection {
+                    selections: [
+                        NamedSelection {
+                            prefix: None,
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "id",
+                                                    ),
+                                                    range: Some(
+                                                        0..2,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        2..2,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    0..2,
+                                ),
+                            },
+                        },
+                        NamedSelection {
+                            prefix: None,
+                            path: WithRange {
+                                node: Path(
+                                    PathSelection {
+                                        path: WithRange {
+                                            node: Key(
+                                                WithRange {
+                                                    node: Field(
+                                                        "name",
+                                                    ),
+                                                    range: Some(
+                                                        3..7,
+                                                    ),
+                                                },
+                                                WithRange {
+                                                    node: Empty,
+                                                    range: Some(
+                                                        7..7,
+                                                    ),
+                                                },
+                                            ),
+                                            range: Some(
+                                                3..7,
+                                            ),
+                                        },
+                                    },
+                                ),
+                                range: Some(
+                                    3..7,
+                                ),
+                            },
+                        },
+                    ],
+                    range: Some(
+                        0..7,
+                    ),
+                },
+            ),
+            spec: V0_4,
+        },
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            TypeSingle,
+        ),
+        spec: V0_4,
+        schema_subtypes_map: {
+            "_Entity": {
+                "Tractor",
+            },
+        },
+        request_headers: {},
+        response_headers: {},
+        request_variable_keys: {
+            $this: {
+                "id",
+            },
+        },
+        response_variable_keys: {},
+        batch_settings: None,
+        error_settings: ConnectorErrorsSettings {
+            message: None,
+            source_extensions: None,
+            connect_extensions: None,
+            connect_is_success: None,
+        },
+        label: Label(
+            "connectors.v1 http: GET /tractors/{$this.id}",
+        ),
+    },
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@entity_query_field_entity_true_v04.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@entity_query_field_entity_true_v04.graphql.snap
@@ -1,0 +1,61 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: raw_sdl
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_entity_true_v04.graphql
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(graphs: [CONNECTORS_QUERY_TRACTOR_0], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]}) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String, usedOverridden: Boolean, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments!) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """EXECUTION features provide metadata necessary for operation execution."""
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+enum join__Graph {
+  CONNECTORS_QUERY_TRACTOR_0 @join__graph(name: "connectors_Query_tractor_0", url: "none")
+}
+
+type Tractor @join__type(graph: CONNECTORS_QUERY_TRACTOR_0, key: "id") {
+  id: ID! @join__field(graph: CONNECTORS_QUERY_TRACTOR_0, type: "ID!")
+  name: String @join__field(graph: CONNECTORS_QUERY_TRACTOR_0, type: "String")
+}
+
+type Query @join__type(graph: CONNECTORS_QUERY_TRACTOR_0) {
+  tractor(id: ID!): Tractor @join__field(graph: CONNECTORS_QUERY_TRACTOR_0, type: "Tractor")
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@entity_query_field_v03.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@entity_query_field_v03.graphql.snap
@@ -1,0 +1,65 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: raw_sdl
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_v03.graphql
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) @link(url: "https://specs.apollo.dev/connect/v0.3", for: EXECUTION) @join__directive(graphs: [CONNECTORS_QUERY_TRACTOR_0, CONNECTORS_TRACTOR_0], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String, usedOverridden: Boolean, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments!) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """EXECUTION features provide metadata necessary for operation execution."""
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+enum join__Graph {
+  CONNECTORS_QUERY_TRACTOR_0 @join__graph(name: "connectors_Query_tractor_0", url: "none")
+  CONNECTORS_TRACTOR_0 @join__graph(name: "connectors_Tractor_0", url: "none")
+}
+
+type Tractor @join__type(graph: CONNECTORS_QUERY_TRACTOR_0) @join__type(graph: CONNECTORS_TRACTOR_0, key: "id") {
+  id: ID! @join__field(graph: CONNECTORS_QUERY_TRACTOR_0, type: "ID!") @join__field(graph: CONNECTORS_TRACTOR_0, type: "ID!")
+  name: String @join__field(graph: CONNECTORS_QUERY_TRACTOR_0, type: "String") @join__field(graph: CONNECTORS_TRACTOR_0, type: "String")
+}
+
+type Query @join__type(graph: CONNECTORS_QUERY_TRACTOR_0) @join__type(graph: CONNECTORS_TRACTOR_0) {
+  tractor(id: ID!): Tractor @join__field(graph: CONNECTORS_QUERY_TRACTOR_0, type: "Tractor")
+  _: ID @inaccessible @join__field(graph: CONNECTORS_TRACTOR_0, type: "ID")
+}

--- a/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@entity_query_field_v04.graphql.snap
+++ b/apollo-federation/src/connectors/expand/tests/snapshots/supergraph@entity_query_field_v04.graphql.snap
@@ -1,0 +1,65 @@
+---
+source: apollo-federation/src/connectors/expand/tests/mod.rs
+expression: raw_sdl
+input_file: apollo-federation/src/connectors/expand/tests/schemas/expand/entity_query_field_v04.graphql
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(graphs: [CONNECTORS_QUERY_TRACTOR_0, CONNECTORS_TRACTOR_0], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]}) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String, usedOverridden: Boolean, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments!) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """EXECUTION features provide metadata necessary for operation execution."""
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+enum join__Graph {
+  CONNECTORS_QUERY_TRACTOR_0 @join__graph(name: "connectors_Query_tractor_0", url: "none")
+  CONNECTORS_TRACTOR_0 @join__graph(name: "connectors_Tractor_0", url: "none")
+}
+
+type Tractor @join__type(graph: CONNECTORS_QUERY_TRACTOR_0) @join__type(graph: CONNECTORS_TRACTOR_0, key: "id") {
+  id: ID! @join__field(graph: CONNECTORS_QUERY_TRACTOR_0, type: "ID!") @join__field(graph: CONNECTORS_TRACTOR_0, type: "ID!")
+  name: String @join__field(graph: CONNECTORS_QUERY_TRACTOR_0, type: "String") @join__field(graph: CONNECTORS_TRACTOR_0, type: "String")
+}
+
+type Query @join__type(graph: CONNECTORS_QUERY_TRACTOR_0) @join__type(graph: CONNECTORS_TRACTOR_0) {
+  tractor(id: ID!): Tractor @join__field(graph: CONNECTORS_QUERY_TRACTOR_0, type: "Tractor")
+  _: ID @inaccessible @join__field(graph: CONNECTORS_TRACTOR_0, type: "ID")
+}


### PR DESCRIPTION
## Summary

Under `connect/v0.4`, when a `@key` entity has **both** a type-level reference-resolver `@connect` (mapping from `$this`) **and** a separate `Query` field `@connect` returning that same type (mapping from `$args`, with `entity` unset), connector expansion copied the entity's declared `@key` onto the `Query`-field connector's generated subgraph as **resolvable**.

That gave the query planner a second, spurious entity path, so it could route entity-reference resolution through the `Query`-field connector — where `$args` is empty during entity resolution — sending a request with the query parameters stripped and surfacing an upstream `400` reported as `CONNECTOR_FETCH` (at a coordinate like `Query.tractor[0]`).

`connect/v0.3` was never affected, so a schema that works on v0.3 can break on v0.4 with no other change.

## Why this matters more than it did when the PR was opened

When this was opened, reaching the bug required a subgraph to `@link` `connect/v0.4` explicitly: `ConnectSpec::latest()` still returned `V0_3`, so v0.4 was never what composition chose on its own. (The separate `preview_connect_v0_4` router opt-in had already been removed in #9644, shipped in v2.16.0.)

That changes with #9839, now on `dev`: `ConnectSpec::latest()` returns `V0_4`, and composition stamps v0.4 as the default version when a subgraph does not declare a connect spec version. From that release on, a subgraph can reach this by declaring nothing at all, and the "stay on v0.3" workaround means explicitly pinning rather than simply not upgrading.

This has been hit in the field more than once, most recently while evaluating connectors against a production schema shape, so it is not a theoretical regression.

## Root cause

`apollo-federation/src/connectors/expand/mod.rs`, `Expander::copy_interface_object_keys` (the v0.4 path). It looped over **all** declared `@key`s on a connector's output type and only appended `resolvable: false` when the type was an `@interfaceObject`. For an ordinary entity type it copied `@key(fields: …)` with no `resolvable` argument, which means `resolvable: true`.

The v0.3 `LegacyExpander` gated the entire copy loop behind `is_interface_object` and always emitted `resolvable: false`, so it never produced the extra path.

A `Query.<field> @connect` on a root type with `entity` unset yields `EntityResolver = None`, so no derived resolvable key, so it falls into `copy_interface_object_keys` on the output type — which for v0.4 was the entity type itself.

## Fix

Restore v0.3 parity in the v0.4 expander: only copy keys for `@interfaceObject` types, and always as `resolvable: false`.

## Tests

Three new expand fixtures (glob-driven snapshot test in `connectors::expand::tests`):

| Fixture | `Tractor` on the `Query.tractor` connector subgraph |
|---|---|
| `entity_query_field_v04` (the bug) | **no key** after fix (was `key: "id"` resolvable before) |
| `entity_query_field_v03` (baseline) | no key — v0.3 was always correct |
| `entity_query_field_entity_true_v04` (workaround) | resolvable `key: "id"` — `entity: true` makes it a real `Explicit` resolver, which is correct |

The `entity_query_field_v04` fixture was checked against an unpatched `dev` to confirm it pins the bug rather than merely recording current output. Without the fix it fails on exactly one line of the composed supergraph:

```diff
-type Tractor @join__type(graph: CONNECTORS_QUERY_TRACTOR_0) @join__type(graph: CONNECTORS_TRACTOR_0, key: "id")
+type Tractor @join__type(graph: CONNECTORS_QUERY_TRACTOR_0, key: "id") @join__type(graph: CONNECTORS_TRACTOR_0, key: "id")
```

Full `apollo-federation` suite passes. No pre-existing snapshot changed its expansion behavior, so the interface-object, implicit-entity and reference-resolver paths are untouched.

## Notes

- Rebased onto current `dev`. The only content change from the original branch is regenerating the three `connectors@*` snapshots for the `output_type` field `Connector` has gained since; the `api@` and `supergraph@` snapshots, where the `@key(resolvable:)` behavior shows up, are unchanged.
- Workaround for affected users until this ships: pin `connect/v0.3`, **or** set `entity: true` on the `Query` connector and drop the type-level reference resolver.


<!-- ROUTER-2114 -->
