### PR TITLE
feat(authentication): add RedactedError mode for JWT auth failures

### DIFF
--- a/.changesets/feat_jwt_redacted_error_mode.md
+++ b/.changesets/feat_jwt_redacted_error_mode.md
@@ -17,4 +17,4 @@ The details of the failure are still available to you: the `apollo::authenticati
 
 The default remains `Error`, so this change doesn't affect existing deployments.
 
-By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/TBD
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9928

--- a/.changesets/feat_jwt_redacted_error_mode.md
+++ b/.changesets/feat_jwt_redacted_error_mode.md
@@ -1,0 +1,20 @@
+### Add a `RedactedError` mode for JWT authentication errors
+
+By default, when JWT authentication fails, the router returns a detailed error message describing the validation failure. Those messages can disclose details of your authentication setup to unauthenticated callers, including which signing algorithms the router accepts, the byte offsets at which token decoding failed, and the issuers and audiences the router is configured to trust.
+
+Setting `authentication.router.jwt.on_error` to `RedactedError` rejects failed requests with the same status codes as `Error`, but replaces every message with a generic `Authentication failed`:
+
+```yaml title="router.yaml"
+authentication:
+  router:
+    jwt:
+      jwks:
+        - url: https://auth.example.com/.well-known/jwks.json
+      on_error: RedactedError
+```
+
+The details of the failure are still available to you: the `apollo::authentication::jwt_status` context value carries the full message, code, and reason, and failures on the `apollo.router.operations.authentication.jwt` metric now carry an `authentication.jwt.failure_code` attribute (for example `CANNOT_DECODE_JWT` or `INVALID_AUDIENCE`) that you can use to break down why authentications fail.
+
+The default remains `Error`, so this change doesn't affect existing deployments.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/TBD

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -182,7 +182,9 @@ impl InstrumentData {
         );
         populate_config_instrument!(
             apollo.router.config.authentication.jwt,
-            "$.authentication[?(@..jwt)]"
+            "$.authentication[?(@..jwt)]",
+            opt.on_error,
+            "$.router.jwt.on_error"
         );
         populate_config_instrument!(
             apollo.router.config.authentication.aws.sigv4,

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@jwt.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@jwt.router.yaml.snap
@@ -6,5 +6,6 @@ expression: "&metrics.non_zero()"
   data:
     datapoints:
       - value: 1
-        attributes: {}
+        attributes:
+          opt.on_error: RedactedError
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -7001,7 +7001,7 @@ expression: "&schema"
               "$ref": "#/definitions/OnError"
             }
           ],
-          "description": "Control the behavior when an error occurs during the authentication process.\n\nDefaults to `Error`. When set to `Continue`, requests that fail JWT authentication will\ncontinue to be processed by the router, but without the JWT claims in the context. When set\nto `Error`, requests that fail JWT authentication will be rejected with a HTTP 403 error."
+          "description": "Control the behavior when an error occurs during the authentication process.\n\nDefaults to `Error`.\n\n* When set to `Continue`, requests that fail JWT authentication will continue to be\n  processed by the router, but without the JWT claims in the context.\n* When set to `Error`, requests that fail JWT authentication will be rejected with a\n  HTTP 403 error.\n* When set to `RedactedError`, requests that fail JWT authentication are rejected in the\n  same way as `Error`, but the response contains a generic error message instead of the\n  details of the validation failure. The details remain available in the\n  `apollo::authentication::jwt_status` context value and in the\n  `apollo.router.operations.authentication.jwt` metric."
         },
         "sources": {
           "description": "Alternative sources to extract the JWT",
@@ -7692,7 +7692,8 @@ expression: "&schema"
     "OnError": {
       "enum": [
         "Continue",
-        "Error"
+        "Error",
+        "RedactedError"
       ],
       "type": "string"
     },

--- a/apollo-router/src/configuration/testdata/metrics/jwt.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/jwt.router.yaml
@@ -3,5 +3,4 @@ authentication:
     jwt:
       jwks:
         - url: https://example.com
-
-
+      on_error: RedactedError

--- a/apollo-router/src/plugins/authentication/error.rs
+++ b/apollo-router/src/plugins/authentication/error.rs
@@ -77,37 +77,46 @@ fn jwt_error_to_reason(jwt_err: &JWTError) -> &'static str {
 }
 
 impl AuthenticationError {
-    pub(super) fn as_context_object(&self) -> ErrorContext {
-        let (code, reason) = match self {
-            AuthenticationError::CannotConvertToString => ("CANNOT_CONVERT_TO_STRING", None),
-            AuthenticationError::InvalidJWTPrefix(_, _) => ("INVALID_PREFIX", None),
-            AuthenticationError::MissingJWTToken(_, _) => ("MISSING_JWT", None),
-            AuthenticationError::InvalidHeader(_, jwt_err) => {
-                ("INVALID_HEADER", Some(jwt_error_to_reason(jwt_err).into()))
-            }
-            AuthenticationError::CannotCreateDecodingKey(jwt_err) => (
-                "CANNOT_CREATE_DECODING_KEY",
-                Some(jwt_error_to_reason(jwt_err).into()),
-            ),
-            AuthenticationError::JWKHasNoAlgorithm => ("JWK_HAS_NO_ALGORITHM", None),
-            AuthenticationError::CannotDecodeJWT(jwt_err) => (
-                "CANNOT_DECODE_JWT",
-                Some(jwt_error_to_reason(jwt_err).into()),
-            ),
+    /// A stable, machine-readable code for this failure. Unlike [`Self::to_string`], this never
+    /// contains details of the token or of the router's configuration, so it is safe to report
+    /// even when the client-facing message is redacted.
+    pub(super) fn code(&self) -> &'static str {
+        match self {
+            AuthenticationError::CannotConvertToString => "CANNOT_CONVERT_TO_STRING",
+            AuthenticationError::InvalidJWTPrefix(_, _) => "INVALID_PREFIX",
+            AuthenticationError::MissingJWTToken(_, _) => "MISSING_JWT",
+            AuthenticationError::InvalidHeader(_, _) => "INVALID_HEADER",
+            AuthenticationError::CannotCreateDecodingKey(_) => "CANNOT_CREATE_DECODING_KEY",
+            AuthenticationError::JWKHasNoAlgorithm => "JWK_HAS_NO_ALGORITHM",
+            AuthenticationError::CannotDecodeJWT(_) => "CANNOT_DECODE_JWT",
             AuthenticationError::CannotInsertClaimsIntoContext(_) => {
-                ("CANNOT_INSERT_CLAIMS_INTO_CONTEXT", None)
+                "CANNOT_INSERT_CLAIMS_INTO_CONTEXT"
             }
-            AuthenticationError::CannotFindKID(_) => ("CANNOT_FIND_KID", None),
-            AuthenticationError::CannotFindSuitableKey(_, _) => ("CANNOT_FIND_SUITABLE_KEY", None),
-            AuthenticationError::InvalidIssuer { .. } => ("INVALID_ISSUER", None),
-            AuthenticationError::InvalidAudience { .. } => ("INVALID_AUDIENCE", None),
-            AuthenticationError::UnsupportedKeyAlgorithm(_) => ("UNSUPPORTED_KEY_ALGORITHM", None),
-        };
+            AuthenticationError::CannotFindKID(_) => "CANNOT_FIND_KID",
+            AuthenticationError::CannotFindSuitableKey(_, _) => "CANNOT_FIND_SUITABLE_KEY",
+            AuthenticationError::InvalidIssuer { .. } => "INVALID_ISSUER",
+            AuthenticationError::InvalidAudience { .. } => "INVALID_AUDIENCE",
+            AuthenticationError::UnsupportedKeyAlgorithm(_) => "UNSUPPORTED_KEY_ALGORITHM",
+        }
+    }
 
+    /// The underlying `jsonwebtoken` failure kind, for the variants that wrap one.
+    fn reason(&self) -> Option<String> {
+        match self {
+            AuthenticationError::InvalidHeader(_, jwt_err)
+            | AuthenticationError::CannotCreateDecodingKey(jwt_err)
+            | AuthenticationError::CannotDecodeJWT(jwt_err) => {
+                Some(jwt_error_to_reason(jwt_err).into())
+            }
+            _ => None,
+        }
+    }
+
+    pub(super) fn as_context_object(&self) -> ErrorContext {
         ErrorContext {
             message: self.to_string(),
-            code: code.into(),
-            reason,
+            code: self.code().into(),
+            reason: self.reason(),
         }
     }
 }

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -59,6 +59,9 @@ mod tests;
 pub(crate) const AUTHENTICATION_SPAN_NAME: &str = "authentication_plugin";
 pub(crate) const APOLLO_AUTHENTICATION_JWT_CLAIMS: &str = "apollo::authentication::jwt_claims";
 const HEADER_TOKEN_TRUNCATED: &str = "(truncated)";
+/// The single message returned to clients when `on_error` is `RedactedError`, in place of the
+/// detailed validation error.
+const REDACTED_AUTH_ERROR_MESSAGE: &str = "Authentication failed";
 
 const DEFAULT_AUTHENTICATION_NETWORK_TIMEOUT: Duration = Duration::from_secs(15);
 const DEFAULT_AUTHENTICATION_DOWNLOAD_INTERVAL: Duration = Duration::from_secs(60);
@@ -76,11 +79,18 @@ struct AuthenticationPlugin {
     connector: Option<ConnectorAuth>,
 }
 
+// TODO: in the next major version, rename these values to snake_case (`continue`, `error`,
+// `redacted_error`). This is the only config option in the router whose values are PascalCase; every
+// other one is snake_case. It needs a config migration, so it can't ship in a patch release.
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Default)]
 enum OnError {
     Continue,
+    // TODO: make `RedactedError` the default in the next major version. Returning the full
+    // validation error to an unauthenticated caller discloses details of the authentication setup
+    // that no client can act on, so the redacting behavior is the safer default.
     #[default]
     Error,
+    RedactedError,
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, serde_derive_default::Default)]
@@ -102,9 +112,17 @@ struct JWTConf {
     sources: Vec<Source>,
     /// Control the behavior when an error occurs during the authentication process.
     ///
-    /// Defaults to `Error`. When set to `Continue`, requests that fail JWT authentication will
-    /// continue to be processed by the router, but without the JWT claims in the context. When set
-    /// to `Error`, requests that fail JWT authentication will be rejected with a HTTP 403 error.
+    /// Defaults to `Error`.
+    ///
+    /// * When set to `Continue`, requests that fail JWT authentication will continue to be
+    ///   processed by the router, but without the JWT claims in the context.
+    /// * When set to `Error`, requests that fail JWT authentication will be rejected with a
+    ///   HTTP 403 error.
+    /// * When set to `RedactedError`, requests that fail JWT authentication are rejected in the
+    ///   same way as `Error`, but the response contains a generic error message instead of the
+    ///   details of the validation failure. The details remain available in the
+    ///   `apollo::authentication::jwt_status` context value and in the
+    ///   `apollo.router.operations.authentication.jwt` metric.
     #[serde(default)]
     on_error: OnError,
 }
@@ -484,8 +502,7 @@ fn authenticate(
         source: Option<&Source>,
     ) -> ControlFlow<router::Response, router::Request> {
         // This is a metric and will not appear in the logs
-        let failed = true;
-        increment_jwt_counter_metric(failed);
+        increment_jwt_counter_metric(Some(error.code()));
         // Record span attributes for JWT failure
         let span = tracing::Span::current();
         span.record("authentication.jwt.failed", true);
@@ -501,33 +518,52 @@ fn authenticate(
             serde_json_bytes::json!(JwtStatus::new_failure(source, error.as_context_object())),
         );
 
-        if config.on_error == OnError::Error {
-            let response = router::Response::infallible_builder()
-                .error(
-                    graphql::Error::builder()
-                        .message(error.to_string())
-                        .extension_code("AUTH_ERROR")
-                        .build(),
-                )
-                .status_code(status)
-                .header(header::CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone())
-                .context(request.context)
-                .build();
+        // The error message is the only part of the response that varies by mode. Note that the
+        // full detail is always kept in the context value inserted above, so redacting here does
+        // not deprive operators of the reason for the failure.
+        let message = match config.on_error {
+            OnError::Continue => return ControlFlow::Continue(request),
+            OnError::Error => error.to_string(),
+            OnError::RedactedError => REDACTED_AUTH_ERROR_MESSAGE.to_string(),
+        };
 
-            ControlFlow::Break(response)
-        } else {
-            ControlFlow::Continue(request)
-        }
+        let response = router::Response::infallible_builder()
+            .error(
+                graphql::Error::builder()
+                    .message(message)
+                    .extension_code("AUTH_ERROR")
+                    .build(),
+            )
+            .status_code(status)
+            .header(header::CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone())
+            .context(request.context)
+            .build();
+
+        ControlFlow::Break(response)
     }
 
-    /// This is the documented metric
-    fn increment_jwt_counter_metric(failed: bool) {
-        u64_counter!(
-            "apollo.router.operations.authentication.jwt",
-            "Number of requests with JWT authentication",
-            1,
-            authentication.jwt.failed = failed
-        );
+    /// This is the documented metric. `failure_code` is the machine-readable code for the
+    /// authentication failure, or `None` when authentication succeeded.
+    fn increment_jwt_counter_metric(failure_code: Option<&'static str>) {
+        match failure_code {
+            Some(code) => {
+                u64_counter!(
+                    "apollo.router.operations.authentication.jwt",
+                    "Number of requests with JWT authentication",
+                    1,
+                    authentication.jwt.failed = true,
+                    authentication.jwt.failure_code = code
+                );
+            }
+            None => {
+                u64_counter!(
+                    "apollo.router.operations.authentication.jwt",
+                    "Number of requests with JWT authentication",
+                    1,
+                    authentication.jwt.failed = false
+                );
+            }
+        }
     }
 
     let mut jwt = None;
@@ -629,8 +665,7 @@ fn authenticate(
             1
         );
         // Use the fixed name too:
-        let failed = false;
-        increment_jwt_counter_metric(failed);
+        increment_jwt_counter_metric(None);
 
         let _ = request.context.insert_json_value(
             JWT_CONTEXT_KEY,

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -127,7 +127,7 @@ fn assert_mock_success(service_response: &router::Response, response: &graphql::
 }
 
 async fn build_a_default_test_harness() -> (router::BoxCloneService, MockHandle) {
-    build_a_test_harness(None, None, false, false, false).await
+    build_a_test_harness(None, None, false, false, None).await
 }
 
 async fn build_a_test_harness(
@@ -135,7 +135,7 @@ async fn build_a_test_harness(
     header_value_prefix: Option<String>,
     multiple_jwks: bool,
     ignore_other_prefixes: bool,
-    continue_on_error: bool,
+    on_error: Option<&str>,
 ) -> (router::BoxCloneService, MockHandle) {
     let (mock_service, handle) =
         tower_test::mock::pair::<supergraph::Request, supergraph::Response>();
@@ -189,9 +189,9 @@ async fn build_a_test_harness(
     config["authentication"]["router"]["jwt"]["ignore_other_prefixes"] =
         serde_json::Value::Bool(ignore_other_prefixes);
 
-    if continue_on_error {
+    if let Some(on_error) = on_error {
         config["authentication"]["router"]["jwt"]["on_error"] =
-            serde_json::Value::String("Continue".to_string());
+            serde_json::Value::String(on_error.to_string());
     }
 
     let test_harness = match crate::TestHarness::builder()
@@ -432,7 +432,7 @@ async fn it_accepts_when_auth_prefix_has_correct_format_and_valid_jwt() {
 
 #[tokio::test]
 async fn it_accepts_when_auth_prefix_does_not_match_config_and_is_ignored() {
-    let (test_harness, handle) = build_a_test_harness(None, None, false, true, false).await;
+    let (test_harness, handle) = build_a_test_harness(None, None, false, true, None).await;
     let driver = spawn_mock_driver(handle);
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
@@ -452,7 +452,7 @@ async fn it_accepts_when_auth_prefix_does_not_match_config_and_is_ignored() {
 
 #[tokio::test]
 async fn it_accepts_when_auth_prefix_has_correct_format_multiple_jwks_and_valid_jwt() {
-    let (test_harness, handle) = build_a_test_harness(None, None, true, false, false).await;
+    let (test_harness, handle) = build_a_test_harness(None, None, true, false, None).await;
     let driver = spawn_mock_driver(handle);
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
@@ -476,7 +476,7 @@ async fn it_accepts_when_auth_prefix_has_correct_format_multiple_jwks_and_valid_
 #[tokio::test]
 async fn it_accepts_when_auth_prefix_has_correct_format_and_valid_jwt_custom_auth() {
     let (test_harness, handle) =
-        build_a_test_harness(Some("SOMETHING".to_string()), None, false, false, false).await;
+        build_a_test_harness(Some("SOMETHING".to_string()), None, false, false, None).await;
     let driver = spawn_mock_driver(handle);
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
@@ -500,7 +500,7 @@ async fn it_accepts_when_auth_prefix_has_correct_format_and_valid_jwt_custom_aut
 #[tokio::test]
 async fn it_accepts_when_auth_prefix_has_correct_format_and_valid_jwt_custom_prefix() {
     let (test_harness, handle) =
-        build_a_test_harness(None, Some("SOMETHING".to_string()), false, false, false).await;
+        build_a_test_harness(None, Some("SOMETHING".to_string()), false, false, None).await;
     let driver = spawn_mock_driver(handle);
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
@@ -524,7 +524,7 @@ async fn it_accepts_when_auth_prefix_has_correct_format_and_valid_jwt_custom_pre
 #[tokio::test]
 async fn it_accepts_when_no_auth_prefix_and_valid_jwt_custom_prefix() {
     let (test_harness, handle) =
-        build_a_test_harness(None, Some("".to_string()), false, false, false).await;
+        build_a_test_harness(None, Some("".to_string()), false, false, None).await;
     let driver = spawn_mock_driver(handle);
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
@@ -547,7 +547,7 @@ async fn it_accepts_when_no_auth_prefix_and_valid_jwt_custom_prefix() {
 
 #[tokio::test]
 async fn it_inserts_success_jwt_status_into_context() {
-    let (test_harness, handle) = build_a_test_harness(None, None, false, false, false).await;
+    let (test_harness, handle) = build_a_test_harness(None, None, false, false, None).await;
     let driver = spawn_mock_driver(handle);
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
@@ -599,7 +599,7 @@ async fn it_inserts_success_jwt_status_into_context() {
 
 #[tokio::test]
 async fn it_inserts_failure_jwt_status_into_context() {
-    let (test_harness, handle) = build_a_test_harness(None, None, false, false, false).await;
+    let (test_harness, handle) = build_a_test_harness(None, None, false, false, None).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
         .header(
@@ -657,7 +657,8 @@ async fn it_inserts_failure_jwt_status_into_context() {
 
 #[tokio::test]
 async fn it_moves_on_after_jwt_errors_when_configured() {
-    let (test_harness, handle) = build_a_test_harness(None, None, false, false, true).await;
+    let (test_harness, handle) =
+        build_a_test_harness(None, None, false, false, Some("Continue")).await;
     let driver = spawn_mock_driver(handle);
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
@@ -712,14 +713,14 @@ async fn it_moves_on_after_jwt_errors_when_configured() {
 #[should_panic]
 async fn it_panics_when_auth_prefix_has_correct_format_but_contains_whitespace() {
     // The build panics, so the handle is never returned — discard the tuple.
-    let _ = build_a_test_harness(None, Some("SOMET HING".to_string()), false, false, false).await;
+    let _ = build_a_test_harness(None, Some("SOMET HING".to_string()), false, false, None).await;
 }
 
 #[tokio::test]
 #[should_panic]
 async fn it_panics_when_auth_prefix_has_correct_format_but_contains_trailing_whitespace() {
     // The build panics, so the handle is never returned — discard the tuple.
-    let _ = build_a_test_harness(None, Some("SOMETHING ".to_string()), false, false, false).await;
+    let _ = build_a_test_harness(None, Some("SOMETHING ".to_string()), false, false, None).await;
 }
 
 #[tokio::test]
@@ -2489,5 +2490,321 @@ mod duplicate_key_retry {
                 panic!("kid-matched entry B should have been retried and accepted: {response:?}");
             }
         }
+    }
+}
+
+/// Redaction of client-visible JWT validation errors (`on_error: RedactedError`).
+///
+/// The detailed messages the router returns by default echo `jsonwebtoken`'s own error text
+/// (base64 byte offsets, the list of supported signing algorithms) and the router's configured
+/// issuers/audiences back to an unauthenticated caller. `RedactedError` rejects the request with
+/// a single generic message instead, while keeping the full detail in the
+/// `apollo::authentication::jwt_status` context object and in telemetry.
+mod redacted_errors {
+    use std::collections::HashSet;
+    use std::ops::ControlFlow;
+
+    use base64::Engine as _;
+    use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+    use http::StatusCode;
+    use http_body_util::BodyExt;
+    use jsonwebtoken::Algorithm;
+    use jsonwebtoken::EncodingKey;
+    use jsonwebtoken::encode;
+    use jsonwebtoken::get_current_timestamp;
+    use p256::ecdsa::SigningKey;
+    use p256::elliptic_curve::Generate;
+    use p256::pkcs8::EncodePrivateKey;
+    use rand::rngs::SysRng;
+    use tower::ServiceExt;
+
+    use super::JWT_CONTEXT_KEY;
+    use super::JWTConf;
+    use super::JwtStatus;
+    use super::build_a_test_harness;
+    use super::common::jwk;
+    use super::make_manager;
+    use super::parse_next_graphql_response;
+    use crate::graphql;
+    use crate::metrics::FutureMetricsExt as _;
+    use crate::plugins::authentication::Source;
+    use crate::plugins::authentication::authenticate;
+    use crate::plugins::authentication::default_header_name;
+    use crate::plugins::authentication::default_header_value_prefix;
+    use crate::services::router;
+    use crate::services::supergraph;
+
+    /// The message every JWT failure collapses to when redaction is on.
+    const REDACTED: &str = "Authentication failed";
+
+    /// A structurally valid JWT whose signature segment is not valid base64, so it fails in
+    /// `jsonwebtoken::decode` with `Base64 error: Invalid last symbol 66, offset 42.`. Same token
+    /// as `it_rejects_when_auth_prefix_has_correct_format_and_invalid_jwt`.
+    const UNDECODABLE_JWT: &str = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6ImtleTEifQ.eyJleHAiOjEwMDAwMDAwMDAwLCJhbm90aGVyIGNsYWltIjoidGhpcyBpcyBhbm90aGVyIGNsYWltIn0.4GrmfxuUST96cs0YUC0DfLAG218m7vn8fO_ENfXnu5B";
+
+    /// A JWT whose header declares the unsigned `none` algorithm. Deserializing that header fails
+    /// with a serde message enumerating every algorithm the router supports — the third
+    /// disclosure example in the report.
+    fn jwt_with_alg_none() -> String {
+        let header = BASE64_URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+        format!("Bearer {header}.e30.")
+    }
+
+    /// A well-formed token signed by `signing_key` whose final signature byte has been altered,
+    /// as a tampered token would be. Signature verification fails inside `jsonwebtoken::decode`.
+    fn tampered_token(signing_key: &SigningKey) -> String {
+        let token = encode(
+            &jsonwebtoken::Header::new(Algorithm::ES256),
+            &serde_json::json!({ "sub": "test", "exp": get_current_timestamp() + 60 }),
+            &EncodingKey::from_ec_der(&signing_key.to_pkcs8_der().unwrap().to_bytes()),
+        )
+        .unwrap();
+
+        let (head, last) = token.split_at(token.len() - 1);
+        let flipped = if last == "A" { "B" } else { "A" };
+        format!("Bearer {head}{flipped}")
+    }
+
+    fn request_with_authorization(authorization: &str) -> router::Request {
+        supergraph::Request::canned_builder()
+            .header(http::header::AUTHORIZATION, authorization)
+            .build()
+            .unwrap()
+            .try_into()
+            .unwrap()
+    }
+
+    /// A `JWTConf` with the default header source, deserialized from JSON so that the `on_error`
+    /// value is exercised the same way a user's `router.yaml` would be.
+    fn jwt_conf(on_error: Option<&str>) -> JWTConf {
+        let mut json = serde_json::json!({ "jwks": [] });
+        if let Some(on_error) = on_error {
+            json["on_error"] = serde_json::Value::String(on_error.to_string());
+        }
+
+        let mut config: JWTConf =
+            serde_json::from_value(json).expect("`on_error` value is accepted");
+        config.sources.push(Source::Header {
+            name: default_header_name(),
+            value_prefix: default_header_value_prefix(),
+        });
+        config
+    }
+
+    async fn send_with_authorization(
+        on_error: Option<&str>,
+        authorization: &str,
+    ) -> (router::Response, graphql::Response) {
+        let (test_harness, handle) = build_a_test_harness(None, None, false, false, on_error).await;
+
+        let request = supergraph::Request::canned_builder()
+            .header(http::header::AUTHORIZATION, authorization)
+            .build()
+            .unwrap();
+
+        let mut service_response = test_harness
+            .oneshot(request.try_into().unwrap())
+            .await
+            .unwrap();
+        let response = parse_next_graphql_response(&mut service_response).await;
+
+        crate::plugin::test::assert_no_mock_calls(handle).await;
+        (service_response, response)
+    }
+
+    /// Assert the response carries exactly one generic `AUTH_ERROR`, and that none of
+    /// `forbidden` appears anywhere in it.
+    fn assert_redacted(response: &graphql::Response, forbidden: &[&str]) {
+        let expected_error = graphql::Error::builder()
+            .message(REDACTED)
+            .extension_code("AUTH_ERROR")
+            .build();
+
+        crate::assert_errors_eq_ignoring_id!(response.errors, [expected_error]);
+
+        let serialized = serde_json::to_string(response).expect("response serializes");
+        for leaked in forbidden {
+            assert!(
+                !serialized.contains(leaked),
+                "response should not disclose {leaked:?}, but was: {serialized}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn it_redacts_jwt_decoding_errors() {
+        let (service_response, response) =
+            send_with_authorization(Some("RedactedError"), UNDECODABLE_JWT).await;
+
+        assert_redacted(&response, &["Base64", "offset", "Cannot decode JWT"]);
+        assert_eq!(StatusCode::UNAUTHORIZED, service_response.response.status());
+    }
+
+    #[tokio::test]
+    async fn it_redacts_jwt_header_errors_including_supported_algorithms() {
+        let (service_response, response) =
+            send_with_authorization(Some("RedactedError"), &jwt_with_alg_none()).await;
+
+        assert_redacted(
+            &response,
+            &[
+                "HS256",
+                "EdDSA",
+                "unknown variant",
+                super::HEADER_TOKEN_TRUNCATED,
+            ],
+        );
+        assert_eq!(StatusCode::BAD_REQUEST, service_response.response.status());
+    }
+
+    #[tokio::test]
+    async fn it_redacts_header_prefix_errors() {
+        // Prefix problems are redacted too: redaction is all-or-nothing, so there is no
+        // per-message judgement about which strings are safe to disclose.
+        let (service_response, response) =
+            send_with_authorization(Some("RedactedError"), "invalid").await;
+
+        assert_redacted(&response, &["Bearer", "prefixed"]);
+        assert_eq!(StatusCode::BAD_REQUEST, service_response.response.status());
+    }
+
+    #[tokio::test]
+    async fn it_redacts_audience_mismatch_without_echoing_configured_audiences() {
+        let signing_key = SigningKey::try_generate_from_rng(&mut SysRng).unwrap();
+        let manager = make_manager(
+            &jwk(&signing_key),
+            None,
+            Some(HashSet::from(["hello".to_string(), "goodbye".to_string()])),
+        );
+
+        let request = super::common::build_request_with_header_token(
+            signing_key,
+            serde_json::json!({
+                "sub": "test",
+                "exp": get_current_timestamp(),
+                "aud": "AAAA",
+            }),
+        );
+
+        match authenticate(&jwt_conf(Some("RedactedError")), &manager, request) {
+            ControlFlow::Break(res) => {
+                assert_eq!(res.response.status(), StatusCode::UNAUTHORIZED);
+                let body = res.response.into_body().collect().await.unwrap();
+                let response: graphql::Response = serde_json::from_slice(&body.to_bytes()).unwrap();
+                assert_redacted(&response, &["hello", "goodbye", "aud", "AAAA"]);
+            }
+            ControlFlow::Continue(_) => panic!("audience check should have failed"),
+        }
+    }
+
+    #[tokio::test]
+    async fn it_keeps_full_error_detail_in_the_context_when_redacting() {
+        let (test_harness, handle) =
+            build_a_test_harness(None, None, false, false, Some("RedactedError")).await;
+
+        let request = supergraph::Request::canned_builder()
+            .header(http::header::AUTHORIZATION, UNDECODABLE_JWT)
+            .build()
+            .unwrap();
+
+        let mut service_response = test_harness
+            .oneshot(request.try_into().unwrap())
+            .await
+            .unwrap();
+
+        // The client sees a generic message...
+        let jwt_context = service_response
+            .context
+            .get::<_, JwtStatus>(JWT_CONTEXT_KEY)
+            .expect("deserialization succeeds")
+            .expect("a context value was set");
+
+        // ...but the operator still has the code, reason and full message in the context, which
+        // is what telemetry selectors, rhai and coprocessors read.
+        match jwt_context.error() {
+            Some(err) => {
+                assert_eq!(err.code, "CANNOT_DECODE_JWT");
+                assert_eq!(err.reason.as_deref(), Some("BASE64_ERROR"));
+                assert_eq!(
+                    err.message,
+                    "Cannot decode JWT: Base64 error: Invalid last symbol 66, offset 42."
+                );
+            }
+            None => panic!("expected an error"),
+        }
+
+        let response = parse_next_graphql_response(&mut service_response).await;
+        assert_redacted(&response, &["Base64", "offset"]);
+        assert_eq!(StatusCode::UNAUTHORIZED, service_response.response.status());
+
+        crate::plugin::test::assert_no_mock_calls(handle).await;
+    }
+
+    #[tokio::test]
+    async fn it_does_not_redact_by_default() {
+        // Redaction is opt-in: omitting `on_error` must keep today's detailed messages.
+        let (service_response, response) = send_with_authorization(None, UNDECODABLE_JWT).await;
+
+        let expected_error = graphql::Error::builder()
+            .message("Cannot decode JWT: Base64 error: Invalid last symbol 66, offset 42.")
+            .extension_code("AUTH_ERROR")
+            .build();
+
+        crate::assert_errors_eq_ignoring_id!(response.errors, [expected_error]);
+        assert_eq!(StatusCode::UNAUTHORIZED, service_response.response.status());
+    }
+
+    // The metric assertions below drive `authenticate` directly rather than going through
+    // `build_a_test_harness`: the router pipeline moves the request onto another task, which is
+    // outside the task-local meter provider that `with_metrics` installs.
+
+    #[tokio::test]
+    async fn it_records_the_failure_code_on_the_jwt_metric() {
+        async {
+            let signing_key = SigningKey::try_generate_from_rng(&mut SysRng).unwrap();
+            let manager = make_manager(&jwk(&signing_key), None, None);
+            let request = request_with_authorization(&tampered_token(&signing_key));
+
+            match authenticate(&jwt_conf(Some("RedactedError")), &manager, request) {
+                ControlFlow::Break(_) => {}
+                ControlFlow::Continue(_) => panic!("a tampered signature should be rejected"),
+            }
+
+            // With the message redacted, this attribute is how an operator sees *why*
+            // authentication failed.
+            assert_counter!(
+                "apollo.router.operations.authentication.jwt",
+                1,
+                authentication.jwt.failed = true,
+                authentication.jwt.failure_code = "CANNOT_DECODE_JWT"
+            );
+        }
+        .with_metrics()
+        .await;
+    }
+
+    #[tokio::test]
+    async fn it_records_no_failure_code_on_success() {
+        async {
+            let signing_key = SigningKey::try_generate_from_rng(&mut SysRng).unwrap();
+            let manager = make_manager(&jwk(&signing_key), None, None);
+            let request = super::common::build_request_with_header_token(
+                signing_key,
+                serde_json::json!({ "sub": "test", "exp": get_current_timestamp() + 60 }),
+            );
+
+            match authenticate(&jwt_conf(None), &manager, request) {
+                ControlFlow::Continue(_) => {}
+                ControlFlow::Break(response) => panic!("a valid token should pass: {response:?}"),
+            }
+
+            assert_counter!(
+                "apollo.router.operations.authentication.jwt",
+                1,
+                authentication.jwt.failed = false
+            );
+        }
+        .with_metrics()
+        .await;
     }
 }

--- a/docs/source/routing/security/jwt.mdx
+++ b/docs/source/routing/security/jwt.mdx
@@ -166,12 +166,13 @@ The default value is `Bearer`.
 </td>
 <td>
 
-This setting controls the behavior of the router when an error occurs during JWT validation. Possible values are `Error` (default) and `Continue`.
+This setting controls the behavior of the router when an error occurs during JWT validation. Possible values are `Error` (default), `RedactedError`, and `Continue`.
 
-- `Error`: The router responds with an error when an error occurs during JWT validation.
+- `Error`: The router responds with an error when an error occurs during JWT validation. The error message describes the validation failure—for example, that the token's signature couldn't be decoded, or that its `aud` claim doesn't match the audiences you configured.
+- `RedactedError`: The router rejects the request the same way as `Error`, but every validation failure returns the same generic `Authentication failed` message with the `AUTH_ERROR` extension code. Use this value on routers reachable from the public internet, where the detailed messages would disclose which signing algorithms the router accepts and which issuers and audiences it's configured with. The details of the failure remain available to you in the request context and in telemetry, as described below.
 - `Continue`: The router continues processing the request when an error occurs during JWT validation. Requests with invalid JWTs will be treated as unauthenticated.
 
-Regardless of whether JWT authentication succeeds, the status of JWT processing is inserted into the request context (`apollo::authentication::jwt_status`). This status is informational and may be used for logging or debugging purposes.
+Regardless of whether JWT authentication succeeds, the status of JWT processing is inserted into the request context (`apollo::authentication::jwt_status`). This status is informational and may be used for logging or debugging purposes. The context value always carries the full details of the failure, including when `on_error` is `RedactedError`, so you can log the reason a request was rejected without returning it to the client.
 
 ```js
 // On failure
