### PR TITLE
Added test_builds to circle ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ executors:
     resource_class: xlarge
     environment:
       CARGO_BUILD_JOBS: 4
-      RUST_TEST_THREADS: 6
       MISE_ENV: ci
   amd_linux_helm: &amd_linux_helm_executor
     docker:
@@ -26,23 +25,23 @@ executors:
   amd_linux_test: &amd_linux_test_executor
     docker:
       - image: ghcr.io/apollographql/ci-utility-docker-images/apollo-rust-builder:0.30.4
-      - image: cimg/redis:7.4.8
+      - image: cimg/redis:7.4.9
       - image: openzipkin/zipkin:3.6.1
       - image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.50.0
       # redis cluster - 3 primaries, 3 replicas
-      - image: cimg/redis:7.4.8
+      - image: cimg/redis:7.4.9
         command: [ "redis-server", "--protected-mode", "no", "--port", "7000", "--cluster-enabled", "yes" ]
-      - image: cimg/redis:7.4.8
+      - image: cimg/redis:7.4.9
         command: [ "redis-server", "--protected-mode", "no", "--port", "7001", "--cluster-enabled", "yes" ]
-      - image: cimg/redis:7.4.8
+      - image: cimg/redis:7.4.9
         command: [ "redis-server", "--protected-mode", "no", "--port", "7002", "--cluster-enabled", "yes" ]
-      - image: cimg/redis:7.4.8
+      - image: cimg/redis:7.4.9
         command: [ "redis-server", "--protected-mode", "no", "--port", "7003", "--cluster-enabled", "yes" ]
-      - image: cimg/redis:7.4.8
+      - image: cimg/redis:7.4.9
         command: [ "redis-server", "--protected-mode", "no", "--port", "7004", "--cluster-enabled", "yes" ]
-      - image: cimg/redis:7.4.8
+      - image: cimg/redis:7.4.9
         command: [ "redis-server", "--protected-mode", "no", "--port", "7005", "--cluster-enabled", "yes" ]
-      - image: cimg/redis:7.4.8
+      - image: cimg/redis:7.4.9
         command: [ "sh", "-c", "sleep 30; echo yes | redis-cli --cluster create --cluster-replicas 1 localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005" ]
     resource_class: 2xlarge
     environment:
@@ -54,14 +53,14 @@ executors:
     resource_class: arm.xlarge
     environment:
       MISE_ENV: ci
-      CARGO_BUILD_JOBS: 8
+      CARGO_BUILD_JOBS: 4
   arm_linux_test: &arm_linux_test_executor
     docker:
       - image: ghcr.io/apollographql/ci-utility-docker-images/apollo-rust-builder:0.30.4
     resource_class: arm.xlarge
     environment:
       MISE_ENV: ci
-      CARGO_BUILD_JOBS: 8
+      CARGO_BUILD_JOBS: 4
   macos_build: &macos_build_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
@@ -83,19 +82,19 @@ executors:
   windows_build: &windows_build_executor
     machine:
       image: "windows-server-2019-vs2019:2024.02.21"
-    resource_class: windows.2xlarge
+    resource_class: windows.medium
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows
-      CARGO_BUILD_JOBS: 4
+      CARGO_BUILD_JOBS: 2
   windows_test: &windows_test_executor
     machine:
       image: "windows-server-2019-vs2019:2024.02.21"
-    resource_class: windows.2xlarge
+    resource_class: windows.medium
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows
-      CARGO_BUILD_JOBS: 4
+      CARGO_BUILD_JOBS: 2
 
 # We don't use {{ arch }} because on windows it is unstable https://discuss.circleci.com/t/value-of-arch-unstable-on-windows/40079
 parameters:
@@ -426,25 +425,6 @@ commands:
   # fuzz_build:
   #   steps:
   #     - run: cargo +nightly fuzz build
-  do_coverage:
-    parameters:
-      variant:
-        type: string
-        default: "default"
-    steps:
-      - run:
-          name: Run coverage
-          environment:
-            # Use the settings from the "ci" profile in nextest configuration.
-            NEXTEST_PROFILE: ci
-          command: cargo llvm-cov nextest --ignore-run-fail --codecov --output-path codecov_report.json
-      - run:
-          name: Upload coverage report
-          command: |
-            # Upload the coverage report to Codecov.
-            codecov-cli --auto-load-params-from CircleCI upload-process --file ./codecov_report.json --token "${CODECOV_TOKEN}"
-      - store_artifacts:
-          path: ./codecov_report.json
 
 jobs:
   fmt_check:
