### PR TITLE
Revert "fix(ci): reduce Windows CARGO_BUILD_JOBS to 2 to prevent OOM"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ executors:
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows
-      CARGO_BUILD_JOBS: 2
+      CARGO_BUILD_JOBS: 4
   windows_test: &windows_test_executor
     machine:
       image: "windows-server-2019-vs2019:2024.02.21"
@@ -94,7 +94,7 @@ executors:
     shell: bash.exe --login -eo pipefail
     environment:
       MISE_ENV: ci,windows
-      CARGO_BUILD_JOBS: 2
+      CARGO_BUILD_JOBS: 4
 
 # We don't use {{ arch }} because on windows it is unstable https://discuss.circleci.com/t/value-of-arch-unstable-on-windows/40079
 parameters:


### PR DESCRIPTION
Reverts apollographql/router#9664

In https://github.com/apollographql/router/pull/9821 we bumped the machine class from medium to xlarge as builds were too slow, so these should be increased too. It has 64GB ram so OOMs should not be an issue.