### PR TITLE
perf(composition): index upgrader types without cloning subgraph metadata

### DIFF
--- a/.changesets/perf_schema_upgrader_type_index.md
+++ b/.changesets/perf_schema_upgrader_type_index.md
@@ -1,9 +1,0 @@
-### Upgrading federation 1 subgraphs no longer clones subgraph metadata once per type ([PR #9946](https://github.com/apollographql/router/pull/9946))
-
-Composition constructs a schema upgrader as soon as **one** input subgraph is a federation 1 schema. The upgrader indexes the object and interface types of every subgraph in the composition — including the federation 2 subgraphs it will never upgrade, because the upgrade rules have to look at what those subgraphs define — and each index entry carried a full clone of the defining subgraph's `SubgraphMetadata`. The index therefore cost the sum, over all subgraphs, of (that subgraph's type count) × (that subgraph's own metadata size), and the great majority of it was spent on behalf of subgraphs that are passed through untouched.
-
-The index now records only where each type is defined. The schema and the metadata a lookup needs are read from the subgraph the entry names, which the upgrader already holds, so exactly one metadata value exists per subgraph instead of one per (type, subgraph) pair. Composition output is unchanged.
-
-On a generated fixture of 40 federation 2 subgraphs, each declaring 120 entity types and 12 interfaces, beside a single 120-byte federation 1 subgraph, peak requested-live heap across composition drops from 1.35 GB to 0.14 GB — a 9.3× reduction. Composing those same 40 federation 2 subgraphs on their own — no federation 1 subgraph, so no upgrader is built — peaks at 0.14 GB, which is the measure of what the one small subgraph used to cost: it added 1.21 GB of peak heap before this change, and adds 0.15 MB after it. The effect grows with the size and number of the federation 2 subgraphs, since they are what the index was being built over.
-
-By [@martijnwalraven](https://github.com/martijnwalraven) in <https://github.com/apollographql/router/pull/9946>

--- a/.changesets/perf_schema_upgrader_type_index.md
+++ b/.changesets/perf_schema_upgrader_type_index.md
@@ -1,4 +1,4 @@
-### Upgrading federation 1 subgraphs no longer clones subgraph metadata once per type ([PR #PR_NUMBER](https://github.com/apollographql/router/pull/PR_NUMBER))
+### Upgrading federation 1 subgraphs no longer clones subgraph metadata once per type ([PR #9946](https://github.com/apollographql/router/pull/9946))
 
 Composition constructs a schema upgrader as soon as **one** input subgraph is a federation 1 schema. The upgrader indexes the object and interface types of every subgraph in the composition — including the federation 2 subgraphs it will never upgrade, because the upgrade rules have to look at what those subgraphs define — and each index entry carried a full clone of the defining subgraph's `SubgraphMetadata`. The index therefore cost the sum, over all subgraphs, of (that subgraph's type count) × (that subgraph's own metadata size), and the great majority of it was spent on behalf of subgraphs that are passed through untouched.
 
@@ -6,4 +6,4 @@ The index now records only where each type is defined. The schema and the metada
 
 On a generated fixture of 40 federation 2 subgraphs, each declaring 120 entity types and 12 interfaces, beside a single 120-byte federation 1 subgraph, peak requested-live heap across composition drops from 1.35 GB to 0.14 GB — a 9.3× reduction. Composing those same 40 federation 2 subgraphs on their own — no federation 1 subgraph, so no upgrader is built — peaks at 0.14 GB, which is the measure of what the one small subgraph used to cost: it added 1.21 GB of peak heap before this change, and adds 0.15 MB after it. The effect grows with the size and number of the federation 2 subgraphs, since they are what the index was being built over.
 
-By [@martijnwalraven](https://github.com/martijnwalraven) in <https://github.com/apollographql/router/pull/PR_NUMBER>
+By [@martijnwalraven](https://github.com/martijnwalraven) in <https://github.com/apollographql/router/pull/9946>

--- a/.changesets/perf_schema_upgrader_type_index.md
+++ b/.changesets/perf_schema_upgrader_type_index.md
@@ -1,0 +1,9 @@
+### Upgrading federation 1 subgraphs no longer clones subgraph metadata once per type ([PR #PR_NUMBER](https://github.com/apollographql/router/pull/PR_NUMBER))
+
+Composition constructs a schema upgrader as soon as **one** input subgraph is a federation 1 schema. The upgrader indexes the object and interface types of every subgraph in the composition — including the federation 2 subgraphs it will never upgrade, because the upgrade rules have to look at what those subgraphs define — and each index entry carried a full clone of the defining subgraph's `SubgraphMetadata`. The index therefore cost the sum, over all subgraphs, of (that subgraph's type count) × (that subgraph's own metadata size), and the great majority of it was spent on behalf of subgraphs that are passed through untouched.
+
+The index now records only where each type is defined. The schema and the metadata a lookup needs are read from the subgraph the entry names, which the upgrader already holds, so exactly one metadata value exists per subgraph instead of one per (type, subgraph) pair. Composition output is unchanged.
+
+On a generated fixture of 40 federation 2 subgraphs, each declaring 120 entity types and 12 interfaces, beside a single 120-byte federation 1 subgraph, peak requested-live heap across composition drops from 1.35 GB to 0.14 GB — a 9.3× reduction. Composing those same 40 federation 2 subgraphs on their own — no federation 1 subgraph, so no upgrader is built — peaks at 0.14 GB, which is the measure of what the one small subgraph used to cost: it added 1.21 GB of peak heap before this change, and adds 0.15 MB after it. The effect grows with the size and number of the federation 2 subgraphs, since they are what the index was being built over.
+
+By [@martijnwalraven](https://github.com/martijnwalraven) in <https://github.com/apollographql/router/pull/PR_NUMBER>

--- a/apollo-federation/CHANGELOG.md
+++ b/apollo-federation/CHANGELOG.md
@@ -22,6 +22,34 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🐛 Fixes
 
+### Upgrading federation 1 subgraphs no longer clones subgraph metadata once per type ([PR #9946](https://github.com/apollographql/router/pull/9946))
+
+Composition constructs a schema upgrader as soon as **one** input subgraph is a
+federation 1 schema. The upgrader indexes the object and interface types of every
+subgraph in the composition — including the federation 2 subgraphs it will never
+upgrade, because the upgrade rules have to look at what those subgraphs define —
+and each index entry carried a full clone of the defining subgraph's
+`SubgraphMetadata`. The index therefore cost the sum, over all subgraphs, of (that
+subgraph's type count) × (that subgraph's own metadata size), and the great majority
+of it was spent on behalf of subgraphs that are passed through untouched.
+
+The index now records only where each type is defined. The schema and the metadata a
+lookup needs are read from the subgraph the entry names, which the upgrader already
+holds, so exactly one metadata value exists per subgraph instead of one per (type,
+subgraph) pair. Composition output is unchanged.
+
+On a generated fixture of 40 federation 2 subgraphs, each declaring 120 entity types
+and 12 interfaces, beside a single 120-byte federation 1 subgraph, peak
+requested-live heap across composition drops from 1.35 GB to 0.14 GB — a 9.3×
+reduction. Composing those same 40 federation 2 subgraphs on their own — no
+federation 1 subgraph, so no upgrader is built — peaks at 0.14 GB, which is the
+measure of what the one small subgraph used to cost: it added 1.21 GB of peak heap
+before this change, and adds 0.15 MB after it. The effect grows with the size and
+number of the federation 2 subgraphs, since they are what the index was being built
+over.
+
+By [@martijnwalraven](https://github.com/martijnwalraven) in <https://github.com/apollographql/router/pull/9946>
+
 ### Reject `@external` fields on nested `@key` paths with cross-subgraph `@requires` ([PR #9832](https://github.com/apollographql/router/pull/9832))
 
 When a subgraph declared a nested `@key` (e.g., `@key(fields: "id u { x }")`) where

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -28,6 +28,7 @@ use crate::error::CompositionError;
 use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
+use crate::internal_error;
 use crate::schema::SchemaElement;
 use crate::schema::SubgraphMetadata;
 use crate::schema::field_set::FieldSetValidation;
@@ -759,8 +760,14 @@ impl SchemaUpgrader {
                     let Some(entries) = self.object_type_map.get(obj_name) else {
                         continue;
                     };
-                    let type_in_other_subgraphs = entries.iter().any(|(subgraph_name, _)| {
-                        let other_subgraph = self.get_subgraph_by_name(subgraph_name).unwrap();
+                    let mut type_in_other_subgraphs = false;
+                    for (subgraph_name, _) in entries.iter() {
+                        let other_subgraph =
+                            self.get_subgraph_by_name(subgraph_name).ok_or_else(|| {
+                                internal_error!(
+                                    "Type index names subgraph \"{subgraph_name}\", which the upgrader does not hold"
+                                )
+                            })?;
                         let field_exists = other_subgraph
                             .schema()
                             .schema()
@@ -773,10 +780,10 @@ impl SchemaUpgrader {
                             && (!other_metadata.is_field_external(&obj_field)
                                 || other_metadata.is_field_partially_external(&obj_field))
                         {
-                            return true;
+                            type_in_other_subgraphs = true;
+                            break;
                         }
-                        false
-                    });
+                    }
                     if type_in_other_subgraphs
                         && !obj_field.has_applied_directive(schema, &shareable_directive_name)
                     {

--- a/apollo-federation/src/schema/schema_upgrader.rs
+++ b/apollo-federation/src/schema/schema_upgrader.rs
@@ -45,13 +45,12 @@ use crate::utils::human_readable::human_readable_subgraph_names;
 #[derive(Debug)]
 pub(crate) struct SchemaUpgrader {
     subgraphs: HashMap<String, Subgraph<Expanded>>,
-    object_type_map: HashMap<Name, HashMap<String, TypeInfo>>,
-}
-
-#[derive(Clone, Debug)]
-struct TypeInfo {
-    pos: TypeDefinitionPosition,
-    metadata: SubgraphMetadata,
+    /// For each object or interface type name, the subgraphs that define it and
+    /// the position it is defined at there. This is an index into `subgraphs`:
+    /// everything else a lookup needs — the defining subgraph's schema and its
+    /// [`SubgraphMetadata`] — is read from `subgraphs` under the same name, so
+    /// no per-entry copy of either is kept here.
+    object_type_map: HashMap<Name, HashMap<String, TypeDefinitionPosition>>,
 }
 
 #[derive(Debug)]
@@ -81,7 +80,8 @@ pub(crate) struct UpgradeResult {
 
 impl SchemaUpgrader {
     pub(crate) fn new(subgraphs: &[Subgraph<Expanded>]) -> Self {
-        let mut object_type_map: HashMap<Name, HashMap<String, TypeInfo>> = Default::default();
+        let mut object_type_map: HashMap<Name, HashMap<String, TypeDefinitionPosition>> =
+            Default::default();
         for subgraph in subgraphs.iter() {
             for pos in subgraph.schema().get_types() {
                 if matches!(
@@ -91,13 +91,7 @@ impl SchemaUpgrader {
                     object_type_map
                         .entry(pos.type_name().clone())
                         .or_default()
-                        .insert(
-                            subgraph.name.clone(),
-                            TypeInfo {
-                                pos: pos.clone(),
-                                metadata: subgraph.metadata().clone(), // TODO: Prefer not to clone
-                            },
-                        );
+                        .insert(subgraph.name.clone(), pos.clone());
                 }
             }
         }
@@ -242,12 +236,11 @@ impl SchemaUpgrader {
                             // Fixed: dereference the string for comparison
                             subgraph_name.as_str() != subgraph.name.as_str()
                         })
-                        .fallible_any(|(other_name, type_info)| {
+                        .fallible_any(|(other_name, other_pos)| {
                             let Some(other_subgraph) = self.get_subgraph_by_name(other_name) else {
                                 return Ok(false);
                             };
-                            let extended_type =
-                                type_info.pos.get(other_subgraph.schema().schema())?;
+                            let extended_type = other_pos.get(other_subgraph.schema().schema())?;
                             // TODO this logic only checks for the explicit `extend type` definitions and ignores
                             //   extensions defined using federation @extends directive. Since fixing it would be
                             //   a breaking change that could affect some customers, we are keeping current behavior
@@ -466,17 +459,17 @@ impl SchemaUpgrader {
                 let Some(entries) = self.object_type_map.get(ty.type_name()) else {
                     continue;
                 };
-                for (subgraph_name, info) in entries.iter() {
+                for (subgraph_name, other_pos) in entries.iter() {
                     if subgraph_name == upgrade_metadata.subgraph_name.as_str() {
                         continue;
                     }
                     let Some(other_schema) = self.get_subgraph_by_name(subgraph_name) else {
                         continue;
                     };
-                    let keys_in_other = info.pos.get_applied_directives(
+                    let keys_in_other = other_pos.get_applied_directives(
                         other_schema.schema(),
-                        &info
-                            .metadata
+                        &other_schema
+                            .metadata()
                             .federation_spec_definition()
                             .key_directive_definition(other_schema.schema())?
                             .name,
@@ -495,7 +488,7 @@ impl SchemaUpgrader {
                         args.fields,
                         false,
                     )? {
-                        if TypeDefinitionPosition::from(field.parent()) != info.pos {
+                        if TypeDefinitionPosition::from(field.parent()) != *other_pos {
                             continue;
                         }
                         let external =
@@ -766,19 +759,19 @@ impl SchemaUpgrader {
                     let Some(entries) = self.object_type_map.get(obj_name) else {
                         continue;
                     };
-                    let type_in_other_subgraphs = entries.iter().any(|(subgraph_name, info)| {
-                        let field_exists = self
-                            .get_subgraph_by_name(subgraph_name)
-                            .unwrap()
+                    let type_in_other_subgraphs = entries.iter().any(|(subgraph_name, _)| {
+                        let other_subgraph = self.get_subgraph_by_name(subgraph_name).unwrap();
+                        let field_exists = other_subgraph
                             .schema()
                             .schema()
                             .type_field(&field.type_name, &field.field_name)
                             .is_ok();
+                        let other_metadata = other_subgraph.metadata();
 
                         if (subgraph_name != upgrade_metadata.subgraph_name.as_str())
                             && field_exists
-                            && (!info.metadata.is_field_external(&obj_field)
-                                || info.metadata.is_field_partially_external(&obj_field))
+                            && (!other_metadata.is_field_external(&obj_field)
+                                || other_metadata.is_field_partially_external(&obj_field))
                         {
                             return true;
                         }
@@ -794,7 +787,7 @@ impl SchemaUpgrader {
                 let Some(entries) = self.object_type_map.get(obj_name) else {
                     continue;
                 };
-                let type_in_other_subgraphs = entries.iter().any(|(subgraph_name, _info)| {
+                let type_in_other_subgraphs = entries.iter().any(|(subgraph_name, _)| {
                     if subgraph_name != upgrade_metadata.subgraph_name.as_str() {
                         return true;
                     }
@@ -2767,6 +2760,110 @@ scalar _FieldSet
             result.is_ok(),
             "Expected upgrade to succeed but got: {:?}",
             result.err()
+        );
+    }
+
+    /// Two subgraphs that both define `T`, one federation 1 and one federation 2.
+    fn mixed_federation_version_subgraphs() -> Vec<Subgraph<Expanded>> {
+        let fed1 = Subgraph::parse(
+            "fed1",
+            "",
+            r#"
+            type Query {
+                t1: T
+            }
+
+            type T @key(fields: "id") {
+                id: String
+                x: Int
+            }
+        "#,
+        )
+        .expect("parses schema")
+        .expand_links()
+        .expect("expands schema");
+
+        let fed2 = Subgraph::parse(
+            "fed2",
+            "",
+            r#"
+            extend schema
+                @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])
+
+            type Query {
+                t2: T
+            }
+
+            type T @key(fields: "id") {
+                id: String
+                x: Int
+            }
+        "#,
+        )
+        .expect("parses schema")
+        .expand_links()
+        .expect("expands schema");
+
+        vec![fed1, fed2]
+    }
+
+    #[test]
+    fn object_type_map_indexes_every_subgraph_that_defines_a_type() {
+        let subgraphs = mixed_federation_version_subgraphs();
+        let upgrader = SchemaUpgrader::new(&subgraphs);
+
+        // The index covers every subgraph that defines the type, including the
+        // federation 2 one that will never be upgraded — the upgrade rules read
+        // it to decide what the subgraph under upgrade has to declare.
+        let defining_subgraphs: Vec<&str> = upgrader
+            .object_type_map
+            .iter()
+            .filter(|(type_name, _)| type_name.as_str() == "T")
+            .flat_map(|(_, per_subgraph)| per_subgraph.keys().map(|name| name.as_str()))
+            .sorted()
+            .collect();
+        assert_eq!(defining_subgraphs, ["fed1", "fed2"]);
+
+        // Each entry is only an index into `subgraphs`: it names a subgraph the
+        // upgrader holds and a position that resolves in that subgraph's schema,
+        // which is where a lookup reads the schema and the metadata it needs.
+        for (type_name, per_subgraph) in &upgrader.object_type_map {
+            for (subgraph_name, pos) in per_subgraph {
+                assert_eq!(pos.type_name(), type_name);
+                let subgraph = upgrader
+                    .get_subgraph_by_name(subgraph_name)
+                    .unwrap_or_else(|| panic!("{subgraph_name} is indexed but not held"));
+                assert!(
+                    pos.get(subgraph.schema().schema()).is_ok(),
+                    "{type_name} is indexed in {subgraph_name} but does not resolve there"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn adds_shareable_for_a_type_also_resolved_by_a_federation_2_subgraph() {
+        // `T.x` in the federation 1 subgraph has to become @shareable because the
+        // federation 2 subgraph resolves it too, even though that subgraph is
+        // itself never upgraded.
+        let [fed1, fed2]: [Subgraph<_>; 2] =
+            upgrade_subgraphs_if_necessary(mixed_federation_version_subgraphs())
+                .expect("upgrades schema")
+                .try_into()
+                .expect("Expected 2 elements");
+
+        assert!(
+            fed1.schema()
+                .schema()
+                .type_field("T", "x")
+                .is_ok_and(|f| f.directives.has("shareable"))
+        );
+        // The federation 2 subgraph is passed through untouched.
+        assert!(
+            fed2.schema()
+                .schema()
+                .type_field("T", "x")
+                .is_ok_and(|f| !f.directives.has("shareable"))
         );
     }
 }


### PR DESCRIPTION

## What this changes

Composing a supergraph that contains even one federation 1 subgraph can spend **gigabytes of peak memory** in `SchemaUpgrader`'s type index. On the largest real-world composition we measured — ~100 subgraphs, ~20 MB of combined subgraph SDL, a single small federation 1 subgraph among them — composition peaked above **8 GB** of heap. With this change the same composition peaks around **0.4 GB** (~20×), and a 40-subgraph fixture shows the same shape: one 120-byte federation 1 subgraph used to add **1.21 GB** of peak, and now adds 0.15 MB. The fix is a de-duplication of the metadata the index carries — no behavior change.

`SchemaUpgrader` is built whenever **at least one** input subgraph is a federation 1 schema — not only for the subgraphs that will be upgraded. Its `object_type_map` indexes the object and interface types of **every** subgraph in the composition, and that breadth is load-bearing: the upgrade rules ask what the *other* subgraphs define, and a federation 2 subgraph sitting beside a federation 1 one is exactly such an "other". Restricting the index to the subgraphs being upgraded would change composition output.

What was not load-bearing is the copy. Each entry looked like this:

```rust
struct TypeInfo {
    pos: TypeDefinitionPosition,
    metadata: SubgraphMetadata,
}
```

and was built with `subgraph.metadata().clone()`, under a `// TODO: Prefer not to clone`. `SubgraphMetadata` is not small — seven `IndexSet`s of field positions plus the external metadata, all sized by the whole subgraph — and one was cloned per **(type, subgraph)** pair. The index therefore cost

> Σ over subgraphs of (that subgraph's object + interface type count) × (that subgraph's own metadata size)

with the great majority of it spent on subgraphs the upgrader never touches.

The upgrader already holds a `Subgraph<Expanded>` per subgraph name, and every site that read `info.metadata` had that subgraph in hand (or fetched it on the next line). So the index now stores only the position, and the lookups read `other_subgraph.metadata()` instead:

```rust
object_type_map: HashMap<Name, HashMap<String, TypeDefinitionPosition>>,
```

Exactly one `SubgraphMetadata` exists per subgraph instead of one per (type, subgraph) pair. The values a lookup sees are the same values the entries used to carry, so this is not a behaviour change.

## Measurement

A generated fixture: 40 federation 2 subgraphs, each declaring 120 entity types and 12 interfaces with `@key` and `@shareable`, plus **one** 120-byte federation 1 subgraph — the whole trigger. Peak requested-live heap across composition phases 1–5, measured with a counting global allocator, mean of three runs (GB here is 10⁹ bytes):

| composition | before | after |
|---|---|---|
| 40 federation 2 subgraphs + 1 federation 1 subgraph | 1,352,065,120 B (1.35 GB) | 144,688,043 B (0.14 GB) |
| the same 40 federation 2 subgraphs alone (no upgrader is built) | 144,534,511 B (0.14 GB) | 144,534,578 B (0.14 GB) |

Read down the first column: adding one 120-byte federation 1 subgraph to those 40 subgraphs used to add **1.21 GB** of peak heap. It now adds **0.15 MB**. Read across: **9.3×** less peak on the mixed composition, and no change at all when no federation 1 subgraph is present, which is the control — the upgrader is not constructed there, so the change cannot and does not move it.

The effect scales with the federation 2 side of the composition, since that is what the index was being built over; a composition with more or larger federation 2 subgraphs sees more.

Beyond the fixture, the change was validated against a large corpus of real production supergraph builds: compositions run before and after the change with outputs compared, and no behavioral differences observed.

## Tests

Two new unit tests in `schema_upgrader.rs`, both over a fixture of one federation 1 and one federation 2 subgraph defining the same type:

- `object_type_map_indexes_every_subgraph_that_defines_a_type` — the index covers the federation 2 subgraph that will never be upgraded, and every entry names a subgraph the upgrader holds and a position that resolves in that subgraph's schema. This is the property the lookups now depend on, and it fails on the tempting wrong version of this change (indexing only the subgraphs that will be upgraded).
- `adds_shareable_for_a_type_also_resolved_by_a_federation_2_subgraph` — the behavioural half: `T.x` in the federation 1 subgraph becomes `@shareable` because the federation 2 subgraph resolves it too. This test passes both before and after the change; it is here to pin behaviour that must not move, not to record new behaviour.

`cargo test -p apollo-federation` and `cargo nextest run -p apollo-federation` are green, as are `cargo clippy -p apollo-federation --all-targets -- -D warnings` and `cargo fmt --check`.

## Risk

The change is a de-duplication: every value a lookup now reads is the value that lookup's entry previously carried, keyed by the same subgraph name. The one assumption it makes explicit is that subgraph names are unique within a composition — which `SchemaUpgrader` already assumed, since both `subgraphs` and `object_type_map`'s inner map are keyed by name and one lookup site already `unwrap()`s the name resolution.
