### PR TITLE
fix(query-planner): handle @requires when key conditions are fetched below the entity

### DIFF
--- a/.changesets/fix_query_plan_requires_with_nested_key_conditions.md
+++ b/.changesets/fix_query_plan_requires_with_nested_key_conditions.md
@@ -1,0 +1,13 @@
+### Fix query planner error on `@requires` when the key's conditions are fetched below the entity
+
+Planning a query could fail with the internal error `Union types don't have field "<field>", only "__typename"` when an entity's `@requires` had to be resolved through a nested `@key` whose own fields came from another subgraph. Concretely, this happens when the entity's key is nested (for example `@key(fields: "subEntity { id2 }")`) and `id2` is only resolvable elsewhere, so the key-resolution *conditions* get fetched at a path *deeper* in the response (`unionField.subEntity`) than the entity that needs them (`unionField`).
+
+In that situation the condition fetch sits below the key fetch, so there is no downward path from the former to the latter. Three places mishandled that:
+
+- `compute_nodes_for_key_resolution()` subtracted the two paths in the wrong direction, producing a path describing the *reverse* relation. That invalid path was then resolved against the entity fetch's `_Entity` union root, which raised the error above.
+- `handle_conditions_tree()` skipped its entire "merge into the grand parent" block when there was no path into the parent, silently dropping the condition fetch nodes it had just created instead of reporting them as created.
+- `create_post_requires_node()` assumed a path into the parent existed whenever there was a single parent, and aborted with `Missing path_in_parent for @require` otherwise.
+
+The first defect masked the other two: they would have ordered the `@requires` fetch *before* the fetch producing the required field, so the entity resolver would have been called without its required data. All three are fixed, and such queries now plan correctly, fetching the required field before the field that requires it.
+
+By [@dariuszkuc](https://github.com/dariuszkuc) in https://github.com/apollographql/router/pull/XXXX

--- a/.changesets/fix_query_plan_requires_with_nested_key_conditions.md
+++ b/.changesets/fix_query_plan_requires_with_nested_key_conditions.md
@@ -8,6 +8,6 @@ In that situation the condition fetch sits below the key fetch, so there is no d
 - `handle_conditions_tree()` skipped its entire "merge into the grand parent" block when there was no path into the parent, silently dropping the condition fetch nodes it had just created instead of reporting them as created.
 - `create_post_requires_node()` assumed a path into the parent existed whenever there was a single parent, and aborted with `Missing path_in_parent for @require` otherwise.
 
-The first defect masked the other two: they would have ordered the `@requires` fetch *before* the fetch producing the required field, so the entity resolver would have been called without its required data. All three are fixed, and such queries now plan correctly, fetching the required field before the field that requires it.
+The first defect masked the other two, which are just as damaging on their own: with only the second unfixed, planning succeeds but the resulting plan *silently omits* the fetch that resolves the field carrying the `@requires`, so that field comes back unresolved and no error is reported; with only the third unfixed, planning aborts outright. All three are fixed, and such queries now plan correctly, fetching the required field before the field that requires it.
 
 By [@dariuszkuc](https://github.com/dariuszkuc) in https://github.com/apollographql/router/pull/9926

--- a/.changesets/fix_query_plan_requires_with_nested_key_conditions.md
+++ b/.changesets/fix_query_plan_requires_with_nested_key_conditions.md
@@ -1,4 +1,4 @@
-### Fix query planner error on `@requires` when the key's conditions are fetched below the entity
+### Fix query planner error on `@requires` when the key's conditions are fetched below the entity ([PR #9926](https://github.com/apollographql/router/pull/9926))
 
 Planning a query could fail with the internal error `Union types don't have field "<field>", only "__typename"` when an entity's `@requires` had to be resolved through a nested `@key` whose own fields came from another subgraph. Concretely, this happens when the entity's key is nested (for example `@key(fields: "subEntity { id2 }")`) and `id2` is only resolvable elsewhere, so the key-resolution *conditions* get fetched at a path *deeper* in the response (`unionField.subEntity`) than the entity that needs them (`unionField`).
 
@@ -10,4 +10,4 @@ In that situation the condition fetch sits below the key fetch, so there is no d
 
 The first defect masked the other two: they would have ordered the `@requires` fetch *before* the fetch producing the required field, so the entity resolver would have been called without its required data. All three are fixed, and such queries now plan correctly, fetching the required field before the field that requires it.
 
-By [@dariuszkuc](https://github.com/dariuszkuc) in https://github.com/apollographql/router/pull/XXXX
+By [@dariuszkuc](https://github.com/dariuszkuc) in https://github.com/apollographql/router/pull/9926

--- a/apollo-federation/src/query_graph/graph_path/operation.rs
+++ b/apollo-federation/src/query_graph/graph_path/operation.rs
@@ -2362,12 +2362,6 @@ impl OpPath {
         self.len() == 0
     }
 
-    pub(crate) fn strip_prefix(&self, maybe_prefix: &Self) -> Option<Self> {
-        self.0
-            .strip_prefix(&*maybe_prefix.0)
-            .map(|slice| Self(slice.to_vec()))
-    }
-
     pub(crate) fn with_pushed(&self, element: Arc<OpPathElement>) -> Self {
         let mut new = self.0.clone();
         new.push(element);

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3974,18 +3974,21 @@ fn compute_nodes_for_key_resolution<'a>(
         // `path_in_parent` possibly followed by a deeper suffix. A non-empty suffix means
         // `condition_node` sits *below* `new_node_id` in the data, and so there is no downward
         // path from `condition_node` to `new_node_id`: the suffix describes the reverse
-        // relation and must not be used here. Only the equal-paths case gives us a usable
-        // (empty) path.
+        // relation and must not be used here. Only equal paths give us a usable (empty) path.
+        //
+        // Note that this is stricter than it strictly needs to be: if `condition_path` were a
+        // *prefix* of `path_in_parent`, then `condition_node` would sit above `new_node_id` and
+        // `path_in_parent.strip_prefix(condition_path)` would be a usable downward path. That case
+        // is not known to be reachable and was not handled before either, so we leave it out.
         let mut path = None;
         let mut iter = dependency_graph.parents_relations_of(condition_node);
         if let (Some(condition_node_parent), None) = (iter.next(), iter.next()) {
             // There is exactly one parent
             if condition_node_parent.parent_node_id == stack_item.node_id
                 && let Some(condition_path) = condition_node_parent.path_in_parent
-                && let Some(suffix) = condition_path.strip_prefix(path_in_parent)
-                && suffix.is_empty()
+                && condition_path == *path_in_parent
             {
-                path = Some(Arc::new(suffix))
+                path = Some(Arc::new(OpPath::default()))
             }
         }
         drop(iter);

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3967,14 +3967,25 @@ fn compute_nodes_for_key_resolution<'a>(
         // then we can infer the path of `new_node_id` into that condition node
         // by looking at the paths of each to their common parent.
         // But otherwise, we cannot have a proper "path in parent".
+        //
+        // Note that the conditions are resolved starting from the very position of
+        // `new_node_id` (see `compute_nodes_for_tree` above, which is passed
+        // `stack_item.node_path`), so `condition_node`'s path into the common parent is always
+        // `path_in_parent` possibly followed by a deeper suffix. A non-empty suffix means
+        // `condition_node` sits *below* `new_node_id` in the data, and so there is no downward
+        // path from `condition_node` to `new_node_id`: the suffix describes the reverse
+        // relation and must not be used here. Only the equal-paths case gives us a usable
+        // (empty) path.
         let mut path = None;
         let mut iter = dependency_graph.parents_relations_of(condition_node);
         if let (Some(condition_node_parent), None) = (iter.next(), iter.next()) {
             // There is exactly one parent
             if condition_node_parent.parent_node_id == stack_item.node_id
                 && let Some(condition_path) = condition_node_parent.path_in_parent
+                && let Some(suffix) = condition_path.strip_prefix(path_in_parent)
+                && suffix.is_empty()
             {
-                path = condition_path.strip_prefix(path_in_parent).map(Arc::new)
+                path = Some(Arc::new(suffix))
             }
         }
         drop(iter);
@@ -4974,6 +4985,13 @@ fn handle_conditions_tree(
                         unmerged_node_ids.push(created_node_id);
                     }
                 }
+            } else {
+                // Without a path into the parent, we cannot even evaluate the "merge into the
+                // grand parent" optimization, so none of the created nodes can be merged. They
+                // must still all be reported as created: they fetch the condition fields that the
+                // post-@requires node depends on, and dropping them here would lose that
+                // dependency and let the @requires be resolved before its conditions are fetched.
+                unmerged_node_ids.extend(newly_created_node_ids);
             }
         }
 
@@ -5043,9 +5061,17 @@ fn create_post_requires_node(
     // aligned with the JS query planner. This could change in the future though, to permit simpler
     // handling and further optimization. (There's also some arguably buggy behavior in this
     // function we ought to resolve in the future.)
+    // Note that we also require a path into the parent: relocating the @requires into the parent
+    // is only possible if we know where in the parent the current node applies. Without it there is
+    // nothing to optimize, and we use the general handling below (which does not need that path).
     let parent_if_tried_optimizing =
         match iter_into_single_item(dependency_graph.parents_relations_of(fetch_node_id)) {
-            Some(parent) if fetch_node_path.path_in_node.has_only_fragments() => Some(parent),
+            Some(parent)
+                if fetch_node_path.path_in_node.has_only_fragments()
+                    && parent.path_in_parent.is_some() =>
+            {
+                Some(parent)
+            }
             _ => None,
         };
 

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
@@ -2068,3 +2068,182 @@ fn external_on_nested_key_fields_with_cross_subgraph_requires() {
       "###
     );
 }
+
+/// The @requires here can only be resolved by first jumping to Subgraph2 to translate
+/// `SubEntity.id1` into `id2`, because Subgraph3's `Entity` key is `subEntity { id2 }`. That makes
+/// the key-resolution *conditions* get fetched at `unionField.subEntity`, which is *deeper* in the
+/// response than the `Entity` needing the @requires (at `unionField`). The key fetch node therefore
+/// has no derivable "path in parent" relative to that condition node, and several places used to
+/// mishandle the resulting absent path: the planner first computed a reversed (and invalid) path,
+/// then silently dropped the condition fetch nodes, which ordered the @requires fetch before the
+/// fetch producing the required field.
+///
+/// The expected plan below bounces Subgraph2 -> Subgraph3 -> Subgraph2 -> Subgraph3, which looks
+/// redundant but is the minimum this schema allows. Each hop unlocks the next, in a strictly linear
+/// chain (this is the same shape as `it_handles_simple_require_chain`, just spread over more
+/// subgraphs):
+///   1. Subgraph1 is the only subgraph with `Query.unionField`, and gives us `subEntity { id1 }`.
+///   2. Subgraph2 turns `id1` into `id2`: Subgraph3's `Entity` key is `subEntity { id2 }`, Subgraph1
+///      only knows `id1`, and Subgraph2 is the only subgraph declaring both keys.
+///   3. Subgraph3 gives us `requiredSubEntity { id2 }`. `requiredSubEntity` is declared *only* in
+///      Subgraph3, so there is no way to know *which* `SubEntity` the @requires refers to without
+///      first asking Subgraph3 -- hence the jump into Subgraph3 before the required field exists.
+///   4. Subgraph2 resolves `requiredField` on it. Subgraph3 declares that field `@external` on a
+///      `resolvable: false` key, so Subgraph3 cannot resolve it itself.
+///   5. Subgraph3 finally resolves `requiringField`, now that it has both the key (2) and the
+///      @requires data (4).
+///
+/// Note also that fetch 3 re-selects `subEntity { id2 }` in its output even though fetch 2 already
+/// fetched exactly that at `unionField.subEntity`. That is `add_post_require_inputs()` adding the
+/// key needed to resume after the @requires to the pre-@requires node unconditionally: as its
+/// comment notes, it cannot cheaply prove the key is already selected, so it adds it and accepts a
+/// no-op when it was. It costs no extra round trip, only a slightly larger response.
+#[test]
+fn handles_requires_when_key_conditions_are_fetched_below_the_entity() {
+    let planner = planner!(
+        Subgraph1: r#"
+            union Union = Entity | Dummy
+
+            type Dummy {
+              dummy: Boolean!
+            }
+
+            type Entity @key(fields: "subEntity { id1 }") {
+              subEntity: SubEntity!
+            }
+
+            type SubEntity @key(fields: "id1") {
+              id1: ID!
+            }
+
+            type Query {
+              unionField: Union
+            }
+        "#,
+        Subgraph2: r#"
+            type SubEntity @key(fields: "id1") @key(fields: "id2") {
+              id1: ID!
+              id2: ID!
+              requiredField: Boolean!
+            }
+        "#,
+        Subgraph3: r#"
+            type Entity @key(fields: "subEntity { id2 }") {
+              subEntity: SubEntity!
+              requiredSubEntity: SubEntity!
+              requiringField: Boolean @requires(fields: "requiredSubEntity { requiredField }")
+            }
+
+            type SubEntity @key(fields: "id2", resolvable: false) {
+              id2: ID!
+              requiredField: Boolean! @external
+            }
+        "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+            query {
+              unionField {
+                ... on Entity {
+                  requiringField
+                }
+              }
+            }
+        "#,
+        @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "Subgraph1") {
+          {
+            unionField {
+              __typename
+              ... on Entity {
+                __typename
+                subEntity {
+                  __typename
+                  id1
+                }
+              }
+            }
+          }
+        },
+        Flatten(path: "unionField.subEntity") {
+          Fetch(service: "Subgraph2") {
+            {
+              ... on SubEntity {
+                __typename
+                id1
+              }
+            } =>
+            {
+              ... on SubEntity {
+                id2
+              }
+            }
+          },
+        },
+        Flatten(path: "unionField") {
+          Fetch(service: "Subgraph3") {
+            {
+              ... on Entity {
+                __typename
+                subEntity {
+                  id2
+                }
+              }
+            } =>
+            {
+              ... on Entity {
+                __typename
+                requiredSubEntity {
+                  __typename
+                  id2
+                }
+                subEntity {
+                  id2
+                }
+              }
+            }
+          },
+        },
+        Flatten(path: "unionField.requiredSubEntity") {
+          Fetch(service: "Subgraph2") {
+            {
+              ... on SubEntity {
+                __typename
+                id2
+              }
+            } =>
+            {
+              ... on SubEntity {
+                requiredField
+              }
+            }
+          },
+        },
+        Flatten(path: "unionField") {
+          Fetch(service: "Subgraph3") {
+            {
+              ... on Entity {
+                __typename
+                requiredSubEntity {
+                  requiredField
+                }
+                subEntity {
+                  id2
+                }
+              }
+            } =>
+            {
+              ... on Entity {
+                requiringField
+              }
+            }
+          },
+        },
+      },
+    }
+    "#
+    );
+}

