### PR TITLE
ci: nightly, ad hoc builds cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,15 @@ parameters:
   quick_nightly:
     type: boolean
     default: false
+  # test_build triggers the standalone `build-test-image` workflow: a single
+  # linux/amd64 Docker image built from whatever branch/commit triggered the
+  # pipeline, tagged by branch+commit (not a release/nightly version), and
+  # pushed to ghcr.io/apollographql/router-test-builds. This is unrelated to
+  # release or nightly versioning -- it exists for ad hoc test builds
+  # consumed by the internal testing framework (RTF).
+  test_build:
+    type: boolean
+    default: false
 
 # These are common environment variables that we want to set on on all jobs.
 # While these could conceivably be set on the CircleCI project settings'
@@ -978,6 +987,94 @@ jobs:
                   VERSION_WITHOUT_LEADING_V="${VERSION#v}"
                   cargo xtask release notes "$VERSION_WITHOUT_LEADING_V" || true
 
+  # Standalone ad hoc test build. Deliberately independent of `build_release`:
+  # no release-versioning (`cargo xtask release prepare`), no nightly/release
+  # tag scheme, no helm chart, no security scan, no notifications. Builds a
+  # single linux/amd64 image from whatever branch/commit triggered the
+  # pipeline and pushes it to a dedicated, non-release image repository for
+  # consumption by the internal testing framework (RTF). See
+  # AD_HOC_TEST_BUILD_PLAN.md for the design rationale.
+  build_test_image:
+    environment:
+      <<: *common_job_environment
+      RELEASE_BIN: router
+      REPO_URL: << pipeline.project.git_url >>
+    executor: amd_linux_build
+    steps:
+      - checkout
+      - setup_environment:
+          platform: amd_linux_build
+      - run:
+          name: Build router binary
+          command: cargo xtask dist
+      - run:
+          command: mkdir -p artifacts
+      - run:
+          name: Package artifact
+          command: cargo xtask package --output artifacts/
+      - store_artifacts:
+          path: artifacts/
+      - setup_remote_docker:
+          # CircleCI Image Policy
+          #   https://circleci.com/docs/remote-docker-images-support-policy/
+          version: docker23
+          docker_layer_caching: true
+      - run:
+          name: Docker build and push test image
+          command: |
+            BASE_VERSION=$(cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[0].version')
+            ARTIFACT_FILENAME="router-v${BASE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+            ARTIFACT_URL="https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/artifacts/${ARTIFACT_FILENAME}"
+            ROUTER_TAG=ghcr.io/apollographql/router-test-builds
+
+            # Tag by branch + short commit sha -- NOT a release/nightly version.
+            # This pipeline has nothing to do with release or nightly versioning.
+            SANITIZED_BRANCH=$(echo "${CIRCLE_BRANCH}" | tr -c 'a-zA-Z0-9' '-')
+            SHORT_SHA=$(git rev-parse --short=8 HEAD)
+            TAG="${SANITIZED_BRANCH}-${SHORT_SHA}"
+
+            # Validate local artifact exists and calculate its checksum as a safety net
+            if [ ! -f "artifacts/${ARTIFACT_FILENAME}" ]; then
+              echo "Error: Local artifact not found: artifacts/${ARTIFACT_FILENAME}"
+              exit 1
+            fi
+            LOCAL_ARTIFACT_SHA256SUM=$(sha256sum "artifacts/${ARTIFACT_FILENAME}" | cut -d' ' -f1)
+            echo "Local artifact checksum: ${LOCAL_ARTIFACT_SHA256SUM}"
+
+            # Download the artifact and calculate its checksum
+            echo "Downloading artifact to calculate checksum..."
+            curl -sSL -H "Circle-Token: ${CIRCLE_TOKEN}" -o "router-artifact.tar.gz" "${ARTIFACT_URL}"
+            ARTIFACT_URL_SHA256SUM=$(sha256sum "router-artifact.tar.gz" | cut -d' ' -f1)
+            rm -f router-artifact.tar.gz
+
+            # Compare local vs remote artifact checksums
+            if [ "${LOCAL_ARTIFACT_SHA256SUM}" != "${ARTIFACT_URL_SHA256SUM}" ]; then
+              echo "Error: Local and remote artifact checksums don't match!"
+              echo "Local:      ${LOCAL_ARTIFACT_SHA256SUM}"
+              echo "Remote: ${ARTIFACT_URL_SHA256SUM}"
+              exit 1
+            fi
+            echo "Local and remote artifact checksums match: ${LOCAL_ARTIFACT_SHA256SUM}"
+
+            echo "REPO_URL: ${REPO_URL}"
+            echo "BASE_VERSION: ${BASE_VERSION}"
+            echo "TAG: ${TAG}"
+            echo "ROUTER_TAG: ${ROUTER_TAG}"
+
+            docker context create buildx-build
+            docker buildx create --driver docker-container --use buildx-build
+            docker buildx inspect --bootstrap
+            echo ${GITHUB_OCI_TOKEN} | docker login ghcr.io -u apollo-bot2 --password-stdin
+            # Build and push debug image
+            docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${TAG} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${TAG}-debug dockerfiles/.
+            docker push ${ROUTER_TAG}:${TAG}-debug
+            # Build and push regular image
+            docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg ROUTER_RELEASE=${TAG} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${TAG} dockerfiles/.
+            docker push ${ROUTER_TAG}:${TAG}
+
+            echo "Pushed: ${ROUTER_TAG}:${TAG}"
+            echo "Pushed: ${ROUTER_TAG}:${TAG}-debug"
+
 workflows:
   ci_checks:
     when:
@@ -985,6 +1082,7 @@ workflows:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
+          - << pipeline.parameters.test_build >>
     jobs:
       - fmt_check:
           matrix:
@@ -1088,6 +1186,7 @@ workflows:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
+          - << pipeline.parameters.test_build >>
     jobs:
       - pre_verify_release:
           matrix:
@@ -1165,6 +1264,7 @@ workflows:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
+          - << pipeline.parameters.test_build >>
     jobs:
       - secops/gitleaks:
           context:
@@ -1178,3 +1278,14 @@ workflows:
             - github-orb
           git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
           disabled-signatures: "rules.providers.semgrep.security.javascript.lang.security.detect-insecure-websocket"
+
+  # Ad hoc test build: trigger manually via CircleCI's "Trigger Pipeline" UI
+  # on any branch, setting the `test_build` boolean parameter to true. Not
+  # part of releases or nightlies -- see AD_HOC_TEST_BUILD_PLAN.md.
+  build-test-image:
+    when: << pipeline.parameters.test_build >>
+    jobs:
+      - build_test_image:
+          context:
+            - router
+            - orb-publishing

--- a/.github/workflows/cleanup-ghcr-images.yml
+++ b/.github/workflows/cleanup-ghcr-images.yml
@@ -1,0 +1,85 @@
+name: Cleanup old GHCR test-build and nightly images
+
+# Prunes GHCR package versions by age. Retention:
+#   - router-test-builds:         7 days  (ad hoc test builds, see build-test-image in .circleci/config.yml)
+#   - nightly/router:            14 days  (scheduled + one-off nightly builds)
+#   - helm-charts-nightly/router: 14 days (nightly Helm chart)
+#
+# Age is based on each version's `created_at` from the GitHub Packages API,
+# not on tag contents, so it applies uniformly regardless of tagging scheme.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List what would be deleted without deleting anything'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: router-test-builds
+            retention_days: 7
+          - package: nightly/router
+            retention_days: 14
+          - package: helm-charts-nightly/router
+            retention_days: 14
+    steps:
+      - name: Delete ${{ matrix.package }} versions older than ${{ matrix.retention_days }} days
+        env:
+          # Requires packages:delete scope (classic PAT) or "Packages: read
+          # and write" (fine-grained PAT). Same identity used elsewhere in
+          # this repo's GitHub Actions (forward-port-dev-to-dev-v3.yml) --
+          # its scope may need to be extended to cover package deletion.
+          GH_TOKEN: ${{ secrets.APOLLO_BOT2_GITHUB_PAT }}
+          PACKAGE: ${{ matrix.package }}
+          RETENTION_DAYS: ${{ matrix.retention_days }}
+          # Defaults to dry-run on every scheduled run and on a plain
+          # "Run workflow". Trigger manually with dry_run=false once a
+          # dry run's output has been reviewed and looks correct, then flip
+          # this default.
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+        run: |
+          set -euo pipefail
+
+          ORG="apollographql"
+          ENCODED_PACKAGE="${PACKAGE//\//%2F}"
+          CUTOFF_EPOCH=$(date -u -d "-${RETENTION_DAYS} days" +%s)
+
+          echo "package=${PACKAGE} retention_days=${RETENTION_DAYS} dry_run=${DRY_RUN}"
+
+          page=1
+          while : ; do
+            versions=$(gh api "/orgs/${ORG}/packages/container/${ENCODED_PACKAGE}/versions?per_page=100&page=${page}")
+            count=$(echo "${versions}" | jq 'length')
+            [ "${count}" -eq 0 ] && break
+
+            while IFS= read -r v; do
+              id=$(echo "${v}" | jq -r '.id')
+              created_at=$(echo "${v}" | jq -r '.created_at')
+              created_epoch=$(date -u -d "${created_at}" +%s)
+              tags=$(echo "${v}" | jq -r '(.metadata.container.tags // []) | join(",")')
+
+              if [ "${created_epoch}" -lt "${CUTOFF_EPOCH}" ]; then
+                if [ "${DRY_RUN}" = "true" ]; then
+                  echo "[dry-run] would delete ${PACKAGE} version ${id} (tags: ${tags:-<untagged>}, created ${created_at})"
+                else
+                  echo "deleting ${PACKAGE} version ${id} (tags: ${tags:-<untagged>}, created ${created_at})"
+                  gh api --method DELETE "/orgs/${ORG}/packages/container/${ENCODED_PACKAGE}/versions/${id}"
+                fi
+              fi
+            done < <(echo "${versions}" | jq -c '.[]')
+
+            [ "${count}" -lt 100 ] && break
+            page=$((page + 1))
+          done

--- a/.github/workflows/cleanup-ghcr-images.yml
+++ b/.github/workflows/cleanup-ghcr-images.yml
@@ -63,6 +63,7 @@ jobs:
             count=$(echo "${versions}" | jq 'length')
             [ "${count}" -eq 0 ] && break
 
+            deleted_this_page=false
             while IFS= read -r v; do
               id=$(echo "${v}" | jq -r '.id')
               created_at=$(echo "${v}" | jq -r '.created_at')
@@ -75,10 +76,21 @@ jobs:
                 else
                   echo "deleting ${PACKAGE} version ${id} (tags: ${tags:-<untagged>}, created ${created_at})"
                   gh api --method DELETE "/orgs/${ORG}/packages/container/${ENCODED_PACKAGE}/versions/${id}"
+                  deleted_this_page=true
                 fi
               fi
             done < <(echo "${versions}" | jq -c '.[]')
 
-            [ "${count}" -lt 100 ] && break
-            page=$((page + 1))
+            # The list endpoint is offset-paginated against the live
+            # collection. Deleting from this page shifts later, not-yet-seen
+            # versions into it, so re-fetch the same page instead of
+            # advancing -- otherwise those shifted-in versions are skipped.
+            # Once a page comes back short, it's the final page: nothing
+            # exists beyond it to shift in, so it's safe to stop even if we
+            # just deleted from it.
+            if [ "${count}" -lt 100 ]; then
+              break
+            elif [ "${deleted_this_page}" = "false" ]; then
+              page=$((page + 1))
+            fi
           done

--- a/.github/workflows/cleanup-ghcr-images.yml
+++ b/.github/workflows/cleanup-ghcr-images.yml
@@ -16,7 +16,7 @@ on:
       dry_run:
         description: 'List what would be deleted without deleting anything'
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read
@@ -44,11 +44,10 @@ jobs:
           GH_TOKEN: ${{ secrets.APOLLO_BOT2_GITHUB_PAT }}
           PACKAGE: ${{ matrix.package }}
           RETENTION_DAYS: ${{ matrix.retention_days }}
-          # Defaults to dry-run on every scheduled run and on a plain
-          # "Run workflow". Trigger manually with dry_run=false once a
-          # dry run's output has been reviewed and looks correct, then flip
-          # this default.
-          DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+          # Deletes for real on every scheduled run and on a plain
+          # "Run workflow". Pass dry_run=true on a manual dispatch to preview
+          # without deleting anything.
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
adds a daily GitHub Action that prunes old GHCR package versions by age (created_at, not tag contents):
  - router-test-builds:         7 days  (ad hoc test-build pipeline)
  - nightly/router:            14 days
  - helm-charts-nightly/router: 14 days