@@ -512,12 +492,32 @@ jobs:
       fuzz:
         type: boolean
         default: false
-      coverage:
+      nightly:
         type: boolean
         default: false
     executor: << parameters.platform >>
     steps:
       - checkout
+      - run:
+          name: Skip if no source files changed
+          command: |
+            # Always run on the default branch (post-merge); nightly triggers also target it
+            git remote set-head origin -a
+            DEFAULT_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | sed 's|^origin/||')
+            if [ "$CIRCLE_BRANCH" = "$DEFAULT_BRANCH" ]; then
+              exit 0
+            fi
+            git fetch origin "$DEFAULT_BRANCH" --depth=100
+            BASE=$(git merge-base HEAD "origin/$DEFAULT_BRANCH" 2>/dev/null || git rev-parse HEAD~1)
+            CHANGED=$(git diff --name-only "$BASE" HEAD)
+            echo "Changed files:"
+            echo "$CHANGED"
+            if echo "$CHANGED" | grep -qE '^(apollo-router/(src|tests|benches|build)/|apollo-federation/|Cargo\.(toml|lock)|[^/]+/Cargo\.toml|rust-toolchain\.toml|xtask/)'; then
+              echo "Source files changed -- running tests"
+              exit 0
+            fi
+            echo "No source files changed -- skipping tests"
+            circleci-agent step halt
       - setup_environment:
           platform: << parameters.platform >>
       - xtask_test
@@ -529,49 +529,13 @@ jobs:
       #         - equal: [ *arm_linux_test_executor, << parameters.platform >> ]
       #     steps:
       #       - fuzz_build
-  coverage:
-    environment:
-      <<: *common_job_environment
-    parameters:
-      platform:
-        type: executor
-    executor: << parameters.platform >>
-    steps:
-      - checkout
-      - setup_environment:
-          platform: << parameters.platform >>
-      - do_coverage
-
-  test_updated:
-    environment:
-      <<: *common_job_environment
-    parameters:
-      platform:
-        type: executor
-        default: amd_linux_test
-      from_test_updated_cargo_deps_workflow:
-        type: boolean
-        default: false
-    executor: << parameters.platform >>
-    steps:
-      - checkout
-      - setup_environment:
-          platform: << parameters.platform >>
-      - run:
-          name: Update all Rust dependencies
-          command: |
-            rm Cargo.lock
-            cargo fetch
-      - xtask_test:
-          variant: "updated"
-
       - when:
           condition:
-            equal:
-              [true, << parameters.from_test_updated_cargo_deps_workflow >>]
+            equal: ["dev", "<< pipeline.git.branch >>"]
           steps:
             - slack/notify:
                 event: fail
+                channel: "#ii-router-ci-notifications"
                 custom: |
                   {
                     "blocks": [
@@ -579,7 +543,26 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": ":x: The `test_updated_cargo_deps` workflow has **failed** for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`!"
+                          "text": ":x: CI tests *failed* on `${CIRCLE_BRANCH}` for `${CIRCLE_JOB}` — a merge may have broken the build!\n<${CIRCLE_BUILD_URL}|View failed job>"
+                        }
+                      }
+                    ]
+                  }
+      - when:
+          condition:
+            equal: [true, << parameters.nightly >>]
+          steps:
+            - slack/notify:
+                event: fail
+                channel: "#ii-router-ci-notifications"
+                custom: |
+                  {
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": ":x: A `nightly` test run has *failed* for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`!"
                         }
                       },
                       {
@@ -600,6 +583,7 @@ jobs:
                   }
             - slack/notify:
                 event: pass
