### PR TITLE
fix(ci): forbid background agent dispatch in claude-review action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: '--model claude-fable-5 --append-system-prompt "Always post a PR comment summarizing your decision, even if you decide to STOP without doing a full review."'
+          claude_args: '--model claude-fable-5 --append-system-prompt "Always post a PR comment summarizing your decision, even if you decide to STOP without doing a full review. Never launch a Task/Agent in background or async mode (i.e. never pass run_in_background: true, and never say you will wait for an agent and then end your turn) -- this is a one-shot headless run with no mechanism to resume the session when a background agent completes, so backgrounded work is silently lost and the review never gets posted. Launch every subagent synchronously: batch independent agent calls into a single turn and wait for all of them to return real results before proceeding."'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }} --comment'


### PR DESCRIPTION
## Summary

The `/claude-review` GitHub Action was silently failing to post PR review comments even though the workflow run reported success. Root cause: the orchestrating model sometimes launches its helper subagents in background/async mode, then ends its turn saying it will "wait for their results" — but `claude-code-action` runs headless and one-shot, with no mechanism to resume the session when a backgrounded agent later completes (unlike the interactive CLI, which auto-continues on a completion notification). Everything after that point (the parallel review agents, confidence scoring, and posting the final `gh` comment) never runs, yet the job step still exits 0.

Confirmed by comparing two runs of the same workflow:
- Run `30279023064` against PR #9819: orchestrator ended after only 4 turns with `stop_reason: end_turn`, having backgrounded two helper agents and never following up — no comment posted.
- Run `30107734287` against PR #9859: everything ran synchronously and a real review was posted.

## Changes

- `.github/workflows/claude-review.yml`: append an explicit instruction to `--append-system-prompt` telling the orchestrator to never dispatch subagents in background/async mode in this environment, and to always wait for subagents to return real results before proceeding.

## Test plan

- [ ] Comment `/claude-review` on a PR and confirm a review comment is actually posted
- [ ] Repeat a few times to check the fix holds up given the underlying behavior is model-driven/nondeterministic

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>