### PR TITLE
chore(mergify): keep .mergify.yml in sync with dev on dev-v2.16.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,16 @@ pull_request_rules:
           - dev-v2.10.x
         assignees:
           - "{{ author }}"
+  - name: backport v2.16.x
+    description: Add a label to backport to 2.16.x
+    conditions:
+      - label = backport-2.16.x
+    actions:
+      backport:
+        branches:
+          - dev-v2.16.x
+        assignees:
+          - "{{ author }}"
 defaults:
   actions:
     backport:


### PR DESCRIPTION
Companion to #9904, which adds the `backport-2.16.x` rule on `dev`. This applies the identical change to `dev-v2.16.x` so the two copies of `.mergify.yml` don't diverge.

To be explicit about what this does and doesn't do: the rule is **inert on this branch**. Mergify evaluates `pull_request_rules` against the base branch of the PR being labeled, so a `backport-2.16.x` rule here would only ever fire for a PR whose base is already `dev-v2.16.x` — backporting the branch into itself. The reason to carry it anyway is drift: `dev`, `dev-v3.x`, and `dev-v2.16.x` currently hold byte-identical copies of this file, and any future `dev` → `dev-v2.16.x` sync conflicts on it the moment they differ. (The existing weekly `forward-port-dev-to-dev-v3.yml` job is the precedent for that kind of sync.)

If you'd rather keep the maintenance branch's config minimal and accept the drift, this PR is the one to close — #9904 is the one that actually makes the label work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)