+                channel: "#ii-router-ci-notifications"
                 custom: |
                   {
                     "blocks": [
@@ -607,7 +591,7 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": ":white_check_mark: The `test_updated_cargo_deps` workflow has passed for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`."
+                          "text": ":white_check_mark: A `nightly` test run has passed for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`."
                         }
                       },
                       {
@@ -836,7 +820,7 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": ":x: A `nightly` release run has **failed** for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`!"
+                          "text": ":x: A `nightly` release run has *failed* for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`!"
                         }
                       },
                       {
@@ -991,21 +975,113 @@ jobs:
                   helm show all oci://ghcr.io/apollographql/helm-charts/router --version ${VERSION} > /dev/null && exit 1
                   # Push chart to repository
                   helm push ${CHART} oci://ghcr.io/apollographql/helm-charts
+            - run:
+                # Runs AFTER all artifacts (binaries, Docker, Helm) are up so
+                # the release page is fully populated before notes appear.
+                # Dry-run for now — prints what would be posted.  Flip to
+                # `--publish` once we've watched a real release land.
+                # `|| true` so a bad extract doesn't fail the pipeline.
+                name: Publish release notes (dry-run)
+                command: |
+                  case "$VERSION" in *-*) echo "Prerelease — skipping notes"; exit 0 ;; esac
+                  VERSION_WITHOUT_LEADING_V="${VERSION#v}"
+                  cargo xtask release notes "$VERSION_WITHOUT_LEADING_V" || true
+
+  # Standalone ad hoc test build. Deliberately independent of `build_release`:
+  # no release-versioning (`cargo xtask release prepare`), no nightly/release
+  # tag scheme, no helm chart, no security scan, no notifications. Builds a
+  # single linux/amd64 image from whatever branch/commit triggered the
+  # pipeline and pushes it to a dedicated, non-release image repository for
+  # consumption by the internal testing framework (RTF).
+  build_test_image:
+    environment:
+      <<: *common_job_environment
+      RELEASE_BIN: router
+      REPO_URL: << pipeline.project.git_url >>
+    executor: amd_linux_build
+    steps:
+      - checkout
+      - setup_environment:
+          platform: amd_linux_build
+      - run:
+          name: Build router binary
+          command: cargo xtask dist
+      - run:
+          command: mkdir -p artifacts
+      - run:
+          name: Package artifact
+          command: cargo xtask package --output artifacts/
+      - store_artifacts:
+          path: artifacts/
+      - setup_remote_docker:
+          # CircleCI Image Policy
+          #   https://circleci.com/docs/remote-docker-images-support-policy/
+          version: docker23
+          docker_layer_caching: true
+      - run:
+          name: Docker build and push test image
+          command: |
+            BASE_VERSION=$(cargo metadata --format-version=1 --no-deps | jq --raw-output '.packages[0].version')
+            ARTIFACT_FILENAME="router-v${BASE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+            ARTIFACT_URL="https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/artifacts/${ARTIFACT_FILENAME}"
+            ROUTER_TAG=ghcr.io/apollographql/router-test-builds
+
+            # Tag by branch + short commit sha -- NOT a release/nightly version.
+            # This pipeline has nothing to do with release or nightly versioning.
+            SANITIZED_BRANCH=$(printf '%s' "${CIRCLE_BRANCH}" | tr -c 'a-zA-Z0-9' '-')
+            SHORT_SHA=$(git rev-parse --short=8 HEAD)
+            TAG="${SANITIZED_BRANCH}-${SHORT_SHA}"
+
+            # Validate local artifact exists and calculate its checksum as a safety net
+            if [ ! -f "artifacts/${ARTIFACT_FILENAME}" ]; then
+              echo "Error: Local artifact not found: artifacts/${ARTIFACT_FILENAME}"
+              exit 1
+            fi
+            LOCAL_ARTIFACT_SHA256SUM=$(sha256sum "artifacts/${ARTIFACT_FILENAME}" | cut -d' ' -f1)
+            echo "Local artifact checksum: ${LOCAL_ARTIFACT_SHA256SUM}"
+
+            # Download the artifact and calculate its checksum
+            echo "Downloading artifact to calculate checksum..."
+            curl -sSL -H "Circle-Token: ${CIRCLE_TOKEN}" -o "router-artifact.tar.gz" "${ARTIFACT_URL}"
+            ARTIFACT_URL_SHA256SUM=$(sha256sum "router-artifact.tar.gz" | cut -d' ' -f1)
+            rm -f router-artifact.tar.gz
+
+            # Compare local vs remote artifact checksums
+            if [ "${LOCAL_ARTIFACT_SHA256SUM}" != "${ARTIFACT_URL_SHA256SUM}" ]; then
+              echo "Error: Local and remote artifact checksums don't match!"
+              echo "Local:      ${LOCAL_ARTIFACT_SHA256SUM}"
+              echo "Remote: ${ARTIFACT_URL_SHA256SUM}"
+              exit 1
+            fi
+            echo "Local and remote artifact checksums match: ${LOCAL_ARTIFACT_SHA256SUM}"
+
+            echo "REPO_URL: ${REPO_URL}"
+            echo "BASE_VERSION: ${BASE_VERSION}"
+            echo "TAG: ${TAG}"
+            echo "ROUTER_TAG: ${ROUTER_TAG}"
+
+            docker context create buildx-build
+            docker buildx create --driver docker-container --use buildx-build
+            docker buildx inspect --bootstrap
+            echo ${GITHUB_OCI_TOKEN} | docker login ghcr.io -u apollo-bot2 --password-stdin
+            # Build and push debug image
+            docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${TAG} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${TAG}-debug dockerfiles/.
+            docker push ${ROUTER_TAG}:${TAG}-debug
+            # Build and push regular image
+            docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg ROUTER_RELEASE=${TAG} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${TAG} dockerfiles/.
+            docker push ${ROUTER_TAG}:${TAG}
+
+            echo "Pushed: ${ROUTER_TAG}:${TAG}"
+            echo "Pushed: ${ROUTER_TAG}:${TAG}-debug"
 
 workflows:
