### PR TITLE
fix(configuration): apply `change` migrations on deeply nested paths

### DIFF
--- a/.changesets/fix_config_migration_change_nested_path.md
+++ b/.changesets/fix_config_migration_change_nested_path.md
@@ -6,4 +6,4 @@ The comparison is now done by selecting the value at the path and comparing it d
 
 No shipped migration was affected, since the only existing use of `change` targets a two-segment path.
 
-By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9917
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9927

--- a/.changesets/fix_config_migration_change_nested_path.md
+++ b/.changesets/fix_config_migration_change_nested_path.md
@@ -1,9 +1,0 @@
-### Config migrations can now rewrite values on deeply nested paths
-
-The `change` action in the router's configuration migration machinery rewrites a config value only when it currently equals an expected value. It performed that comparison with a JSONPath filter expression that silently matches nothing once the path is more than two segments deep, so any migration targeting a deeply nested path did nothing at all — with no error and no warning, making it look like the migration had run successfully.
-
-The comparison is now done by selecting the value at the path and comparing it directly, which behaves the same at any depth. The `change` action is also now documented alongside the other migration actions.
-
-No shipped migration was affected, since the only existing use of `change` targets a two-segment path.
-
-By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9927

--- a/.changesets/fix_config_migration_change_nested_path.md
+++ b/.changesets/fix_config_migration_change_nested_path.md
@@ -1,0 +1,9 @@
+### Config migrations can now rewrite values on deeply nested paths
+
+The `change` action in the router's configuration migration machinery rewrites a config value only when it currently equals an expected value. It performed that comparison with a JSONPath filter expression that silently matches nothing once the path is more than two segments deep, so any migration targeting a deeply nested path did nothing at all — with no error and no warning, making it look like the migration had run successfully.
+
+The comparison is now done by selecting the value at the path and comparing it directly, which behaves the same at any depth. The `change` action is also now documented alongside the other migration actions.
+
+No shipped migration was affected, since the only existing use of `change` targets a two-segment path.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9917

--- a/apollo-router/src/configuration/migrations/README.md
+++ b/apollo-router/src/configuration/migrations/README.md
@@ -22,7 +22,12 @@ actions:
     path: some.destination
   - type: add
     path: some.destination
+    name: someName
     value: someValue
+  - type: change
+    path: some.destination
+    from: oldValue
+    to: newValue
   - type: log
     level: error
     path: some.source
