### PR TITLE
fix(composition): propagate directives from `@interfaceObject` fields to `@external` implementations (backport 2.16)

### DIFF
--- a/apollo-federation/CHANGELOG.md
+++ b/apollo-federation/CHANGELOG.md
@@ -22,6 +22,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🐛 Fixes
 
+### Propagate directives from `@interfaceObject` fields to `@external` implementations ([PR #9831](https://github.com/apollographql/router/pull/9831))
+
+When an implementation re-declares a field as `@external` (e.g. to reference it in `@requires`), the field's only resolvable definition lives on the abstracting `@interfaceObject`. Directives like `@tag` applied there were not being propagated to the implementation's copy in the supergraph.
+
+During `add_interface_object_fields`, detect implementation fields where every `@join__field` is `external: true` and the field is provided by an `@interfaceObject`, then copy applicable directives onto the implementation field.
+
+By [@dariuszkuc](https://github.com/dariuszkuc) in https://github.com/apollographql/router/pull/9831
+
 ### Fix composition field merging when subtyping ([PR #9751](https://github.com/apollographql/router/pull/9751))
 
 When composition merges fields with different return types, it was previously allowing nullable types to be considered subtypes of non-null supertypes. The resulting supergraph schema could cause query plan execution to error if the subgraph returns null at runtime. This bug has been fixed, and composition will now appropriately error.

--- a/apollo-federation/src/merger/merger.rs
+++ b/apollo-federation/src/merger/merger.rs
@@ -12,6 +12,7 @@ use apollo_compiler::Schema;
 use apollo_compiler::ast::Argument;
 use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::DirectiveDefinition;
+use apollo_compiler::ast::DirectiveList;
 use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::ast::NamedType;
 use apollo_compiler::ast::Type;
@@ -1988,6 +1989,8 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
     ) -> Result<(), FederationError> {
         let mut fields_to_insert: IndexMap<ObjectFieldDefinitionPosition, FieldDefinition> =
             IndexMap::default();
+        let mut external_fields_to_update: IndexMap<ObjectFieldDefinitionPosition, DirectiveList> =
+            IndexMap::default();
 
         let access_control_directive_names: IndexSet<Name> = self
             .access_control_directives_in_supergraph
@@ -2006,9 +2009,56 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                                 type_name: name.clone(),
                                 field_name: intf_field_name.clone(),
                             };
-                            if !object.fields.contains_key(intf_field_name)
-                                && !fields_to_insert.contains_key(&candidate_field)
+
+                            // check if field was already processed
+                            if fields_to_insert.contains_key(&candidate_field)
+                                || external_fields_to_update.contains_key(&candidate_field)
                             {
+                                continue;
+                            }
+
+                            if let Some(obj_field) = object.fields.get(intf_field_name) {
+                                // An implementation may locally declare a field as `@external` purely to reference it in
+                                // a `@requires` clause, in which case it already exists on the object so it won't be
+                                // propagated from interface object. But that field's only "real" definition is the abstracting
+                                // `@interfaceObject` field, so directives that only apply there (e.g. `@tag`) still need
+                                // to be propagated onto it.
+
+                                // we need to check if field is fully @external i.e. it is defined in all subgraphs as @external
+                                if !obj_field.directives.is_empty()
+                                    && obj_field.directives.iter().all(|d| {
+                                        self.join_spec_definition
+                                            .field_directive_arguments(d)
+                                            .is_ok_and(|args| args.external.is_some_and(|e| e))
+                                    })
+                                {
+                                    // NOTE: This is a sanity check as this field HAS TO be provided by
+                                    // @interfaceObject. Otherwise, it would result in invalid graph as
+                                    // we wouldn't be able to resolve a field that is external everywhere
+                                    // (we already validated it when merging field).
+                                    if self.is_field_provided_by_an_interface_object(
+                                        intf_field_name,
+                                        intf,
+                                    ) {
+                                        let copied_directives = intf_field
+                                            .directives
+                                            .iter()
+                                            .filter(|d| {
+                                                // filter access control directives for now as they will be merged later one
+                                                !access_control_directive_names.contains(&d.name)
+                                                // filter join__field directives as they don't have to be added
+                                                && !self
+                                                .join_spec_definition
+                                                .is_spec_directive_name(&self.merged, &d.name)
+                                                .unwrap_or(false)
+                                            })
+                                            .cloned()
+                                            .collect();
+                                        external_fields_to_update
+                                            .insert(candidate_field, copied_directives);
+                                    }
+                                }
+                            } else {
                                 // Note that we don't blindly add the field yet, that would be incorrect in many cases (and we
                                 // have a specific validation that return a user-friendly error in such incorrect cases, see
                                 // `postMergeValidations`). We must first check that there is some subgraph that implement
@@ -2092,6 +2142,27 @@ format!("Field \"{field}\" of {} type \"{}\" is defined in some but not all subg
                 &dest.clone().into(),
                 &FieldMergeContext::new(sources.keys().copied()),
             )?;
+        }
+
+        for (external_field, directives_to_copy) in external_fields_to_update {
+            trace!("Propagating @interfaceObject directives onto external field {external_field}");
+            let dest_position: DirectiveTargetPosition = external_field.clone().into();
+            external_field
+                .directives_mut(self.merged.schema_mut())?
+                .extend(directives_to_copy);
+
+            let additional_sources = self.access_control_additional_sources()?;
+            let ac_directives_to_merge: Vec<_> = self
+                .access_control_directives_in_supergraph
+                .iter()
+                .filter(|(ac_name, _)| {
+                    additional_sources.contains_key(&format!("{dest_position}_{ac_name}"))
+                })
+                .map(|(_, name_in_supergraph)| name_in_supergraph.clone())
+                .collect();
+            for name in &ac_directives_to_merge {
+                self.merge_applied_directive(name, &Default::default(), &dest_position)?;
+            }
         }
 
         Ok(())

