### PR TITLE
feat(state_machine): coalesce stacked reloads

### DIFF
--- a/.changesets/feat_coalesce_stacked_reloads.md
+++ b/.changesets/feat_coalesce_stacked_reloads.md
@@ -1,0 +1,9 @@
+### Coalesce queued schema, configuration, and license reloads ([PR #9890](https://github.com/apollographql/router/pull/9890))
+
+When several schema, configuration, or license updates are already queued together, the router now collapses them into a single reload of the newest state rather than building each intermediate state in turn. Because every reload includes query-planner warm-up, a rapid burst of updates previously spent time warming up states that were immediately superseded; those intermediate builds are now skipped.
+
+The router also distinguishes transient reload failures from permanent ones. A schema that fails to parse, or a configuration or license that violates enforcement, cannot succeed on retry, so it no longer retries on a timer and instead keeps serving the previous good state until the inputs change. Transient failures are retried as before.
+
+A new metric, `apollo.router.state.reload.coalesced`, counts the reloads skipped by coalescing.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9890

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -50,6 +50,14 @@ use crate::uplink::schema::SchemaState;
 
 const STATE_CHANGE: &str = "state change";
 
+/// Upper bound on how many reloads may be coalesced (skipped) in a row before a
+/// build is forced. Coalescing collapses a burst of queued updates into one
+/// reload, but without a cap a relentless stream of ready events could defer the
+/// reload indefinitely and starve the router of any new state. Hitting the cap
+/// forces a build of the newest-merged-so-far target and resets the count, so we
+/// always make forward progress. Realistic bursts are far smaller than this.
+const MAX_COALESCED_RELOADS: usize = 100;
+
 #[derive(Default, Clone)]
 pub(crate) struct ListenAddresses {
     pub(crate) graphql_listen_address: Option<ListenAddr>,
@@ -918,6 +926,10 @@ where
         // only the single peeked event is ever held.
         let mut messages = messages.peekable();
 
+        // How many reloads we've coalesced (skipped) in a row. Capped at
+        // MAX_COALESCED_RELOADS so a relentless burst can't defer a build forever.
+        let mut consecutive_coalesced: usize = 0;
+
         // Process events and retry-timer ticks until we reach a terminal state or
         // run out of events.
         loop {
@@ -959,8 +971,11 @@ where
                     // Coalesce: if this was an input event and another input event is
                     // already queued right behind it, skip the reload — the next event
                     // will supersede this target. A control event (Shutdown / NoMore*)
-                    // or an empty queue is always a reload boundary.
+                    // or an empty queue is always a reload boundary, and we force a
+                    // build once we've skipped MAX_COALESCED_RELOADS in a row so a
+                    // relentless burst can't defer the reload forever.
                     let coalesce_with_next = current_is_input
+                        && consecutive_coalesced < MAX_COALESCED_RELOADS
                         && matches!(
                             std::pin::Pin::new(&mut messages).peek().now_or_never(),
                             Some(Some(next)) if is_input_event(next)
@@ -968,6 +983,7 @@ where
 
                     if coalesce_with_next {
                         // A queued input supersedes this target; skip building it.
+                        consecutive_coalesced += 1;
                         u64_counter_with_unit!(
                             "apollo.router.state.reload.coalesced",
                             "Number of intermediate reload targets skipped by coalescing queued updates",
@@ -976,6 +992,7 @@ where
                         );
                     } else {
                         state = state.attempt_reload(&mut self).await;
+                        consecutive_coalesced = 0;
                     }
 
                     self.record_transition(event_name, previous_state, &state);
@@ -988,6 +1005,7 @@ where
                 _ = retry_future => {
                     let previous_state = format!("{state:?}");
                     state = state.attempt_reload(&mut self).await;
+                    consecutive_coalesced = 0;
                     self.record_transition("retry".to_string(), previous_state, &state);
                     if matches!(&state, Stopped | Errored(_)) {
                         break;
@@ -2386,6 +2404,34 @@ mod tests {
             Ok(())
         );
         assert_eq!(shutdown_receivers.0.lock().len(), 1);
+    }
+
+    // Coalescing is capped: a burst larger than MAX_COALESCED_RELOADS forces an
+    // intermediate build so a relentless stream can't defer the reload forever.
+    // Without the cap this whole burst would collapse into a single build; the cap
+    // makes it two (one forced mid-burst, one for the final update).
+    #[test(tokio::test)]
+    async fn coalescing_is_capped() {
+        let mut events = vec![
+            UpdateSchema(example_schema()),
+            UpdateLicense(Default::default()),
+        ];
+        // Configuration has no equality check, so each fresh config is a distinct
+        // reload target. Queue more than the cap so it trips exactly once.
+        for _ in 0..(MAX_COALESCED_RELOADS + 5) {
+            events.push(UpdateConfiguration(Arc::new(
+                Configuration::builder().build().unwrap(),
+            )));
+        }
+        events.push(Shutdown);
+
+        let router_factory = create_mock_router_configurator(2);
+        let (server_factory, shutdown_receivers) = create_mock_server_factory(2);
+        assert_matches!(
+            execute_burst(server_factory, router_factory, stream::iter(events)).await,
+            Ok(())
+        );
+        assert_eq!(shutdown_receivers.0.lock().len(), 2);
     }
 
     #[test(tokio::test)]

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -875,6 +875,28 @@ where
         }
     }
 
+    /// Record a single state transition: fire the test signal, emit the tracing
+    /// span, and bump the `apollo.router.state.change.total` counter.
+    fn record_transition(&self, event_name: String, previous_state: String, state: &State<FA>) {
+        #[cfg(test)]
+        self.notify_updated.notify_one();
+
+        tracing::info!(
+            event = event_name,
+            state = ?state,
+            previous_state,
+            "state machine transitioned"
+        );
+        u64_counter!(
+            "apollo.router.state.change.total",
+            "Router state changes",
+            1,
+            event = event_name,
+            state = format!("{state:?}"),
+            previous_state = previous_state
+        );
+    }
+
     pub(crate) async fn process_events(
         mut self,
         mut messages: impl Stream<Item = Event> + Unpin,
@@ -902,64 +924,96 @@ where
                 futures::future::Either::Right(std::future::pending())
             };
 
-            let (event_name, previous_state) = tokio::select! {
+            tokio::select! {
                 biased;
 
                 event = messages.next() => {
                     let Some(event) = event else { break };
-                    let event_name = event.to_string();
-                    let previous_state = format!("{state:?}");
+                    // Drain any events already queued in the channel so a burst of
+                    // publishes coalesces into a single reload of the newest merged
+                    // target, instead of building each obsolete intermediate.
+                    let mut batch = vec![event];
+                    let mut stream_ended = false;
+                    loop {
+                        match messages.next().now_or_never() {
+                            Some(Some(event)) => batch.push(event),
+                            // Stream closed: finish this batch, then exit the loop.
+                            Some(None) => {
+                                stream_ended = true;
+                                break;
+                            }
+                            // Nothing more ready right now.
+                            None => break,
+                        }
+                    }
 
-                    state = match event {
-                        UpdateConfiguration(configuration) => {
-                            state.accumulate_inputs(None, Some(configuration), None, false)
+                    let is_input: Vec<bool> = batch.iter().map(is_input_event).collect();
+                    let mut coalesced: u64 = 0;
+                    let mut terminal = false;
+                    for (i, event) in batch.into_iter().enumerate() {
+                        // Coalesce only runs of consecutive input events; a control
+                        // event (Shutdown / NoMore*) is always a reload boundary.
+                        let coalesce_with_next =
+                            is_input[i] && is_input.get(i + 1).copied().unwrap_or(false);
+                        let event_name = event.to_string();
+                        let previous_state = format!("{state:?}");
+
+                        state = match event {
+                            UpdateConfiguration(configuration) => {
+                                state.accumulate_inputs(None, Some(configuration), None, false)
+                            }
+                            NoMoreConfiguration => state.no_more_configuration().await,
+                            UpdateSchema(schema) => {
+                                state.accumulate_inputs(Some(Arc::new(schema)), None, None, false)
+                            }
+                            NoMoreSchema => state.no_more_schema().await,
+                            UpdateLicense(license) => {
+                                state.accumulate_inputs(None, None, Some(license), false)
+                            }
+                            Reload => state.accumulate_inputs(None, None, None, false),
+                            RhaiReload => state.accumulate_inputs(None, None, None, true),
+                            NoMoreLicense => state.no_more_license().await,
+                            Shutdown => state.shutdown().await,
+                        };
+
+                        if coalesce_with_next {
+                            // A later input supersedes this one; skip building it.
+                            coalesced += 1;
+                        } else {
+                            state = state.attempt_reload(&mut self).await;
                         }
-                        NoMoreConfiguration => state.no_more_configuration().await,
-                        UpdateSchema(schema) => {
-                            state.accumulate_inputs(Some(Arc::new(schema)), None, None, false)
+
+                        self.record_transition(event_name, previous_state, &state);
+
+                        // If we've errored then exit even if there are more messages.
+                        if matches!(&state, Stopped | Errored(_)) {
+                            terminal = true;
+                            break;
                         }
-                        NoMoreSchema => state.no_more_schema().await,
-                        UpdateLicense(license) => {
-                            state.accumulate_inputs(None, None, Some(license), false)
-                        }
-                        Reload => state.accumulate_inputs(None, None, None, false),
-                        RhaiReload => state.accumulate_inputs(None, None, None, true),
-                        NoMoreLicense => state.no_more_license().await,
-                        Shutdown => state.shutdown().await,
-                    };
-                    state = state.attempt_reload(&mut self).await;
-                    (event_name, previous_state)
+                    }
+
+                    if coalesced > 0 {
+                        u64_counter_with_unit!(
+                            "apollo.router.state.reload.coalesced",
+                            "Number of intermediate reload targets skipped by coalescing a queued burst of updates",
+                            "{update}",
+                            coalesced
+                        );
+                    }
+
+                    if terminal || stream_ended {
+                        break;
+                    }
                 }
                 _ = retry_future => {
                     let previous_state = format!("{state:?}");
                     state = state.attempt_reload(&mut self).await;
-                    (String::from("retry"), previous_state)
+                    self.record_transition("retry".to_string(), previous_state, &state);
+                    if matches!(&state, Stopped | Errored(_)) {
+                        break;
+                    }
                 }
             };
-
-            // Update the shared state
-            #[cfg(test)]
-            self.notify_updated.notify_one();
-
-            tracing::info!(
-                event = event_name,
-                state = ?state,
-                previous_state,
-                "state machine transitioned"
-            );
-            u64_counter!(
-                "apollo.router.state.change.total",
-                "Router state changes",
-                1,
-                event = event_name,
-                state = format!("{state:?}"),
-                previous_state = previous_state
-            );
-
-            // If we've errored then exit even if there are potentially more messages
-            if matches!(&state, Stopped | Errored(_)) {
-                break;
-            }
         }
         tracing::info!("stopped");
 
@@ -971,6 +1025,16 @@ where
             }
         }
     }
+}
+
+/// Whether an event is an "input" update (as opposed to a control event like
+/// `Shutdown` or `NoMore*`). Only consecutive input events are coalesced into a
+/// single reload; control events are always reload boundaries.
+fn is_input_event(event: &Event) -> bool {
+    matches!(
+        event,
+        UpdateConfiguration(_) | UpdateSchema(_) | UpdateLicense(_) | Reload | RhaiReload
+    )
 }
 
 /// Computes the retry delay: base delay plus up to 25% random positive jitter.
