### PR TITLE
Fix subgraph errors being silently dropped on Flatten fetches

### DIFF
--- a/.changesets/fix_router_1919_flatten_error_type_condition.md
+++ b/.changesets/fix_router_1919_flatten_error_type_condition.md
@@ -1,0 +1,9 @@
+### Fix subgraph errors being silently dropped on Flatten fetches crossing a type-conditioned field
+
+A subgraph-level error with no `_entities`-indexed path (for example, the error produced by a `traffic_shaping` timeout) could be silently dropped instead of surfacing to the client, when the erroring fetch's `Flatten` path crossed an abstract-typed (interface or union) field reached through a type condition on a single-valued field rather than on an array wildcard (e.g. `...edges.@.node|[SomeConcreteType].collection`).
+
+The router expands such an error across every entity in the batch by matching the error's declared path (which retains its type condition) against each entity's real, already-materialized path (which never carries one). That match only special-cased array `Index`/`Flatten` pairs and otherwise required exact structural equality, so a `Key` path element with a type condition never matched the same `Key` without one — the error matched none of the batch's entities and was dropped entirely, with no trace in the response's `errors` or anywhere else, while the corresponding data was simply missing.
+
+`Path::equal_if_flattened` now also treats two `Key` path elements as equal whenever their names match, regardless of any type condition attached to either side, so these errors correctly surface once per affected entity instead of vanishing silently.
+
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/PLACEHOLDER

--- a/.changesets/fix_router_1919_flatten_error_type_condition.md
+++ b/.changesets/fix_router_1919_flatten_error_type_condition.md
@@ -6,4 +6,4 @@ The router expands such an error across every entity in the batch by matching th
 
 `Path::equal_if_flattened` now also treats two `Key` path elements as equal whenever their names match, regardless of any type condition attached to either side, so these errors correctly surface once per affected entity instead of vanishing silently.
 
-By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/PLACEHOLDER
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/9925

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -1073,7 +1073,15 @@ impl Path {
     }
 
     // Checks whether self and other are equal if PathElement::Flatten and PathElement::Index are