--- a/apollo-federation/tests/query_plan/supergraphs/handles_requires_when_key_conditions_are_fetched_below_the_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_requires_when_key_conditions_are_fetched_below_the_entity.graphql
@@ -1,0 +1,96 @@
+# Composed from subgraphs with hash: 0d554b7f6826717e157fad6081e12681ba45caa4
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Dummy
+  @join__type(graph: SUBGRAPH1)
+{
+  dummy: Boolean!
+}
+
+type Entity
+  @join__type(graph: SUBGRAPH1, key: "subEntity { id1 }")
+  @join__type(graph: SUBGRAPH3, key: "subEntity { id2 }")
+{
+  subEntity: SubEntity!
+  requiredSubEntity: SubEntity! @join__field(graph: SUBGRAPH3)
+  requiringField: Boolean @join__field(graph: SUBGRAPH3, requires: "requiredSubEntity { requiredField }")
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+{
+  unionField: Union @join__field(graph: SUBGRAPH1)
+}
+
+type SubEntity
+  @join__type(graph: SUBGRAPH1, key: "id1")
+  @join__type(graph: SUBGRAPH2, key: "id1")
+  @join__type(graph: SUBGRAPH2, key: "id2")
+  @join__type(graph: SUBGRAPH3, key: "id2", resolvable: false)
+{
+  id1: ID! @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH2)
+  id2: ID! @join__field(graph: SUBGRAPH2) @join__field(graph: SUBGRAPH3)
+  requiredField: Boolean! @join__field(graph: SUBGRAPH2) @join__field(graph: SUBGRAPH3, external: true)
+}
+
+union Union
+  @join__type(graph: SUBGRAPH1)
+  @join__unionMember(graph: SUBGRAPH1, member: "Entity")
+  @join__unionMember(graph: SUBGRAPH1, member: "Dummy")
+ = Entity | Dummy