@@ -2263,6 +2327,46 @@ mod tests {
         assert_eq!(shutdown_receivers.0.lock().len(), 1);
     }
 
+    // A burst of input events already queued in the channel collapses into a
+    // single build of the newest merged target; the superseded intermediates are
+    // skipped and counted by the coalesced metric.
+    #[test(tokio::test)]
+    async fn coalesces_queued_burst_into_single_reload() {
+        let minimal_schema = include_str!("testdata/minimal_supergraph.graphql");
+        let router_factory = create_mock_router_configurator(1);
+        let (server_factory, shutdown_receivers) = create_mock_server_factory(1);
+        async move {
+            assert_matches!(
+                execute_burst(
+                    server_factory,
+                    router_factory,
+                    stream::iter(vec![
+                        UpdateConfiguration(Arc::new(Configuration::builder().build().unwrap())),
+                        UpdateLicense(Default::default()),
+                        UpdateSchema(SchemaState {
+                            sdl: minimal_schema.to_owned(),
+                            launch_id: None,
+                        }),
+                        UpdateSchema(example_schema()),
+                        UpdateSchema(SchemaState {
+                            sdl: minimal_schema.to_owned(),
+                            launch_id: None,
+                        }),
+                        Shutdown,
+                    ])
+                )
+                .await,
+                Ok(())
+            );
+            // Only the newest target is built (one server start); the four earlier
+            // inputs were coalesced away.
+            assert_eq!(shutdown_receivers.0.lock().len(), 1);
+            assert_counter!("apollo.router.state.reload.coalesced", 4);
+        }
+        .with_metrics()
+        .await;
+    }
+
     #[test(tokio::test)]
     async fn state_change_metrics() {
         let router_factory = create_mock_router_configurator(2);
@@ -2440,6 +2544,25 @@ mod tests {
         let is_telemetry_disabled = false;
         let state_machine =
             StateMachine::new(is_telemetry_disabled, server_factory, router_factory);
+        // Space the events apart so the coalescing drain in `process_events` sees an
+        // empty queue between them — mirroring production, where schema/config/
+        // license updates arrive spread out rather than all at once. Tests that
+        // specifically exercise coalescing feed a genuine burst via `execute_burst`.
+        let events = Box::pin(events.then(|event| async move {
+            tokio::task::yield_now().await;
+            event
+        }));
+        state_machine.process_events(events).await
+    }
+
+    /// Like `execute`, but feeds every event at once so `process_events` sees them
+    /// all already queued and coalesces the burst. Used to test coalescing.
+    async fn execute_burst(
+        server_factory: MockMyHttpServerFactory,
+        router_factory: MockMyRouterConfigurator,
+        events: impl Stream<Item = Event> + Unpin,
+    ) -> Result<(), ApolloRouterError> {
+        let state_machine = StateMachine::new(false, server_factory, router_factory);
         state_machine.process_events(events).await
     }
 

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -947,6 +947,9 @@ where
                 event = messages.next() => {
                     let Some(event) = event else { break };
                     let current_is_input = is_input_event(&event);
+                    // Captured before `event` is consumed below so we can compare it
+                    // against the next queued event's variant when deciding to coalesce.
+                    let current_kind = std::mem::discriminant(&event);
                     let event_name = event.to_string();
                     let previous_state = format!("{state:?}");
 
@@ -968,17 +971,21 @@ where
                         Shutdown => state.shutdown().await,
                     };
 
-                    // Coalesce: if this was an input event and another input event is
-                    // already queued right behind it, skip the reload — the next event
-                    // will supersede this target. A control event (Shutdown / NoMore*)
-                    // or an empty queue is always a reload boundary, and we force a
-                    // build once we've skipped MAX_COALESCED_RELOADS in a row so a
-                    // relentless burst can't defer the reload forever.
+                    // Coalesce: if this was an input event and another update of the
+                    // *same kind* is already queued right behind it, skip the reload —
+                    // the next event will supersede this target. We only coalesce
+                    // same-kind updates so that, say, a failing license or config
+                    // publish queued alongside a schema publish can't prevent the
+                    // schema from being applied (they build separately). A different
+                    // kind, a control event (Shutdown / NoMore*), or an empty queue is
+                    // always a reload boundary, and we force a build once we've skipped
+                    // MAX_COALESCED_RELOADS in a row so a relentless burst can't defer
+                    // the reload forever.
                     let coalesce_with_next = current_is_input
                         && consecutive_coalesced < MAX_COALESCED_RELOADS
                         && matches!(
                             std::pin::Pin::new(&mut messages).peek().now_or_never(),
-                            Some(Some(next)) if is_input_event(next)
+                            Some(Some(next)) if std::mem::discriminant(next) == current_kind
                         );
 
                     if coalesce_with_next {
@@ -2325,14 +2332,15 @@ mod tests {
         assert_eq!(shutdown_receivers.0.lock().len(), 1);
     }
 
-    // A burst of input events already queued in the channel collapses into a
-    // single build of the newest merged target; the superseded intermediates are
-    // skipped and counted by the coalesced metric.
+    // A queued burst of same-kind updates collapses into a single build of the
+    // newest; the superseded intermediates are skipped and counted by the metric.
+    // Startup's config/schema/license are different kinds and so don't coalesce;
+    // the schema burst that follows does.
     #[test(tokio::test)]
     async fn coalesces_queued_burst_into_single_reload() {
         let minimal_schema = include_str!("testdata/minimal_supergraph.graphql");
-        let router_factory = create_mock_router_configurator(1);
-        let (server_factory, shutdown_receivers) = create_mock_server_factory(1);
+        let router_factory = create_mock_router_configurator(2);
+        let (server_factory, shutdown_receivers) = create_mock_server_factory(2);
         async move {
             assert_matches!(
                 execute_burst(
@@ -2340,7 +2348,9 @@ mod tests {
                     router_factory,
                     stream::iter(vec![
                         UpdateConfiguration(Arc::new(Configuration::builder().build().unwrap())),
+                        UpdateSchema(example_schema()),
                         UpdateLicense(Default::default()),
+                        // A queued burst of schema updates — same kind, so coalesced.
                         UpdateSchema(SchemaState {
                             sdl: minimal_schema.to_owned(),
                             launch_id: None,
@@ -2356,17 +2366,17 @@ mod tests {
                 .await,
                 Ok(())
             );
-            // Only the newest target is built (one server start); the four earlier
-            // inputs were coalesced away.
-            assert_eq!(shutdown_receivers.0.lock().len(), 1);
-            assert_counter!("apollo.router.state.reload.coalesced", 4);
+            // Startup builds once; the schema burst collapses to one more build for
+            // the newest, skipping the two intermediate schemas.
+            assert_eq!(shutdown_receivers.0.lock().len(), 2);
+            assert_counter!("apollo.router.state.reload.coalesced", 2);
         }
         .with_metrics()
         .await;
     }
 
-    // Coalescing must apply the NEWEST value of each input, not an intermediate.
-    // Two configs are queued; only the newest (homepage enabled) may reach create().
+    // Coalescing must apply the NEWEST value, not an intermediate. Two same-kind
+    // configs are queued back-to-back; only the newest (homepage enabled) is built.
     #[test(tokio::test)]
     async fn coalesced_burst_applies_newest_input() {
         let mut router_factory = MockMyRouterConfigurator::new();
@@ -2386,11 +2396,11 @@ mod tests {
                 server_factory,
                 router_factory,
                 stream::iter(vec![
-                    // Intermediate config (homepage disabled) — coalesced away.
-                    UpdateConfiguration(Arc::new(Configuration::builder().build().unwrap())),
                     UpdateSchema(example_schema()),
                     UpdateLicense(Default::default()),
-                    // Newest config (homepage enabled) — the one that must be built.
+                    // Two configs queued back-to-back (same kind → coalesced); only
+                    // the newest (homepage enabled) may reach create().
+                    UpdateConfiguration(Arc::new(Configuration::builder().build().unwrap())),
                     UpdateConfiguration(Arc::new(
                         Configuration::builder()
                             .homepage(Homepage::builder().enabled(true).build())
@@ -2404,6 +2414,44 @@ mod tests {
             Ok(())
         );
         assert_eq!(shutdown_receivers.0.lock().len(), 1);
+    }
+
+    // Different-kind updates queued together are NOT coalesced: a schema and a
+    // config build separately, so an unrelated (possibly failing) config or license
+    // can't block a schema publish queued alongside it. Here the schema and the
+    // config each build, on top of startup, for three builds total.
+    #[test(tokio::test)]
+    async fn mixed_kind_updates_are_not_coalesced() {
+        let minimal_schema = include_str!("testdata/minimal_supergraph.graphql");
+        let router_factory = create_mock_router_configurator(3);
+        let (server_factory, shutdown_receivers) = create_mock_server_factory(3);
+        assert_matches!(
+            execute_burst(
+                server_factory,
+                router_factory,
+                stream::iter(vec![
+                    UpdateConfiguration(Arc::new(Configuration::builder().build().unwrap())),
+                    UpdateSchema(example_schema()),
+                    UpdateLicense(Default::default()),
+                    // A schema then a config, queued together but different kinds:
+                    // each is built separately rather than merged into one reload.
+                    UpdateSchema(SchemaState {
+                        sdl: minimal_schema.to_owned(),
+                        launch_id: None,
+                    }),
+                    UpdateConfiguration(Arc::new(
+                        Configuration::builder()
+                            .homepage(Homepage::builder().enabled(true).build())
+                            .build()
+                            .unwrap()
+                    )),
+                    Shutdown,
+                ])
+            )
+            .await,
+            Ok(())
+        );
+        assert_eq!(shutdown_receivers.0.lock().len(), 3);
     }
 
     // Coalescing is capped: a burst larger than MAX_COALESCED_RELOADS forces an

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -2367,6 +2367,47 @@ mod tests {
         .await;
     }
 
+    // Coalescing must apply the NEWEST value of each input, not an intermediate.
+    // Two configs are queued; only the newest (homepage enabled) may reach create().
+    #[test(tokio::test)]
+    async fn coalesced_burst_applies_newest_input() {
+        let mut router_factory = MockMyRouterConfigurator::new();
+        router_factory
+            .expect_create()
+            .times(1)
+            .withf(|_, configuration, _, _, _, _| configuration.homepage.enabled)
+            .returning(|_, _, _, _, _, _| {
+                let mut router = MockMyRouterFactory::new();
+                router.expect_clone().return_once(MockMyRouterFactory::new);
+                router.expect_web_endpoints().returning(MultiMap::new);
+                Ok(router)
+            });
+        let (server_factory, shutdown_receivers) = create_mock_server_factory(1);
+        assert_matches!(
+            execute_burst(
+                server_factory,
+                router_factory,
+                stream::iter(vec![
+                    // Intermediate config (homepage disabled) — coalesced away.
+                    UpdateConfiguration(Arc::new(Configuration::builder().build().unwrap())),
+                    UpdateSchema(example_schema()),
+                    UpdateLicense(Default::default()),
+                    // Newest config (homepage enabled) — the one that must be built.
+                    UpdateConfiguration(Arc::new(
+                        Configuration::builder()
+                            .homepage(Homepage::builder().enabled(true).build())
+                            .build()
+                            .unwrap()
+                    )),
+                    Shutdown,
+                ])
+            )
+            .await,
+            Ok(())
+        );
+        assert_eq!(shutdown_receivers.0.lock().len(), 1);
+    }
+
     #[test(tokio::test)]
     async fn state_change_metrics() {
         let router_factory = create_mock_router_configurator(2);

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -55,8 +55,9 @@ const STATE_CHANGE: &str = "state change";
 /// reload, but without a cap a relentless stream of ready events could defer the
 /// reload indefinitely and starve the router of any new state. Hitting the cap
 /// forces a build of the newest-merged-so-far target and resets the count, so we
-/// always make forward progress. Realistic bursts are far smaller than this.
-const MAX_COALESCED_RELOADS: usize = 100;
+/// always make forward progress. More than this many rapid same-kind publishes
+/// queued at once is unusual and likely points to a problem upstream.
+const MAX_COALESCED_RELOADS: usize = 10;
 
 #[derive(Default, Clone)]
 pub(crate) struct ListenAddresses {
@@ -946,10 +947,32 @@ where
 
                 event = messages.next() => {
                     let Some(event) = event else { break };
-                    let current_is_input = is_input_event(&event);
+
+                    // Consider whether to skip this event in favor of the next one. If another event
+                    // of the *same kind* is already queued right behind it, skip the reload —
+                    // the next event will supersede this target.
+                    //
+                    // We only coalesce same-kind updates so that, say, a failing license or config
+                    // publish queued alongside a schema publish can't prevent the
+                    // schema from being applied (they build separately).
+                    if can_be_superseded(&event) && consecutive_coalesced < MAX_COALESCED_RELOADS {
+                        let next_event = Pin::new(&mut messages).peek().now_or_never();
+                        if let Some(Some(next_event)) = next_event
+                            && std::mem::discriminant(&event) == std::mem::discriminant(next_event) {
+                            // A queued input supersedes this target; skip building it.
+                            consecutive_coalesced += 1;
+                            u64_counter_with_unit!(
+                                "apollo.router.state.reload.coalesced",
+                                "Number of intermediate reload targets skipped by coalescing queued updates",
+                                "{update}",
+                                1u64
+                            );
+                            continue;
+                        }
+                    }
+
                     // Captured before `event` is consumed below so we can compare it
                     // against the next queued event's variant when deciding to coalesce.
-                    let current_kind = std::mem::discriminant(&event);
                     let event_name = event.to_string();
                     let previous_state = format!("{state:?}");
 
@@ -971,54 +994,22 @@ where
                         Shutdown => state.shutdown().await,
                     };
 
-                    // Coalesce: if this was an input event and another update of the
-                    // *same kind* is already queued right behind it, skip the reload —
-                    // the next event will supersede this target. We only coalesce
-                    // same-kind updates so that, say, a failing license or config
-                    // publish queued alongside a schema publish can't prevent the
-                    // schema from being applied (they build separately). A different
-                    // kind, a control event (Shutdown / NoMore*), or an empty queue is
-                    // always a reload boundary, and we force a build once we've skipped
-                    // MAX_COALESCED_RELOADS in a row so a relentless burst can't defer
-                    // the reload forever.
-                    let coalesce_with_next = current_is_input
-                        && consecutive_coalesced < MAX_COALESCED_RELOADS
-                        && matches!(
-                            std::pin::Pin::new(&mut messages).peek().now_or_never(),
-                            Some(Some(next)) if std::mem::discriminant(next) == current_kind
-                        );
-
-                    if coalesce_with_next {
-                        // A queued input supersedes this target; skip building it.
-                        consecutive_coalesced += 1;
-                        u64_counter_with_unit!(
-                            "apollo.router.state.reload.coalesced",
-                            "Number of intermediate reload targets skipped by coalescing queued updates",
-                            "{update}",
-                            1u64
-                        );
-                    } else {
-                        state = state.attempt_reload(&mut self).await;
-                        consecutive_coalesced = 0;
-                    }
+                    state = state.attempt_reload(&mut self).await;
+                    consecutive_coalesced = 0;
 
                     self.record_transition(event_name, previous_state, &state);
-
-                    // If we've errored then exit even if there are more messages.
-                    if matches!(&state, Stopped | Errored(_)) {
-                        break;
-                    }
                 }
                 _ = retry_future => {
                     let previous_state = format!("{state:?}");
                     state = state.attempt_reload(&mut self).await;
                     consecutive_coalesced = 0;
                     self.record_transition("retry".to_string(), previous_state, &state);
-                    if matches!(&state, Stopped | Errored(_)) {
-                        break;
-                    }
                 }
-            };
+            }
+
+            if matches!(&state, Stopped | Errored(_)) {
+                break;
+            }
         }
         tracing::info!("stopped");
 
@@ -1032,13 +1023,14 @@ where
     }
 }
 
-/// Whether an event is an "input" update (as opposed to a control event like
-/// `Shutdown` or `NoMore*`). Only consecutive input events are coalesced into a
-/// single reload; control events are always reload boundaries.
-fn is_input_event(event: &Event) -> bool {
+/// Whether this event's reload target can be superseded by a later update of the
+/// same kind — i.e. a schema, configuration, or license publish. Forced reloads
+/// (`Reload` / `RhaiReload`) and control events (`Shutdown` / `NoMore*`) are never
+/// coalesced away.
+fn can_be_superseded(event: &Event) -> bool {
     matches!(
         event,
-        UpdateConfiguration(_) | UpdateSchema(_) | UpdateLicense(_) | Reload | RhaiReload
+        UpdateConfiguration(_) | UpdateSchema(_) | UpdateLicense(_)
     )
 }
 

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -884,28 +884,6 @@ where
         }
     }
 
-    /// Record a single state transition: fire the test signal, emit the tracing
-    /// span, and bump the `apollo.router.state.change.total` counter.
-    fn record_transition(&self, event_name: String, previous_state: String, state: &State<FA>) {
-        #[cfg(test)]
-        self.notify_updated.notify_one();
-
-        tracing::info!(
-            event = event_name,
-            state = ?state,
-            previous_state,
-            "state machine transitioned"
-        );
-        u64_counter!(
-            "apollo.router.state.change.total",
-            "Router state changes",
-            1,
-            event = event_name,
-            state = format!("{state:?}"),
-            previous_state = previous_state
-        );
-    }
-
     pub(crate) async fn process_events(
         mut self,
         messages: impl Stream<Item = Event> + Unpin,
@@ -942,24 +920,25 @@ where
                 futures::future::Either::Right(std::future::pending())
             };
 
-            tokio::select! {
+            let (event_name, previous_state) = tokio::select! {
                 biased;
 
                 event = messages.next() => {
                     let Some(event) = event else { break };
 
-                    // Consider whether to skip this event in favor of the next one. If another event
-                    // of the *same kind* is already queued right behind it, skip the reload —
-                    // the next event will supersede this target.
+                    // Consider whether to skip this event in favor of the next one. If
+                    // another event of the *same kind* is already queued right behind it,
+                    // skip building this one — the next event will supersede it.
                     //
-                    // We only coalesce same-kind updates so that, say, a failing license or config
-                    // publish queued alongside a schema publish can't prevent the
-                    // schema from being applied (they build separately).
+                    // We only coalesce same-kind updates so that, say, a failing license
+                    // or config publish queued alongside a schema publish can't prevent
+                    // the schema from being applied (they build separately).
                     if can_be_superseded(&event) && consecutive_coalesced < MAX_COALESCED_RELOADS {
                         let next_event = Pin::new(&mut messages).peek().now_or_never();
                         if let Some(Some(next_event)) = next_event
-                            && std::mem::discriminant(&event) == std::mem::discriminant(next_event) {
-                            // A queued input supersedes this target; skip building it.
+                            && std::mem::discriminant(&event) == std::mem::discriminant(next_event)
+                        {
+                            // A queued update supersedes this target; skip building it.
                             consecutive_coalesced += 1;
                             u64_counter_with_unit!(
                                 "apollo.router.state.reload.coalesced",
@@ -971,8 +950,6 @@ where
                         }
                     }
 
-                    // Captured before `event` is consumed below so we can compare it
-                    // against the next queued event's variant when deciding to coalesce.
                     let event_name = event.to_string();
                     let previous_state = format!("{state:?}");
 
@@ -996,17 +973,36 @@ where
 
                     state = state.attempt_reload(&mut self).await;
                     consecutive_coalesced = 0;
-
-                    self.record_transition(event_name, previous_state, &state);
+                    (event_name, previous_state)
                 }
                 _ = retry_future => {
                     let previous_state = format!("{state:?}");
                     state = state.attempt_reload(&mut self).await;
                     consecutive_coalesced = 0;
-                    self.record_transition("retry".to_string(), previous_state, &state);
+                    (String::from("retry"), previous_state)
                 }
-            }
+            };
 
+            // Update the shared state
+            #[cfg(test)]
+            self.notify_updated.notify_one();
+
+            tracing::info!(
+                event = event_name,
+                state = ?state,
+                previous_state,
+                "state machine transitioned"
+            );
+            u64_counter!(
+                "apollo.router.state.change.total",
+                "Router state changes",
+                1,
+                event = event_name,
+                state = format!("{state:?}"),
+                previous_state = previous_state
+            );
+
+            // If we've errored then exit even if there are potentially more messages
             if matches!(&state, Stopped | Errored(_)) {
                 break;
             }

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -409,7 +409,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                     &mut listen_addresses_guard,
                     vec![],
                 )
-                .map_ok_or_else(Errored, |f| f.0)
+                .map_ok_or_else(|err| Errored(ApolloRouterError::from(err)), |f| f.0)
                 .await
             }
 
@@ -472,11 +472,20 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                         new_state
                     }
                     Err(e) if server_handle.is_some() => {
-                        // Decrement the retry budget (saturating so it stops at 0, not wrapping).
-                        let retries_remaining = retries_remaining.map(|n| n.saturating_sub(1));
+                        // Decrement the retry budget (saturating so it stops at 0, not
+                        // wrapping). A permanent error will fail identically on every
+                        // retry, so pin the budget at 0 to stop the retry timer.
+                        let is_transient = e.is_transient();
+                        let retries_remaining = if is_transient {
+                            retries_remaining.map(|n| n.saturating_sub(1))
+                        } else {
+                            Some(0)
+                        };
+                        let e: ApolloRouterError = e.into();
 
                         tracing::error!(
                             error = %e,
+                            transient_error = is_transient,
                             retries_remaining = retries_remaining
                                 .map_or("unlimited".to_string(), |n| n.to_string()),
                             event = STATE_CHANGE,
@@ -504,6 +513,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                     // The point of no return was passed — server handle consumed
                     // before the failure. Fatal.
                     Err(e) => {
+                        let e: ApolloRouterError = e.into();
                         tracing::error!(
                             error = %e,
                             event = STATE_CHANGE,
@@ -561,14 +571,16 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         license: Arc<LicenseState>,
         listen_addresses_guard: &mut OwnedRwLockWriteGuard<ListenAddresses>,
         mut all_connections_stopped_signals: Vec<mpsc::Receiver<()>>,
-    ) -> Result<(State<FA>, Arc<Schema>), ApolloRouterError>
+    ) -> Result<(State<FA>, Arc<Schema>), ReloadError>
     where
         S: HttpServerFactory,
         FA: RouterSuperServiceFactory,
     {
         let schema = Arc::new(
-            Schema::parse_arc(schema_state.clone(), &configuration)
-                .map_err(|e| ServiceCreationError(e.to_string().into()))?,
+            Schema::parse_arc(schema_state.clone(), &configuration).map_err(|e| {
+                // A schema that fails to parse will fail identically on every retry.
+                ReloadError::Permanent(ServiceCreationError(e.to_string().into()))
+            })?,
         );
         // Check the license
         let report = LicenseEnforcementReport::build(&configuration, &schema, &license);
@@ -582,7 +594,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                     );
                     return Err(ApolloRouterError::LicenseViolation(
                         report.restricted_features_in_use(),
-                    ));
+                    ))?;
                 } else {
                     tracing::debug!("A valid Apollo license has been detected.");
                     limits
@@ -596,7 +608,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                     );
                     return Err(ApolloRouterError::LicenseViolation(
                         report.restricted_features_in_use(),
-                    ));
+                    ))?;
                 } else {
                     tracing::warn!(
                         "License warning period has started. The Router will stop serving requests after the license expires. In order to continue using these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
@@ -643,7 +655,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                 }
                 return Err(ApolloRouterError::LicenseViolation(
                     report.restricted_features_in_use(),
-                ));
+                ))?;
             }
             _ => {
                 tracing::debug!(
@@ -670,7 +682,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                 "The schema contains preview features not enabled in configuration.\n\n{}",
                 feature_gate_violations.iter().join("\n")
             );
-            return Err(ApolloRouterError::FeatureGateViolation);
+            return Err(ApolloRouterError::FeatureGateViolation)?;
         }
 
         let router_service_factory = state_machine
@@ -748,6 +760,44 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
             },
             schema,
         ))
