### PR TITLE
fix: skip `@requires` field set validation during fed v1 schema upgrade (backport 2.16)

### DIFF
--- a/apollo-federation/CHANGELOG.md
+++ b/apollo-federation/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-All notable changes to `apollo-federation` will be documented in this file.
+All notable changes to Apollo Composition are documented in this file.
+
+> [!NOTE]
+> Query planner changes are documented in the router [CHANGELOG](../CHANGELOG.md).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -8,100 +11,83 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 > Important: X breaking changes below, indicated by **BREAKING**
 
-## BREAKING
+## ❗ BREAKING CHANGES ❗
+## 🚀 Features
+## 🐛 Fixes
+## 🛠 Maintenance
+## 📚 Documentation
+-->
 
-## Features
+# [2.16.x](unreleased) - Unreleased
 
-## Fixes
+## 🐛 Fixes
 
-## Maintenance
-## Documentation-->
+### Skip `@requires` field set validation during fed v1 schema upgrade ([PR #9722](https://github.com/apollographql/router/pull/9722))
 
-# [0.0.11](https://crates.io/crates/apollo-federation/0.0.11) - 2024-04-12
+Updates `@requires` validation logic to allow type selection conditions in the field selections that are only valid
+against the supergraph. `@requires` is now partially validated against subgraph schema during subgraph upgrade process
+and fully validated against supergraph schema during the merge process.
 
