### PR TITLE
docs(authorization): document and test precedence over @include/@skip

### DIFF
--- a/.changesets/docs_authorization_include_skip_precedence.md
+++ b/.changesets/docs_authorization_include_skip_precedence.md
@@ -1,0 +1,5 @@
+### Document that authorization directives take precedence over `@include`/`@skip`
+
+The interaction between `@requiresScopes`/`@authenticated`/`@policy` and GraphQL's built-in `@include`/`@skip` directives was previously undocumented. The router enforces authorization requirements against the operation as written, so referencing a protected field produces an `UNAUTHORIZED_FIELD_OR_TYPE` error even when `@include(if: false)` or `@skip(if: true)` excludes that field from the response. The authorization documentation now states this precedence explicitly, notes that it applies to both literal and variable `if` arguments, and recommends omitting a field entirely rather than excluding it conditionally when a request doesn't meet its requirements.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9891

--- a/.changesets/docs_authorization_include_skip_precedence.md
+++ b/.changesets/docs_authorization_include_skip_precedence.md
@@ -1,5 +1,0 @@
-### Document that authorization directives take precedence over `@include`/`@skip`
-
-The interaction between `@requiresScopes`/`@authenticated`/`@policy` and GraphQL's built-in `@include`/`@skip` directives was previously undocumented. The router enforces authorization requirements against the operation as written, so referencing a protected field produces an `UNAUTHORIZED_FIELD_OR_TYPE` error even when `@include(if: false)` or `@skip(if: true)` excludes that field from the response. The authorization documentation now states this precedence explicitly, notes that it applies to both literal and variable `if` arguments, and recommends omitting a field entirely rather than excluding it conditionally when a request doesn't meet its requirements.
-
-By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9891

--- a/apollo-router/src/plugins/authorization/authenticated.rs
+++ b/apollo-router/src/plugins/authorization/authenticated.rs
@@ -621,6 +621,61 @@ mod tests {
         }
     }
 
+    // Authorization directives take precedence over `@include`/`@skip`: `internal` requires
+    // authentication the request doesn't have, so it is reported as unauthorized even though
+    // the operation excludes it from the response. Whether a client may request a field is a
+    // separate question from whether the field is ultimately fetched. This precedence is
+    // documented in `docs/source/routing/security/authorization.mdx`; if it is ever changed
+    // deliberately, that documentation needs to change with it.
+    #[test]
+    fn include_skip_does_not_bypass_authentication_requirements() {
+        static INCLUDE_FALSE: &str = r#"
+        query {
+            topProducts {
+                type
+                internal @include(if: false)
+            }
+        }
+        "#;
+
+        let (_doc, paths) = filter(BASIC_SCHEMA, INCLUDE_FALSE);
+        assert_eq!(
+            paths.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+            vec!["/topProducts/internal"]
+        );
+
+        static SKIP_TRUE: &str = r#"
+        query {
+            topProducts {
+                type
+                internal @skip(if: true)
+            }
+        }
+        "#;
+
+        let (_doc, paths) = filter(BASIC_SCHEMA, SKIP_TRUE);
+        assert_eq!(
+            paths.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+            vec!["/topProducts/internal"]
+        );
+
+        // The same holds when the condition is a variable rather than a literal.
+        static INCLUDE_VARIABLE: &str = r#"
+        query($shouldInclude: Boolean!) {
+            topProducts {
+                type
+                internal @include(if: $shouldInclude)
+            }
+        }
+        "#;
+
+        let (_doc, paths) = filter(BASIC_SCHEMA, INCLUDE_VARIABLE);
+        assert_eq!(
+            paths.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+            vec!["/topProducts/internal"]
+        );
+    }
+
     #[test]
     fn mutation() {
         static QUERY: &str = r#"

--- a/apollo-router/src/plugins/authorization/policy.rs
+++ b/apollo-router/src/plugins/authorization/policy.rs
@@ -825,6 +825,61 @@ mod tests {
         });
     }
 
+    // Authorization directives take precedence over `@include`/`@skip`: `internal` requires
+    // policies the request doesn't have, so it is reported as unauthorized even though the
+    // operation excludes it from the response. Whether a client may request a field is a
+    // separate question from whether the field is ultimately fetched. This precedence is
+    // documented in `docs/source/routing/security/authorization.mdx`; if it is ever changed
+    // deliberately, that documentation needs to change with it.
+    #[test]
+    fn include_skip_does_not_bypass_policy_requirements() {
+        static INCLUDE_FALSE: &str = r#"
+        query {
+            topProducts {
+                type
+                internal @include(if: false)
+            }
+        }
+        "#;
+
+        let (_doc, paths) = filter(BASIC_SCHEMA, INCLUDE_FALSE, HashSet::new());
+        assert_eq!(
+            paths.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+            vec!["/topProducts/internal"]
+        );
+
+        static SKIP_TRUE: &str = r#"
+        query {
+            topProducts {
+                type
+                internal @skip(if: true)
+            }
+        }
+        "#;
+
+        let (_doc, paths) = filter(BASIC_SCHEMA, SKIP_TRUE, HashSet::new());
+        assert_eq!(
+            paths.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+            vec!["/topProducts/internal"]
+        );
+
+        // The same holds when the condition is a variable rather than a literal.
+        static INCLUDE_VARIABLE: &str = r#"
+        query($shouldInclude: Boolean!) {
+            topProducts {
+                type
+                internal @include(if: $shouldInclude)
+            }
+        }
+        "#;
+
+        let (_doc, paths) = filter(BASIC_SCHEMA, INCLUDE_VARIABLE, HashSet::new());
+        assert_eq!(
+            paths.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+            vec!["/topProducts/internal"]
+        );
+    }
+
     #[test]
     fn mutation() {
         static QUERY: &str = r#"

--- a/apollo-router/src/plugins/authorization/scopes.rs
+++ b/apollo-router/src/plugins/authorization/scopes.rs
@@ -827,6 +827,61 @@ mod tests {
         });
     }
 
