### PR TITLE
docs: clarify scope of --anonymous-telemetry-disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Options:
       --apollo-uplink-endpoints <APOLLO_UPLINK_ENDPOINTS>
           The endpoints (comma separated) polled to fetch the latest supergraph schema [env: APOLLO_UPLINK_ENDPOINTS=]
       --anonymous-telemetry-disabled
-          Disable sending anonymous usage information to Apollo [env: APOLLO_TELEMETRY_DISABLED=]
+          Disable the router's fully anonymous usage ping. Doesn't affect usage reporting to Apollo Studio for graphs configured with APOLLO_KEY and APOLLO_GRAPH_REF [env: APOLLO_TELEMETRY_DISABLED=]
       --apollo-uplink-timeout <APOLLO_UPLINK_TIMEOUT>
           The timeout for an http call to Apollo uplink. Defaults to 30s [env: APOLLO_UPLINK_TIMEOUT=] [default: 30s]
       --listen <LISTEN_ADDRESS>

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -47,6 +47,7 @@ pub(crate) static APOLLO_ROUTER_SUPERGRAPH_PATH_IS_SET: AtomicBool = AtomicBool:
 pub(crate) static APOLLO_ROUTER_SUPERGRAPH_URLS_IS_SET: AtomicBool = AtomicBool::new(false);
 pub(crate) static APOLLO_ROUTER_LICENCE_IS_SET: AtomicBool = AtomicBool::new(false);
 pub(crate) static APOLLO_ROUTER_LICENCE_PATH_IS_SET: AtomicBool = AtomicBool::new(false);
+// Unlike its siblings above, this is never read via `populate_cli_instrument` (or anywhere else) today.
 pub(crate) static APOLLO_TELEMETRY_DISABLED: AtomicBool = AtomicBool::new(false);
 pub(crate) static APOLLO_ROUTER_LISTEN_ADDRESS: Mutex<Option<SocketAddr>> = Mutex::new(None);
 pub(crate) static APOLLO_ROUTER_GRAPH_ARTIFACT_REFERENCE: Mutex<Option<String>> = Mutex::new(None);
@@ -187,7 +188,8 @@ pub struct Opt {
     #[clap(long, env = "APOLLO_GRAPH_ARTIFACT_REFERENCE", action = ArgAction::Append)]
     graph_artifact_reference: Option<String>,
 
-    /// Disable sending anonymous usage information to Apollo.
+    /// Disable the router's fully anonymous usage ping. Doesn't affect usage reporting to Apollo
+    /// Studio for graphs configured with APOLLO_KEY and APOLLO_GRAPH_REF.
     #[clap(long, env = "APOLLO_TELEMETRY_DISABLED", value_parser = FalseyValueParser::new())]
     anonymous_telemetry_disabled: bool,
 

--- a/docs/source/routing/configuration/cli.mdx
+++ b/docs/source/routing/configuration/cli.mdx
@@ -221,7 +221,7 @@ The default value is `30s` (thirty seconds).
 </td>
 <td>
 
-If set, disables sending anonymous usage information to Apollo.
+If set, disables the router's fully anonymous usage ping (no `APOLLO_KEY` required). This doesn't affect the usage reporting that Apollo Router sends to Apollo Studio for graphs configured with `APOLLO_KEY` and `APOLLO_GRAPH_REF`.
 
 </td>
 </tr>


### PR DESCRIPTION
<!-- start metadata -->
<!-- [ROUTER-1603] -->
---

## What
- Reworded the `--anonymous-telemetry-disabled` docs entry (`docs/source/routing/configuration/cli.mdx`) to state that it only disables the router's fully anonymous "orbiter" usage ping, and doesn't affect Apollo Studio usage reporting for graphs configured with `APOLLO_KEY`/`APOLLO_GRAPH_REF`.
- Updated the matching CLI `--help` doc-comment in `apollo-router/src/executable.rs` and the pasted `--help` snapshot in `README.md` to the same wording.
- Added a comment noting that the `APOLLO_TELEMETRY_DISABLED` atomic (`apollo-router/src/executable.rs`) is currently write-only — unlike its sibling atomics, it isn't read by `populate_cli_instrument`.

## Verified
- `cargo fmt --all --check` passed
- `cargo clippy -- -D warnings` passed
- CHANGELOG.md not modified
- No changeset files added or modified

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

No behavior change — this is a wording-only fix to docs, CLI help text, and a code comment. Manually verified via `--help` output and running the built binary with the flag set/unset. No metric or test additions since nothing about runtime behavior changed.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

[ROUTER-1603]: https://apollographql.atlassian.net/browse/ROUTER-1603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