### PR TITLE
Update multipart protocol documentation

### DIFF
--- a/docs/source/routing/operations/subscriptions/multipart-protocol.mdx
+++ b/docs/source/routing/operations/subscriptions/multipart-protocol.mdx
@@ -12,7 +12,7 @@ Use this reference if you're adding protocol support to a new GraphQL client lib
 
 To execute a subscription on the GraphOS Router, a GraphQL client sends an HTTP request with _almost_ the exact same format that it uses for query and mutation requests.
 
-Clients signal that they can accept multipart subscription by including `multipart/mixed;subscriptionSpec=1.0` in the `Accept` header:
+Clients signal that they can accept multipart subscriptions by including `multipart/mixed;subscriptionSpec=1.0` in the `Accept` header:
 
 ```text title="Example header"
 Accept: multipart/mixed;subscriptionSpec=1.0, application/json

--- a/docs/source/routing/operations/subscriptions/multipart-protocol.mdx
+++ b/docs/source/routing/operations/subscriptions/multipart-protocol.mdx
@@ -12,15 +12,15 @@ Use this reference if you're adding protocol support to a new GraphQL client lib
 
 To execute a subscription on the GraphOS Router, a GraphQL client sends an HTTP request with _almost_ the exact same format that it uses for query and mutation requests.
 
-The only difference is that the request should include the following `Accept` header:
+Clients signal that they can accept multipart subscription by including `multipart/mixed;subscriptionSpec=1.0` in the `Accept` header:
 
 ```text title="Example header"
-Accept: multipart/mixed;subscriptionSpec="1.0", application/json
+Accept: multipart/mixed;subscriptionSpec=1.0, application/json
 ```
 
 <Tip>
 
-The value for `boundary` should _always_ be `graphql`, and the value for `subscriptionSpec` should _always_ be `1.0`.
+The server decides the multipart boundary. Servers may use `graphql` for consistency but this is not required.
 
 </Tip>
 


### PR DESCRIPTION
Clarify the Accept header format for multipart subscriptions and update boundary specification.

See https://github.com/apollographql/apollo-client/pull/13387 and https://github.com/apollographql/router/pull/4395