+    // Authorization directives take precedence over `@include`/`@skip`: `internal` requires
+    // scopes the request doesn't have, so it is reported as unauthorized even though the
+    // operation excludes it from the response. Whether a client may request a field is a
+    // separate question from whether the field is ultimately fetched. This precedence is
+    // documented in `docs/source/routing/security/authorization.mdx`; if it is ever changed
+    // deliberately, that documentation needs to change with it.
+    #[test]
+    fn include_skip_does_not_bypass_scope_requirements() {
+        static INCLUDE_FALSE: &str = r#"
+        query {
+            topProducts {
+                type
+                internal @include(if: false)
+            }
+        }
+        "#;
+
+        let (_doc, paths) = filter(BASIC_SCHEMA, INCLUDE_FALSE, HashSet::new());
+        assert_eq!(
+            paths.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+            vec!["/topProducts/internal"]
+        );
+
+        static SKIP_TRUE: &str = r#"
+        query {
+            topProducts {
+                type
+                internal @skip(if: true)
+            }
+        }
+        "#;
+
+        let (_doc, paths) = filter(BASIC_SCHEMA, SKIP_TRUE, HashSet::new());
+        assert_eq!(
+            paths.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+            vec!["/topProducts/internal"]
+        );
+
+        // The same holds when the condition is a variable rather than a literal.
+        static INCLUDE_VARIABLE: &str = r#"
+        query($shouldInclude: Boolean!) {
+            topProducts {
+                type
+                internal @include(if: $shouldInclude)
+            }
+        }
+        "#;
+
+        let (_doc, paths) = filter(BASIC_SCHEMA, INCLUDE_VARIABLE, HashSet::new());
+        assert_eq!(
+            paths.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+            vec!["/topProducts/internal"]
+        );
+    }
+
     #[test]
     fn mutation() {
         static QUERY: &str = r#"

--- a/docs/source/routing/security/authorization.mdx
+++ b/docs/source/routing/security/authorization.mdx
@@ -915,6 +915,38 @@ query {
 
 The response would include an `"UNAUTHORIZED_FIELD_OR_TYPE"` error at the `/posts/... on PrivateBlog` path.
 
+## Authorization directives and `@include`/`@skip`
+
+Authorization directives take precedence over GraphQL's built-in `@include` and `@skip` directives. If an operation references a field protected by `@requiresScopes`, `@authenticated`, or `@policy`, the router enforces that requirement even when `@include(if: false)` or `@skip(if: true)` excludes the field from the response.
+
+Continuing the [social media example](#example-requiresscopes-use-case), a request without the `read:email` scope receives an `UNAUTHORIZED_FIELD_OR_TYPE` error at the `/users/@/email` path for both of these operations:
+
+<CodeColumns>
+
+```graphql title="Field requested unconditionally"
+query {
+  users {
+    username
+    email
+  }
+}
+```
+
+```graphql title="Field excluded with @include"
+query {
+  users {
+    username
+    email @include(if: false)
+  }
+}
+```
+
+</CodeColumns>
+
+This applies whether the `if` argument is a literal value or a variable.
+
+Whether a client is allowed to request a field is a separate question from whether the router fetches it. Treat an authorization directive as governing every reference to a field within an operation: if a request doesn't meet a field's requirements, omit the field from the operation entirely rather than excluding it with `@include` or `@skip`.
+
 ## Query deduplication
 
 You can enable [query deduplication](/router/configuration/traffic-shaping/#query-deduplication) in the router to reduce redundant requests to a subgraph. The router does this by buffering similar queries and reusing the result.


### PR DESCRIPTION
## What

- Adds an `Authorization directives and @include/@skip` section to `docs/source/routing/security/authorization.mdx` stating that `@requiresScopes`, `@authenticated`, and `@policy` are enforced against the operation as written, so referencing a protected field produces an `UNAUTHORIZED_FIELD_OR_TYPE` error even when `@include(if: false)` or `@skip(if: true)` excludes it from the response. Notes that this holds for both literal and variable `if` arguments, and advises omitting a field entirely rather than excluding it conditionally when a request doesn't meet its requirements.
- Adds a regression test to each of `ScopeFilteringVisitor`, `AuthenticatedVisitor`, and `PolicyFilteringVisitor` asserting the documented precedence: a protected field the request isn't authorized for still lands in `unauthorized_paths` under `@include(if: false)`, `@skip(if: true)`, and a variable-conditioned `@include`.

## Context

This precedence was previously undocumented, which left it ambiguous whether the observed behavior was an enforcement-order bug or an intentional fail-closed decision. This PR documents it as intentional: whether a client is allowed to request a field is a separate question from whether the router ends up fetching it.

This supersedes #9859, which took the opposite approach and changed the authorization visitors to skip statically-excluded fields. That direction coupled authorization decisions to query-execution semantics; documenting the existing fail-closed behavior avoids that coupling.

No changeset is included: this documents and tests existing behavior rather than changing it.

## Verified

- `cargo test -p apollo-router --lib plugins::authorization::` — 89 passed, 0 failed (86 pre-existing plus the 3 new tests).
- The three new tests assert exact paths (`["/topProducts/internal"]`) and pass against unmodified `dev`, so the documented behavior is confirmed empirically rather than asserted only in prose. They are also load-bearing against the superseded approach: #9859's tests asserted `paths.is_empty()` for these same queries, so that change would fail these.
- `cargo fmt --all --check` passed.
- `cargo clippy --all-targets -p apollo-router -- -D warnings` passed.