### PR TITLE
refactor(authorization): delegate authentication checks to the authentication plugin

### DIFF
--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -1,6 +1,7 @@
 //! Authentication plugin
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::ops::ControlFlow;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -28,6 +29,7 @@ use self::jwks::JwksManager;
 use self::subgraph::SigningParams;
 use self::subgraph::SigningParamsConfig;
 use self::subgraph::SubgraphAuth;
+use crate::Context;
 use crate::graphql;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::PluginInit;
@@ -651,6 +653,24 @@ fn authenticate(
         StatusCode::UNAUTHORIZED,
         source_of_extracted_jwt,
     )
+}
+
+/// Returns whether this request presented a JWT that passed validation. This is currently
+/// equivalent to "has this request authenticated" since JWT is the router's only inbound
+/// authentication mechanism — but if another one is ever added, callers relying on this for
+/// a general "is authenticated" answer will need it updated (or a new check added) too.
+pub(crate) fn has_authenticated_jwt(context: &Context) -> bool {
+    context.contains_key(APOLLO_AUTHENTICATION_JWT_CLAIMS)
+}
+
+/// Returns the space-delimited OAuth `scope` claim from the request's validated JWT, if any.
+pub(crate) fn jwt_scopes(context: &Context) -> Option<HashSet<String>> {
+    context
+        .get_json_value(APOLLO_AUTHENTICATION_JWT_CLAIMS)?
+        .as_object()?
+        .get("scope")?
+        .as_str()
+        .map(|s| s.split(' ').map(|s| s.to_string()).collect())
 }
 
 // This macro allows us to use it in our plugin registry!

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -50,6 +50,8 @@ use super::JWTConf;
 use super::JwtStatus;
 use super::Source;
 use super::authenticate;
+use super::has_authenticated_jwt;
+use crate::Context;
 use crate::assert_errors_eq_ignoring_id;
 use crate::assert_response_eq_ignoring_error_id;
 use crate::assert_snapshot_subscriber;
@@ -65,6 +67,17 @@ use crate::plugins::authentication::jwks::search_jwks;
 use crate::services::router;
 use crate::services::router::body::RouterBody;
 use crate::services::supergraph;
