### PR TITLE
perf(query-planning): Cache condition resolutions across all context/exclusion combinations (backport 2.16)

### DIFF
--- a/.changesets/perf_condition_resolver_cache_multi_entry.md
+++ b/.changesets/perf_condition_resolver_cache_multi_entry.md
@@ -1,0 +1,63 @@
+### Cache condition resolutions across all context/exclusion combinations ([PR #9741](https://github.com/apollographql/router/pull/9741))
+
+Extends the condition resolver cache introduced in #9740 to cache
+resolutions for all combinations of `@include`/`@skip` context and
+excluded conditions, not just the first combination seen per edge.
+
+Previously, the cache stored a single `(resolution, excluded_destinations)`
+pair per edge, and bailed out entirely when the `OpGraphPathContext`
+(active `@include`/`@skip` directives) or `ExcludedConditions` were
+non-empty. For types with multiple `@key` directives, this meant only
+the first key's resolution was cached — all subsequent keys were
+re-evaluated from scratch every time they were encountered.
+
+Now the cache stores a `Vec<CachedConditionEntry>` per edge, where each
+entry records the full `(context, excluded_destinations,
+excluded_conditions)` triple. On lookup, entries are scanned for an
+exact match. On miss (no matching entry found), the new resolution is
+inserted — allowing the cache to accumulate results across all
+combinations encountered during planning.
+
+Example: A `Product` type with two keys across three subgraphs.
+
+```graphql
+# Subgraph "products"
+type Product @key(fields: "id") @key(fields: "sku") {
+  id: ID!
+  sku: String!
+}
+
+# Subgraph "pricing"
+type Product @key(fields: "id") { id: ID!, price: Int }
+
+# Subgraph "inventory"
+type Product @key(fields: "sku") { sku: String!, inStock: Boolean }
+```
+
+```graphql
+{ product { price inStock } }
+```
+
+When the planner evaluates how to reach `pricing` and `inventory` from
+`products`, it tries each key edge in order. The first key (`id`) is
+evaluated with `excluded_destinations: {pricing}`, and the second key
+(`sku`) is evaluated with `excluded_destinations: {pricing, inventory}`.
+These are different exclusion sets, so each produces a distinct cache
+entry for the same edge.
+
+With the old single-entry cache, only the first key's resolution was
+stored. The second key hit a different `excluded_destinations` value,
+returned `NotApplicable`, and was re-evaluated from scratch — every
+time, across every root field that touches `Product`.
+
+With the multi-entry cache, both resolutions are stored and looked up
+on subsequent encounters. Every additional root field returning
+`Product` reuses both cached key resolutions instead of re-evaluating
+them.
+
+The same applies to `@requires` conditions evaluated under different
+`@include`/`@skip` contexts — each distinct `(context,
+excluded_destinations, excluded_conditions)` combination is cached and
+reused independently.
+
+By [@tninesling](https://github.com/tninesling) in https://github.com/apollographql/router/pull/9741

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -108,17 +108,15 @@ pub(crate) enum ConditionResolutionCacheResult {
     NotApplicable,
 }
 
+struct CachedConditionEntry {
+    resolution: ConditionResolution,
+    context: OpGraphPathContext,
+    excluded_destinations: ExcludedDestinations,
+    excluded_conditions: ExcludedConditions,
+}
+
 pub(crate) struct ConditionResolverCache {
-    // For every edge having a condition, we cache the resolution its conditions when possible.
-    // We save resolution with the set of excluded edges that were used to compute it: the reason we do this is
-    // that excluded edges impact the resolution, so we should only used a cached value if we know the excluded
-    // edges are the same as when caching, and while we could decide to cache only when we have no excluded edges
-    // at all, this would sub-optimal for types that have multiple keys, as the algorithm will always at least
-    // include the previous key edges to the excluded edges of other keys. In other words, if we only cached
-    // when we have no excluded edges, we'd only ever use the cache for the first key of every type. However,
-    // as the algorithm always try keys in the same order (the order of the edges in the query graph), including
-    // the excluded edges we see on the first ever call is actually the proper thing to do.
-    edge_states: IndexMap<EdgeIndex, (ConditionResolution, ExcludedDestinations)>,
+    edge_states: IndexMap<EdgeIndex, Vec<CachedConditionEntry>>,
 }
 
 impl ConditionResolverCache {
@@ -139,29 +137,18 @@ impl ConditionResolverCache {
         if extra_conditions.is_some() {
             return ConditionResolutionCacheResult::NotApplicable;
         }
-        // We don't cache if there is a context or excluded conditions because those would impact the resolution and
-        // we don't want to cache a value per-context and per-excluded-conditions (we also don't cache per-excluded-edges though
-        // instead we cache a value only for the first-see excluded edges; see above why that work in practice).
-        // TODO: we could actually have a better handling of the context: it doesn't really change how we'd resolve the condition, it's only
-        // that the context, if not empty, would have to be added to the trigger of key edges in the resolution path tree when appropriate
-        // and we currently don't handle that. But we could cache with an empty context, and then apply the proper transformation on the
-        // cached value `pathTree` when the context is not empty. That said, the context is about active @include/@skip and it's not use
-        // that commonly, so this is probably not an urgent improvement.
-        if !context.is_empty() || !excluded_conditions.is_empty() {
-            return ConditionResolutionCacheResult::NotApplicable;
-        }
 
-        if let Some((cached_resolution, cached_excluded_destinations)) = self.edge_states.get(&edge)
-        {
-            // Cache hit.
-            // Ensure we have the same excluded destinations as when we cached the value.
-            if cached_excluded_destinations == excluded_destinations {
-                return ConditionResolutionCacheResult::Hit(cached_resolution.clone());
+        if let Some(entries) = self.edge_states.get(&edge) {
+            for cached in entries {
+                if &cached.context == context
+                    && &cached.excluded_destinations == excluded_destinations
+                    && &cached.excluded_conditions == excluded_conditions
+                {
+                    return ConditionResolutionCacheResult::Hit(cached.resolution.clone());
+                }
             }
-            // Otherwise, fall back to non-cached computation
-            ConditionResolutionCacheResult::NotApplicable
+            ConditionResolutionCacheResult::Miss
         } else {
-            // Cache miss
             ConditionResolutionCacheResult::Miss
         }
     }
@@ -170,10 +157,19 @@ impl ConditionResolverCache {
         &mut self,
         edge: EdgeIndex,
         resolution: ConditionResolution,
+        context: OpGraphPathContext,
         excluded_destinations: ExcludedDestinations,
+        excluded_conditions: ExcludedConditions,
     ) {
         self.edge_states
-            .insert(edge, (resolution, excluded_destinations));
+            .entry(edge)
+            .or_default()
+            .push(CachedConditionEntry {
+                resolution,
+                context,
+                excluded_destinations,
+                excluded_conditions,
+            });
     }
 }
 
@@ -225,10 +221,14 @@ pub(crate) trait CachingConditionResolver {
             excluded_conditions,
             extra_conditions,
         )?;
-        // See if this resolution is eligible to be inserted into the cache.
         if cache_result.is_miss() {
-            self.resolver_cache()
-                .insert(edge, resolution.clone(), excluded_destinations.clone());
+            self.resolver_cache().insert(
+                edge,
+                resolution.clone(),
+                context.clone(),
+                excluded_destinations.clone(),
+                excluded_conditions.clone(),
+            );
         }
         Ok(resolution)
     }
@@ -293,7 +293,9 @@ mod tests {
         cache.insert(
             edge1,
             ConditionResolution::unsatisfied_conditions(),
+            empty_context.clone(),
             empty_destinations.clone(),
+            empty_conditions.clone(),
         );
 
         assert!(

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -272,10 +272,6 @@ impl Default for ExcludedDestinations {
 pub(crate) struct ExcludedConditions(Arc<Vec<Arc<SelectionSet>>>);
 
 impl ExcludedConditions {
-    pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
     fn is_excluded(&self, condition: Option<&Arc<SelectionSet>>) -> bool {
         let Some(condition) = condition else {
             return false;
@@ -288,6 +284,13 @@ impl ExcludedConditions {
         let mut result = self.0.as_ref().clone();
         result.push(value.clone().into());
         ExcludedConditions(Arc::new(result))
+    }
+}
+
+impl PartialEq for ExcludedConditions {
+    fn eq(&self, other: &ExcludedConditions) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+            || (self.0.len() == other.0.len() && self.0.iter().all(|x| other.0.contains(x)))
     }
 }
 


### PR DESCRIPTION
## Summary
- Extends the condition resolver cache from #9740 to store multiple entries per edge, keyed by the full `(context, excluded_destinations, excluded_conditions)` triple
- Removes the bail-out guard that skipped caching when `@include`/`@skip` context or excluded conditions were non-empty
- Returns `Miss` instead of `NotApplicable` when entries exist but none match, allowing new combinations to be cached

Backport of https://github.com/apollographql/router/pull/9741