-## Fixes
-- Forbid aliases in `@requires(fields:)` / `@key(fields:)` argument, by [duckki] in [pull/251]
+By [@dariuszkuc](https://github.com/dariuszkuc) in https://github.com/apollographql/router/pull/9722
 
-## Features
-- Expose subgraphs schemas to crate consumers, by [SimonSapin] in [pull/257]
+# [2.16.0](https://crates.io/crates/apollo-federation/2.16.0) - 2026-06-30
 
-## Maintenance
-- Update `apollo-compiler`, by [goto-bus-stop]
+Adds support for Apollo Federation v2.15.
 
-[duckki]: https://github.com/duckki
-[goto-bus-stop]: https://github.com/goto-bus-stop
-[SimonSapin]: https://github.com/SimonSapin
-[pull/251]: https://github.com/apollographql/federation-next/pull/251
-[pull/257]: https://github.com/apollographql/federation-next/pull/257
+Composition is now written in Rust. No new directives or composition behavior were introduced. Your supergraphs are semantically equivalent to those built with the previous version. The main benefits are faster builds and significantly improved error messages.
 
-# [0.0.10](https://crates.io/crates/apollo-federation/0.0.10) - 2024-04-09
+Because the Rust implementation is more rigorous, composition now catches several categories of schema problems that were previously inconsistent or missing. If you upgrade and encounter new errors, the following sections explain what to fix.
 
-## Features
-- Query plan changes for initial router integration, by [SimonSapin] in [pull/240]
-- Mark join/v0.4 spec as supported for non-query planning purpose, by [SimonSapin] in [pull/233], [pull/237]
-- Continued work on core query planning implementation, by [duckki], [SimonSapin], [TylerBloom]
+#### New validations
 
-## Maintenance
-- Update `apollo-compiler`, by [goto-bus-stop] in [pull/253]
+##### Interfaces implementing `@interfaceObject` now fail explicitly
 
-[duckki]: https://github.com/duckki
-[goto-bus-stop]: https://github.com/goto-bus-stop
-[SimonSapin]: https://github.com/SimonSapin
-[TylerBloom]: https://github.com/TylerBloom
-[pull/233]: https://github.com/apollographql/federation-next/pull/233
-[pull/237]: https://github.com/apollographql/federation-next/pull/237
-[pull/240]: https://github.com/apollographql/federation-next/pull/240
-[pull/253]: https://github.com/apollographql/federation-next/pull/253
+Federation doesn't support interfaces implementing `@interfaceObject` interfaces. If your schema uses this pattern, composition now reports `INTERFACE_OBJECT_USAGE_ERROR`.
 
-# [0.0.9](https://crates.io/crates/apollo-federation/0.0.9) - 2024-03-20
+##### Invalid `@override` labels are dropped
 
-## Features
-- Continued work on core query planning implementation, by [goto-bus-stop] in [pull/229]
+If an `@override` directive's `label` references a subgraph name that doesn't exist in your graph, composition now drops that label. Review your `@override` usage to ensure all labels are valid subgraph names.
 
-## Maintenance
-- Update `apollo-compiler`, by [goto-bus-stop] in [pull/230]
+##### Merged directives on `@external` fields are rejected
 
-[goto-bus-stop]: https://github.com/goto-bus-stop
-[pull/229]: https://github.com/apollographql/federation-next/pull/229
-[pull/230]: https://github.com/apollographql/federation-next/pull/230
+Applying a merged directive to an `@external` field now produces a `MERGED_DIRECTIVE_APPLICATION_ON_EXTERNAL` error. Review your `@external` field definitions.
 
-# [0.0.8](https://crates.io/crates/apollo-federation/0.0.8) - 2024-03-06
+##### Custom spec URLs can't use the Apollo domain
 
-## Features
-- Support legacy `@core` link syntax, by [goto-bus-stop] in [pull/224]  
-  This is not meant to be a long term feature, `@core()` is not intended
-  to be supported in most of the codebase.
-- Continued work on core query planning implementation, by [SimonSapin], [goto-bus-stop] in [pull/172], [pull/175]
+Custom specifications can no longer import from `https://specs.apollo.dev`. This prevents future conflicts with new Apollo specifications.
 
-## Maintenance
-- `@link(url: String!)` argument is non-null, by [SimonSapin] in [pull/220]
-- Enable operation normalization tests using `@defer`, by [goto-bus-stop] in [pull/224]
+##### Invalid input object defaults are removed
 
-[SimonSapin]: https://github.com/SimonSapin
-[goto-bus-stop]: https://github.com/goto-bus-stop
-[pull/172]: https://github.com/apollographql/federation-next/pull/172
-[pull/175]: https://github.com/apollographql/federation-next/pull/175
-[pull/220]: https://github.com/apollographql/federation-next/pull/220
-[pull/223]: https://github.com/apollographql/federation-next/pull/223
-[pull/224]: https://github.com/apollographql/federation-next/pull/224
+Default values for input objects are now validated at composition time. If a default object value is missing required fields, composition removes it from the supergraph.
 
-# [0.0.7](https://crates.io/crates/apollo-federation/0.0.7) - 2024-02-22
+##### `@tag` validation runs during composition
 
-## Features
-- Continued work on core query planning implementation, by [SimonSapin] in [pull/121]
+`@tag` errors now surface during the main composition process so you can catch tag problems at build time.
 
-## Fixes
-- Fix `@defer` directive definition in API schema generation, by [goto-bus-stop] in [pull/221]
+##### Root type inference fix
 
-[SimonSapin]: https://github.com/SimonSapin
-[goto-bus-stop]: https://github.com/goto-bus-stop
-[pull/121]: https://github.com/apollographql/federation-next/pull/121
-[pull/221]: https://github.com/apollographql/federation-next/pull/221
+Composition ensures that it only infers default root operation types (e.g. `Mutation`) if they aren't referenced by
+other schema elements.
 
-# [0.0.3](https://crates.io/crates/apollo-federation/0.0.3) - 2023-11-08
+##### `FieldSet` arguments must be strings
 
-## Features
-- Extracting subgraph information from a supergraph for the purposes of query planning by [sachindshinde] in [pull/56]
+The `_FieldSet` scalar no longer accepts non-string values through automatic coercion. Make sure all `fields` arguments on `@key`, `@requires`, and `@provides` directives use quoted strings.
 
-[sachindshinde]: https://github.com/sachindshinde
-[pull/56]: https://github.com/apollographql/federation-next/pull/56
+#### Improved error messages
+
+##### Hints are emitted on composition failure
+
+The composition process now emits hints even when composition fails, giving you more context to diagnose what went wrong.
+
+##### Input object defaults are fully expanded
+
+When an input object has a default value of `{}`, composition now expands it to list all field defaults explicitly — for example, `{}` becomes `{ limit: 100, sort: DESC }`.
+
+##### Default values are normalized to their correct types
+
+If a field's default value is a coercible type (for example, an integer default on a `Float` field), composition normalizes it — for example, `weight: Float = 1` becomes `weight: Float = 1.0`.
+
+##### Errors include line numbers and schema references
+
+Error messages now include line numbers and point to the relevant parts of your schema, making it faster to locate and fix problems.
+

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -1082,6 +1082,7 @@ impl SelectionSet {
             type_position.type_name().clone(),
             source_text,
             false,
+            crate::schema::field_set::FieldSetValidation::Validate,
         )?
         .0;
         let fragments = Default::default();

--- a/apollo-federation/src/schema/field_set.rs
+++ b/apollo-federation/src/schema/field_set.rs
@@ -110,12 +110,20 @@ pub(crate) fn parse_field_set(
 /// a boolean indicating whether the field set was modified to fix such string/enum value issues.
 ///
 /// Outside these specific purposes, you should prefer to use `parse_field_set()` instead.
+#[derive(Clone, Copy)]
+pub(crate) enum FieldSetValidation {
+    Validate,
+    Skip,
+}
+
 pub(crate) fn parse_field_set_without_normalization(
     schema: &Valid<Schema>,
     parent_type_name: NamedType,
     field_set: &str,
     fix_string_enum_values: bool,
+    validation: FieldSetValidation,
 ) -> Result<(executable::SelectionSet, bool), FederationError> {
+    let validate = matches!(validation, FieldSetValidation::Validate);
     // Note this parsing takes care of adding curly braces ("{" and "}") if they aren't in the
     // string.
     let (field_set, is_modified) = if fix_string_enum_values {
@@ -126,15 +134,20 @@ pub(crate) fn parse_field_set_without_normalization(
             "field_set.graphql",
         )?;
         let is_modified = fix_string_enum_values_in_field_set(schema, &mut field_set);
-        field_set.validate(schema)?;
+        if validate {
+            field_set.validate(schema)?;
+        }
         // `FieldSet::validate()` strangely doesn't return `Valid<FieldSet>`, so we instead use
         // `Valid::assume_valid()` here.
         (Valid::assume_valid(field_set), is_modified)
-    } else {
+    } else if validate {
         (
             FieldSet::parse_and_validate(schema, parent_type_name, field_set, "field_set.graphql")?,
             false,
         )
+    } else {
+        let field_set = FieldSet::parse(schema, parent_type_name, field_set, "field_set.graphql")?;
+        (Valid::assume_valid(field_set), false)
     };
     Ok((field_set.into_inner().selection_set, is_modified))
 }

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -30,6 +30,7 @@ use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
 use crate::schema::SchemaElement;
 use crate::schema::SubgraphMetadata;
+use crate::schema::field_set::FieldSetValidation;
 use crate::subgraph::SubgraphError;
 use crate::subgraph::typestate::Expanded;
 use crate::subgraph::typestate::Subgraph;
@@ -520,9 +521,13 @@ impl SchemaUpgrader {
         schema: &mut FederationSchema,
     ) -> Result<(), FederationError> {
         let cloned_schema = schema.clone();
+        // NOTE: we should be passing a supergraph schema so we could verify the remaining `@requires`
+        // field set values are valid. Schema upgrader runs before merge process, we don't have
+        // access to the supergraph so we need to skip the validation.
         remove_inactive_requires_and_provides_from_subgraph(
-            &cloned_schema, // TODO: I don't know what this value should be
+            &cloned_schema,
             schema,
+            FieldSetValidation::Skip,
         )
     }
 

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -63,6 +63,7 @@ use crate::link::spec::Version;
 use crate::link::spec_definition::SpecDefinition;
 use crate::schema::FederationSchema;
 use crate::schema::ValidFederationSchema;
+use crate::schema::field_set::FieldSetValidation;
 use crate::schema::field_set::parse_field_set_without_normalization;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::DirectiveDefinitionPosition;
@@ -589,6 +590,7 @@ fn extract_subgraphs_from_fed_2_supergraph(
         remove_inactive_requires_and_provides_from_subgraph(
             supergraph_schema,
             &mut subgraph.schema,
+            FieldSetValidation::Validate,
         )?;
         remove_unused_types_from_subgraph(&mut subgraph.schema)?;
         for definition in all_executable_directive_definitions.iter() {
@@ -2002,6 +2004,7 @@ fn add_federation_operations(
 pub(crate) fn remove_inactive_requires_and_provides_from_subgraph(
     supergraph_schema: &FederationSchema,
     schema: &mut FederationSchema,
+    field_set_validation: FieldSetValidation,
 ) -> Result<(), FederationError> {
     let federation_spec_definition = get_federation_spec_definition_from_subgraph(schema)?;
     let requires_directive_definition_name = federation_spec_definition
@@ -2057,6 +2060,7 @@ pub(crate) fn remove_inactive_requires_and_provides_from_subgraph(
             FieldSetDirectiveKind::Requires,
             &requires_directive_definition_name,
             pos.clone(),
+            &field_set_validation,
         )?;
         remove_inactive_applications(
             supergraph_schema,
@@ -2065,6 +2069,7 @@ pub(crate) fn remove_inactive_requires_and_provides_from_subgraph(
             FieldSetDirectiveKind::Provides,
             &provides_directive_definition_name,
             pos,
+            &field_set_validation,
         )?;
     }
 
@@ -2083,6 +2088,7 @@ fn remove_inactive_applications(
     directive_kind: FieldSetDirectiveKind,
     name_in_schema: &Name,
     object_or_interface_field_definition_position: ObjectOrInterfaceFieldDefinitionPosition,
+    field_set_validation: &FieldSetValidation,
 ) -> Result<(), FederationError> {
     let mut replacement_directives = Vec::new();
     let field = object_or_interface_field_definition_position.get(schema.schema())?;
@@ -2132,6 +2138,7 @@ fn remove_inactive_applications(
             parent_type_pos.type_name().clone(),
             fields,
             true,
+            *field_set_validation,
         )?;
 
         if remove_non_external_leaf_fields(schema, &mut fields)? {

--- a/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
@@ -1,4 +1,6 @@
 use apollo_compiler::coord;
+use apollo_federation::composition::CompositionOptions;
+use apollo_federation::composition::compose;
 use apollo_federation::composition::upgrade_subgraphs_if_necessary;
 use apollo_federation::subgraph::typestate::Subgraph;
 use insta::assert_snapshot;
@@ -268,4 +270,78 @@ fn upgrade_does_not_add_shareable_to_key_fields_in_partial_schemas() {
 
     assert_snapshot!("s1", upgraded[0].schema_string());
     assert_snapshot!("s2", upgraded[1].schema_string());
+}
+
+/// Fed v1 subgraph with `@requires` containing an inline fragment type condition that is only
+/// valid in the supergraph should upgrade and compose successfully.
+///
+/// Subgraph A defines two unrelated interfaces (`Animal` and `Pet`) and uses
+/// `@requires(fields: "data { ... on Pet { name } }")` where `data` returns `Animal`.
+/// In subgraph A alone, `Animal` and `Pet` have no type intersection.
+/// Subgraph B defines `Dog implements Animal & Pet`, making the type condition valid
+/// in the supergraph.
+#[test]
+fn fed1_requires_with_cross_subgraph_inline_fragment_type_condition() {
+    let subgraph_a = Subgraph::parse(
+        "subgraphA",
+        "",
+        r#"
+            type Query {
+                records: [Record]
+            }
+
+            interface Animal {
+                id: ID!
+            }
+
+            interface Pet {
+                name: String!
+            }
+
+            type Record @key(fields: "id") @extends {
+                id: ID! @external
+                data: Animal! @external
+                label: String! @requires(fields: "data { id ... on Pet { name } }")
+            }
+        "#,
+    )
+    .expect("parses subgraphA");
+
+    let subgraph_b = Subgraph::parse(
+        "subgraphB",
+        "",
+        r#"
+            type Query {
+                animals: [Animal]
+            }
+
+            interface Animal {
+                id: ID!
+            }
+
+            interface Pet {
+                name: String!
+            }
+
+            type Dog implements Animal & Pet {
+                id: ID!
+                name: String!
+                breed: String!
+            }
+
+            type Cat implements Animal {
+                id: ID!
+                color: String!
+            }
+
+            type Record @key(fields: "id") {
+                id: ID!
+                data: Animal!
+            }
+        "#,
+    )
+    .expect("parses subgraphB");
+
+    compose(vec![subgraph_a, subgraph_b], CompositionOptions::default())
+        .expect("composition succeeds");
 }


### PR DESCRIPTION
During fed v1 → fed v2 upgrade, `fix_inactive_provides_and_requires` calls `remove_inactive_requires_and_provides_from_subgraph` with a clone of the subgraph as the "supergraph". This causes `@requires` field sets with inline fragment type conditions (e.g. `... on Pet`) to fail validation when the type condition is only valid cross-subgraph (the subgraph defines unrelated interfaces, but another subgraph has a type implementing both).

The fix adds a `FieldSetValidation` enum (`Validate`/`Skip`) to `parse_field_set_without_normalization` and threads it through `remove_inactive_requires_and_provides_from_subgraph`. The upgrade path passes `Skip` since the real supergraph isn't available yet — full validation happens later during post-merge against the merged supergraph. The supergraph extraction path continues to pass `Validate`.

Backport of https://github.com/apollographql/router/pull/9722