+
+#[test]
+fn has_authenticated_jwt_reflects_context_state() {
+    let context = Context::new();
+    assert!(!has_authenticated_jwt(&context));
+
+    context
+        .insert(APOLLO_AUTHENTICATION_JWT_CLAIMS, "placeholder".to_string())
+        .unwrap();
+    assert!(has_authenticated_jwt(&context));
+}
 
 pub(crate) fn create_an_url(filename: &str) -> String {
     let jwks_base = Path::new("tests");

--- a/apollo-router/src/plugins/authorization/authenticated.rs
+++ b/apollo-router/src/plugins/authorization/authenticated.rs
@@ -517,7 +517,7 @@ mod tests {
     use crate::http_ext::TryIntoHeaderValue;
     use crate::json_ext::Path;
     use crate::plugin::test::MockSubgraph;
-    use crate::plugins::authorization::APOLLO_AUTHENTICATION_JWT_CLAIMS;
+    use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
     use crate::plugins::authorization::authenticated::AuthenticatedVisitor;
     use crate::services::router::ClientRequestAccepts;
     use crate::services::supergraph;

--- a/apollo-router/src/plugins/authorization/mod.rs
+++ b/apollo-router/src/plugins/authorization/mod.rs
@@ -34,7 +34,7 @@ use crate::json_ext::Path;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
-use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
+use crate::plugins::authentication;
 use crate::query_planner::FilteredQuery;
 use crate::query_planner::QueryKey;
 use crate::services::execution;
@@ -300,18 +300,9 @@ impl AuthorizationPlugin {
     }
 
     pub(crate) fn update_cache_key(context: &Context) {
-        let is_authenticated = context.contains_key(APOLLO_AUTHENTICATION_JWT_CLAIMS);
+        let is_authenticated = authentication::has_authenticated_jwt(context);
 
-        let request_scopes = context
-            .get_json_value(APOLLO_AUTHENTICATION_JWT_CLAIMS)
-            .and_then(|value| {
-                value.as_object().and_then(|object| {
-                    object.get("scope").and_then(|v| {
-                        v.as_str()
-                            .map(|s| s.split(' ').map(|s| s.to_string()).collect::<HashSet<_>>())
-                    })
-                })
-            });
+        let request_scopes = authentication::jwt_scopes(context);
         let query_scopes = context.get_json_value(REQUIRED_SCOPES_KEY).and_then(|v| {
             v.as_array().map(|v| {
                 v.iter()
@@ -590,12 +581,10 @@ impl Plugin for AuthorizationPlugin {
         if self.require_authentication {
             ServiceBuilder::new()
                 .checkpoint(move |request: supergraph::Request| {
-                    // XXX(@goto-bus-stop): Why are we doing this here, as opposed to the
-                    // authentication plugin, which manages this context value?
-                    if request
-                        .context
-                        .contains_key(APOLLO_AUTHENTICATION_JWT_CLAIMS)
-                    {
+                    // Whether to reject unauthenticated requests is an authorization policy,
+                    // same as `@authenticated`/`@requiresScopes`/`@policy` — authentication only
+                    // verifies tokens, it doesn't decide this.
+                    if authentication::has_authenticated_jwt(&request.context) {
                         Ok(ControlFlow::Continue(request))
                     } else {
                         tracing::error!("rejecting unauthenticated request");

--- a/apollo-router/src/plugins/authorization/tests.rs
+++ b/apollo-router/src/plugins/authorization/tests.rs
@@ -14,7 +14,7 @@ use crate::MockedSubgraphs;
 use crate::TestHarness;
 use crate::graphql;
 use crate::plugin::test::MockSubgraph;
-use crate::plugins::authorization::APOLLO_AUTHENTICATION_JWT_CLAIMS;
+use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
 use crate::plugins::authorization::CacheKeyMetadata;
 use crate::services::router;
 use crate::services::router::body;


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-985] -->
---

## What changed

The authorization plugin's `require_authentication` checkpoint, and its cache-key scope extraction in `update_cache_key`, both read the authentication plugin's raw `APOLLO_AUTHENTICATION_JWT_CLAIMS` context key directly. An unresolved review comment (`XXX(@goto-bus-stop)`, added during #6486's review) asked why this check lives in authorization instead of authentication.

This adds two small `pub(crate)` functions to the authentication plugin — `has_authenticated_jwt()` and `jwt_scopes()` — and updates both authorization call sites to use them instead of reaching into the context key themselves. The `XXX` comment is replaced with an explanation of why the check legitimately still lives in authorization: `require_authentication` is the whole-request-granularity version of the same policy decision as the `@authenticated`/`@requiresScopes`/`@policy` directives, which authorization already owns — authentication is deliberately mechanism-only (verify tokens, extract claims) and was never meant to decide whether unauthenticated access is allowed at all (see #2708, #3002).

This is a pure internal refactor — no config, behavior, or API change.

## Why not relocate the whole feature instead?

We considered moving `require_authentication` (config + enforcement) into the authentication plugin entirely, since the ticket's title suggested that. But `require_authentication` is architecturally paired with the `@authenticated` directive enforcement already in authorization (same concept, different granularity), and authentication was deliberately kept mechanism-only in 2023 (#2708). Relocating would split that pairing across two plugins for no behavioral benefit, so we went with encapsulation instead.

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes — N/A, no user-facing or config change
- [x] Changes are compatible
- [ ] Documentation completed — N/A, no config/behavior change to document
- [x] Performance impact assessed and acceptable — trivial function-call indirection, no measurable impact
- [ ] Metrics and logs are added and documented — N/A, no new config option or feature
- Tests added and passing
    - [x] Unit tests — added `has_authenticated_jwt_reflects_context_state`; existing `authenticated_request`/`unauthenticated_request` tests in both `authorization/tests.rs` and `authorization/authenticated.rs` pass unmodified, proving the delegation preserves behavior
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

No changeset — this is an internal refactor with no effect on router behavior or configuration.

Fixes [ROUTER-985](https://apollographql.atlassian.net/browse/ROUTER-985)


[ROUTER-985]: https://apollographql.atlassian.net/browse/ROUTER-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROUTER-985]: https://apollographql.atlassian.net/browse/ROUTER-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