+    }
+}
+
+/// A `try_start` failure, classified by whether retrying the same inputs could
+/// succeed. Drives the retry decision in `attempt_reload`.
+enum ReloadError {
+    /// A transient failure (e.g. a resource or network blip during creation) that
+    /// a later retry of the same inputs might resolve.
+    Transient(ApolloRouterError),
+    /// A permanent failure (bad schema/config/license) that will fail identically
+    /// on every retry; the caller should stop retrying these inputs.
+    Permanent(ApolloRouterError),
+}
+
+impl ReloadError {
+    fn is_transient(&self) -> bool {
+        matches!(self, ReloadError::Transient(_))
+    }
+}
+
+impl From<ApolloRouterError> for ReloadError {
+    fn from(err: ApolloRouterError) -> Self {
+        match err {
+            ApolloRouterError::FeatureGateViolation | ApolloRouterError::LicenseViolation(_) => {
+                ReloadError::Permanent(err)
+            }
+            // Default to treating failures as transient (this also covers any newly
+            // added error variants) so we retry rather than give up prematurely.
+            err => ReloadError::Transient(err),
+        }
+    }
+}
+
+impl From<ReloadError> for ApolloRouterError {
+    fn from(err: ReloadError) -> Self {
+        match err {
+            ReloadError::Transient(err) | ReloadError::Permanent(err) => err,
+        }
     }
 }
 

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -2219,6 +2219,50 @@ mod tests {
         assert_eq!(shutdown_receivers.0.lock().len(), 2);
     }
 
