### PR TITLE
[DO NOT MERGE] Add OPA policy provider integration

### DIFF
--- a/.changesets/authorization_needs_policies_metric.md
+++ b/.changesets/authorization_needs_policies_metric.md
@@ -1,0 +1,5 @@
+### Report operations that require policy authorization
+
+The authorization metric now includes the `authorization.needs_policies` attribute. The router also
+emits the metric for operations that require `@policy` labels but don't require authentication or
+scope checks.

--- a/.changesets/native_opa_policy_provider.md
+++ b/.changesets/native_opa_policy_provider.md
@@ -1,0 +1,11 @@
+### Add a native, fail-closed OPA policy provider
+
+Routers can evaluate `@policy` labels with native OPA providers. Configure
+`authorization.policy.providers` and routing, keep `authorization.directives.enabled: true`,
+and explicitly allowlist claim, header, variable, and context names. Claims are not forwarded by
+default. Provider calls use the shared HTTP client, support HTTP(S) and Unix sidecars, bounded
+250ms total evaluation by default, two attempts, static transport headers, and temporary replica
+ejection. Provider failures reject with HTTP 503 by default; `failure.mode: deny` continues field
+filtering with all policies denied. Use `directives.dry_run` to observe failures without rejecting.
+
+Native provider decisions take precedence over Rhai and coprocessor policy context when configured.

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -381,6 +381,19 @@ impl InstrumentData {
         );
 
         populate_config_instrument!(
+            apollo.router.config.authorization_policy,
+            "$.authorization.policy",
+            opt.enabled,
+            "$.enabled",
+            opt.failure_mode,
+            "$.failure.mode",
+            opt.claims_input,
+            "$..input.claims.include",
+            opt.provider_type,
+            "$..providers.*.type"
+        );
+
+        populate_config_instrument!(
             apollo.router.config.file_uploads.multipart,
             "$.preview_file_uploads[?(@.enabled == true)].protocols.multipart[?(@.enabled == true)]",
             opt.limits.max_file_size,

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization_policy.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization_policy.router.yaml.snap
@@ -1,0 +1,20 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "& metrics.non_zero()"
+---
+- name: apollo.router.config.authorization
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.directives: false
+          opt.require_authentication: false
+- name: apollo.router.config.authorization_policy
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.claims_input: false
+          opt.enabled: false
+          opt.failure_mode: false
+          opt.provider_type: opa

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/tests.rs
-assertion_line: 28
 expression: "&schema"
 ---
 {
@@ -611,6 +610,17 @@ expression: "&schema"
             }
           ],
           "description": "`@authenticated`, `@requiresScopes` and `@policy` directives"
+        },
+        "policy": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PolicyConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Native evaluation of policies referenced by `@policy`."
         },
         "require_authentication": {
           "default": false,
@@ -3530,6 +3540,19 @@ expression: "&schema"
       ],
       "type": "string"
     },
+    "EndpointConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "description": "OPA base URL. Supports HTTP(S) and Unix sockets (`unix:///path.sock?path=/http-base`).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "type": "object"
+    },
     "EntityType": {
       "anyOf": [
         {
@@ -5593,6 +5616,34 @@ expression: "&schema"
       },
       "type": "object"
     },
+    "FailureConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FailureMode"
+            }
+          ],
+          "description": "Provider failures either reject the request or deny all policies."
+        }
+      },
+      "type": "object"
+    },
+    "FailureMode": {
+      "oneOf": [
+        {
+          "const": "reject",
+          "description": "Reject the operation with a provider evaluation error.",
+          "type": "string"
+        },
+        {
+          "const": "deny",
+          "description": "Continue authorization by denying every requested policy.",
+          "type": "string"
+        }
+      ]
+    },
     "FieldName": {
       "oneOf": [
         {
@@ -6314,6 +6365,20 @@ expression: "&schema"
       ],
       "type": "object"
     },
+    "IncludeConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "include": {
+          "default": [],
+          "description": "Explicit names to include. Values are never wildcard-expanded.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "IncludeSubgraphErrorsConfig": {
       "additionalProperties": false,
       "description": "Configuration for exposing errors that originate from subgraphs",
@@ -6334,6 +6399,44 @@ expression: "&schema"
           "default": {},
           "description": "Overrides global configuration on a per-subgraph basis",
           "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "InputConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "claims": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/IncludeConfig"
+            }
+          ],
+          "description": "Selects authenticated JWT claim names included in policy input. Empty by default."
+        },
+        "context": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/IncludeConfig"
+            }
+          ],
+          "description": "Selects router context values included in the policy input."
+        },
+        "headers": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/IncludeConfig"
+            }
+          ],
+          "description": "Selects request headers included in the policy input."
+        },
+        "variables": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/IncludeConfig"
+            }
+          ],
+          "description": "Selects GraphQL variables included in the policy input."
         }
       },
       "type": "object"
@@ -7090,6 +7193,29 @@ expression: "&schema"
       ],
       "description": "Listening address."
     },
+    "LoadBalancingConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "strategy": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/LoadBalancingStrategy"
+            }
+          ],
+          "description": "Strategy used to select an endpoint for each initial request and retry."
+        }
+      },
+      "type": "object"
+    },
+    "LoadBalancingStrategy": {
+      "oneOf": [
+        {
+          "const": "round_robin",
+          "description": "Select endpoints in sequence, skipping endpoints that are temporarily unhealthy.",
+          "type": "string"
+        }
+      ]
+    },
     "Logging": {
       "additionalProperties": false,
       "description": "Logging configuration.",
@@ -7560,6 +7686,19 @@ expression: "&schema"
       ],
       "type": "string"
     },
+    "OpaApiConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "decision": {
+          "description": "OPA Data API decision path, without `/v1/data/`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "decision"
+      ],
+      "type": "object"
+    },
     "Operation": {
       "oneOf": [
         {
@@ -7869,6 +8008,44 @@ expression: "&schema"
       },
       "type": "object"
     },
+    "PolicyConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "default": true,
+          "description": "Enables native policy provider evaluation. When false, the configuration is retained but providers are not built or called.",
+          "type": "boolean"
+        },
+        "failure": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/FailureConfig"
+            }
+          ],
+          "description": "Controls behavior when a provider cannot evaluate a policy."
+        },
+        "providers": {
+          "additionalProperties": {
+            "$ref": "#/definitions/ProviderConfig"
+          },
+          "description": "Named policy providers available for evaluating `@policy` labels.",
+          "type": "object"
+        },
+        "routing": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/RoutingConfig"
+            }
+          ],
+          "description": "Routes policy labels to configured providers."
+        }
+      },
+      "required": [
+        "providers",
+        "routing"
+      ],
+      "type": "object"
+    },
     "PrivateNetworkAccessPolicy": {
       "additionalProperties": false,
       "properties": {
@@ -8017,6 +8194,56 @@ expression: "&schema"
         "http"
       ],
       "type": "string"
+    },
+    "ProviderConfig": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "api": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/OpaApiConfig"
+                }
+              ],
+              "description": "Configures the OPA Data API decision queried by the router."
+            },
+            "endpoints": {
+              "description": "Equivalent OPA service endpoints used for load balancing and retries.",
+              "items": {
+                "$ref": "#/definitions/EndpointConfig"
+              },
+              "type": "array"
+            },
+            "input": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/InputConfig"
+                }
+              ],
+              "description": "Selects request data included in the OPA policy input document."
+            },
+            "transport": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/TransportConfig"
+                }
+              ],
+              "description": "Configures communication with the OPA service endpoints."
+            },
+            "type": {
+              "const": "opa",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "api",
+            "endpoints"
+          ],
+          "type": "object"
+        }
+      ]
     },
     "Query": {
       "oneOf": [
@@ -8589,6 +8816,19 @@ expression: "&schema"
         }
       ]
     },
+    "RetryConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "max_attempts": {
+          "default": 2,
+          "description": "Maximum total number of attempts, including the initial request.",
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "RhaiConfig": {
       "additionalProperties": false,
       "description": "Configuration for the Rhai Plugin",
@@ -8613,6 +8853,67 @@ expression: "&schema"
           ]
         }
       },
+      "type": "object"
+    },
+    "RouteMatch": {
+      "additionalProperties": false,
+      "properties": {
+        "exact": {
+          "default": [],
+          "description": "Policy labels that must match exactly.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "prefix": {
+          "default": [],
+          "description": "Policy label prefixes matched using longest-prefix precedence.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "RouteRule": {
+      "additionalProperties": false,
+      "properties": {
+        "match": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouteMatch"
+            }
+          ],
+          "description": "Exact labels and prefixes matched by this rule."
+        },
+        "target": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouteTarget"
+            }
+          ],
+          "description": "Provider that evaluates labels matched by this rule."
+        }
+      },
+      "required": [
+        "match",
+        "target"
+      ],
+      "type": "object"
+    },
+    "RouteTarget": {
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "description": "Name of the provider to call.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider"
+      ],
       "type": "object"
     },
     "Router": {
@@ -9389,6 +9690,30 @@ expression: "&schema"
           "$ref": "#/definitions/RouterSelector"
         }
       ]
+    },
+    "RoutingConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/RouteTarget"
+            }
+          ],
+          "description": "Provider used when no routing rule matches a policy label."
+        },
+        "rules": {
+          "description": "Ordered policy-label routing rules.",
+          "items": {
+            "$ref": "#/definitions/RouteRule"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "default"
+      ],
+      "type": "object"
     },
     "Sampler": {
       "oneOf": [
@@ -12331,6 +12656,20 @@ expression: "&schema"
       ],
       "type": "string"
     },
+    "TimeoutConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "total": {
+          "default": {
+            "nanos": 250000000,
+            "secs": 0
+          },
+          "description": "Maximum duration for the complete evaluation, including input construction and all attempts.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "Tls": {
       "additionalProperties": false,
       "description": "TLS related configuration options.",
@@ -12671,6 +13010,52 @@ expression: "&schema"
           },
           "description": "Applied on specific subgraphs",
           "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "TransportConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "client": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/Client"
+            }
+          ],
+          "description": "HTTP client connection, DNS, HTTP/2, and pool settings for provider calls."
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "Static HTTP headers included in every request to this provider.",
+          "type": "object"
+        },
+        "load_balancing": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/LoadBalancingConfig"
+            }
+          ],
+          "description": "Selects how requests are distributed across equivalent endpoints."
+        },
+        "retry": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/RetryConfig"
+            }
+          ],
+          "description": "Controls retry attempts across equivalent endpoints."
+        },
+        "timeouts": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/TimeoutConfig"
+            }
+          ],
+          "description": "Limits the total time available for a policy evaluation."
         }
       },
       "type": "object"

--- a/apollo-router/src/configuration/testdata/metrics/authorization_policy.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/authorization_policy.router.yaml
@@ -1,0 +1,13 @@
+authorization:
+  policy:
+    enabled: false
+    providers:
+      primary:
+        type: opa
+        api:
+          decision: apollo/router/authorize
+        endpoints:
+          - url: http://127.0.0.1:8181
+    routing:
+      default:
+        provider: primary

