### PR TITLE
docs: require usage metrics for new config options and features in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,37 @@
-# Apollo Router — Code Review Guidelines
+# Apollo Router — Engineering Guidelines
 
-The following patterns are known sources of bugs in this codebase. During code review, check for all of them in addition to general correctness, performance, and security concerns.
+This file applies both when writing new code and when reviewing it: the "Required" rule below must be followed by anyone (or any AI tooling) authoring changes, and the "Known patterns to check" list is what to look for during code review — including whether the "Required" rule was actually followed.
 
-## Known patterns to check
+## Required when writing code
+
+### Usage metric for every new config option or feature
+
+Any new config option or feature must ship with a usage metric, so adoption is measurable from day one. Knowing how many deployments actually use a feature is what makes decisions like deprecation, further investment, or support prioritization possible — without it, those calls get made blind.
+
+- The metric must be **always-on**: emitted once per router startup/config-reload (an `ObservableGauge` populated from the parsed config), not a per-request counter that scales with traffic volume. A feature used by one router instance serving zero requests must still be visible.
+- Follow the existing pattern in `populate_config_instruments` (`apollo-router/src/configuration/metrics.rs`), which registers instruments via the `populate_config_instrument!` macro. Name the metric `apollo.router.config.<feature>` and add it there — do not build a parallel mechanism.
+- It's fine for the metric to just record "this is enabled" with no immediate consumer. The goal is a black-hole signal — cheap to emit, ignorable for now, queryable later if adoption becomes a question.
+
+Example, following `apollo.router.config.authorization` in `apollo-router/src/configuration/metrics.rs`:
+
+```rust
+populate_config_instrument!(
+    apollo.router.config.my_new_feature, // metric name
+    "$.my_new_feature[?(@.enabled == true)]", // path to the feature in config
+    opt.some_sub_option, // attribute name
+    "$[?(@.some_sub_option == true)]" // path to the attribute, relative to the feature
+);
+```
+
+This sets `apollo.router.config.my_new_feature` to `1` whenever `my_new_feature.enabled: true` is present in the router's YAML config (with an `opt_some_sub_option` attribute for the sub-option), and reports it on every metrics collection cycle regardless of request traffic.
+
+## Known patterns to check during code review
+
+The following patterns are known sources of bugs in this codebase. Check for all of them in addition to general correctness, performance, and security concerns.
+
+**Missing usage metric for a new config option or feature.**
+- When a diff adds a new config option or feature flag, check whether `populate_config_instruments` in `apollo-router/src/configuration/metrics.rs` was updated to register it.
+- Flag config/feature additions with no corresponding `apollo.router.config.*` gauge — see the "Required" section above.
 
 **Test asserts on the wrong side of the wire.**
 - For each external call in the diff (HTTP, IPC, DB, etc.), ask: where's the metric/log/span that records it happened?


### PR DESCRIPTION
Adds an explicit `CLAUDE.md` rule requiring that any new config option or feature ship with a usage metric, and retitles the file from "Code Review Guidelines" to "Engineering Guidelines" since the new rule applies to authoring, not just review.

- **Required when writing code**: new section stating the metric must be always-on (an `ObservableGauge` tied to config load/reload), not a per-request counter proportional to traffic — so adoption is visible even for a feature that's enabled but never exercised by a request.
- Points at the existing `populate_config_instruments` pattern in [`apollo-router/src/configuration/metrics.rs`](https://github.com/apollographql/router/blob/dev/apollo-router/src/configuration/metrics.rs), with a worked example based on the real `apollo.router.config.authorization` metric.
- **Known patterns to check during code review**: added a matching review checklist item so a missing usage metric gets flagged in review, not just at authoring time.

This convention isn't new — it matches the existing "Config metrics" guidance in [`dev-docs/metrics.md`](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#config-metrics) ("Each new feature MUST have a config metric that gives us information if a feature has been enabled"). This PR makes that convention something AI tooling (and human contributors reading `CLAUDE.md`) will reliably see and follow, since the team has found config/feature adoption gaps too late to act on them.

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

This is a docs-only change to `CLAUDE.md` (an internal contributor/AI-tooling guideline). No code, config, or user-facing behavior changed, so a changeset, performance assessment, metrics/logs, and tests are not applicable.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

[ROUTER-1965]: https://apollographql.atlassian.net/browse/ROUTER-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