-    // treated as equal
+    // treated as equal, and PathElement::Key type conditions are ignored.
+    //
+    // Type conditions on a `Key` only matter while a path is still being matched against live,
+    // still-typed data (see `iterate_path`, which strips them once matched: they're a filter
+    // applied once, not part of a materialized path's identity). By the time we're comparing an
+    // error's declared path (which can still carry a type condition from the query plan) against
+    // the real per-entity paths a fetch actually produced, every candidate path already satisfies
+    // whatever type condition applied, so a `Key` with a type condition and a `Key` without one at
+    // the same position denote the same location and must compare equal here.
     pub fn equal_if_flattened(&self, other: &Path) -> bool {
         if self.len() != other.len() {
             return false;
@@ -1083,6 +1091,7 @@ impl Path {
             let equal_elements = match (elem1, elem2) {
                 (PathElement::Index(_), PathElement::Flatten(_)) => true,
                 (PathElement::Flatten(_), PathElement::Index(_)) => true,
+                (PathElement::Key(k1, _), PathElement::Key(k2, _)) => k1 == k2,
                 (elem1, elem2) => elem1 == elem2,
             };
             if !equal_elements {
@@ -1432,6 +1441,30 @@ mod tests {
         let path = Path::from("obj/arr/@/obj2");
         let result = Value::from_path(&path, json);
         assert_eq!(result, json!({"obj":{"arr":null}}));
+    }
+
+    #[test]
+    fn test_equal_if_flattened_ignores_key_type_conditions() {
+        // A fetch-level error's declared path (from the query plan) can retain a
+        // type condition on a `Key` element when the fetch is reached through an abstract-typed
+        // (interface/union) field, e.g. `.../node|[BlockBuilderCoreListingCollection]/collection`.
+        // The real per-entity paths produced during execution never carry that type condition
+        // (`iterate_path` strips it once matched). These must still compare equal, or a fetch-level
+        // error (e.g. a subgraph timeout) silently fails to attach to any entity and is dropped.
+        let declared_error_path =
+            Path::from("edges/@/node|[BlockBuilderCoreListingCollection]/collection");
+        let real_entity_path = Path::from("edges/3/node/collection");
+        assert!(declared_error_path.equal_if_flattened(&real_entity_path));
+        assert!(real_entity_path.equal_if_flattened(&declared_error_path));
+
+        // Different key names must still not match, type condition or no.
+        let different_key = Path::from("edges/3/node/otherField");
+        assert!(!declared_error_path.equal_if_flattened(&different_key));
+
+        // Pre-existing Index/Flatten equivalence must still hold.
+        let flatten_path = Path::from("edges/@/node/collection");
+        let index_path = Path::from("edges/7/node/collection");
+        assert!(flatten_path.equal_if_flattened(&index_path));
     }
 
     #[test]

--- a/apollo-router/tests/fixtures/router_1919/artwork.json
+++ b/apollo-router/tests/fixtures/router_1919/artwork.json
@@ -1,0 +1,46 @@
+{
+    "mocks": [
+        {
+            "request": {
+                "query": "query($representations: [_Any!]!, $movieResultParam: String) { _entities(representations: $representations) { ... on EntityCollectionSection { title artwork(params: $movieResultParam) } ... on GallerySection { artwork(params: $movieResultParam) } } }",
+                "variables": {
+                    "movieResultParam": "movieResultEnabled",
+                    "representations": [
+                        {"__typename": "EntityCollectionSection", "id": "ecs1"},
+                        {"__typename": "GallerySection", "id": "gs1"}
+                    ]
+                }
+            },
+            "response": {
+                "errors": [
+                    {
+                        "message": "Your request has been timed out",
+                        "extensions": {
+                            "code": "GATEWAY_TIMEOUT"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "request": {
+                "query": "query($representations: [_Any!]!, $articleResultParam: String) { _entities(representations: $representations) { ... on EntityCollectionSection { title artwork(params: $articleResultParam) } ... on GallerySection { artwork(params: $articleResultParam) } } }",
+                "variables": {
+                    "articleResultParam": "articleResultEnabled",
+                    "representations": [
+                        {"__typename": "EntityCollectionSection", "id": "ecs2"},
+                        {"__typename": "GallerySection", "id": "gs2"}
+                    ]
+                }
+            },
+            "response": {
+                "data": {
+                    "_entities": [
+                        {"title": "ecs2 title", "artwork": "articleResultEnabled artwork"},
+                        {"artwork": "articleResultEnabled artwork"}
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/apollo-router/tests/fixtures/router_1919/router_1919.graphql
+++ b/apollo-router/tests/fixtures/router_1919/router_1919.graphql
@@ -1,0 +1,90 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type ArticleResult
+  @join__type(graph: SEARCHSUBGRAPH)
+{
+  id: ID!
+  sections: [Section]
+}
+
+type Container
+  @join__type(graph: SEARCHSUBGRAPH, key: "id")
+{
+  id: ID!
+  result: SearchResult
+}
+
+type EntityCollectionSection
+  @join__type(graph: ARTWORKSUBGRAPH, key: "id")
+  @join__type(graph: SEARCHSUBGRAPH, key: "id")
+{
+  id: ID!
+  title: String @join__field(graph: ARTWORKSUBGRAPH)
+  artwork(params: String): String @join__field(graph: ARTWORKSUBGRAPH)
+}
+
+type GallerySection
+  @join__type(graph: ARTWORKSUBGRAPH, key: "id")
+  @join__type(graph: SEARCHSUBGRAPH, key: "id")
+{
+  id: ID!
+  artwork(params: String): String @join__field(graph: ARTWORKSUBGRAPH)
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ARTWORKSUBGRAPH @join__graph(name: "artworkSubgraph", url: "http://localhost:4042")
+  SEARCHSUBGRAPH @join__graph(name: "searchSubgraph", url: "http://localhost:4041")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type MovieResult
+  @join__type(graph: SEARCHSUBGRAPH)
+{
+  id: ID!
+  sections: [Section]
+}
+
+type Query
+  @join__type(graph: SEARCHSUBGRAPH)
+{
+  containers: [Container!] @join__field(graph: SEARCHSUBGRAPH)
+}
+
+union SearchResult
+  @join__type(graph: SEARCHSUBGRAPH)
+  @join__unionMember(graph: SEARCHSUBGRAPH, member: "MovieResult")
+  @join__unionMember(graph: SEARCHSUBGRAPH, member: "ArticleResult")
+ = MovieResult | ArticleResult
+
+union Section
+  @join__type(graph: SEARCHSUBGRAPH)
+  @join__unionMember(graph: SEARCHSUBGRAPH, member: "EntityCollectionSection")
+  @join__unionMember(graph: SEARCHSUBGRAPH, member: "GallerySection")
+ = EntityCollectionSection | GallerySection

--- a/apollo-router/tests/fixtures/router_1919/search.json
+++ b/apollo-router/tests/fixtures/router_1919/search.json
@@ -1,0 +1,35 @@
+{
+    "mocks": [
+        {
+            "request": {
+                "query": "{ containers { id result { __typename ... on MovieResult { sections { ...c } } ... on ArticleResult { sections { ...c } } } } } fragment a on EntityCollectionSection { __typename id } fragment b on GallerySection { __typename id } fragment c on Section { __typename ...a ...b }"
+            },
+            "response": {
+                "data": {
+                    "containers": [
+                        {
+                            "id": "c1",
+                            "result": {
+                                "__typename": "MovieResult",
+                                "sections": [
+                                    {"__typename": "EntityCollectionSection", "id": "ecs1"},
+                                    {"__typename": "GallerySection", "id": "gs1"}
+                                ]
+                            }
+                        },
+                        {
+                            "id": "c2",
+                            "result": {
+                                "__typename": "ArticleResult",
+                                "sections": [
+                                    {"__typename": "EntityCollectionSection", "id": "ecs2"},
+                                    {"__typename": "GallerySection", "id": "gs2"}
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/apollo-router/tests/router_1919_flatten_error_type_condition.rs
+++ b/apollo-router/tests/router_1919_flatten_error_type_condition.rs
@@ -1,0 +1,196 @@
+//! ROUTER-1919 regression test.
+//!
+//! A subgraph-level error with no `_entities`-indexed path (e.g. the error a `traffic_shaping`
+//! timeout produces) on a `Flatten` fetch whose path crosses a type-conditioned abstract-typed
+//! field must still surface for every entity in the batch, rather than being silently dropped.
+//!
+//! Schema shape: `Query.containers: [Container!]` (a plain list, `Flatten` with no type
+//! condition) -> `Container.result: SearchResult` (a *single-valued* union field, `MovieResult |
+//! ArticleResult`) -> `sections: [Section]`. Because `result` is single-valued, routing its two
+//! possible types to two separate batched fetches (one per `$movieResultParam`/
+//! `$articleResultParam`) requires the query planner to annotate the *`result` `Key` path element
+//! itself* with a type condition (`result|[MovieResult]`), rather than a `Flatten` element -- this
+//! is exactly the RH-1382 production shape (`...edges.@.node|[ConcreteType].collection`), and is
+//! what actually exercises the bug (a schema where the type condition lands on a `Flatten` instead
+//! -- e.g. a union-typed *list* field -- does not, since `Path::equal_if_flattened` already treated
+//! `Flatten`/`Index` pairs as equal regardless of type condition).
+//!
+//! Root cause: the declared error path for such a fetch keeps its type condition
+//! (`Key("result", Some(["MovieResult"]))`), but the real per-entity paths built during execution
+//! have it stripped (`iterate_path` always writes back `Key(k, None)`). `Path::equal_if_flattened`,
+//! used to match the error against each real entity path, only special-cased `Index`/`Flatten`
+//! pairs and fell back to strict structural equality for everything else -- so a `Key` with a type
+//! condition never matched a `Key` without one, the error matched zero of the real entity paths,
+//! and was dropped entirely with no trace anywhere in the client response.
+
+use apollo_router::MockedSubgraphs;
+use apollo_router::TestHarness;
+use apollo_router::graphql::JsonPathElement;
+use apollo_router::graphql::Response;
+use apollo_router::plugin::test::MockSubgraph;
+use apollo_router::services::supergraph;
+use serde::Deserialize;
+use serde_json::json;
+use serde_json_bytes::ByteString;
+use serde_json_bytes::Value;
+use tower::ServiceExt;
+
+type JsonMap = serde_json_bytes::Map<ByteString, Value>;
+
+#[derive(Deserialize)]
+struct SubgraphMock {
+    mocks: Vec<RequestAndResponse>,
+}
+
+#[derive(Deserialize)]
+struct RequestAndResponse {
+    request: apollo_router::graphql::Request,
+    response: Response,
+}
+
+static QUERY: &str = r#"
+query Test($movieResultParam: String, $articleResultParam: String) {
+  containers {
+    id
+    result {
+      ... on MovieResult {
+        sections {
+          ... on EntityCollectionSection {
+            title
+            artwork(params: $movieResultParam)
+          }
+          ... on GallerySection {
+            artwork(params: $movieResultParam)
+          }
+        }
+      }
+      ... on ArticleResult {
+        sections {
+          ... on EntityCollectionSection {
+            title
+            artwork(params: $articleResultParam)
+          }
+          ... on GallerySection {
+            artwork(params: $articleResultParam)
+          }
+        }
+      }
+    }
+  }
+}"#;
+
+fn setup() -> TestHarness<'static> {
+    let mut mocked_subgraphs = MockedSubgraphs::default();
+
+    for (name, m) in [
+        (
+            "searchSubgraph",
+            include_str!("fixtures/router_1919/search.json"),
+        ),
+        (
+            "artworkSubgraph",
+            include_str!("fixtures/router_1919/artwork.json"),
+        ),
+    ] {
+        let subgraph_mock: SubgraphMock = serde_json::from_str(m).unwrap();
+        let mut builder = MockSubgraph::builder();
+        for mock in subgraph_mock.mocks {
+            builder = builder.with_json(
+                serde_json::to_value(mock.request).unwrap(),
+                serde_json::to_value(mock.response).unwrap(),
+            );
+        }
+        mocked_subgraphs.insert(name, builder.build());
+    }
+
+    let schema = include_str!("fixtures/router_1919/router_1919.graphql");
+    TestHarness::builder()
+        .try_log_level("info")
+        .configuration_json(json! {{
+            "experimental_type_conditioned_fetching": true,
+            "include_subgraph_errors": {
+                "all": true
+            }
+        }})
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(mocked_subgraphs)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subgraph_error_not_dropped_on_flattened_type_conditioned_fetch() {
+    let harness = setup();
+    let supergraph_service = harness.build_supergraph().await.unwrap();
+    let mut variables = JsonMap::new();
+    variables.insert("movieResultParam", "movieResultEnabled".into());
+    variables.insert("articleResultParam", "articleResultEnabled".into());
+    let request = supergraph::Request::fake_builder()
+        .query(QUERY.to_string())
+        .variables(variables)
+        .build()
+        .expect("expecting valid request");
+
+    let response = supergraph_service
+        .oneshot(request)
+        .await
+        .unwrap()
+        .next_response()
+        .await
+        .unwrap();
+
+    // The movie-batch artwork fetch (2 entities: EntityCollectionSection "ecs1" + GallerySection
+    // "gs1") errored with no path, simulating a subgraph timeout. Before the fix this vanished
+    // silently (`errors` would be empty). After the fix it must surface -- once per affected
+    // entity, since the error applies to the whole batch.
+    assert_eq!(
+        response.errors.len(),
+        2,
+        "expected the error to be attached to each of the 2 entities in the errored (movie) \
+         batch, got: {:#?}",
+        response.errors
+    );
+
+    let mut error_paths: Vec<String> = response
+        .errors
+        .iter()
+        .map(|error| {
+            assert_eq!(error.message, "Your request has been timed out");
+            assert_eq!(
+                error.extensions.get("code").and_then(|c| c.as_str()),
+                Some("GATEWAY_TIMEOUT")
+            );
+            let path = error.path.as_ref().expect("error must have a path");
+            assert!(
+                !path
+                    .iter()
+                    .any(|elem| matches!(elem, JsonPathElement::Flatten(_))),
+                "error path must be a concrete per-entity path, not a dangling Flatten: {path:?}"
+            );
+            path.to_string()
+        })
+        .collect();
+    error_paths.sort();
+    assert_eq!(
+        error_paths,
+        vec![
+            "/containers/0/result/sections/0",
+            "/containers/0/result/sections/1"
+        ],
+        "the error must be attached to both entities of the errored movie batch specifically, \
+         not the (unaffected) article batch"
+    );
+
+    // The article-batch artwork fetch was unaffected and its data must still come through
+    // normally -- confirms the bug (and the fix) is scoped to the errored fetch only.
+    let data = response.data.expect("expected some data");
+    let article_container = &data["containers"][1];
+    assert_eq!(article_container["id"], serde_json_bytes::json!("c2"));
+    assert_eq!(
+        article_container["result"]["sections"][0]["title"],
+        serde_json_bytes::json!("ecs2 title")
+    );
+    assert_eq!(
+        article_container["result"]["sections"][0]["artwork"],
+        serde_json_bytes::json!("articleResultEnabled artwork")
+    );
+}


### PR DESCRIPTION
A subgraph-level error with no `_entities`-indexed path (for example, the error produced by a `traffic_shaping` timeout) could be silently dropped instead of surfacing to the client, when the erroring fetch's `Flatten` path crossed an abstract-typed (interface or union) field reached through a type condition on a single-valued field rather than on an array wildcard (e.g. `...edges.@.node|[SomeConcreteType].collection`).

The router expands such an error across every entity in the batch by matching the error's declared path (which retains its type condition) against each entity's real, already-materialized path (which never carries one). That match only special-cased array `Index`/`Flatten` pairs and otherwise required exact structural equality, so a `Key` path element with a type condition never matched the same `Key` without one — the error matched none of the batch's entities and was dropped entirely, with no trace in the response's `errors` or anywhere else, while the corresponding data was simply missing.

`Path::equal_if_flattened` now also treats two `Key` path elements as equal whenever their names match, regardless of any type condition attached to either side, so these errors correctly surface once per affected entity instead of vanishing silently.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