@@ -262,7 +263,7 @@ After the GraphOS Router validates a client request's JWT, it adds that token's 
 
 > - If no JWT is present for a client request, this context value is the empty tuple, `()`.
 > - If a JWT _is_ present but validation of the JWT fails,
->     - When `on_error` is set to `Error`, the router _rejects_ the request.
+>     - When `on_error` is set to `Error` or `RedactedError`, the router _rejects_ the request.
 >     - When `on_error` is set to `Continue`, the router _continues_ processing the request, and the context value is the empty tuple, `()`.
 
 If unauthenticated requests should be rejected, the router can be configured like this:
@@ -805,6 +806,8 @@ If you _do_ need to pass entire JWTs to subgraphs, you can do so via the GraphOS
 If your router enables [tracing](/router/configuration/telemetry/exporters/tracing/overview), the JWT authentication plugin has its own tracing span: `authentication_plugin`
 
 If your router [exports metrics](/graphos/routing/observability/telemetry/metrics-exporters/overview), the JWT authentication plugin exports the `apollo.router.operations.authentication.jwt` metric. You can use the metric's `authentication.jwt.failed` attribute to count failed authentications. If the `authentication.jwt.failed` attribute is absent or `false`, the authentication succeeded.
+
+Failed authentications also carry an `authentication.jwt.failure_code` attribute holding a machine-readable code for the failure, such as `CANNOT_DECODE_JWT`, `INVALID_AUDIENCE`, or `CANNOT_FIND_KID`. Use this attribute to break down why authentications fail—particularly when [`on_error`](#on_error) is `RedactedError` and the reason isn't in the response.
 
 ## Additional resources
 


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-2043] -->