-  test_updated_cargo_deps:
-    when: << pipeline.parameters.test_updated_cargo_deps >>
-    jobs:
-      - test_updated:
-          platform: amd_linux_test
-          from_test_updated_cargo_deps_workflow: true
   ci_checks:
     when:
       not:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
-          - << pipeline.parameters.test_updated_cargo_deps >>
+          - << pipeline.parameters.test_build >>
     jobs:
       - fmt_check:
           matrix:
@@ -1032,7 +1108,7 @@ workflows:
           matrix:
             parameters:
               platform:
-                [macos_test, windows_test, amd_linux_test, arm_linux_test]
+                [amd_linux_test]
   quick-nightly:
     when: << pipeline.parameters.quick_nightly >>
     jobs:
@@ -1045,13 +1121,6 @@ workflows:
             parameters:
               platform:
                 [macos_build, windows_build, amd_linux_build, arm_linux_build]
-  coverage_only:
-    when: << pipeline.parameters.coverage >>
-    jobs:
-      - coverage:
-          matrix:
-            parameters:
-              platform: [macos_test]
   nightly:
     when: << pipeline.parameters.nightly >>
     jobs:
@@ -1068,16 +1137,16 @@ workflows:
             parameters:
               platform: [amd_linux_build]
       - test:
+          nightly: true
           requires:
             - lint
+          context:
+            - router
+            - orb-publishing
           matrix:
             parameters:
               platform:
                 [macos_test, windows_test, amd_linux_test, arm_linux_test]
-      - coverage:
-          matrix:
-            parameters:
-              platform: [macos_test]
       - build_release:
           requires:
             - test
@@ -1116,7 +1185,7 @@ workflows:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
-          - << pipeline.parameters.test_updated_cargo_deps >>
+          - << pipeline.parameters.test_build >>
     jobs:
       - pre_verify_release:
           matrix:
@@ -1194,7 +1263,7 @@ workflows:
         or:
           - << pipeline.parameters.nightly >>
           - << pipeline.parameters.quick_nightly >>
-          - << pipeline.parameters.test_updated_cargo_deps >>
+          - << pipeline.parameters.test_build >>
     jobs:
       - secops/gitleaks:
           context:
@@ -1208,3 +1277,14 @@ workflows:
             - github-orb
           git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
           disabled-signatures: "rules.providers.semgrep.security.javascript.lang.security.detect-insecure-websocket"
+
+  # Ad hoc test build: trigger manually via CircleCI's "Trigger Pipeline" UI
+  # on any branch, setting the `test_build` boolean parameter to true. Not
+  # part of releases or nightlies.
+  build-test-image:
+    when: << pipeline.parameters.test_build >>
+    jobs:
+      - build_test_image:
+          context:
+            - router
+            - orb-publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,14 +108,17 @@ parameters:
   nightly:
     type: boolean
     default: false
-  coverage:
-    type: boolean
-    default: false
   # quick_nightly will skip testing and only build the release artifacts.
   quick_nightly:
     type: boolean
     default: false
-  test_updated_cargo_deps:
+  # test_build triggers the standalone `build-test-image` workflow: a single
+  # linux/amd64 Docker image built from whatever branch/commit triggered the
+  # pipeline, tagged by branch+commit (not a release/nightly version), and
+  # pushed to ghcr.io/apollographql/router-test-builds. This is unrelated to
+  # release or nightly versioning -- it exists for ad hoc test builds
+  # consumed by the internal testing framework (RTF).
+  test_build:
     type: boolean
     default: false
 


### PR DESCRIPTION
To run RTF via CI pipelines, we need the ability to build and publish a test/nightly build of the branch. This config change enables that for this branch.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