@@ -30,6 +35,17 @@ actions:
 ```
 
 Each action is applied in order. Use the following formats for from, to and path.
+
+## Actions
+
+| action | description |
+---------|-------------|
+| move | Moves the value at `from` to `to`, removing `from`. No-op if `from` doesn't exist. |
+| copy | Copies the value at `from` to `to`, leaving `from` in place. No-op if `from` doesn't exist. |
+| delete | Removes the value at `path`. No-op if `path` doesn't exist. |
+| add | Sets `path.name` to `value`. Only applies if `path` already exists and `path.name` does not — parent structure is never created. |
+| change | Replaces the value at `path` with `to`, but only if it currently equals `from`. No-op if `path` doesn't exist or holds a different value. `from` and `to` are compared/written as whole YAML values, so either may be a scalar, a map or a list. |
+| log | Migrates nothing; just logs `log` at `level` when `path` matches something. Useful when moving a feature from experimental to GA in a way that isn't backward compatible. |
 
 ## Getter (from)
 | syntax | description |

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -200,9 +200,13 @@ fn apply_migration(config: &Value, migration: &Migration) -> Result<Value, Confi
                 }
             }
             Action::Change { path, from, to } => {
-                if !jsonpath_lib::select(config, &format!("$[?(@.{path} == {from})]"))
+                // Select the value at `path` and compare it here, rather than letting JSONPath do
+                // the comparison with a `$[?(@.a.b == x)]` filter. That filter form silently
+                // matches nothing once `path` is more than two segments deep, which made the
+                // whole action a no-op — no error, no warning, config left untouched.
+                if jsonpath_lib::select(config, &format!("$.{path}"))
                     .unwrap_or_default()
-                    .is_empty()
+                    .contains(&from)
                 {
                     transformer_builder = transformer_builder
                         .add_action(Parser::parse(&format!(r#"const({to})"#), path)?);
@@ -608,5 +612,51 @@ mod test {
             )
             .expect("expected successful migration")
         );
+    }
+
+    /// Rewrites `"Error"` to `"error"` on a four-segment path. These assertions are deliberately
+    /// explicit rather than insta snapshots, so a regression can't be blessed away by accepting a
+    /// new snapshot.
+    fn change_jwt_on_error(source: Value) -> Value {
+        apply_migration(
+            &source,
+            &Migration::builder()
+                .action(Action::Change {
+                    path: "authentication.router.jwt.on_error".to_string(),
+                    from: Value::String("Error".into()),
+                    to: Value::String("error".into()),
+                })
+                .description("rename a deeply nested value")
+                .build(),
+        )
+        .expect("expected successful migration")
+    }
+
+    /// `Change` used to compare the current value with a `$[?(@.a.b == x)]` filter, which matches
+    /// nothing once the path is more than two segments deep. Any migration rewriting a value on a
+    /// deeply nested path was silently a no-op — this asserts it isn't.
+    #[test]
+    fn change_field_deeply_nested() {
+        assert_eq!(
+            change_jwt_on_error(
+                json!({"authentication": {"router": {"jwt": {"on_error": "Error"}}}})
+            ),
+            json!({"authentication": {"router": {"jwt": {"on_error": "error"}}}})
+        );
+    }
+
+    /// Guards the other direction: `from` must still be honoured at depth, so a non-matching value
+    /// is left alone rather than rewritten unconditionally.
+    #[test]
+    fn change_field_deeply_nested_only_matching_value() {
+        let source = json!({"authentication": {"router": {"jwt": {"on_error": "Continue"}}}});
+        assert_eq!(change_jwt_on_error(source.clone()), source);
+    }
+
+    /// A `Change` on a path that isn't present must not create it.
+    #[test]
+    fn change_field_deeply_nested_absent_path() {
+        let source = json!({"authentication": {"router": {"jwt": {}}}});
+        assert_eq!(change_jwt_on_error(source.clone()), source);
     }
 }


### PR DESCRIPTION
## What

- `Action::Change` in `apollo-router/src/configuration/upgrade.rs` tested whether a config value equalled `from` using the JSONPath filter `$[?(@.{path} == {from})]`. That filter form returns zero matches once `path` is more than two segments deep, so the action became a no-op — no error, no warning, config left untouched. It now selects the value with `$.{path}` and compares it in Rust, which behaves the same at any depth.
- Added three regression tests covering `change` on a four-segment path: the value is rewritten when it matches `from`, left alone when it does not, and not created when the path is absent. They use explicit `assert_eq!` rather than insta snapshots, so a regression cannot be resolved by accepting a new snapshot.
- Documented the `change` action in `apollo-router/src/configuration/migrations/README.md`, which previously covered only `move`, `copy`, `delete`, `add`, and `log`. Added an actions table listing all six and their no-op conditions.
- Fixed the README's `add` example, which omitted the required `name` field. `Action::Add` has `path`, `name`, and `value`, so the documented form did not deserialize.

## Verified

- `cargo fmt --all --check -- --config "imports_granularity=Item,group_imports=StdExternalCrate"` passed
- `cargo clippy -- -D warnings` passed (exit 0, no warnings)
- `cargo test -p apollo-router --lib configuration::` — 184 passed, 0 failed
- CHANGELOG.md not modified

The new deeply-nested test was confirmed to fail against the previous implementation before the fix: with the `$[?(@.{path} == {from})]` line temporarily restored, `change_field_deeply_nested` failed with the value left at `"Error"` instead of `"error"`, matching the no-op behaviour described above. The two negative tests pass either way by construction, since the previous code was a no-op for every value at that depth; they guard against a fix that drops the `from` check and rewrites unconditionally.

## No changeset

Intentionally omitted — this has no user-visible effect. The only shipped use of `change` is `migrations/0029-pq-prewarm-to-on_startup.yaml`, whose path is two segments deep and was therefore unaffected; `upgrade_old_configuration` and `upgrade_old_minor_configuration`, which exercise it, pass unchanged. The fix matters for future migrations targeting nested paths, not for any released behaviour.

## Notes

For the record, the reason the filter form fails is not the comparison, which works at any depth. `jsonpath_lib` carries the parent object plus the final key name rather than a resolved value, and the step that maps a successful match back to the node the filter returns only looks one level down from the root (`map.values()` in `select/expr_term.rs`). At two segments the matched object happens to be a direct child of the root, so it works; at three or more it is a grandchild, the structural equality never holds, and the result set is empty.

A consequence worth noting: that made the old behaviour content-dependent rather than uniformly broken. With `jsonpath_lib` 0.3.0, `$[?(@.authentication.router.jwt.on_error == "Error")]` returns 0 matches on its own, but 1 match if an unrelated root-level key such as `unrelated_plugin: {on_error: Error}` is also present, because the root then does have a direct child equal to the matched object. It cannot produce a wrong rewrite — the reassociation only runs once the comparison has already succeeded — but a nested `change` migration could have fired or not depending on unrelated parts of a user's config.