### PR DESCRIPTION
Planning could fail with the internal error `Union types don't have field "<field>", only "__typename"` when an entity's `@requires` had to be resolved through a nested `@key` whose own fields came from another subgraph.

When the entity's key is nested (e.g. `@key(fields: "subEntity { id2 }")`) and `id2` is only resolvable in another subgraph, the key-resolution *conditions* get fetched at a path deeper in the response (`unionField.subEntity`) than the entity needing them (`unionField`). The condition fetch node therefore sits *below* the key fetch node, and no downward path exists from the former to the latter. Three places mishandled that absent path:

- `compute_nodes_for_key_resolution()` computed the new key node's path in the condition node as `condition_path.strip_prefix(path_in_parent)`. That yields the tail of the condition node's path, i.e. the *reverse* relation. Because conditions are always resolved starting at the key node's own position, a non-empty remainder always means the condition node is deeper and no path exists, so only the equal-paths (empty) case is usable. The bogus path was then walked by `type_at_path()` against the entity fetch's `_Entity` union root, raising the error above.

- `handle_conditions_tree()` skipped its whole `if parent.path_in_parent .is_some()` block when there was no path into the parent, leaving `unmerged_node_ids` empty even though `newly_created_node_ids` was not. The condition fetch nodes it had just created were silently dropped from `created_node_ids`, losing the dependency they represent.

- `create_post_requires_node()` treated a single parent as proof the "relocate into the parent" optimization applied, and hit `bail!("Missing path_in_parent for @require ...")` when that parent had no path. It now also requires the path, falling back to the general handling, which does not need it.

The first defect masked the other two: they would have ordered the `@requires` fetch before the fetch producing the required field, calling the entity resolver without its required data. Such queries now plan correctly.

The new test's doc comment also explains why the expected plan legitimately bounces `Subgraph2 -> Subgraph3 -> Subgraph2 -> Subgraph3`: `requiredSubEntity` is declared only in Subgraph3, so the required sub-entity cannot be identified without first entering Subgraph3, while `requiredField` is `@external` there on a `resolvable: false` key and so must come from Subgraph2.
