### PR TITLE
chore(mergify): add backport-2.16.x label rule for dev-v2.16.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,16 @@ pull_request_rules:
           - dev-v2.10.x
         assignees:
           - "{{ author }}"
+  - name: backport v2.16.x
+    description: Add a label to backport to 2.16.x
+    conditions:
+      - label = backport-2.16.x
+    actions:
+      backport:
+        branches:
+          - dev-v2.16.x
+        assignees:
+          - "{{ author }}"
 defaults:
   actions:
     backport:


### PR DESCRIPTION
Adds a `backport-2.16.x` label rule pointing at the new `dev-v2.16.x` maintenance branch.

`.mergify.yml` only had a rule for `backport-2.10.x`, so the 2.16 backports that landed this week had to be cherry-picked by hand. This makes them label-driven like every other line.

Mergify reads `pull_request_rules` from the base branch of the PR being labeled, so this file has to change on `dev` for the label to do anything on PRs targeting `dev` — that's what this PR is for. A companion PR keeps `dev-v2.16.x`'s copy of the file identical so the two don't drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)