--- a/apollo-router/src/plugins/authorization/mod.rs
+++ b/apollo-router/src/plugins/authorization/mod.rs
@@ -632,15 +632,17 @@ impl Plugin for AuthorizationPlugin {
                 let filtered = !request.query_plan.query.unauthorized.paths.is_empty();
                 let needs_authenticated = request.context.contains_key(AUTHENTICATION_REQUIRED_KEY);
                 let needs_requires_scopes = request.context.contains_key(REQUIRED_SCOPES_KEY);
+                let needs_policies = request.context.contains_key(REQUIRED_POLICIES_KEY);
 
-                if needs_authenticated || needs_requires_scopes {
+                if needs_authenticated || needs_requires_scopes || needs_policies {
                     u64_counter!(
                         "apollo.router.operations.authorization",
                         "Number of subgraph requests requiring authorization",
                         1,
                         authorization.filtered = filtered,
                         authorization.needs_authenticated = needs_authenticated,
-                        authorization.needs_requires_scopes = needs_requires_scopes
+                        authorization.needs_requires_scopes = needs_requires_scopes,
+                        authorization.needs_policies = needs_policies
                     );
                 }
 

--- a/apollo-router/src/plugins/authorization/mod.rs
+++ b/apollo-router/src/plugins/authorization/mod.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 use std::ops::ControlFlow;
+use std::sync::Arc;
 
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::ast;
@@ -21,6 +22,9 @@ use self::authenticated::AuthenticatedVisitor;
 use self::policy::POLICY_SPEC_VERSION_RANGE;
 use self::policy::PolicyExtractionVisitor;
 use self::policy::PolicyFilteringVisitor;
+use self::provider::PolicyConfig;
+use self::provider::PolicyProviderRegistry;
+use self::provider::ProviderPolicyDecisions;
 use self::scopes::REQUIRES_SCOPES_SPEC_VERSION_RANGE;
 use self::scopes::ScopeExtractionVisitor;
 use self::scopes::ScopeFilteringVisitor;
@@ -46,6 +50,7 @@ use crate::spec::query::traverse;
 pub(crate) mod authenticated;
 pub(crate) mod extract_authorization_checks_layer;
 pub(crate) mod policy;
+pub(crate) mod provider;
 pub(crate) mod scopes;
 
 pub(crate) const AUTHENTICATION_REQUIRED_KEY: &str =
@@ -70,6 +75,9 @@ pub(crate) struct Conf {
     /// `@authenticated`, `@requiresScopes` and `@policy` directives
     #[serde(default)]
     directives: Directives,
+    /// Native evaluation of policies referenced by `@policy`.
+    #[serde(default)]
+    policy: Option<PolicyConfig>,
 }
 
 impl Conf {
@@ -194,6 +202,8 @@ fn default_enable_directives() -> bool {
 
 pub(crate) struct AuthorizationPlugin {
     require_authentication: bool,
+    policy_providers: Option<Arc<PolicyProviderRegistry>>,
+    directives_dry_run: bool,
 }
 
 impl AuthorizationPlugin {
@@ -287,18 +297,24 @@ impl AuthorizationPlugin {
         scopes.sort();
 
         let mut policies = context
-            .get_json_value(REQUIRED_POLICIES_KEY)
-            .and_then(|v| {
-                v.as_object().map(|v| {
-                    v.iter()
-                        .filter_map(|(policy, result)| match result {
-                            Value::Bool(true) => Some(policy.as_str().to_string()),
-                            _ => None,
+            .extensions()
+            .with_lock(|lock| lock.get::<ProviderPolicyDecisions>().cloned())
+            .map(|decisions| decisions.allowed_policies())
+            .unwrap_or_else(|| {
+                context
+                    .get_json_value(REQUIRED_POLICIES_KEY)
+                    .and_then(|v| {
+                        v.as_object().map(|v| {
+                            v.iter()
+                                .filter_map(|(policy, result)| match result {
+                                    Value::Bool(true) => Some(policy.as_str().to_string()),
+                                    _ => None,
+                                })
+                                .collect::<Vec<String>>()
                         })
-                        .collect::<Vec<String>>()
-                })
-            })
-            .unwrap_or_default();
+                    })
+                    .unwrap_or_default()
+            });
         policies.sort();
 
         context.extensions().with_lock(|lock| {
@@ -540,8 +556,29 @@ impl Plugin for AuthorizationPlugin {
     type Config = Conf;
 
     async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
+        if init
+            .config
+            .policy
+            .as_ref()
+            .is_some_and(|policy| policy.enabled)
+            && !init.config.directives.enabled
+        {
+            return Err(
+                "authorization.policy requires authorization.directives.enabled: true".into(),
+            );
+        }
+        let policy_providers = init
+            .config
+            .policy
+            .clone()
+            .filter(|config| config.enabled)
+            .map(PolicyProviderRegistry::new)
+            .transpose()?
+            .map(Arc::new);
         Ok(AuthorizationPlugin {
             require_authentication: init.config.require_authentication,
+            policy_providers,
+            directives_dry_run: init.config.directives.dry_run,
         })
     }
 
@@ -549,15 +586,24 @@ impl Plugin for AuthorizationPlugin {
         &self,
         service: supergraph::BoxCloneService,
     ) -> supergraph::BoxCloneService {
+        let service = match &self.policy_providers {
+            Some(policy_providers) => ServiceBuilder::new()
+                .layer(provider::PolicyProviderLayer::with_dry_run(
+                    policy_providers.clone(),
+                    self.directives_dry_run,
+                ))
+                .service(service)
+                .boxed_clone(),
+            None => service,
+        };
+
         if self.require_authentication {
             ServiceBuilder::new()
-                .checkpoint_async(move |request: supergraph::Request| async move {
+                .checkpoint_async(|request: supergraph::Request| async move {
                     // Whether to reject unauthenticated requests is an authorization policy,
                     // same as `@authenticated`/`@requiresScopes`/`@policy` — authentication only
                     // verifies tokens, it doesn't decide this.
-                    if authentication::has_authenticated_jwt(&request.context) {
-                        Ok(ControlFlow::Continue(request))
-                    } else {
+                    if !authentication::has_authenticated_jwt(&request.context) {
                         tracing::error!("rejecting unauthenticated request");
                         let response = supergraph::Response::error_builder()
                             .error(
@@ -569,8 +615,9 @@ impl Plugin for AuthorizationPlugin {
                             .status_code(StatusCode::UNAUTHORIZED)
                             .context(request.context)
                             .build()?;
-                        Ok(ControlFlow::Break(response))
+                        return Ok(ControlFlow::Break(response));
                     }
+                    Ok(ControlFlow::Continue(request))
                 })
                 .service(service)
                 .boxed_clone()

--- a/apollo-router/src/plugins/authorization/provider/config.rs
+++ b/apollo-router/src/plugins/authorization/provider/config.rs
@@ -1,0 +1,197 @@
+use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
+use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PolicyConfig {
+    /// Enables native policy provider evaluation. When false, the configuration is retained but providers are not built or called.
+    #[serde(default = "default_enabled")]
+    pub(crate) enabled: bool,
+    /// Named policy providers available for evaluating `@policy` labels.
+    pub(super) providers: BTreeMap<String, ProviderConfig>,
+    /// Routes policy labels to configured providers.
+    pub(super) routing: RoutingConfig,
+    /// Controls behavior when a provider cannot evaluate a policy.
+    #[serde(default)]
+    pub(super) failure: FailureConfig,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub(super) enum ProviderConfig {
+    Opa(OpaConfig),
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(super) struct OpaConfig {
+    /// Configures the OPA Data API decision queried by the router.
+    pub(super) api: OpaApiConfig,
+    /// Equivalent OPA service endpoints used for load balancing and retries.
+    pub(super) endpoints: Vec<EndpointConfig>,
+    /// Configures communication with the OPA service endpoints.
+    #[serde(default)]
+    pub(super) transport: TransportConfig,
+    /// Selects request data included in the OPA policy input document.
+    #[serde(default)]
+    pub(super) input: InputConfig,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(super) struct OpaApiConfig {
+    /// OPA Data API decision path, without `/v1/data/`.
+    pub(super) decision: String,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(super) struct EndpointConfig {
+    /// OPA base URL. Supports HTTP(S) and Unix sockets (`unix:///path.sock?path=/http-base`).
+    pub(super) url: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct TransportConfig {
+    /// HTTP client connection, DNS, HTTP/2, and pool settings for provider calls.
+    #[serde(default)]
+    pub(super) client: crate::configuration::shared::Client,
+    /// Selects how requests are distributed across equivalent endpoints.
+    pub(super) load_balancing: LoadBalancingConfig,
+    /// Limits the total time available for a policy evaluation.
+    pub(super) timeouts: TimeoutConfig,
+    /// Controls retry attempts across equivalent endpoints.
+    pub(super) retry: RetryConfig,
+    /// Static HTTP headers included in every request to this provider.
+    pub(super) headers: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct LoadBalancingConfig {
+    /// Strategy used to select an endpoint for each initial request and retry.
+    pub(super) strategy: LoadBalancingStrategy,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum LoadBalancingStrategy {
+    /// Select endpoints in sequence, skipping endpoints that are temporarily unhealthy.
+    #[default]
+    RoundRobin,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct TimeoutConfig {
+    /// Maximum duration for the complete evaluation, including input construction and all attempts.
+    #[serde(deserialize_with = "humantime_serde::deserialize")]
+    #[schemars(with = "String")]
+    pub(super) total: Duration,
+}
+
+impl Default for TimeoutConfig {
+    fn default() -> Self {
+        Self {
+            total: Duration::from_millis(250),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct RetryConfig {
+    /// Maximum total number of attempts, including the initial request.
+    pub(super) max_attempts: NonZeroUsize,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: NonZeroUsize::new(2).expect("two is non-zero"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct InputConfig {
+    /// Selects authenticated JWT claim names included in policy input. Empty by default.
+    pub(super) claims: IncludeConfig,
+    /// Selects request headers included in the policy input.
+    pub(super) headers: IncludeConfig,
+    /// Selects GraphQL variables included in the policy input.
+    pub(super) variables: IncludeConfig,
+    /// Selects router context values included in the policy input.
+    pub(super) context: IncludeConfig,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct IncludeConfig {
+    /// Explicit names to include. Values are never wildcard-expanded.
+    pub(super) include: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(super) struct RoutingConfig {
+    /// Provider used when no routing rule matches a policy label.
+    pub(super) default: RouteTarget,
+    /// Ordered policy-label routing rules.
+    #[serde(default)]
+    pub(super) rules: Vec<RouteRule>,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(super) struct RouteRule {
+    /// Exact labels and prefixes matched by this rule.
+    pub(super) r#match: RouteMatch,
+    /// Provider that evaluates labels matched by this rule.
+    pub(super) target: RouteTarget,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(super) struct RouteMatch {
+    /// Policy labels that must match exactly.
+    #[serde(default)]
+    pub(super) exact: Vec<String>,
+    /// Policy label prefixes matched using longest-prefix precedence.
+    #[serde(default)]
+    pub(super) prefix: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(super) struct RouteTarget {
+    /// Name of the provider to call.
+    pub(super) provider: String,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum FailureMode {
+    /// Reject the operation with a provider evaluation error.
+    #[default]
+    Reject,
+    /// Continue authorization by denying every requested policy.
+    Deny,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub(super) struct FailureConfig {
+    /// Provider failures either reject the request or deny all policies.
+    pub(super) mode: FailureMode,
+}
+
+fn default_enabled() -> bool {
+    true
+}

--- a/apollo-router/src/plugins/authorization/provider/mod.rs
+++ b/apollo-router/src/plugins/authorization/provider/mod.rs
@@ -1,0 +1,252 @@
+//! Native policy providers for `@policy`.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fmt;
+
+use futures::future::try_join_all;
+use tower::BoxError;
+
+use crate::Context;
+use crate::plugins::authorization::REQUIRED_POLICIES_KEY;
+use crate::services::supergraph;
+
+mod config;
+mod opa;
+mod service;
+#[cfg(test)]
+mod tests;
+
+pub(crate) use config::PolicyConfig;
+use config::*;
+use opa::OpaProvider;
+pub(crate) use service::PolicyProviderLayer;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ProviderPolicyDecisions(BTreeMap<String, bool>);
+
+impl ProviderPolicyDecisions {
+    fn required(context: &Context) -> BTreeSet<String> {
+        context
+            .get_json_value(REQUIRED_POLICIES_KEY)
+            .and_then(|value| {
+                value.as_object().map(|policies| {
+                    policies
+                        .keys()
+                        .map(|policy| policy.as_str().to_string())
+                        .collect()
+                })
+            })
+            .unwrap_or_default()
+    }
+
+    fn deny_all(policies: BTreeSet<String>) -> Self {
+        Self(policies.into_iter().map(|policy| (policy, false)).collect())
+    }
+
+    fn store(&self, context: &Context) -> Result<(), BoxError> {
+        context.insert_json_value(REQUIRED_POLICIES_KEY, serde_json_bytes::to_value(&self.0)?);
+        context
+            .extensions()
+            .with_lock(|lock| lock.insert(self.clone()));
+        Ok(())
+    }
+
+    pub(crate) fn allowed_policies(&self) -> Vec<String> {
+        self.0
+            .iter()
+            .filter_map(|(policy, allowed)| allowed.then_some(policy.clone()))
+            .collect()
+    }
+}
+
+pub(crate) struct PolicyProviderRegistry {
+    providers: BTreeMap<String, PolicyProvider>,
+    routing: RoutingTable,
+    failure_mode: FailureMode,
+}
+
+enum PolicyProvider {
+    Opa(OpaProvider),
+}
+
+struct RoutingTable {
+    default_provider: String,
+    exact_routes: BTreeMap<String, String>,
+    prefix_routes: Vec<(String, String)>,
+}
+
+struct ProviderEvaluationError {
+    provider_name: String,
+    source: BoxError,
+}
+
+impl fmt::Display for ProviderEvaluationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.source.fmt(formatter)
+    }
+}
+
+impl fmt::Debug for ProviderEvaluationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl std::error::Error for ProviderEvaluationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+impl PolicyProviderRegistry {
+    pub(crate) fn new(config: PolicyConfig) -> Result<Self, BoxError> {
+        if config.providers.is_empty() {
+            return Err("authorization.policy.providers must not be empty".into());
+        }
+        let routing = RoutingTable::new(&config.routing, &config.providers)?;
+
+        let mut providers = BTreeMap::new();
+        for (name, provider) in config.providers {
+            providers.insert(name.clone(), PolicyProvider::new(name, provider)?);
+        }
+
+        Ok(Self {
+            providers,
+            routing,
+            failure_mode: config.failure.mode,
+        })
+    }
+
+    pub(crate) async fn evaluate(
+        &self,
+        request: &supergraph::Request,
+        policies: BTreeSet<String>,
+    ) -> Result<ProviderPolicyDecisions, BoxError> {
+        let mut grouped: BTreeMap<&str, BTreeSet<String>> = BTreeMap::new();
+        for policy in policies {
+            grouped
+                .entry(self.routing.provider_for(&policy))
+                .or_default()
+                .insert(policy);
+        }
+
+        let calls = grouped
+            .into_iter()
+            .map(|(provider_name, policies)| async move {
+                self.providers[provider_name]
+                    .evaluate(request, policies)
+                    .await
+                    .map_err(|source| {
+                        Box::new(ProviderEvaluationError {
+                            provider_name: provider_name.to_string(),
+                            source,
+                        }) as BoxError
+                    })
+            });
+
+        let mut decisions = BTreeMap::new();
+        for provider_decisions in try_join_all(calls).await? {
+            decisions.extend(provider_decisions);
+        }
+        Ok(ProviderPolicyDecisions(decisions))
+    }
+
+    fn failure_mode(&self) -> FailureMode {
+        self.failure_mode
+    }
+
+    fn provider_name_for_error(error: &BoxError) -> &str {
+        error
+            .downcast_ref::<ProviderEvaluationError>()
+            .map(|error| error.provider_name.as_str())
+            .unwrap_or("unknown")
+    }
+}
+
+impl PolicyProvider {
+    fn new(name: String, config: ProviderConfig) -> Result<Self, BoxError> {
+        match config {
+            ProviderConfig::Opa(config) => Ok(Self::Opa(OpaProvider::new(name, config)?)),
+        }
+    }
+
+    async fn evaluate(
+        &self,
+        request: &supergraph::Request,
+        policies: BTreeSet<String>,
+    ) -> Result<BTreeMap<String, bool>, BoxError> {
+        match self {
+            Self::Opa(provider) => provider.evaluate(request, policies).await,
+        }
+    }
+}
+
+impl RoutingTable {
+    fn new(
+        config: &RoutingConfig,
+        providers: &BTreeMap<String, ProviderConfig>,
+    ) -> Result<Self, BoxError> {
+        if !providers.contains_key(&config.default.provider) {
+            return Err(format!(
+                "unknown default policy provider `{}`",
+                config.default.provider
+            )
+            .into());
+        }
+
+        let mut exact_routes = BTreeMap::new();
+        let mut prefix_routes = BTreeMap::new();
+        for rule in &config.rules {
+            if !providers.contains_key(&rule.target.provider) {
+                return Err(format!("unknown policy provider `{}`", rule.target.provider).into());
+            }
+            for policy in &rule.r#match.exact {
+                if exact_routes
+                    .insert(policy.clone(), rule.target.provider.clone())
+                    .is_some()
+                {
+                    return Err(format!("policy `{policy}` is routed more than once").into());
+                }
+            }
+            for prefix in &rule.r#match.prefix {
+                if prefix.is_empty() {
+                    return Err("policy route prefixes must not be empty".into());
+                }
+                if prefix_routes
+                    .insert(prefix.clone(), rule.target.provider.clone())
+                    .is_some()
+                {
+                    return Err(format!("policy prefix `{prefix}` is routed more than once").into());
+                }
+            }
+            if rule.r#match.exact.is_empty() && rule.r#match.prefix.is_empty() {
+                return Err(
+                    "policy routing rules must match at least one exact label or prefix".into(),
+                );
+            }
+        }
+        let mut prefix_routes = prefix_routes.into_iter().collect::<Vec<_>>();
+        // Longest prefix wins, so a narrow namespace can override a broad one.
+        prefix_routes.sort_by(|(left, _), (right, _)| {
+            right.len().cmp(&left.len()).then_with(|| left.cmp(right))
+        });
+
+        Ok(Self {
+            default_provider: config.default.provider.clone(),
+            exact_routes,
+            prefix_routes,
+        })
+    }
+
+    fn provider_for(&self, policy: &str) -> &str {
+        self.exact_routes
+            .get(policy)
+            .or_else(|| {
+                self.prefix_routes
+                    .iter()
+                    .find_map(|(prefix, provider)| policy.starts_with(prefix).then_some(provider))
+            })
+            .unwrap_or(&self.default_provider)
+    }
+}

--- a/apollo-router/src/plugins/authorization/provider/opa.rs
+++ b/apollo-router/src/plugins/authorization/provider/opa.rs
@@ -1,0 +1,746 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fmt;
+use std::future::Ready;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use http::HeaderName;
+use http::HeaderValue;
+use http::Method;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use tower::BoxError;
+use tower::Layer;
+use tower::Service;
+use tower::ServiceExt;
+use tower::retry::Policy;
+use tower::retry::RetryLayer;
+use tower::timeout::TimeoutLayer;
+use tracing::Instrument;
+
+use super::config::InputConfig;
+use super::config::LoadBalancingStrategy;
+use super::config::OpaConfig;
+use crate::Context;
+use crate::context::OPERATION_KIND;
+use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
+use crate::services::http::{HttpClientService, HttpRequest};
+use crate::services::router;
+use crate::services::supergraph;
+
+pub(super) const CONTRACT_VERSION: &str = "apollo.router.policy/v1";
+
+#[derive(Clone)]
+pub(super) struct OpaProvider {
+    name: String,
+    client: HttpClientService,
+    endpoints: Arc<EndpointPool>,
+    decision: String,
+    timeout: Duration,
+    max_attempts: NonZeroUsize,
+    headers: BTreeMap<String, String>,
+    input: InputConfig,
+}
+
+struct EndpointPool {
+    endpoints: Vec<reqwest::Url>,
+    health: Vec<EndpointHealth>,
+    selector: EndpointSelector,
+}
+
+struct EndpointHealth {
+    failures: AtomicUsize,
+    ejected_until: Mutex<Option<tokio::time::Instant>>,
+}
+
+enum EndpointSelector {
+    RoundRobin(AtomicUsize),
+}
+
+#[derive(Serialize)]
+struct OpaRequest<'a> {
+    input: PolicyInput<'a>,
+}
+
+#[derive(Serialize)]
+struct PolicyInput<'a> {
+    contract: &'static str,
+    policies: &'a BTreeSet<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    identity: Option<IdentityInput>,
+    operation: OperationInput,
+    request: RequestInput,
+    context: BTreeMap<String, Value>,
+}
+
+#[derive(Serialize)]
+struct IdentityInput {
+    claims: Value,
+}
+
+#[derive(Serialize)]
+struct OperationInput {
+    name: Option<String>,
+    kind: Option<Value>,
+    variables: BTreeMap<String, Value>,
+}
+
+#[derive(Serialize)]
+struct RequestInput {
+    headers: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct OpaResponse {
+    #[serde(default)]
+    decision_id: Option<String>,
+    result: Option<OpaResult>,
+}
+
+#[derive(Deserialize)]
+struct OpaResult {
+    contract: String,
+    decisions: BTreeMap<String, bool>,
+}
+
+enum AttemptError {
+    Retryable {
+        endpoint_index: usize,
+        source: BoxError,
+    },
+    Fatal(BoxError),
+}
+
+struct EvaluationError(BoxError);
+
+impl fmt::Display for EvaluationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl fmt::Debug for EvaluationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl std::error::Error for EvaluationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.0.as_ref())
+    }
+}
+
+impl fmt::Display for AttemptError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Retryable { source, .. } | Self::Fatal(source) => source.fmt(formatter),
+        }
+    }
+}
+
+impl fmt::Debug for AttemptError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl std::error::Error for AttemptError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Retryable { source, .. } | Self::Fatal(source) => Some(source.as_ref()),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct AttemptRequest {
+    body: Arc<[u8]>,
+    start: usize,
+    attempt: usize,
+}
+
+#[derive(Clone)]
+struct AttemptService {
+    name: Arc<str>,
+    client: HttpClientService,
+    endpoints: Arc<EndpointPool>,
+    decision: Arc<str>,
+    headers: Arc<BTreeMap<String, String>>,
+}
+
+#[derive(Clone)]
+struct RetryPolicy {
+    name: Arc<str>,
+    endpoints: Arc<EndpointPool>,
+    retries_remaining: usize,
+}
+
+struct InputSource {
+    context: Context,
+    body: crate::graphql::Request,
+    headers: http::HeaderMap,
+}
+
+impl OpaProvider {
+    pub(super) fn new(name: String, config: OpaConfig) -> Result<Self, BoxError> {
+        if config.endpoints.is_empty() {
+            return Err(format!("OPA provider `{name}` must have at least one endpoint").into());
+        }
+        if config.transport.timeouts.total.is_zero() {
+            return Err(format!("OPA provider `{name}` timeout must be greater than zero").into());
+        }
+        let decision = config.api.decision.trim_matches('/').to_string();
+        if decision.is_empty() {
+            return Err(format!("OPA provider `{name}` decision must not be empty").into());
+        }
+        let endpoints = config
+            .endpoints
+            .into_iter()
+            .map(|endpoint| {
+                crate::services::validate_external_service_url(
+                    &endpoint.url,
+                    &format!("OPA provider `{name}` endpoint"),
+                    false,
+                    crate::services::UnixSocketQueryPolicy::OptionalAbsolutePath,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut unique_endpoints = BTreeSet::new();
+        for endpoint in &endpoints {
+            if !unique_endpoints.insert(endpoint.as_str()) {
+                return Err(format!(
+                    "OPA provider `{name}` contains duplicate endpoint `{endpoint}`"
+                )
+                .into());
+            }
+        }
+        for (header_name, header_value) in &config.transport.headers {
+            HeaderName::try_from(header_name)?;
+            HeaderValue::try_from(header_value)?;
+        }
+
+        let transport = config.transport;
+        Ok(Self {
+            name: name.clone(),
+            client: HttpClientService::from_config_for_policy_provider(
+                name.clone(),
+                &crate::Configuration::default(),
+                &HttpClientService::native_roots_store(),
+                transport.client.clone(),
+            )?,
+            endpoints: Arc::new(EndpointPool::new(
+                endpoints,
+                transport.load_balancing.strategy,
+            )),
+            decision,
+            timeout: transport.timeouts.total,
+            max_attempts: transport.retry.max_attempts,
+            headers: transport.headers,
+            input: config.input,
+        })
+    }
+
+    pub(super) async fn evaluate(
+        &self,
+        request: &supergraph::Request,
+        policies: BTreeSet<String>,
+    ) -> Result<BTreeMap<String, bool>, BoxError> {
+        let provider_name = self.name.clone();
+        let outcome = std::sync::Arc::new(Mutex::new("failure"));
+        let outcome_for_timer = outcome.clone();
+        let _timer = crate::plugins::telemetry::utils::Timer::new(move |duration| {
+            let outcome = outcome_for_timer
+                .lock()
+                .map(|value| *value)
+                .unwrap_or("failure");
+            f64_histogram!(
+                "apollo.router.operations.policy_provider.duration",
+                "Duration of native policy provider evaluation",
+                duration.as_secs_f64(),
+                policy.provider.type = "opa",
+                policy.provider.name = provider_name,
+                policy.provider.outcome = outcome
+            );
+        });
+        let span = tracing::info_span!(
+            "policy_provider.evaluate",
+            "otel.kind" = "INTERNAL",
+            "policy.provider.type" = "opa",
+            "policy.provider.name" = self.name.as_str(),
+            "policy.count" = policies.len()
+        );
+        let input_source = InputSource {
+            context: request.context.clone(),
+            body: request.supergraph_request.body().clone(),
+            headers: request.supergraph_request.headers().clone(),
+        };
+        let provider = self.clone();
+        let outcome_for_evaluation = Arc::clone(&outcome);
+        let evaluation = tower::service_fn(move |(input_source, policies)| {
+            let outcome = Arc::clone(&outcome_for_evaluation);
+            let provider = provider.clone();
+            async move {
+                let result: Result<BTreeMap<String, bool>, EvaluationError> = async {
+                    let body = OpaRequest {
+                        input: provider
+                            .build_input(&input_source, &policies)
+                            .map_err(EvaluationError)?,
+                    };
+                    let body: Arc<[u8]> = serde_json::to_vec(&body)
+                        .map_err(|error| EvaluationError(Box::new(error)))?
+                        .into();
+                    let start = provider.endpoints.next_start();
+                    let attempt_service = AttemptService {
+                        name: Arc::from(provider.name.as_str()),
+                        client: provider.client.clone(),
+                        endpoints: Arc::clone(&provider.endpoints),
+                        decision: Arc::from(provider.decision.as_str()),
+                        headers: Arc::new(provider.headers.clone()),
+                    };
+                    let retry_policy = RetryPolicy {
+                        name: Arc::from(provider.name.as_str()),
+                        endpoints: Arc::clone(&provider.endpoints),
+                        retries_remaining: provider.max_attempts.get() - 1,
+                    };
+                    let response = RetryLayer::new(retry_policy)
+                        .layer(attempt_service)
+                        .oneshot(AttemptRequest {
+                            body,
+                            start,
+                            attempt: 0,
+                        })
+                        .await
+                        .map_err(|error| EvaluationError(Box::new(error)))?;
+                    let decisions = provider
+                        .decisions(response, policies)
+                        .map_err(EvaluationError);
+                    if let Ok(mut value) = outcome.lock() {
+                        *value = if decisions.is_ok() {
+                            "success"
+                        } else {
+                            "contract_error"
+                        };
+                    }
+                    decisions
+                }
+                .await;
+                result
+            }
+        });
+
+        match TimeoutLayer::new(self.timeout)
+            .layer(evaluation)
+            .oneshot((input_source, policies))
+            .instrument(span)
+            .await
+        {
+            Ok(decisions) => Ok(decisions),
+            Err(error) if error.is::<tower::timeout::error::Elapsed>() => {
+                if let Ok(mut value) = outcome.lock() {
+                    *value = "timeout";
+                }
+                Err(format!("OPA provider `{}` timed out", self.name).into())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn decisions(
+        &self,
+        response: OpaResponse,
+        policies: BTreeSet<String>,
+    ) -> Result<BTreeMap<String, bool>, BoxError> {
+        if let Some(decision_id) = response.decision_id {
+            tracing::debug!(
+                opa.decision_id = decision_id,
+                policy.provider.name = self.name,
+                "OPA policy decision"
+            );
+        }
+        let Some(result) = response.result else {
+            u64_counter!(
+                "apollo.router.operations.policy_provider.missing_result",
+                "OPA responses missing the result field",
+                1,
+                policy.provider.name = self.name.clone()
+            );
+            tracing::warn!(
+                policy.provider.name = self.name,
+                "OPA response omitted result; denying policies"
+            );
+            return Ok(policies.into_iter().map(|policy| (policy, false)).collect());
+        };
+        if result.contract != CONTRACT_VERSION {
+            return Err(format!(
+                "OPA provider `{}` returned unsupported contract `{}`",
+                self.name, result.contract
+            )
+            .into());
+        }
+        if result
+            .decisions
+            .keys()
+            .any(|policy| !policies.contains(policy))
+        {
+            return Err(format!(
+                "OPA provider `{}` returned a decision for an unrequested policy",
+                self.name
+            )
+            .into());
+        }
+        Ok(policies
+            .into_iter()
+            .map(|policy| {
+                let allowed = result.decisions.get(&policy).copied().unwrap_or(false);
+                if allowed {
+                    u64_counter!(
+                        "apollo.router.operations.policy_provider.allow",
+                        "OPA policy decisions",
+                        1,
+                        policy.provider.name = self.name.clone()
+                    );
+                } else {
+                    u64_counter!(
+                        "apollo.router.operations.policy_provider.deny",
+                        "OPA policy decisions",
+                        1,
+                        policy.provider.name = self.name.clone()
+                    );
+                }
+                (policy, allowed)
+            })
+            .collect())
+    }
+
+    fn build_input<'a>(
+        &self,
+        request: &'a InputSource,
+        policies: &'a BTreeSet<String>,
+    ) -> Result<PolicyInput<'a>, BoxError> {
+        let identity = (!self.input.claims.include.is_empty()).then(|| IdentityInput {
+            claims: context_value(&request.context, APOLLO_AUTHENTICATION_JWT_CLAIMS)
+                .map(|claims| select_claims(claims, &self.input.claims.include))
+                .unwrap_or(Value::Null),
+        });
+        let variables = self
+            .input
+            .variables
+            .include
+            .iter()
+            .filter_map(|name| {
+                request
+                    .body
+                    .variables
+                    .get(name.as_str())
+                    .and_then(|value| serde_json::to_value(value).ok())
+                    .map(|value| (name.clone(), value))
+            })
+            .collect();
+        let headers = self
+            .input
+            .headers
+            .include
+            .iter()
+            .map(|name| {
+                let header_name = HeaderName::try_from(name.as_str()).map_err(|error| {
+                    format!(
+                        "OPA provider `{}` cannot forward invalid header name `{name}`: {error}",
+                        self.name
+                    )
+                })?;
+                let values = request.headers.get_all(header_name);
+                let values = values
+                    .iter()
+                    .map(|value| value.to_str().map(str::to_owned))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|_| {
+                        format!(
+                            "OPA provider `{}` cannot forward non-UTF-8 header `{name}`",
+                            self.name
+                        )
+                    })?;
+                Ok((name.to_ascii_lowercase(), values))
+            })
+            .collect::<Result<BTreeMap<_, _>, BoxError>>()?;
+        let context = self
+            .input
+            .context
+            .include
+            .iter()
+            .filter_map(|name| {
+                context_value(&request.context, name).map(|value| (name.clone(), value))
+            })
+            .collect();
+
+        Ok(PolicyInput {
+            contract: CONTRACT_VERSION,
+            policies,
+            identity,
+            operation: OperationInput {
+                name: request.body.operation_name.clone(),
+                kind: context_value(&request.context, OPERATION_KIND),
+                variables,
+            },
+            request: RequestInput { headers },
+            context,
+        })
+    }
+}
+
+impl Service<AttemptRequest> for AttemptService {
+    type Response = OpaResponse;
+    type Error = AttemptError;
+    type Future = futures::future::BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: AttemptRequest) -> Self::Future {
+        let name = Arc::clone(&self.name);
+        let client = self.client.clone();
+        let endpoints = Arc::clone(&self.endpoints);
+        let decision = Arc::clone(&self.decision);
+        let headers = Arc::clone(&self.headers);
+
+        Box::pin(async move {
+            let (endpoint_index, endpoint) = endpoints.choose(request.start + request.attempt);
+            let endpoint = endpoint.clone();
+            let retryable = |source: BoxError| AttemptError::Retryable {
+                endpoint_index,
+                source,
+            };
+            let mut url = endpoint.clone();
+            let base_path = endpoint.path().trim_end_matches('/');
+            if endpoint.scheme() != "unix" {
+                url.set_path(&format!("{base_path}/v1/data/{decision}"));
+            }
+            let uri = if url.scheme() == "unix" {
+                #[cfg(unix)]
+                {
+                    let socket = url.path();
+                    let base = endpoint
+                        .query_pairs()
+                        .find_map(|(key, value)| (key == "path").then_some(value))
+                        .unwrap_or_else(|| "/".into());
+                    let path = format!("{}/v1/data/{decision}", base.trim_end_matches('/'));
+                    let converted: http::Uri = hyperlocal::Uri::new(socket, &path).into();
+                    converted
+                }
+                #[cfg(not(unix))]
+                {
+                    return Err(AttemptError::Fatal(
+                        "unix socket URLs are unsupported on this platform".into(),
+                    ));
+                }
+            } else {
+                url.as_str()
+                    .parse::<http::Uri>()
+                    .map_err(|error| AttemptError::Fatal(Box::new(error)))?
+            };
+            let mut http_request = http::Request::builder()
+                .method(Method::POST)
+                .uri(uri)
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(http::header::ACCEPT, "application/json")
+                .body(router::body::from_bytes(request.body.to_vec()))
+                .map_err(|error| AttemptError::Fatal(Box::new(error)))?;
+            for (header_name, header_value) in headers.iter() {
+                http_request.headers_mut().insert(
+                    HeaderName::try_from(header_name)
+                        .map_err(|error| AttemptError::Fatal(Box::new(error)))?,
+                    HeaderValue::try_from(header_value)
+                        .map_err(|error| AttemptError::Fatal(Box::new(error)))?,
+                );
+            }
+
+            let response = client
+                .oneshot(HttpRequest {
+                    http_request,
+                    context: crate::Context::new(),
+                })
+                .await
+                .map_err(&retryable)?;
+            let status = response.http_response.status();
+            if status.is_server_error()
+                || status == http::StatusCode::REQUEST_TIMEOUT
+                || status == http::StatusCode::TOO_MANY_REQUESTS
+            {
+                return Err(retryable(
+                    format!("OPA provider `{name}` returned {status}").into(),
+                ));
+            }
+            if !status.is_success() {
+                return Err(AttemptError::Fatal(
+                    format!("OPA provider `{name}` returned {status}").into(),
+                ));
+            }
+            let bytes = router::body::into_bytes(response.http_response.into_body())
+                .await
+                .map_err(|error| {
+                    retryable(
+                        format!("OPA provider `{name}` returned an invalid response: {error}")
+                            .into(),
+                    )
+                })?;
+            let response = serde_json::from_slice(&bytes).map_err(|error| {
+                retryable(
+                    format!("OPA provider `{name}` returned an invalid response: {error}").into(),
+                )
+            })?;
+            endpoints.success(endpoint_index);
+            Ok(response)
+        })
+    }
+}
+
+impl Policy<AttemptRequest, OpaResponse, AttemptError> for RetryPolicy {
+    type Future = Ready<()>;
+
+    fn retry(
+        &mut self,
+        request: &mut AttemptRequest,
+        result: &mut Result<OpaResponse, AttemptError>,
+    ) -> Option<Self::Future> {
+        let Err(AttemptError::Retryable { endpoint_index, .. }) = result else {
+            return None;
+        };
+        self.endpoints.failure(*endpoint_index, &self.name);
+        if self.retries_remaining == 0 {
+            u64_counter!(
+                "apollo.router.operations.policy_provider.retry_exhausted",
+                "OPA provider retry exhaustion",
+                1,
+                policy.provider.name = self.name.to_string()
+            );
+            return None;
+        }
+
+        self.retries_remaining -= 1;
+        request.attempt += 1;
+        u64_counter!(
+            "apollo.router.operations.policy_provider.retry",
+            "OPA provider retries",
+            1,
+            policy.provider.name = self.name.to_string(),
+            policy.provider.endpoint.index = *endpoint_index as i64
+        );
+        Some(std::future::ready(()))
+    }
+
+    fn clone_request(&mut self, request: &AttemptRequest) -> Option<AttemptRequest> {
+        Some(request.clone())
+    }
+}
+
+impl EndpointPool {
+    fn new(endpoints: Vec<reqwest::Url>, strategy: LoadBalancingStrategy) -> Self {
+        let selector = match strategy {
+            LoadBalancingStrategy::RoundRobin => EndpointSelector::RoundRobin(AtomicUsize::new(0)),
+        };
+        let health = (0..endpoints.len())
+            .map(|_| EndpointHealth {
+                failures: AtomicUsize::new(0),
+                ejected_until: Mutex::new(None),
+            })
+            .collect();
+        Self {
+            endpoints,
+            health,
+            selector,
+        }
+    }
+
+    fn next_start(&self) -> usize {
+        match &self.selector {
+            EndpointSelector::RoundRobin(next) => next.fetch_add(1, Ordering::Relaxed),
+        }
+    }
+
+    fn choose(&self, index: usize) -> (usize, &reqwest::Url) {
+        for offset in 0..self.endpoints.len() {
+            let candidate = (index + offset) % self.endpoints.len();
+            let ejected = self.health[candidate]
+                .ejected_until
+                .lock()
+                .ok()
+                .and_then(|until| *until)
+                .is_some_and(|until| until > tokio::time::Instant::now());
+            if !ejected {
+                return (candidate, &self.endpoints[candidate]);
+            }
+        }
+        (
+            index % self.endpoints.len(),
+            &self.endpoints[index % self.endpoints.len()],
+        )
+    }
+
+    fn success(&self, index: usize) {
+        self.health[index].failures.store(0, Ordering::Relaxed);
+    }
+
+    fn failure(&self, index: usize, provider_name: &str) {
+        let failures = self.health[index].failures.fetch_add(1, Ordering::Relaxed) + 1;
+        if failures >= 2 {
+            if let Ok(mut until) = self.health[index].ejected_until.lock() {
+                *until = Some(tokio::time::Instant::now() + Duration::from_secs(1));
+            }
+            u64_counter!(
+                "apollo.router.operations.policy_provider.endpoint_ejected",
+                "OPA provider endpoint ejections",
+                1,
+                policy.provider.name = provider_name.to_string(),
+                policy.provider.endpoint.index = index as i64
+            );
+        }
+    }
+}
+
+fn context_value(context: &Context, key: &str) -> Option<Value> {
+    context
+        .get_json_value(key)
+        .and_then(|value| serde_json::to_value(value).ok())
+}
+
+fn select_claims(claims: Value, names: &[String]) -> Value {
+    let Some(object) = claims.as_object() else {
+        return Value::Null;
+    };
+    let selected = names
+        .iter()
+        .filter_map(|name| object.get(name).map(|v| (name.clone(), v.clone())))
+        .collect::<serde_json::Map<_, _>>();
+    Value::Object(selected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn ejects_failed_endpoint_and_allows_it_after_cooldown() {
+        let endpoints = vec![
+            "http://127.0.0.1:8181".parse().unwrap(),
+            "http://127.0.0.1:8182".parse().unwrap(),
+        ];
+        let pool = EndpointPool::new(endpoints, LoadBalancingStrategy::RoundRobin);
+
+        pool.failure(0, "primary");
+        pool.failure(0, "primary");
+        assert_eq!(pool.choose(0).0, 1);
+
+        tokio::time::sleep(Duration::from_millis(1_050)).await;
+        assert_eq!(pool.choose(0).0, 0);
+    }
+}

--- a/apollo-router/src/plugins/authorization/provider/opa.rs
+++ b/apollo-router/src/plugins/authorization/provider/opa.rs
@@ -30,7 +30,8 @@ use super::config::OpaConfig;
 use crate::Context;
 use crate::context::OPERATION_KIND;
 use crate::plugins::authentication::APOLLO_AUTHENTICATION_JWT_CLAIMS;
-use crate::services::http::{HttpClientService, HttpRequest};
+use crate::services::http::HttpClientService;
+use crate::services::http::HttpRequest;
 use crate::services::router;
 use crate::services::supergraph;
 

--- a/apollo-router/src/plugins/authorization/provider/service.rs
+++ b/apollo-router/src/plugins/authorization/provider/service.rs
@@ -1,0 +1,134 @@
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+
+use futures::future::BoxFuture;
+use http::StatusCode;
+use tower::BoxError;
+use tower::Layer;
+use tower::Service;
+
+use super::FailureMode;
+use super::PolicyProviderRegistry;
+use super::ProviderPolicyDecisions;
+use crate::graphql;
+use crate::services::supergraph;
+
+/// Evaluates the policies required by a supergraph request before calling the inner service.
+#[derive(Clone)]
+pub(crate) struct PolicyProviderLayer {
+    registry: Arc<PolicyProviderRegistry>,
+    dry_run: bool,
+}
+
+impl PolicyProviderLayer {
+    pub(crate) fn with_dry_run(registry: Arc<PolicyProviderRegistry>, dry_run: bool) -> Self {
+        Self { registry, dry_run }
+    }
+}
+
+impl<S> Layer<S> for PolicyProviderLayer {
+    type Service = PolicyProviderService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        PolicyProviderService {
+            inner,
+            registry: Arc::clone(&self.registry),
+            dry_run: self.dry_run,
+        }
+    }
+}
+
+/// Tower service produced by [`PolicyProviderLayer`].
+#[derive(Clone)]
+pub(crate) struct PolicyProviderService<S> {
+    inner: S,
+    registry: Arc<PolicyProviderRegistry>,
+    dry_run: bool,
+}
+
+impl<S> Service<supergraph::Request> for PolicyProviderService<S>
+where
+    S: Service<supergraph::Request, Response = supergraph::Response, Error = BoxError>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = supergraph::Response;
+    type Error = BoxError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: supergraph::Request) -> Self::Future {
+        let registry = Arc::clone(&self.registry);
+        let inner = self.inner.clone();
+        let dry_run = self.dry_run;
+        let mut inner = std::mem::replace(&mut self.inner, inner);
+
+        Box::pin(async move {
+            let required = ProviderPolicyDecisions::required(&request.context);
+            if required.is_empty() {
+                return inner.call(request).await;
+            }
+
+            let evaluation = registry.evaluate(&request, required.clone());
+            match evaluation.await {
+                Ok(decisions) => {
+                    decisions.store(&request.context)?;
+                    inner.call(request).await
+                }
+                Err(error) if dry_run => {
+                    let provider_name = PolicyProviderRegistry::provider_name_for_error(&error);
+                    u64_counter!(
+                        "apollo.router.operations.policy_provider.failure",
+                        "OPA policy provider evaluation failures",
+                        1,
+                        policy.provider.name = provider_name.to_string(),
+                        policy.provider.outcome = "dry_run_failure"
+                    );
+                    tracing::warn!(error = %error, "policy provider evaluation failed during authorization dry run");
+                    ProviderPolicyDecisions::deny_all(required).store(&request.context)?;
+                    inner.call(request).await
+                }
+                Err(error) if registry.failure_mode() == FailureMode::Deny => {
+                    let provider_name = PolicyProviderRegistry::provider_name_for_error(&error);
+                    u64_counter!(
+                        "apollo.router.operations.policy_provider.failure",
+                        "OPA policy provider evaluation failures",
+                        1,
+                        policy.provider.name = provider_name.to_string(),
+                        policy.provider.outcome = "deny_failure"
+                    );
+                    tracing::error!(error = %error, "policy provider evaluation failed; denying policies");
+                    ProviderPolicyDecisions::deny_all(required).store(&request.context)?;
+                    inner.call(request).await
+                }
+                Err(error) => {
+                    let provider_name = PolicyProviderRegistry::provider_name_for_error(&error);
+                    u64_counter!(
+                        "apollo.router.operations.policy_provider.failure",
+                        "OPA policy provider evaluation failures",
+                        1,
+                        policy.provider.name = provider_name.to_string(),
+                        policy.provider.outcome = "reject_failure"
+                    );
+                    tracing::error!(error = %error, "policy provider evaluation failed");
+                    Ok(supergraph::Response::error_builder()
+                        .error(
+                            graphql::Error::builder()
+                                .message("policy evaluation failed".to_string())
+                                .extension_code("POLICY_EVALUATION_FAILED")
+                                .build(),
+                        )
+                        .status_code(StatusCode::SERVICE_UNAVAILABLE)
+                        .context(request.context)
+                        .build()?)
+                }
+            }
+        })
+    }
+}

--- a/apollo-router/src/plugins/authorization/provider/tests.rs
+++ b/apollo-router/src/plugins/authorization/provider/tests.rs
@@ -1,0 +1,1181 @@
+use super::opa::CONTRACT_VERSION;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use http::HeaderValue;
+use serde_json::json;
+use tower::ServiceExt;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::body_json;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+use super::*;
+
+fn config(yaml: &str) -> PolicyConfig {
+    serde_yaml::from_str(yaml).unwrap()
+}
+
+fn request() -> supergraph::Request {
+    supergraph::Request::fake_builder()
+        .query("query Test($accountId: ID!) { private { id } }")
+        .operation_name("Test")
+        .variable("accountId", "account-1")
+        .header("x-tenant-id", "tenant-1")
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn native_decisions_remain_authoritative_for_cache_keys() {
+    use crate::plugins::authorization::AuthorizationPlugin;
+    use crate::plugins::authorization::CacheKeyMetadata;
+    use crate::plugins::authorization::REQUIRED_POLICIES_KEY;
+
+    let context = Context::new();
+    // A later context mutation must not replace decisions made by the native provider.
+    context
+        .insert(
+            REQUIRED_POLICIES_KEY,
+            BTreeMap::from([
+                ("native_allowed".to_string(), false),
+                ("context_allowed".to_string(), true),
+            ]),
+        )
+        .unwrap();
+    context.extensions().with_lock(|lock| {
+        lock.insert(ProviderPolicyDecisions(BTreeMap::from([
+            ("native_allowed".to_string(), true),
+            ("context_allowed".to_string(), false),
+        ])))
+    });
+
+    AuthorizationPlugin::update_cache_key(&context);
+
+    let metadata = context
+        .extensions()
+        .with_lock(|lock| lock.get::<CacheKeyMetadata>().cloned())
+        .unwrap();
+    assert_eq!(metadata.policies, vec!["native_allowed"]);
+}
+
+#[test]
+fn legacy_context_decisions_supply_cache_keys_without_native_provider() {
+    use crate::plugins::authorization::AuthorizationPlugin;
+    use crate::plugins::authorization::CacheKeyMetadata;
+    use crate::plugins::authorization::REQUIRED_POLICIES_KEY;
+
+    let context = Context::new();
+    context
+        .insert(
+            REQUIRED_POLICIES_KEY,
+            BTreeMap::from([("allowed".to_string(), true), ("denied".to_string(), false)]),
+        )
+        .unwrap();
+    AuthorizationPlugin::update_cache_key(&context);
+
+    let metadata = context
+        .extensions()
+        .with_lock(|lock| lock.get::<CacheKeyMetadata>().cloned())
+        .unwrap();
+    assert_eq!(metadata.policies, vec!["allowed"]);
+}
+
+#[tokio::test]
+async fn disabled_policy_provider_skips_registry_construction() {
+    use crate::plugin::Plugin;
+    use crate::plugin::PluginInit;
+    use crate::plugins::authorization::AuthorizationPlugin;
+    use crate::plugins::authorization::Conf;
+
+    let config = serde_json::from_value::<Conf>(json!({
+        "directives": {"enabled": false},
+        "policy": {
+            "enabled": false,
+            "providers": {
+                "primary": {
+                    "type": "opa",
+                    "api": {"decision": "apollo/router/authorize"},
+                    "endpoints": [{"url": "http://127.0.0.1:8181"}]
+                }
+            },
+            "routing": {"default": {"provider": "primary"}}
+        }
+    }))
+    .unwrap();
+    let plugin = AuthorizationPlugin::new(PluginInit::fake_new(
+        config,
+        std::sync::Arc::new(String::new()),
+    ))
+    .await
+    .unwrap();
+    assert!(plugin.policy_providers.is_none());
+}
+
+fn single_provider_yaml(endpoints: &[String]) -> String {
+    let endpoints = endpoints
+        .iter()
+        .map(|url| format!("          - url: {url}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        r#"
+providers:
+  primary:
+    type: opa
+    api:
+      decision: apollo/router/authorize
+    endpoints:
+{endpoints}
+    input:
+      claims:
+        include: []
+      headers:
+        include: [x-tenant-id]
+      variables:
+        include: [accountId]
+routing:
+  default:
+    provider: primary
+"#
+    )
+}
+
+fn retrying_registry(endpoints: &[String]) -> PolicyProviderRegistry {
+    let endpoints = endpoints
+        .iter()
+        .map(|url| format!("      - {{ url: {url} }}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    PolicyProviderRegistry::new(config(&format!(
+        r#"
+providers:
+  primary:
+    type: opa
+    api: {{ decision: apollo/router/authorize }}
+    endpoints:
+{endpoints}
+    transport:
+      retry: {{ max_attempts: 2 }}
+routing:
+  default: {{ provider: primary }}
+"#
+    )))
+    .unwrap()
+}
+
+#[tokio::test]
+async fn round_robins_across_equivalent_endpoints() {
+    let first = MockServer::start().await;
+    let second = MockServer::start().await;
+    for server in [&first, &second] {
+        Mock::given(method("POST"))
+            .and(path("/v1/data/apollo/router/authorize"))
+            .and(body_json(json!({
+                "input": {
+                    "contract": CONTRACT_VERSION,
+                    "policies": ["read_profile"],
+                    "operation": {
+                        "name": "Test",
+                        "kind": null,
+                        "variables": {"accountId": "account-1"}
+                    },
+                    "request": {"headers": {"x-tenant-id": ["tenant-1"]}},
+                    "context": {}
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "decision_id": "decision-1",
+                "result": {
+                    "contract": CONTRACT_VERSION,
+                    "decisions": {"read_profile": true},
+                    "future_field": "ignored"
+                },
+                "future_top_level": true
+            })))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    let registry =
+        PolicyProviderRegistry::new(config(&single_provider_yaml(&[first.uri(), second.uri()])))
+            .unwrap();
+    let policies = BTreeSet::from(["read_profile".to_string()]);
+
+    for _ in 0..2 {
+        let decisions = registry
+            .evaluate(&request(), policies.clone())
+            .await
+            .unwrap();
+        assert_eq!(decisions.0.get("read_profile"), Some(&true));
+    }
+}
+
+#[tokio::test]
+async fn retries_server_errors_on_the_next_replica() {
+    let unavailable = MockServer::start().await;
+    let healthy = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(503))
+        .expect(1)
+        .mount(&unavailable)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/opa/v1/data/apollo/router/authorize"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": {
+                "contract": CONTRACT_VERSION,
+                "decisions": {"read_profile": true}
+            }
+        })))
+        .expect(1)
+        .mount(&healthy)
+        .await;
+    let healthy_endpoint = format!("{}/opa", healthy.uri());
+
+    let registry = retrying_registry(&[unavailable.uri(), healthy_endpoint]);
+
+    let decisions = registry
+        .evaluate(&request(), BTreeSet::from(["read_profile".to_string()]))
+        .await
+        .unwrap();
+    assert_eq!(decisions.0.get("read_profile"), Some(&true));
+}
+
+#[tokio::test]
+async fn retries_response_decode_errors_on_the_next_replica() {
+    let malformed = MockServer::start().await;
+    let healthy = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("{", "application/json"))
+        .expect(1)
+        .mount(&malformed)
+        .await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": {
+                "contract": CONTRACT_VERSION,
+                "decisions": {"read_profile": true}
+            }
+        })))
+        .expect(1)
+        .mount(&healthy)
+        .await;
+
+    let registry = retrying_registry(&[malformed.uri(), healthy.uri()]);
+
+    let decisions = registry
+        .evaluate(&request(), BTreeSet::from(["read_profile".to_string()]))
+        .await
+        .unwrap();
+    assert_eq!(decisions.0.get("read_profile"), Some(&true));
+}
+
+#[tokio::test]
+async fn retries_a_single_endpoint() {
+    let opa = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(1)
+        .mount(&opa)
+        .await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": {
+                "contract": CONTRACT_VERSION,
+                "decisions": {"read_profile": true}
+            }
+        })))
+        .expect(1)
+        .mount(&opa)
+        .await;
+
+    let registry = retrying_registry(std::slice::from_ref(&opa.uri()));
+    let decisions = registry
+        .evaluate(&request(), BTreeSet::from(["read_profile".to_string()]))
+        .await
+        .unwrap();
+    assert_eq!(decisions.0.get("read_profile"), Some(&true));
+}
+
+#[tokio::test]
+async fn retries_request_timeout_and_rate_limit_statuses() {
+    for status in [
+        http::StatusCode::REQUEST_TIMEOUT,
+        http::StatusCode::TOO_MANY_REQUESTS,
+    ] {
+        let opa = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(status.as_u16()))
+            .up_to_n_times(1)
+            .mount(&opa)
+            .await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "result": {
+                    "contract": CONTRACT_VERSION,
+                    "decisions": {"read_profile": true}
+                }
+            })))
+            .expect(1)
+            .mount(&opa)
+            .await;
+
+        let registry = retrying_registry(std::slice::from_ref(&opa.uri()));
+        let decisions = registry
+            .evaluate(&request(), BTreeSet::from(["read_profile".to_string()]))
+            .await
+            .unwrap();
+        assert_eq!(decisions.0.get("read_profile"), Some(&true));
+    }
+}
+
+#[tokio::test]
+async fn total_timeout_is_fail_closed() {
+    let opa = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_millis(100)))
+        .expect(1)
+        .mount(&opa)
+        .await;
+    let registry = PolicyProviderRegistry::new(config(&format!(
+        r#"
+providers:
+  primary:
+    type: opa
+    api: {{ decision: apollo/router/authorize }}
+    endpoints: [{{ url: {} }}]
+    transport:
+      timeouts: {{ total: 20ms }}
+      retry: {{ max_attempts: 1 }}
+routing:
+  default: {{ provider: primary }}
+"#,
+        opa.uri()
+    )))
+    .unwrap();
+    let error = registry
+        .evaluate(&request(), BTreeSet::from(["read_profile".to_string()]))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("timed out"));
+}
+
+#[tokio::test]
+async fn one_total_timeout_budget_covers_multiple_delayed_attempts() {
+    let opa = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(503).set_delay(Duration::from_millis(40)))
+        .mount(&opa)
+        .await;
+    let registry = PolicyProviderRegistry::new(config(&format!(
+        r#"
+providers:
+  primary:
+    type: opa
+    api: {{ decision: apollo/router/authorize }}
+    endpoints: [{{ url: {} }}]
+    transport:
+      timeouts: {{ total: 70ms }}
+      retry: {{ max_attempts: 3 }}
+routing:
+  default: {{ provider: primary }}
+"#,
+        opa.uri()
+    )))
+    .unwrap();
+
+    let started = tokio::time::Instant::now();
+    let error = registry
+        .evaluate(&request(), BTreeSet::from(["read_profile".to_string()]))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("timed out"));
+    assert!(
+        started.elapsed() < Duration::from_millis(110),
+        "attempts exceeded one total timeout budget: {:?}",
+        started.elapsed()
+    );
+}
+
+#[test]
+fn validates_external_endpoint_urls_strictly() {
+    for endpoint in [
+        "unix://relative/path.sock",
+        "unix:///tmp/opa.sock?path=relative",
+        "unix:///tmp/opa.sock?path=/opa&extra=value",
+        "unix:///tmp/opa.sock?path=/opa&path=/other",
+        "http://localhost:8181?extra=value",
+    ] {
+        let error =
+            PolicyProviderRegistry::new(config(&single_provider_yaml(&[endpoint.to_string()])))
+                .err()
+                .unwrap();
+        assert!(
+            error
+                .to_string()
+                .contains("OPA provider `primary` endpoint"),
+            "unexpected error for {endpoint}: {error}"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn evaluates_opa_over_a_unix_socket_with_a_base_path() {
+    use std::convert::Infallible;
+
+    use bytes::Bytes;
+    use http_body_util::Full;
+    use hyper::body::Incoming;
+    use hyper_util::rt::TokioExecutor;
+    use hyper_util::rt::TokioIo;
+
+    let directory = tempfile::tempdir().unwrap();
+    let socket_path = directory.path().join("opa.sock");
+    let listener = tokio::net::UnixListener::bind(&socket_path).unwrap();
+    let (path_sender, path_receiver) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let path_sender = Arc::new(std::sync::Mutex::new(Some(path_sender)));
+        let service = hyper::service::service_fn(move |request: http::Request<Incoming>| {
+            if let Some(sender) = path_sender.lock().unwrap().take() {
+                let _ = sender.send(request.uri().path().to_string());
+            }
+            async move {
+                Ok::<_, Infallible>(http::Response::new(Full::new(Bytes::from_static(
+                    br#"{"result":{"contract":"apollo.router.policy/v1","decisions":{"read_profile":true}}}"#,
+                ))))
+            }
+        });
+        hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+            .serve_connection(TokioIo::new(stream), service)
+            .await
+            .unwrap();
+    });
+    let endpoint = format!("unix://{}?path=/opa", socket_path.display());
+    let registry = PolicyProviderRegistry::new(config(&single_provider_yaml(&[endpoint]))).unwrap();
+
+    let decisions = registry
+        .evaluate(&request(), BTreeSet::from(["read_profile".to_string()]))
+        .await
+        .unwrap();
+    assert_eq!(decisions.0.get("read_profile"), Some(&true));
+    assert_eq!(
+        path_receiver.await.unwrap(),
+        "/opa/v1/data/apollo/router/authorize"
+    );
+    server.abort();
+}
+
+#[tokio::test]
+async fn routes_by_exact_match_then_longest_prefix() {
+    let primary = MockServer::start().await;
+    let finance = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": {
+                "contract": CONTRACT_VERSION,
+                "decisions": {
+                    "read_profile": true,
+                    "finance:special": true
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&primary)
+        .await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": {
+                "contract": CONTRACT_VERSION,
+                "decisions": {"finance:approve_refund": false}
+            }
+        })))
+        .expect(1)
+        .mount(&finance)
+        .await;
+
+    let registry = PolicyProviderRegistry::new(config(&format!(
+        r#"
+providers:
+  primary:
+    type: opa
+    api: {{ decision: apollo/router/authorize }}
+    endpoints: [{{ url: {} }}]
+  finance:
+    type: opa
+    api: {{ decision: finance/router/authorize }}
+    endpoints: [{{ url: {} }}]
+routing:
+  default: {{ provider: primary }}
+  rules:
+    - match:
+        prefix: ["fin"]
+      target: {{ provider: primary }}
+    - match:
+        prefix: ["finance:"]
+      target: {{ provider: finance }}
+    - match:
+        exact: ["finance:special"]
+      target: {{ provider: primary }}
+"#,
+        primary.uri(),
+        finance.uri()
+    )))
+    .unwrap();
+
+    let decisions = registry
+        .evaluate(
+            &request(),
+            BTreeSet::from([
+                "read_profile".to_string(),
+                "finance:approve_refund".to_string(),
+                "finance:special".to_string(),
+            ]),
+        )
+        .await
+        .unwrap();
+    assert_eq!(decisions.0.get("read_profile"), Some(&true));
+    assert_eq!(decisions.0.get("finance:approve_refund"), Some(&false));
+    assert_eq!(decisions.0.get("finance:special"), Some(&true));
+}
+
+#[tokio::test]
+async fn undefined_and_omitted_decisions_fail_closed() {
+    let undefined = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&undefined)
+        .await;
+    let registry =
+        PolicyProviderRegistry::new(config(&single_provider_yaml(&[undefined.uri()]))).unwrap();
+    let decisions = registry
+        .evaluate(&request(), BTreeSet::from(["read_profile".to_string()]))
+        .await
+        .unwrap();
+    assert_eq!(decisions.0.get("read_profile"), Some(&false));
+
+    let omitted = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": {
+                "contract": CONTRACT_VERSION,
+                "decisions": {}
+            }
+        })))
+        .expect(1)
+        .mount(&omitted)
+        .await;
+    let registry =
+        PolicyProviderRegistry::new(config(&single_provider_yaml(&[omitted.uri()]))).unwrap();
+    let decisions = registry
+        .evaluate(&request(), BTreeSet::from(["read_profile".to_string()]))
+        .await
+        .unwrap();
+    assert_eq!(decisions.0.get("read_profile"), Some(&false));
+}
+
+#[tokio::test]
+async fn forwards_repeated_headers_as_arrays() {
+    let opa = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(body_json(json!({
+            "input": {
+                "contract": CONTRACT_VERSION,
+                "policies": ["read_profile"],
+                "operation": {
+                    "name": "Test",
+                    "kind": null,
+                    "variables": {"accountId": "account-1"}
+                },
+                "request": {"headers": {"x-tenant-id": ["tenant-1", "tenant-2"]}},
+                "context": {}
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": {
+                "contract": CONTRACT_VERSION,
+                "decisions": {"read_profile": true}
+            }
+        })))
+        .expect(1)
+        .mount(&opa)
+        .await;
+    let mut request = request();
+    request
+        .supergraph_request
+        .headers_mut()
+        .append("x-tenant-id", HeaderValue::from_static("tenant-2"));
+    let registry =
+        PolicyProviderRegistry::new(config(&single_provider_yaml(&[opa.uri()]))).unwrap();
+    registry
+        .evaluate(&request, BTreeSet::from(["read_profile".to_string()]))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn missing_result_emits_diagnostic_counter() {
+    use crate::metrics::FutureMetricsExt;
+
+    async {
+        let opa = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .expect(1)
+            .mount(&opa)
+            .await;
+        let registry =
+            PolicyProviderRegistry::new(config(&single_provider_yaml(&[opa.uri()]))).unwrap();
+        registry
+            .evaluate(&request(), BTreeSet::from(["read_profile".to_string()]))
+            .await
+            .unwrap();
+
+        assert_counter!(
+            "apollo.router.operations.policy_provider.missing_result",
+            1,
+            "policy.provider.name" = "primary"
+        );
+    }
+    .with_metrics()
+    .await;
+}
+
+#[tokio::test]
+async fn records_success_decision_retry_duration_and_connection_metrics() {
+    use crate::metrics::FutureMetricsExt;
+
+    async {
+        let unavailable = MockServer::start().await;
+        let healthy = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(1)
+            .mount(&unavailable)
+            .await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "result": {
+                    "contract": CONTRACT_VERSION,
+                    "decisions": {"allow": true, "deny": false}
+                }
+            })))
+            .expect(1)
+            .mount(&healthy)
+            .await;
+        let registry = retrying_registry(&[unavailable.uri(), healthy.uri()]);
+
+        registry
+            .evaluate(
+                &request(),
+                BTreeSet::from(["allow".to_string(), "deny".to_string()]),
+            )
+            .await
+            .unwrap();
+
+        assert_counter!(
+            "apollo.router.operations.policy_provider.retry",
+            1,
+            "policy.provider.name" = "primary",
+            "policy.provider.endpoint.index" = 0i64
+        );
+        assert_counter!(
+            "apollo.router.operations.policy_provider.allow",
+            1,
+            "policy.provider.name" = "primary"
+        );
+        assert_counter!(
+            "apollo.router.operations.policy_provider.deny",
+            1,
+            "policy.provider.name" = "primary"
+        );
+        assert_histogram_count!(
+            "apollo.router.operations.policy_provider.duration",
+            1,
+            "policy.provider.type" = "opa",
+            "policy.provider.name" = "primary",
+            "policy.provider.outcome" = "success"
+        );
+        assert_histogram_count!(
+            "apollo.router.connection.acquire.duration",
+            2,
+            "network.transport" = "tcp",
+            "policy.provider.name" = "primary"
+        );
+    }
+    .with_metrics()
+    .await;
+}
+
+#[tokio::test]
+async fn records_exhaustion_and_endpoint_ejection_without_counting_a_final_retry() {
+    use crate::metrics::FutureMetricsExt;
+
+    async {
+        let opa = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(2)
+            .mount(&opa)
+            .await;
+        let registry = retrying_registry(std::slice::from_ref(&opa.uri()));
+
+        registry
+            .evaluate(&request(), BTreeSet::from(["read_profile".to_string()]))
+            .await
+            .unwrap_err();
+
+        assert_counter!(
+            "apollo.router.operations.policy_provider.retry",
+            1,
+            "policy.provider.name" = "primary",
+            "policy.provider.endpoint.index" = 0i64
+        );
+        assert_counter!(
+            "apollo.router.operations.policy_provider.retry_exhausted",
+            1,
+            "policy.provider.name" = "primary"
+        );
+        assert_counter!(
+            "apollo.router.operations.policy_provider.endpoint_ejected",
+            1,
+            "policy.provider.name" = "primary",
+            "policy.provider.endpoint.index" = 0i64
+        );
+    }
+    .with_metrics()
+    .await;
+}
+
+#[tokio::test]
+async fn rejects_non_utf8_selected_headers() {
+    let opa = MockServer::start().await;
+    let mut request = request();
+    request
+        .supergraph_request
+        .headers_mut()
+        .insert("x-tenant-id", HeaderValue::from_bytes(&[0xff]).unwrap());
+    let registry =
+        PolicyProviderRegistry::new(config(&single_provider_yaml(&[opa.uri()]))).unwrap();
+    let error = registry
+        .evaluate(&request, BTreeSet::from(["read_profile".to_string()]))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("non-UTF-8 header"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn native_provider_drives_router_policy_filtering() {
+    use crate::MockedSubgraphs;
+    use crate::TestHarness;
+    use crate::plugin::test::MockSubgraph;
+
+    let opa = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/data/apollo/router/authorize"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": {
+                "contract": CONTRACT_VERSION,
+                "decisions": {"admin": false}
+            }
+        })))
+        .expect(1)
+        .mount(&opa)
+        .await;
+
+    let mut subgraphs = MockedSubgraphs::default();
+    subgraphs.insert(
+        "subgraph_a",
+        MockSubgraph::builder()
+            .with_json(
+                json!({"query": "{private{id}}"}),
+                json!({"data": {"private": {"id": "123"}}}),
+            )
+            .build(),
+    );
+    let router = TestHarness::builder()
+        .configuration_json(json!({
+            "authorization": {
+                "policy": {
+                    "providers": {
+                        "primary": {
+                            "type": "opa",
+                            "api": {"decision": "apollo/router/authorize"},
+                            "endpoints": [{"url": opa.uri()}]
+                        }
+                    },
+                    "routing": {"default": {"provider": "primary"}}
+                }
+            }
+        }))
+        .unwrap()
+        .schema(include_str!(
+            "../../../../tests/fixtures/directives/policy/policy_basic_schema.graphql"
+        ))
+        .extra_plugin(subgraphs)
+        .build_router()
+        .await
+        .unwrap();
+    let request = crate::services::router::Request::fake_builder()
+        .method(http::Method::POST)
+        .header("content-type", "application/json")
+        .header("accept", "application/json")
+        .body(json!({"query": "{ private { id } }"}).to_string())
+        .build()
+        .unwrap();
+
+    let response = router
+        .oneshot(request)
+        .await
+        .unwrap()
+        .next_response()
+        .await
+        .unwrap()
+        .unwrap();
+    let response: serde_json::Value = serde_json::from_slice(&response).unwrap();
+    assert!(response["data"]["private"].is_null());
+    assert_eq!(response["errors"][0]["path"], json!(["private"]));
+    assert_eq!(
+        response["errors"][0]["extensions"]["code"],
+        "UNAUTHORIZED_FIELD_OR_TYPE"
+    );
+}
+
+#[test]
+fn rejects_duplicate_routes() {
+    let error = PolicyProviderRegistry::new(config(
+        r#"
+providers:
+  primary:
+    type: opa
+    api: { decision: test }
+    endpoints: [{ url: http://localhost:8181 }]
+routing:
+  default: { provider: primary }
+  rules:
+    - match: { exact: [admin] }
+      target: { provider: primary }
+    - match: { exact: [admin] }
+      target: { provider: primary }
+"#,
+    ))
+    .err()
+    .unwrap();
+    assert!(error.to_string().contains("routed more than once"));
+}
+
+/// Local validation against the three OPA processes documented in
+/// `examples/opa-policy-provider/README.md`.
+#[tokio::test]
+#[ignore = "requires local OPA services on ports 18181, 18182, and 18281"]
+async fn validates_multiple_real_opa_services() {
+    let registry = PolicyProviderRegistry::new(config(
+        r#"
+providers:
+  primary:
+    type: opa
+    api: { decision: apollo/router/authorize }
+    endpoints:
+      - { url: http://127.0.0.1:18181 }
+      - { url: http://127.0.0.1:18182 }
+  finance:
+    type: opa
+    api: { decision: finance/router/authorize }
+    endpoints:
+      - { url: http://127.0.0.1:18281 }
+routing:
+  default: { provider: primary }
+  rules:
+    - match: { prefix: ["finance:"] }
+      target: { provider: finance }
+"#,
+    ))
+    .unwrap();
+    let requested = BTreeSet::from([
+        "read_profile".to_string(),
+        "unknown".to_string(),
+        "finance:approve_refund".to_string(),
+    ]);
+
+    // Run twice so round-robin reaches both equivalent primary replicas.
+    for _ in 0..2 {
+        let decisions = registry
+            .evaluate(&request(), requested.clone())
+            .await
+            .unwrap();
+        assert_eq!(decisions.0.get("read_profile"), Some(&true));
+        assert_eq!(decisions.0.get("unknown"), Some(&false));
+        assert_eq!(decisions.0.get("finance:approve_refund"), Some(&true));
+    }
+}
+
+mod service_layer {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use http::StatusCode;
+    use serde_json::json;
+    use tower::Layer;
+    use tower::Service;
+    use tower::ServiceExt as _;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+
+    use super::*;
+    use crate::Context;
+    use crate::plugins::authorization::REQUIRED_POLICIES_KEY;
+    use crate::plugins::authorization::provider::PolicyConfig;
+
+    fn registry(endpoint: &str, failure_mode: FailureMode) -> Arc<PolicyProviderRegistry> {
+        let failure_mode = match failure_mode {
+            FailureMode::Reject => "reject",
+            FailureMode::Deny => "deny",
+        };
+        let config = serde_yaml::from_str::<PolicyConfig>(&format!(
+            r#"
+providers:
+  primary:
+    type: opa
+    api: {{ decision: apollo/router/authorize }}
+    endpoints: [{{ url: {endpoint} }}]
+    transport:
+      retry: {{ max_attempts: 1 }}
+routing:
+  default: {{ provider: primary }}
+failure:
+  mode: {failure_mode}
+"#
+        ))
+        .unwrap();
+        Arc::new(PolicyProviderRegistry::new(config).unwrap())
+    }
+
+    fn request(policies: &[&str]) -> supergraph::Request {
+        let context = Context::new();
+        if !policies.is_empty() {
+            context
+                .insert(
+                    REQUIRED_POLICIES_KEY,
+                    policies
+                        .iter()
+                        .map(|policy| (policy.to_string(), None::<bool>))
+                        .collect::<BTreeMap<_, _>>(),
+                )
+                .unwrap();
+        }
+        supergraph::Request::fake_builder()
+            .context(context)
+            .build()
+            .unwrap()
+    }
+
+    fn inner_service(calls: Arc<AtomicUsize>) -> supergraph::BoxCloneService {
+        supergraph::BoxCloneService::new(tower::service_fn(move |request: supergraph::Request| {
+            let calls = calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::Relaxed);
+                Ok(supergraph::Response::fake_builder()
+                    .context(request.context)
+                    .build()
+                    .unwrap())
+            }
+        }))
+    }
+
+    #[tokio::test]
+    async fn passes_through_requests_without_required_policies() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut service = PolicyProviderLayer::with_dry_run(
+            registry("http://127.0.0.1:1", FailureMode::Reject),
+            false,
+        )
+        .layer(inner_service(calls.clone()));
+
+        service
+            .ready()
+            .await
+            .unwrap()
+            .call(request(&[]))
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn stores_provider_decisions_before_calling_inner_service() {
+        let opa = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "result": {
+                    "contract": super::super::opa::CONTRACT_VERSION,
+                    "decisions": {"allow": true, "deny": false}
+                }
+            })))
+            .expect(1)
+            .mount(&opa)
+            .await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut service =
+            PolicyProviderLayer::with_dry_run(registry(&opa.uri(), FailureMode::Reject), false)
+                .layer(inner_service(calls.clone()));
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call(request(&["allow", "deny"]))
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            response
+                .context
+                .get_json_value(REQUIRED_POLICIES_KEY)
+                .unwrap(),
+            serde_json_bytes::json!({"allow": true, "deny": false})
+        );
+        assert_eq!(
+            response.context.extensions().with_lock(|lock| lock
+                .get::<ProviderPolicyDecisions>()
+                .unwrap()
+                .allowed_policies()),
+            vec!["allow"]
+        );
+    }
+
+    #[tokio::test]
+    async fn deny_failure_mode_stores_denials_and_calls_inner_service() {
+        let opa = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(1)
+            .mount(&opa)
+            .await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut service =
+            PolicyProviderLayer::with_dry_run(registry(&opa.uri(), FailureMode::Deny), false)
+                .layer(inner_service(calls.clone()));
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call(request(&["first", "second"]))
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            response
+                .context
+                .get_json_value(REQUIRED_POLICIES_KEY)
+                .unwrap(),
+            serde_json_bytes::json!({"first": false, "second": false})
+        );
+    }
+
+    #[tokio::test]
+    async fn reject_failure_mode_returns_503_without_calling_inner_service() {
+        let opa = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(1)
+            .mount(&opa)
+            .await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut service =
+            PolicyProviderLayer::with_dry_run(registry(&opa.uri(), FailureMode::Reject), false)
+                .layer(inner_service(calls.clone()));
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call(request(&["admin"]))
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
+        assert_eq!(response.response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn dry_run_provider_failure_continues_without_503() {
+        let opa = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(1)
+            .mount(&opa)
+            .await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut service =
+            PolicyProviderLayer::with_dry_run(registry(&opa.uri(), FailureMode::Reject), true)
+                .layer(inner_service(calls.clone()));
+
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call(request(&["admin"]))
+            .await
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(response.response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .context
+                .get_json_value(REQUIRED_POLICIES_KEY)
+                .unwrap(),
+            serde_json_bytes::json!({"admin": false})
+        );
+    }
+
+    #[tokio::test]
+    async fn failure_metric_includes_provider_identity_and_handling() {
+        use crate::metrics::FutureMetricsExt;
+
+        async {
+            let opa = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(ResponseTemplate::new(503))
+                .expect(1)
+                .mount(&opa)
+                .await;
+            let calls = Arc::new(AtomicUsize::new(0));
+            let mut service =
+                PolicyProviderLayer::with_dry_run(registry(&opa.uri(), FailureMode::Reject), false)
+                    .layer(inner_service(calls));
+
+            service
+                .ready()
+                .await
+                .unwrap()
+                .call(request(&["admin"]))
+                .await
+                .unwrap();
+
+            assert_counter!(
+                "apollo.router.operations.policy_provider.failure",
+                1,
+                "policy.provider.name" = "primary",
+                "policy.provider.outcome" = "reject_failure"
+            );
+        }
+        .with_metrics()
+        .await;
+    }
+}

--- a/apollo-router/src/plugins/authorization/provider/tests.rs
+++ b/apollo-router/src/plugins/authorization/provider/tests.rs
@@ -1,4 +1,3 @@
-use super::opa::CONTRACT_VERSION;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -13,6 +12,7 @@ use wiremock::matchers::body_json;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 
+use super::opa::CONTRACT_VERSION;
 use super::*;
 
 fn config(yaml: &str) -> PolicyConfig {

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -42,6 +42,7 @@ use crate::plugins::telemetry::config_new::subgraph::selectors::SubgraphSelector
 use crate::services;
 use crate::services::PATH_QUERY_PARAM;
 use crate::services::PipelineStep;
+use crate::services::UnixSocketQueryPolicy;
 use crate::services::external::Control;
 use crate::services::external::DEFAULT_EXTERNALIZATION_TIMEOUT;
 use crate::services::external::EXTERNALIZABLE_VERSION;
@@ -596,21 +597,13 @@ fn default_response_validation() -> bool {
 /// Validate a coprocessor URL.
 /// Returns an error if the URL is invalid or if it's a Unix socket URL with an empty path.
 pub(crate) fn validate_coprocessor_url(url: &str, config_path: &str) -> Result<(), BoxError> {
+    crate::services::validate_external_service_url(
+        url,
+        config_path,
+        true,
+        UnixSocketQueryPolicy::Any,
+    )?;
     if let Some(path) = url.strip_prefix("unix://") {
-        if path.is_empty() {
-            return Err(format!(
-                "{config_path}: Unix socket URL must include a path (e.g., 'unix:///var/run/coprocessor.sock')"
-            )
-            .into());
-        }
-        // Basic sanity check - path should be absolute
-        if !path.starts_with('/') {
-            return Err(format!(
-                "{config_path}: Unix socket path should be absolute (e.g., 'unix:///var/run/coprocessor.sock'), got 'unix://{path}'"
-            )
-            .into());
-        }
-
         // WARN: this might cause us heart burn later, but since filenames can include `?` we
         // should emit a warning if we have a `?` and yet no `path=` rather than return an error
         // and hope that folks see this in their logs if they're getting a bunch of request errors
@@ -619,10 +612,6 @@ pub(crate) fn validate_coprocessor_url(url: &str, config_path: &str) -> Result<(
                 "{config_path}: Unix sockets should use valid query parameters if using `?` (e.g., 'unix:///var/run/coprocessor.sock?path=some_path'), got 'unix://{path}'"
             );
         }
-    } else {
-        // Validate HTTP/HTTPS URLs can be parsed
-        url.parse::<http::Uri>()
-            .map_err(|e| format!("{config_path}: invalid URL '{url}': {e}"))?;
     }
     Ok(())
 }

--- a/apollo-router/src/services/http.rs
+++ b/apollo-router/src/services/http.rs
@@ -97,4 +97,6 @@ enum ServiceTarget {
     Subgraph { name: Arc<str> },
     /// A connector source: emits `connector.source.name = name`.
     Connector { name: Arc<str> },
+    /// A native authorization policy provider.
+    PolicyProvider { name: Arc<str> },
 }

--- a/apollo-router/src/services/http/connection_timing.rs
+++ b/apollo-router/src/services/http/connection_timing.rs
@@ -30,6 +30,9 @@ impl<C> ConnectionTimingConnector<C> {
                 KeyValue::new("connector.source.name", name.to_string())
             }
             ServiceTarget::Coprocessor => KeyValue::new("coprocessor", true),
+            ServiceTarget::PolicyProvider { name } => {
+                KeyValue::new("policy.provider.name", name.to_string())
+            }
         };
         let metric_attributes = Arc::from(
             [

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -248,7 +248,9 @@ impl HttpClientService {
     ) -> Result<Self, BoxError> {
         let service_name: Arc<str> = match &service_target {
             ServiceTarget::Coprocessor => Arc::from("coprocessor"),
-            ServiceTarget::Subgraph { name } | ServiceTarget::Connector { name } => name.clone(),
+            ServiceTarget::Subgraph { name }
+            | ServiceTarget::Connector { name }
+            | ServiceTarget::PolicyProvider { name } => name.clone(),
         };
         let mut http_connector =
             new_async_http_connector(client_config.dns_resolution_strategy.unwrap_or_default())?;
@@ -427,6 +429,24 @@ impl HttpClientService {
         let tls_client_config = generate_tls_client_config(tls_root_store.clone(), None)?;
 
         Self::new(ServiceTarget::Coprocessor, tls_client_config, client_config)
+    }
+
+    /// Creates a client for a native authorization policy provider.
+    pub(crate) fn from_config_for_policy_provider(
+        name: impl Into<String>,
+        _configuration: &Configuration,
+        tls_root_store: &RootCertStore,
+        client_config: crate::configuration::shared::Client,
+    ) -> Result<Self, BoxError> {
+        let name = name.into();
+        let tls_client_config = generate_tls_client_config(tls_root_store.clone(), None)?;
+        Self::new(
+            ServiceTarget::PolicyProvider {
+                name: Arc::from(name.as_str()),
+            },
+            tls_client_config,
+            client_config,
+        )
     }
 
     /// Creates a root certificate store with native certificates. These are used for root-of-trust

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -7,6 +7,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 use strum::Display;
+use tower::BoxError;
 
 pub(crate) use self::query_planner::*;
 pub(crate) use self::subgraph::service::*;
@@ -112,6 +113,79 @@ pub(crate) const MULTIPART_SUBSCRIPTION_SPEC_VALUE: &str = "1.0";
 #[cfg(unix)]
 pub(crate) const DEFAULT_SOCKET_PATH: &str = "/";
 pub(crate) const PATH_QUERY_PARAM: &str = "path=";
+
+/// How a caller permits query parameters on an external Unix-socket URL.
+#[derive(Clone, Copy)]
+pub(crate) enum UnixSocketQueryPolicy {
+    /// Preserve the historically permissive coprocessor query handling.
+    Any,
+    /// Accept no query, or exactly one non-empty absolute `path` parameter.
+    OptionalAbsolutePath,
+}
+
+/// Parse and validate a URL for an external HTTP service.
+///
+/// This centralizes the common HTTP(S)/Unix scheme and absolute-socket-path checks while allowing
+/// callers to choose whether ordinary HTTP queries and legacy Unix queries are accepted.
+pub(crate) fn validate_external_service_url(
+    url: &str,
+    config_path: &str,
+    allow_http_query: bool,
+    unix_query_policy: UnixSocketQueryPolicy,
+) -> Result<reqwest::Url, BoxError> {
+    if url == "unix://" {
+        return Err(format!("{config_path}: Unix socket URL must include a path").into());
+    }
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|error| format!("{config_path}: invalid URL `{url}`: {error}"))?;
+    if parsed.fragment().is_some() {
+        return Err(format!("{config_path}: URL must not contain a fragment").into());
+    }
+
+    match parsed.scheme() {
+        "http" | "https" => {
+            if !allow_http_query && parsed.query().is_some() {
+                return Err(format!("{config_path}: URL must not contain a query").into());
+            }
+        }
+        "unix" => {
+            if parsed.host_str().is_some() || !parsed.path().starts_with('/') {
+                return Err(format!(
+                    "{config_path}: Unix socket path should be absolute (for example, `unix:///var/run/service.sock`)"
+                )
+                .into());
+            }
+            if parsed.path() == "/" {
+                return Err(format!("{config_path}: Unix socket URL must include a path").into());
+            }
+            if matches!(
+                unix_query_policy,
+                UnixSocketQueryPolicy::OptionalAbsolutePath
+            ) && parsed.query().is_some()
+            {
+                let pairs = parsed.query_pairs().collect::<Vec<_>>();
+                if pairs.len() != 1
+                    || pairs[0].0 != "path"
+                    || pairs[0].1.is_empty()
+                    || !pairs[0].1.starts_with('/')
+                {
+                    return Err(format!(
+                        "{config_path}: Unix socket query must contain exactly one absolute `path` parameter"
+                    )
+                    .into());
+                }
+            }
+        }
+        scheme => {
+            return Err(format!(
+                "{config_path}: URL must use http, https, or unix, not `{scheme}`"
+            )
+            .into());
+        }
+    }
+
+    Ok(parsed)
+}
 
 /// Parse a Unix socket URL path (the part after `unix://`) and extract the socket path
 /// and HTTP path (if provided). Supports an optional `path` query parameter to specify the HTTP path.

--- a/docs/shared/config/authorization.mdx
+++ b/docs/shared/config/authorization.mdx
@@ -10,4 +10,40 @@ authorization:
       response: errors
     reject_unauthorized: false
   require_authentication: false
+  policy:
+    enabled: true
+    providers:
+      primary:
+        type: opa
+        api:
+          decision: apollo/router/authorize
+        endpoints:
+          - url: http://opa-1.example.com:8181
+          - url: http://opa-2.example.com:8181
+        transport:
+          client: {}
+          load_balancing:
+            strategy: round_robin
+          timeouts:
+            total: 250ms
+          retry:
+            max_attempts: 2
+          headers: {}
+        input:
+          claims:
+            include: []
+          headers:
+            include: []
+          variables:
+            include: []
+          context:
+            include: []
+    routing:
+      default:
+        provider: primary
+      rules: []
+    failure:
+      mode: reject
 ```
+
+Configure `policy` to evaluate [`@policy`](/graphos/routing/security/authorization#policy) labels with a native Open Policy Agent (OPA) provider. See [Open Policy Agent policy provider](/graphos/routing/security/opa-policy-provider) for configuration details, the OPA input and response contract, and examples for multiple providers.

--- a/docs/source/_sidebar.yaml
+++ b/docs/source/_sidebar.yaml
@@ -35,6 +35,8 @@ items:
             href: "./security/persisted-queries"
           - label: "Authorization"
             href: "./security/authorization"
+          - label: "Open Policy Agent"
+            href: "./security/opa-policy-provider"
           - label: "Authentication"
             children:
               - label: "JWT Authentication"

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -160,6 +160,30 @@ The `apollo.router.cache.redis.errors` metric also includes an `error_type` attr
   - `rhai.stage`: string (`RouterRequest`, `RouterResponse`, `SupergraphRequest`, `SupergraphResponse`, `ExecutionRequest`, `ExecutionResponse`, `SubgraphRequest`, `SubgraphResponse`)
   - `rhai.succeeded`: bool
 
+## Policy providers
+
+- `apollo.router.operations.policy_provider.duration` - Time in seconds for a complete native policy-provider evaluation, including retries. Attributes:
+  - `policy.provider.type`: Provider type (`opa`).
+  - `policy.provider.name`: Configured provider name.
+  - `policy.provider.outcome`: Evaluation outcome (`success`, `contract_error`, `timeout`, or `failure`).
+- `apollo.router.operations.policy_provider.allow` - Number of allowed policy decisions.
+  - `policy.provider.name`: Configured provider name.
+- `apollo.router.operations.policy_provider.deny` - Number of denied policy decisions, including omitted decisions that fail closed.
+  - `policy.provider.name`: Configured provider name.
+- `apollo.router.operations.policy_provider.failure` - Number of provider evaluation failures. Attributes:
+  - `policy.provider.name`: Configured provider name associated with the failure.
+  - `policy.provider.outcome`: Failure handling (`dry_run_failure`, `deny_failure`, or `reject_failure`).
+- `apollo.router.operations.policy_provider.retry` - Number of retry attempts that were started after retryable transport, response-body, HTTP 408, HTTP 429, or HTTP 5xx failures. Attributes:
+  - `policy.provider.name`: Configured provider name.
+  - `policy.provider.endpoint.index`: Zero-based index of the endpoint that failed.
+- `apollo.router.operations.policy_provider.retry_exhausted` - Number of evaluations that ended after all configured attempts returned retryable failures.
+  - `policy.provider.name`: Configured provider name.
+- `apollo.router.operations.policy_provider.endpoint_ejected` - Number of times an unhealthy endpoint was temporarily removed from selection. Attributes:
+  - `policy.provider.name`: Configured provider name.
+  - `policy.provider.endpoint.index`: Zero-based index of the ejected endpoint.
+- `apollo.router.operations.policy_provider.missing_result` - Number of successful OPA responses without a `result` field. These evaluations deny all requested policies.
+  - `policy.provider.name`: Configured provider name.
+
 ## Performance
 
 - `apollo_router_schema_load_duration` - Time spent loading the schema in seconds.
@@ -259,6 +283,7 @@ Similar to the initial call to Uplink, the router does not record metrics for ca
   - `subgraph.name`: name of the subgraph (subgraph connections only)
   - `connector.source.name`: name of the connector source (connector connections only)
   - `coprocessor`: `true` (coprocessor connections only)
+  - `policy.provider.name`: configured provider name (native policy-provider connections only)
 
 ## Subscriptions
 

--- a/docs/source/routing/security/authorization-overview.mdx
+++ b/docs/source/routing/security/authorization-overview.mdx
@@ -86,7 +86,7 @@ The GraphOS Router provides access controls via **authorization directives** tha
 
 - The [`@requiresScopes`](/graphos/routing/security/authorization#requiresscopes) directive allows granular access control through the scopes you define.
 - The [`@authenticated`](/graphos/routing/security/authorization#authenticated) directive allows access to the annotated field or type for _authenticated requests only_.
-- The [`@policy`](/graphos/routing/security/authorization#policy) directive offloads authorization validation to a [Rhai script](/graphos/routing/customization/rhai/) or a [coprocessor](/router/customizations/coprocessor) and integrates the result in the router. It's useful when your authorization policies go beyond simple authentication and scopes.
+- The [`@policy`](/graphos/routing/security/authorization#policy) directive evaluates policy labels with a native [Open Policy Agent (OPA) policy provider](/graphos/routing/security/opa-policy-provider), a [Rhai script](/graphos/routing/customization/rhai/), or a [coprocessor](/router/customizations/coprocessor). It's useful when your authorization policies go beyond simple authentication and scopes.
 
 For example, imagine you're building a social media platform that includes a `Users` subgraph. You can use the [`@requiresScopes`](/graphos/routing/security/authorization#requiresscopes) directive to declare that viewing other users' information requires the `read:user` scope:
 

--- a/docs/source/routing/security/authorization.mdx
+++ b/docs/source/routing/security/authorization.mdx
@@ -401,14 +401,15 @@ The `@policy` directive includes a `policies` argument that defines an array of 
 @policy(policies: [["roles:support"]])
 ```
 
-Using the `@policy` directive requires a [Supergraph plugin](/router/customizations/overview) to evaluate the authorization policies. This is useful to bridge router authorization with an existing authorization stack or link policy execution with lookups in a database.
+You can evaluate policies with a [Rhai script](/graphos/routing/customization/rhai/) or [coprocessor](/router/customizations/coprocessor), which is useful when you need to connect the router to an existing authorization stack or database.
+
+You can also configure a native [Open Policy Agent (OPA) policy provider](/graphos/routing/security/opa-policy-provider). The router evaluates policy labels with OPA before query planning and applies OPA's atomic decisions during normal `@policy` filtering. When you don't configure a native provider, the existing Rhai and coprocessor context behavior is unchanged.
 
 An overview of how `@policy` is processed through the router's request lifecycle:
 
 - At the [`RouterService` level](/graphos/routing/request-lifecycle), the GraphOS Router extracts the list of policies relevant to a request from the schema and then stores them in the request's context in `apollo::authorization::required_policies` as a map `policy -> null|true|false`.
 
-- At the `SupergraphService` level, you must provide a Rhai script or coprocessor to evaluate the map.
-  If the policy is validated, the script or coprocessor should set its value to `true` or otherwise set it to `false`. If the value is left to `null`, it will be treated as `false` by the router. Afterward, the router filters the requests' types and fields to only those where the policy is `true`.
+- At the `SupergraphService` level, a configured native provider evaluates the map before query planning. Without a native provider, you must provide a Rhai script or coprocessor to evaluate it. If the policy is validated, the evaluator should set its value to `true` or otherwise set it to `false`. If the value is left as `null`, it is treated as `false`. Afterward, the router filters the request's types and fields to only those where the policy is `true`.
 
 - If no field of a subgraph query passes its authorization policies, the router stops further processing of the query and precludes unauthorized subgraph requests. This efficiency gain is a key benefit of the `@policy` and other authorization directives.
 
@@ -438,7 +439,7 @@ directive @policy(
 ) on OBJECT | FIELD_DEFINITION | INTERFACE | SCALAR | ENUM
 ```
 
-Using the `@policy` directive requires a [Supergraph plugin](/router/customizations/overview) to evaluate the authorization policies. You can do this with a [Rhai script](/graphos/routing/customization/rhai/) or [coprocessor](/router/customizations/coprocessor). Refer to the following [example use case](#example-policy-use-case) for more information. (Although a [native plugin](/router/customizations/native) can also evaluate authorization policies, we don't recommend using it.)
+To evaluate `@policy` directives, use a [native Open Policy Agent (OPA) policy provider](/graphos/routing/security/opa-policy-provider), a [Rhai script](/graphos/routing/customization/rhai/), or a [coprocessor](/router/customizations/coprocessor). Refer to the following [example use case](#example-policy-use-case) for more information about using a coprocessor or Rhai. (Although a [native plugin](/router/customizations/native) can also evaluate authorization policies, we don't recommend using it.)
 
 #### Combining policies with `AND`/`OR` logic
 

--- a/docs/source/routing/security/opa-policy-provider.mdx
+++ b/docs/source/routing/security/opa-policy-provider.mdx
@@ -1,0 +1,251 @@
+---
+title: Open Policy Agent policy provider
+subtitle: Evaluate `@policy` directives with Open Policy Agent
+description: Configure the GraphOS Router to evaluate `@policy` directives with Open Policy Agent.
+---
+
+<PlanRequired plans={["Free", "Developer", "Standard", "Enterprise"]}>
+
+Rate limits apply on the Free plan.
+</PlanRequired>
+
+Use the native Open Policy Agent (OPA) policy provider to evaluate the policy labels that you declare with the [`@policy`](/graphos/routing/security/authorization#policy) directive. The router sends those labels and an explicitly selected set of request data to OPA before query planning. OPA returns an allow or deny decision for each label, and the router applies the directive's existing authorization rules.
+
+This integration is useful when policy evaluation needs data or logic beyond JWT claims and scopes, while you want to keep policy definitions in OPA.
+
+When a native provider is configured alongside Rhai or a coprocessor, native provider decisions are authoritative and take precedence over policy values supplied by those integrations.
+
+If `authorization.policy` is omitted (or `authorization.policy.enabled: false`), the router does not
+construct or call providers and retains the legacy authorization context and query-plan cache-key
+behavior.
+
+## Prerequisites
+
+- A graph that uses the [`@policy`](/graphos/routing/security/authorization#policy) directive.
+- Authorization directives enabled in the router. They are enabled by default.
+- An OPA server that the router can reach over HTTP or HTTPS.
+- [JWT authentication](/graphos/routing/security/jwt) if your OPA policies need validated JWT claims. The policy provider doesn't authenticate requests itself.
+
+## Quickstart
+
+First, annotate a field or type in a subgraph schema with a policy label:
+
+```graphql
+type Query {
+  me: User @policy(policies: [["read_profile"]])
+}
+```
+
+The nested array syntax is part of the `@policy` directive. In this example, `read_profile` must be allowed for the field to be available. See [combining policies with `AND`/`OR` logic](/graphos/routing/security/authorization#combining-policies-with-andor-logic) for more examples.
+
+Next, configure a provider in the router:
+
+```yaml title="router.yaml"
+authorization:
+  policy:
+    providers:
+      primary:
+        type: opa
+        api:
+          decision: apollo/router/authorize
+        endpoints:
+          - url: http://127.0.0.1:8181
+    routing:
+      default:
+        provider: primary
+```
+
+The router calls OPA's Data API at `POST /v1/data/apollo/router/authorize` on the configured endpoint. To use an endpoint behind a reverse proxy, include its base path in `url`. For example, an endpoint URL of `https://policy.example.com/opa` uses `/opa/v1/data/apollo/router/authorize`. Set `api.decision` to the path after `/v1/data/`.
+
+Finally, create the OPA policy at that decision path:
+
+```rego title="primary.rego"
+package apollo.router
+
+import rego.v1
+
+authorize := {
+  "contract": input.contract,
+  "decisions": {policy: allowed(policy) | some policy in input.policies},
+}
+
+allowed(policy) := policy in {"read_profile", "read_credit_card"}
+```
+
+This policy allows `read_profile` and denies every other requested policy label.
+
+<Tip>
+
+The [multi-provider example](https://github.com/apollographql/router/tree/main/examples/opa-policy-provider) includes this Rego policy and commands to run it locally.
+
+</Tip>
+
+## OPA input and response contract
+
+For each configured provider, the router sends an OPA Data API request containing the atomic policy labels routed to that provider. OPA evaluates these labels individually; the router then applies the directive's `AND`/`OR` logic. The request body has this shape:
+
+```json title="Request to OPA"
+{
+  "input": {
+    "contract": "apollo.router.policy/v1",
+    "policies": ["read_profile"],
+    "identity": {
+      "claims": {
+        "sub": "user-1"
+      }
+    },
+    "operation": {
+      "name": "GetProfile",
+      "kind": "query",
+      "variables": {
+        "accountId": "account-1"
+      }
+    },
+    "request": {
+      "headers": {
+        "x-tenant-id": ["tenant-1"]
+      }
+    },
+    "context": {}
+  }
+}
+```
+
+When OPA supplies a result, it must use the same contract version, and each supplied decision must be a boolean:
+
+```json title="Response from OPA"
+{
+  "result": {
+    "contract": "apollo.router.policy/v1",
+    "decisions": {
+      "read_profile": true
+    }
+  }
+}
+```
+
+An OPA response can include its usual `decision_id`. The router records it in a debug log event to help correlate requests with OPA logs.
+
+<Caution>
+
+The router denies a label when OPA returns no result or omits that label from `decisions`. A response with a different contract version, or a decision for a label the router didn't request, is a policy-evaluation error. Return an explicit `true` or `false` for every supplied label.
+
+</Caution>
+
+### Select policy input
+
+The router sends no JWT claims by default. Select exact claim names with `input.claims.include`; only those names leave the router. If no selected claims are available, `identity.claims` is `null`. There is no wildcard claim selector.
+
+Headers, variables, and router context values are never included unless you explicitly allowlist them. This lets you provide the policy data it needs without sending every request value to OPA:
+
+```yaml title="router.yaml"
+authorization:
+  policy:
+    providers:
+      primary:
+        type: opa
+        api: { decision: apollo/router/authorize }
+        endpoints: [{ url: "http://127.0.0.1:8181" }]
+        input:
+          claims:
+            include: [sub, tenant]
+          headers:
+            include: [x-tenant-id]
+          variables:
+            include: [accountId]
+          context:
+            include: ["my-app::account-tier"]
+    routing:
+      default: { provider: primary }
+```
+
+Header names are normalized to lowercase and every selected header is represented as an array, preserving repeated values. Non-UTF-8 selected headers fail evaluation rather than being dropped. Forwarding headers can expose authorization or cookie credentials; prefer static provider transport credentials and allowlist only non-sensitive headers.
+
+## Configure multiple providers and endpoints
+
+An OPA provider can have multiple equivalent endpoint replicas. The router selects replicas with round-robin load balancing. Configure different policy authorities as separate named providers, then route labels to them:
+
+```yaml title="router.yaml"
+authorization:
+  policy:
+    providers:
+      primary:
+        type: opa
+        api: { decision: apollo/router/authorize }
+        endpoints:
+          - { url: "http://opa-primary-1:8181" }
+          - { url: "http://opa-primary-2:8181" }
+      finance:
+        type: opa
+        api: { decision: finance/router/authorize }
+        endpoints:
+          - { url: "http://opa-finance:8181" }
+    routing:
+      default: { provider: primary }
+      rules:
+        - match:
+            prefix: ["finance:"]
+          target: { provider: finance }
+```
+
+The router evaluates labels for distinct providers concurrently, then combines the atomic decisions before it applies the `@policy` directive's `AND`/`OR` logic. Configure only equivalent replicas in one provider. Use separate providers for distinct policy authorities or policy data.
+
+Routing rules can match `exact` labels or `prefix` namespaces. Exact matches take precedence over prefix matches. When more than one prefix matches, the longest prefix takes precedence. Rule order doesn't change this precedence.
+
+## Configure retries and failures
+
+The following configuration adds a second replica, a total evaluation timeout, a retry budget, and a static provider credential:
+
+```yaml title="router.yaml"
+authorization:
+  policy:
+    providers:
+      primary:
+        type: opa
+        api: { decision: apollo/router/authorize }
+        endpoints:
+          - { url: "https://opa-1.example.com" }
+          - { url: "https://opa-2.example.com" }
+        transport:
+          timeouts:
+            total: 250ms
+          retry:
+            max_attempts: 2
+          headers:
+            authorization: "Bearer <token>"
+    routing:
+      default: { provider: primary }
+    failure:
+      mode: reject
+```
+
+`timeouts.total` defaults to `250ms` and applies to a provider evaluation, including retries. `retry.max_attempts` defaults to `2` and can retry a single endpoint. The router retries connection errors, `408`, `429`, `5xx` responses, and responses that it can't decode as the expected JSON shape. It doesn't retry other non-success HTTP responses or a decoded response with an unsupported contract or an unrequested label.
+
+Use [variable expansion](/graphos/routing/configuration/yaml#variable-expansion) or a secrets manager to provide production credentials instead of storing them directly in `router.yaml`.
+
+The default `failure.mode: reject` stops the operation before query planning and returns HTTP `503` with the GraphQL error code `POLICY_EVALUATION_FAILED`. Set `failure.mode: deny` to deny all policies required by the operation and continue normal field filtering. Both modes fail closed.
+
+<Note>
+
+Endpoint URLs must be unique. HTTP(S) URLs cannot contain query strings or fragments. Unix sidecars use `unix:///absolute/socket.sock?path=/optional/http/base`; the query is used only to select the HTTP path. `transport.client` accepts the shared Router HTTP client settings (DNS, HTTP/2, pool, and keepalive). `transport.load_balancing.strategy` currently supports `round_robin`, which is also the default. Unhealthy replicas are temporarily ejected after repeated failures.
+
+</Note>
+
+## Validate the integration
+
+Before starting the router, send a representative request directly to the configured OPA decision path:
+
+```bash
+curl --request POST http://127.0.0.1:8181/v1/data/apollo/router/authorize \
+  --header 'content-type: application/json' \
+  --data '{"input":{"contract":"apollo.router.policy/v1","policies":["read_profile"]}}'
+```
+
+The example Rego policy returns `read_profile: true` in the `decisions` object. You can also use the repository's [multi-provider example](https://github.com/apollographql/router/tree/main/examples/opa-policy-provider) to exercise two equivalent replicas, provider routing, and fail-closed decisions locally.
+
+## Troubleshooting
+
+- **The router returns `POLICY_EVALUATION_FAILED`.** Check the OPA endpoint, its HTTP status, and the decision path. Set `api.decision` to the path after `/v1/data/`; don't include `/v1/data` itself.
+- **OPA doesn't receive expected data.** Add the required header, variable, or context key to the provider's `input` allowlist. Configure JWT authentication when the policy needs claims.
+- **A label is unexpectedly denied.** Verify that the policy returns the exact requested label with the contract `apollo.router.policy/v1`. Undefined decisions and omitted labels are denied by design.
+- **Replica behavior differs.** Make sure all endpoints within one provider run equivalent OPA bundles and policy data. Use separate providers and routing rules for different policy authorities.

--- a/examples/opa-policy-provider/README.md
+++ b/examples/opa-policy-provider/README.md
@@ -1,0 +1,77 @@
+# OPA policy provider example
+
+This example runs two equivalent Open Policy Agent (OPA) replicas for the `primary` policy provider and one distinct `finance` provider. The policies implement the Router's `apollo.router.policy/v1` contract.
+
+## Start OPA
+
+From the repository root, start each command in a separate terminal:
+
+```bash title="Primary replica 1"
+docker run --rm -p 18181:8181 \
+  -v "$PWD/examples/opa-policy-provider/primary.rego:/policy.rego:ro" \
+  openpolicyagent/opa:latest run --server --addr=0.0.0.0:8181 /policy.rego
+```
+
+```bash title="Primary replica 2"
+docker run --rm -p 18182:8181 \
+  -v "$PWD/examples/opa-policy-provider/primary.rego:/policy.rego:ro" \
+  openpolicyagent/opa:latest run --server --addr=0.0.0.0:8181 /policy.rego
+```
+
+```bash title="Finance provider"
+docker run --rm -p 18281:8181 \
+  -v "$PWD/examples/opa-policy-provider/finance.rego:/policy.rego:ro" \
+  openpolicyagent/opa:latest run --server --addr=0.0.0.0:8181 /policy.rego
+```
+
+## Configure the Router
+
+Configure the first two URLs as replicas of one logical provider. Configure the finance service as a separate provider and route the `finance:` policy namespace to it:
+
+```yaml title="router.yaml"
+authorization:
+  policy:
+    enabled: true
+    providers:
+      primary:
+        type: opa
+        api:
+          decision: apollo/router/authorize
+        endpoints:
+          - url: http://127.0.0.1:18181
+          - url: http://127.0.0.1:18182
+        input:
+          claims:
+            include: []
+      finance:
+        type: opa
+        api:
+          decision: finance/router/authorize
+        endpoints:
+          - url: http://127.0.0.1:18281
+        input:
+          claims:
+            include: []
+    routing:
+      default:
+        provider: primary
+      rules:
+        - match:
+            prefix: ["finance:"]
+          target:
+            provider: finance
+```
+
+The `primary` policy allows `read_profile` and `read_credit_card`; it denies other labels. The finance policy allows `finance:approve_refund`.
+
+## Validate the example
+
+With all three OPA servers running, run the ignored integration test from the repository root:
+
+```bash
+cargo test -p apollo-router \
+  plugins::authorization::provider::tests::validates_multiple_real_opa_services \
+  --lib -- --ignored
+```
+
+The test evaluates `read_profile`, an unknown primary policy, and `finance:approve_refund` twice. It exercises the configured round-robin path, confirms that the `finance:` label reaches the finance provider, and verifies that an unknown label is denied.

--- a/examples/opa-policy-provider/finance.rego
+++ b/examples/opa-policy-provider/finance.rego
@@ -1,0 +1,10 @@
+package finance.router
+
+import rego.v1
+
+authorize := {
+    "contract": input.contract,
+    "decisions": {policy: allowed(policy) | some policy in input.policies},
+}
+
+allowed(policy) := policy == "finance:approve_refund"

--- a/examples/opa-policy-provider/primary.rego
+++ b/examples/opa-policy-provider/primary.rego
@@ -1,0 +1,10 @@
+package apollo.router
+
+import rego.v1
+
+authorize := {
+    "contract": input.contract,
+    "decisions": {policy: allowed(policy) | some policy in input.policies},
+}
+
+allowed(policy) := policy in {"read_profile", "read_credit_card"}


### PR DESCRIPTION
## Summary

- add a native Open Policy Agent provider for `@policy`
- support named policy authorities, equivalent replica endpoint pools, round-robin balancing, bounded failover, and reverse-proxy base paths
- route policy labels by exact match or longest prefix and evaluate distinct providers concurrently
- define the versioned `apollo.router.policy/v1` wire contract with allowlisted request inputs and fail-closed response handling
- preserve existing Rhai and coprocessor behavior when no native provider is configured
- add documentation, generated configuration schema coverage, a changeset, and runnable Rego examples

## Why

Today, `@policy` exposes policy requirements through context for custom Rhai or coprocessor evaluation. This adds a first-class OPA integration while establishing configuration and wire boundaries that can grow to additional provider types, endpoint transport options, routing strategies, and future contract versions without restructuring the top-level configuration.

## User and developer impact

Native provider decisions are evaluated before query planning and remain authoritative for field filtering and authorization cache keys. Multiple OPA replicas can serve one logical authority, while separate named providers can own different policy namespaces. Provider failures default to a 503 `POLICY_EVALUATION_FAILED`; the optional `deny` mode denies all required policies and continues normal filtering.

## Validation

- `cargo test -p apollo-router plugins::authorization:: -- --nocapture` — 97 passed, 1 ignored
- focused provider suite — 7 passed, 1 real-OPA test ignored
- real-OPA test passed against three live OPA v1.17.0 services: two equivalent primary replicas and one separately routed finance authority
- generated configuration schema and schema validity tests passed
- `cargo clippy -p apollo-router --lib --tests --message-format short -- -D warnings`
- `git diff --check`

## Do not merge

This is an implementation proposal for design review and must not be merged in its current state.