## What

- Adds a third value to `authentication.router.jwt.on_error`: `RedactedError`. It rejects failed requests with the same status codes as `Error`, but replaces the message with a generic `Authentication failed`, keeping the `AUTH_ERROR` extension code.
- Failures on `apollo.router.operations.authentication.jwt` now carry an `authentication.jwt.failure_code` attribute (bounded at the 13 existing error codes, e.g. `CANNOT_DECODE_JWT`, `INVALID_AUDIENCE`). The success path emits `authentication.jwt.failed = false` with no code attribute.
- The `apollo.router.config.authentication.jwt` gauge gains an `opt.on_error` attribute reporting the configured value, so adoption of the new mode is queryable.
- Records two `TODO`s on `OnError` for the next major version — rename the values to snake_case (needs a config migration, so it can't ride a patch release) and make `RedactedError` the default.

## Motivation

The client-facing error is `AuthenticationError::to_string()`, which interpolates `jsonwebtoken`'s own error text and the router's configured JWKS values. An unauthenticated caller sending a malformed or tampered token receives, verbatim:

- `Cannot decode JWT: Base64 error: Invalid last symbol 66, offset 42.`
- ``'(truncated)' is not a valid JWT header: JSON error: unknown variant `none`, expected one of `HS256`, `HS384`, ... `EdDSA` at line 1 column 13`` — the full list of accepted signing algorithms
- ``Invalid audience: the token's `aud` was 'X', but 'Y' was expected`` — the configured audiences
- ``Invalid issuer: the token's `iss` was 'X', but signed with a key from JWKS configured to only accept from 'Y'`` — the configured issuers

None of this is actionable for a client, and it gives an attacker a probing oracle for the authentication setup.

`RedactedError` suppresses it from the response while keeping the full detail available to operators: the `apollo::authentication::jwt_status` context value is unchanged (readable from telemetry selectors, Rhai, and coprocessors), and the failure code is now on the metric.

The default remains `Error`, so nothing changes for existing deployments unless the option is set.

## Verified

- `cargo fmt --all --check -- --config "imports_granularity=Item,group_imports=StdExternalCrate"` passed
- `cargo clippy -- -D warnings` passed
- CHANGELOG.md not modified
- Changeset title contains no conventional-commit prefix
- `cargo test -p apollo-router --lib plugins::authentication` — 106 passed
- `cargo test -p apollo-router --lib configuration` — 204 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ROUTER-2043]: https://apollographql.atlassian.net/browse/ROUTER-2043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