--- a/apollo-federation/tests/composition/compose_interface_object.rs
+++ b/apollo-federation/tests/composition/compose_interface_object.rs
@@ -545,6 +545,72 @@ fn interface_object_with_inaccessible_field() {
 }
 
 #[test]
+fn interface_object_field_tag_propagates_to_locally_external_field() {
+    // Regression test: a `@tag` applied only on the `@interfaceObject` side of a field must
+    // still reach implementations that are forced to re-declare that same field locally as
+    // `@external` (a common pattern used to satisfy a `@requires`).
+    //
+    // Setup:
+    // - subgraph_a: abstracts `Product` as an `@interfaceObject` and tags `name`.
+    // - subgraph_b: defines the real `Product` interface and `Book`, which implements it.
+    //   `Book.name` is declared `@external` only so it can be referenced by `@requires`.
+    //
+    // Without the fix, `Book.name` in the supergraph would be missing `@tag(name: "custom")`
+    // even though the interface's merged `Product.name` field has it.
+    let subgraph_a = r#"
+        extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key", "@tag", "@interfaceObject"])
+
+        type Query {
+            product: Product
+        }
+
+        type Product @key(fields: "id") @interfaceObject {
+            id: ID!
+            name: String @tag(name: "custom")
+        }
+    "#;
+
+    let subgraph_b = r#"
+        extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key", "@external", "@requires"])
+
+        type Query {
+            book: Book
+        }
+
+        interface Product @key(fields: "id") {
+            id: ID!
+        }
+
+        type Book implements Product @key(fields: "id") {
+            id: ID!
+            name: String @external
+            description: String @requires(fields: "name")
+        }
+    "#;
+
+    let parsed_a =
+        Subgraph::parse("subgraph-a", "http://example.com", subgraph_a).expect("valid subgraph");
+    let parsed_b =
+        Subgraph::parse("subgraph-b", "http://example.com", subgraph_b).expect("valid subgraph");
+
+    let supergraph = compose(vec![parsed_a, parsed_b]).expect("Expected composition to succeed");
+
+    let name_field = supergraph
+        .schema()
+        .schema()
+        .type_field("Book", "name")
+        .expect("Book.name field should exist");
+    assert_eq!(
+        name_field.to_string(),
+        r#"name: String @join__field(graph: SUBGRAPH_B, external: true) @tag(name: "custom")"#,
+        "Book.name should inherit @tag from the abstracting @interfaceObject field \
+         even though it's locally declared @external"
+    );
+}
+
+#[test]
 fn interface_with_non_resolvable_key_does_not_require_all_implementations() {
     // subgraphA defines the interface with a resolvable key and all implementations
     let subgraph_a = ServiceDefinition {


### PR DESCRIPTION
When an implementation re-declares a field as `@external` (e.g. to reference it in `@requires`), the field's only resolvable definition lives on the abstracting `@interfaceObject`. Directives like `@tag` applied there were not being propagated to the implementation's copy in the supergraph.

During `add_interface_object_fields`, detect implementation fields where every `@join__field` is `external: true` and the field is provided by an `@interfaceObject`, then copy applicable directives onto the implementation field.

<!-- [FED-1074](https://apollographql.atlassian.net/browse/FED-1074) -->


[FED-1074]: https://apollographql.atlassian.net/browse/FED-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