### PR TITLE
chore: document the lack of backpressure in query planner

### DIFF
--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -226,6 +226,13 @@ where
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        // We don't propagate backpressure from the query planner itself,
+        // because compared to short-lived work, query planning can take a long time and is
+        // more sensitive to pool saturation. In that case, we want the router to stop serving
+        // requests containing _new_ queries, but it's still capable of serving requests with
+        // already planned queries.
+        // XXX(@goto-bus-stop): to maintain this behaviour once we adopt apollo-cache layers, we can
+        // add a load shed layer on the query planner.
         task::Poll::Ready(Ok(()))
     }
 

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -359,6 +359,8 @@ impl Service<QueryPlannerRequest> for QueryPlannerService {
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Backpressure is not exerted by the compute job pool currently, so we can only let the
+        // caller know about pool saturation once we actually try to submit a job.
         Poll::Ready(Ok(()))
     }
 


### PR DESCRIPTION
We had a ticket to fix backpressure propagation in the query planner, but we actually currently can't / don't want to. These comments justify why we're returning `Poll::Ready` directly.

When we adopt the upcoming reusable caching layers from Apollo Platform, it would instead look a bit like this:

```rust
ServiceBuilder::new()
  .cache_in_memory(config.in_memory)
  .cache_redis(config.redis)
  .load_shed()
  .concurrency(24)
  .blocking_service(query_planner)
```

<!-- start metadata -->

<!-- [ROUTER-1872] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

Adding comments only.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1872]: https://apollographql.atlassian.net/browse/ROUTER-1872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