+    // The transient/permanent classification decides whether attempt_reload keeps
+    // retrying the same inputs (transient) or gives up on them (permanent).
+    #[test]
+    fn reload_error_classification() {
+        // Bad config/license/schema won't build on retry → permanent.
+        assert!(!ReloadError::from(ApolloRouterError::FeatureGateViolation).is_transient());
+        assert!(!ReloadError::from(ApolloRouterError::LicenseViolation(vec![])).is_transient());
+        // Anything else (e.g. a service-creation blip) defaults to transient → retried.
+        assert!(
+            ReloadError::from(ApolloRouterError::ServiceCreationError(BoxError::from(
+                "boom"
+            )))
+            .is_transient()
+        );
+    }
+
+    // A schema that fails to parse must not take down the running router: it stays
+    // on the previously committed schema and shuts down cleanly. The unparseable
+    // schema fails before create(), so only the startup build happens.
+    #[test(tokio::test)]
+    async fn reload_with_unparseable_schema_keeps_running() {
+        let router_factory = create_mock_router_configurator(1);
+        let (server_factory, shutdown_receivers) = create_mock_server_factory(1);
+        assert_matches!(
+            execute(
+                server_factory,
+                router_factory,
+                stream::iter(vec![
+                    UpdateConfiguration(Arc::new(Configuration::builder().build().unwrap())),
+                    UpdateSchema(example_schema()),
+                    UpdateLicense(Default::default()),
+                    UpdateSchema(SchemaState {
+                        sdl: "this is not valid graphql".to_owned(),
+                        launch_id: None,
+                    }),
+                    Shutdown,
+                ])
+            )
+            .await,
+            Ok(())
+        );
+        assert_eq!(shutdown_receivers.0.lock().len(), 1);
+    }
+
     #[test(tokio::test)]
     async fn state_change_metrics() {
         let router_factory = create_mock_router_configurator(2);

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -899,7 +899,7 @@ where
 
     pub(crate) async fn process_events(
         mut self,
-        mut messages: impl Stream<Item = Event> + Unpin,
+        messages: impl Stream<Item = Event> + Unpin,
     ) -> Result<(), ApolloRouterError> {
         tracing::debug!("starting");
         // The listen address guard is transferred to the startup state. It will get consumed when moving to running.
@@ -912,6 +912,11 @@ where
                 .take()
                 .expect("must have listen address guard"),
         };
+
+        // `peek` lets us inspect the next already-queued event without consuming
+        // it, so a run of input events can be coalesced without buffering them —
+        // only the single peeked event is ever held.
+        let mut messages = messages.peekable();
 
         // Process events and retry-timer ticks until we reach a terminal state or
         // run out of events.
@@ -929,79 +934,54 @@ where
 
                 event = messages.next() => {
                     let Some(event) = event else { break };
-                    // Drain any events already queued in the channel so a burst of
-                    // publishes coalesces into a single reload of the newest merged
-                    // target, instead of building each obsolete intermediate.
-                    let mut batch = vec![event];
-                    let mut stream_ended = false;
-                    loop {
-                        match messages.next().now_or_never() {
-                            Some(Some(event)) => batch.push(event),
-                            // Stream closed: finish this batch, then exit the loop.
-                            Some(None) => {
-                                stream_ended = true;
-                                break;
-                            }
-                            // Nothing more ready right now.
-                            None => break,
+                    let current_is_input = is_input_event(&event);
+                    let event_name = event.to_string();
+                    let previous_state = format!("{state:?}");
+
+                    state = match event {
+                        UpdateConfiguration(configuration) => {
+                            state.accumulate_inputs(None, Some(configuration), None, false)
                         }
-                    }
-
-                    let is_input: Vec<bool> = batch.iter().map(is_input_event).collect();
-                    let mut coalesced: u64 = 0;
-                    let mut terminal = false;
-                    for (i, event) in batch.into_iter().enumerate() {
-                        // Coalesce only runs of consecutive input events; a control
-                        // event (Shutdown / NoMore*) is always a reload boundary.
-                        let coalesce_with_next =
-                            is_input[i] && is_input.get(i + 1).copied().unwrap_or(false);
-                        let event_name = event.to_string();
-                        let previous_state = format!("{state:?}");
-
-                        state = match event {
-                            UpdateConfiguration(configuration) => {
-                                state.accumulate_inputs(None, Some(configuration), None, false)
-                            }
-                            NoMoreConfiguration => state.no_more_configuration().await,
-                            UpdateSchema(schema) => {
-                                state.accumulate_inputs(Some(Arc::new(schema)), None, None, false)
-                            }
-                            NoMoreSchema => state.no_more_schema().await,
-                            UpdateLicense(license) => {
-                                state.accumulate_inputs(None, None, Some(license), false)
-                            }
-                            Reload => state.accumulate_inputs(None, None, None, false),
-                            RhaiReload => state.accumulate_inputs(None, None, None, true),
-                            NoMoreLicense => state.no_more_license().await,
-                            Shutdown => state.shutdown().await,
-                        };
-
-                        if coalesce_with_next {
-                            // A later input supersedes this one; skip building it.
-                            coalesced += 1;
-                        } else {
-                            state = state.attempt_reload(&mut self).await;
+                        NoMoreConfiguration => state.no_more_configuration().await,
+                        UpdateSchema(schema) => {
+                            state.accumulate_inputs(Some(Arc::new(schema)), None, None, false)
                         }
-
-                        self.record_transition(event_name, previous_state, &state);
-
-                        // If we've errored then exit even if there are more messages.
-                        if matches!(&state, Stopped | Errored(_)) {
-                            terminal = true;
-                            break;
+                        NoMoreSchema => state.no_more_schema().await,
+                        UpdateLicense(license) => {
+                            state.accumulate_inputs(None, None, Some(license), false)
                         }
-                    }
+                        Reload => state.accumulate_inputs(None, None, None, false),
+                        RhaiReload => state.accumulate_inputs(None, None, None, true),
+                        NoMoreLicense => state.no_more_license().await,
+                        Shutdown => state.shutdown().await,
+                    };
 
-                    if coalesced > 0 {
+                    // Coalesce: if this was an input event and another input event is
+                    // already queued right behind it, skip the reload — the next event
+                    // will supersede this target. A control event (Shutdown / NoMore*)
+                    // or an empty queue is always a reload boundary.
+                    let coalesce_with_next = current_is_input
+                        && matches!(
+                            std::pin::Pin::new(&mut messages).peek().now_or_never(),
+                            Some(Some(next)) if is_input_event(next)
+                        );
+
+                    if coalesce_with_next {
+                        // A queued input supersedes this target; skip building it.
                         u64_counter_with_unit!(
                             "apollo.router.state.reload.coalesced",
-                            "Number of intermediate reload targets skipped by coalescing a queued burst of updates",
+                            "Number of intermediate reload targets skipped by coalescing queued updates",
                             "{update}",
-                            coalesced
+                            1u64
                         );
+                    } else {
+                        state = state.attempt_reload(&mut self).await;
                     }
 
-                    if terminal || stream_ended {
+                    self.record_transition(event_name, previous_state, &state);
+
+                    // If we've errored then exit even if there are more messages.
+                    if matches!(&state, Stopped | Errored(_)) {
                         break;
                     }
                 }


### PR DESCRIPTION
## Problem

`process_events` in `state_machine.rs` pulled one event, accumulated it, then awaited the entire reload — including the slow query-planner warm-up in `router_configurator.create()` — before pulling the next event. A burst of publishes (schema B, C, D, or config/license changes) already queued in the channel was drained serially, so every obsolete intermediate state got a full build + warm-up before the newest was reached.

## Changes

- **Coalesce queued bursts of the same kind.** In the `process_events` loop, after pulling an event, peek whether another update *of the same kind* is already queued right behind it; if so, skip building this one and let the next supersede it. A run of queued same-kind updates collapses into a single build of the newest. Control events (`Shutdown` / `NoMore*`) and explicit forced reloads (`Reload` / `RhaiReload`) are never coalesced.
- **Cap consecutive coalesces** (`MAX_COALESCED_RELOADS`) so a relentless stream can't defer a build indefinitely — hitting the cap forces a build of the newest-so-far target and resets the count.
- **Classify reload failures as transient vs permanent** (`ReloadError`). A permanent failure (schema parse error, license or feature-gate violation) cannot succeed on retry, so it stops the retry timer instead of churning; transient failures retry as before.
- **New metric** `apollo.router.state.reload.coalesced` — number of reloads skipped by coalescing.

## Tradeoffs — please reflect on this

Coalescing merges queued updates into a single build, so the intermediate states in a burst are never built. Worth weighing:

- **If the newest update in a coalesced run fails to build, the good *intermediate* updates in that run are not served** — the router stays on the last committed (good) state. There is no fallback to the newest-that-builds (out of scope for this PR). This is the same "newest wins" outcome as a normal reload to the latest state.
- **Only same-kind updates coalesce**, specifically so independent concerns aren't coupled: a failing config or license publish queued alongside a schema publish can't block the schema, because they build separately rather than being merged into one reload. (Caveat: a permanently-failing config/license that is *already pending* still blocks subsequent reloads until the inputs change — but that is pre-existing merged-target behavior in `Reloading`, unchanged by this PR.)

## Notes for reviewers

- Coalescing only triggers when events are genuinely queued together. When updates arrive spread out (the normal case) the queue is empty between them and behavior is per-event, exactly as before.
- Uses a `Peekable` stream, so at most one event is ever held — no buffering of a batch.
- **Metrics note:** a coalesced (skipped) update no longer emits a `apollo.router.state.change.total` transition — only the update that actually reloads does. So during a burst that counter shows fewer events than the number of publishes; the new `reload.coalesced` counter accounts for the skipped ones.
- Out of scope: concurrency/cancellation (sibling subtask) and newest-good fallback across candidate states.

## Tests

- Coalescing: a same-kind queued burst collapses to a single build and increments `reload.coalesced`; a burst applies the newest input; the cap forces an intermediate build; a mixed-kind burst is *not* coalesced (builds separately).
- Classification: a unit test of the mapping, plus a behavioral test that an unparseable schema published at reload leaves the router serving the previous schema.
- The `execute` test helper now spaces events apart to mirror production timing; the full `state_machine` suite passes.