### PR TITLE
Update `shape` crate from version 0.7.0 to 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6763,9 +6763,9 @@ dependencies = [
 
 [[package]]
 name = "shape"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68f64918904ec44a5574808ffa986a2a1abf14738ebfc8479eed64d2882b0b1"
+checksum = "8687837087ee58ab3479bbbf80dd7b2c119a523ddf8b439317078fb22265896f"
 dependencies = [
  "apollo-compiler",
  "indexmap 2.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6791,9 +6791,9 @@ dependencies = [
 
 [[package]]
 name = "shape"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8687837087ee58ab3479bbbf80dd7b2c119a523ddf8b439317078fb22265896f"
+checksum = "6f760e846df748dda86464a7b53022f7d91c27a04fa97913e9fd731bada8d3c3"
 dependencies = [
  "apollo-compiler",
  "indexmap 2.14.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6791,9 +6791,9 @@ dependencies = [
 
 [[package]]
 name = "shape"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68f64918904ec44a5574808ffa986a2a1abf14738ebfc8479eed64d2882b0b1"
+checksum = "8687837087ee58ab3479bbbf80dd7b2c119a523ddf8b439317078fb22265896f"
 dependencies = [
  "apollo-compiler",
  "indexmap 2.14.2",

--- a/apollo-federation/CHANGELOG.md
+++ b/apollo-federation/CHANGELOG.md
@@ -38,6 +38,32 @@ By [@tninesling](https://github.com/tninesling) in <https://github.com/apollogra
 
 ## 🐛 Fixes
 
+### Fix connector composition validation for `->toString`, `->get`, `->contains`, and `->in` with concrete array and object shapes ([PR #10118](https://github.com/apollographql/router/pull/10118))
+
+The shape checks used by several connector selection methods to identify arrays
+and objects were broken: they tested whether a closed empty container *accepted*
+the input, which was always false for non-empty containers. As a result:
+
+- `->toString` silently skipped its "cannot convert arrays or objects" guard for
+  any non-trivially-shaped object or array. Schemas that compose a
+  `someObject->toString` selection will now correctly receive a composition error
+  directing the user toward `->jsonStringify` or `->joinNotNull`.
+- `->get` fell through to the unknown/error branch for non-empty objects and
+  arrays, producing less precise shape information than intended.
+- `->contains` and `->in` did not recognize non-empty arrays as arrays, falling
+  through to an incorrect error path.
+
+All four methods now use the shape crate's `is_object()` / `is_array()` helpers,
+which correctly identify any object or array regardless of its fields or
+elements.
+
+Additionally, composition error diagnostics that reference shape types have
+updated display formatting: `List<T>` now appears as `[...T]`, `Dict<T>` as
+`{...T}`, and error shapes as `<type> (err "message")` rather than
+`Error<"message">`.
+
+By [@benjamn](https://github.com/benjamn) and [@tninesling](https://github.com/tninesling) in <https://github.com/apollographql/router/pull/10118>
+
 ### Fix `GROUP_SELECTION_IS_NOT_OBJECT` for union/interface fields in nested `@connect` selections ([PR #9990](https://github.com/apollographql/router/pull/9990))
 
 Connectors validation rejected `->match` results assigned to union- or

--- a/apollo-federation/CHANGELOG.md
+++ b/apollo-federation/CHANGELOG.md
@@ -38,7 +38,7 @@ By [@tninesling](https://github.com/tninesling) in <https://github.com/apollogra
 
 ## 🐛 Fixes
 
-### Fix connector composition validation for `->toString`, `->get`, `->contains`, and `->in` with concrete array and object shapes ([PR #10118](https://github.com/apollographql/router/pull/10118))
+### Fix connector composition validation for `->toString`, `->get`, `->contains`, and `->in` with concrete array and object shapes ([PR #9947](https://github.com/apollographql/router/pull/9947))
 
 The shape checks used by several connector selection methods to identify arrays
 and objects were broken: they tested whether a closed empty container *accepted*
@@ -62,7 +62,7 @@ updated display formatting: `List<T>` now appears as `[...T]`, `Dict<T>` as
 `{...T}`, and error shapes as `<type> (err "message")` rather than
 `Error<"message">`.
 
-By [@benjamn](https://github.com/benjamn) and [@tninesling](https://github.com/tninesling) in <https://github.com/apollographql/router/pull/10118>
+By [@benjamn](https://github.com/benjamn) and [@tninesling](https://github.com/tninesling) in <https://github.com/apollographql/router/pull/9947>
 
 ### Fix `GROUP_SELECTION_IS_NOT_OBJECT` for union/interface fields in nested `@connect` selections ([PR #9990](https://github.com/apollographql/router/pull/9990))
 

--- a/apollo-federation/CHANGELOG.md
+++ b/apollo-federation/CHANGELOG.md
@@ -38,32 +38,6 @@ By [@tninesling](https://github.com/tninesling) in <https://github.com/apollogra
 
 ## 🐛 Fixes
 
-### Fix connector composition validation for `->toString`, `->get`, `->contains`, and `->in` with concrete array and object shapes ([PR #9947](https://github.com/apollographql/router/pull/9947))
-
-The shape checks used by several connector selection methods to identify arrays
-and objects were broken: they tested whether a closed empty container *accepted*
-the input, which was always false for non-empty containers. As a result:
-
-- `->toString` silently skipped its "cannot convert arrays or objects" guard for
-  any non-trivially-shaped object or array. Schemas that compose a
-  `someObject->toString` selection will now correctly receive a composition error
-  directing the user toward `->jsonStringify` or `->joinNotNull`.
-- `->get` fell through to the unknown/error branch for non-empty objects and
-  arrays, producing less precise shape information than intended.
-- `->contains` and `->in` did not recognize non-empty arrays as arrays, falling
-  through to an incorrect error path.
-
-All four methods now use the shape crate's `is_object()` / `is_array()` helpers,
-which correctly identify any object or array regardless of its fields or
-elements.
-
-Additionally, composition error diagnostics that reference shape types have
-updated display formatting: `List<T>` now appears as `[...T]`, `Dict<T>` as
-`{...T}`, and error shapes as `<type> (err "message")` rather than
-`Error<"message">`.
-
-By [@benjamn](https://github.com/benjamn) and [@tninesling](https://github.com/tninesling) in <https://github.com/apollographql/router/pull/9947>
-
 ### Fix `GROUP_SELECTION_IS_NOT_OBJECT` for union/interface fields in nested `@connect` selections ([PR #9990](https://github.com/apollographql/router/pull/9990))
 
 Connectors validation rejected `->match` results assigned to union- or
@@ -132,6 +106,19 @@ subgraph bullets that would have appeared without dedup. The set of schemas that
 pass or fail validation is unchanged.
 
 By [@tninesling](https://github.com/tninesling) in <https://github.com/apollographql/router/pull/10134>
+
+## 🛠 Maintenance
+
+### Composition errors print shape types in the newer `shape` notation ([PR #9947](https://github.com/apollographql/router/pull/9947))
+
+Composition error messages that quote a shape now use the notation introduced by
+`shape` 0.8: `List<T>` prints as `[...T]`, `Dict<T>` as `{...T}`, and a shape
+carrying an error as `<type> (err "message")` rather than `Error<"message">`.
+
+No validation outcome changes. Anything matching on the previous strings, such as
+a test snapshot or a log query, needs updating.
+
+By [@benjamn](https://github.com/benjamn) and [@tninesling](https://github.com/tninesling) in <https://github.com/apollographql/router/pull/9947>
 
 # [2.16.2](https://crates.io/crates/apollo-federation/2.16.2) - 2026-08-13
 

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -59,7 +59,7 @@ url = "2"
 either = "1.13.0"
 tracing = "0.1.40"
 ron = { version = "0.12.0", optional = true }
-shape = "=0.7.0"
+shape = "=0.8.0"
 form_urlencoded = "1.2.1"
 parking_lot = "0.12.4"
 mime = "0.3.17"

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -59,7 +59,7 @@ url = "2"
 either = "1.13.0"
 tracing = "0.1.40"
 ron = { version = "0.12.0", optional = true }
-shape = "=0.8.0"
+shape = "=0.8.3"
 form_urlencoded = "1.2.1"
 parking_lot = "0.12.4"
 mime = "0.3.17"

--- a/apollo-federation/src/connectors/expand/visitors/selection.rs
+++ b/apollo-federation/src/connectors/expand/visitors/selection.rs
@@ -436,15 +436,6 @@ impl<'a> TypeShapeWalker<'a> {
                     object.type_name.as_str(),
                 )));
             }
-
-            ShapeCase::Error(shape::Error { partial, .. }) => {
-                if let Some(partial) = partial {
-                    // Errors with partial shapes still mostly behave like those
-                    // shapes (except for simplification), so we need to
-                    // validate the object against the partial shape.
-                    self.walk_object_helper(object, new_object_type, partial)?;
-                }
-            }
         };
 
         Ok(())
@@ -582,15 +573,6 @@ impl<'a> TypeShapeWalker<'a> {
                     "Unexpected primitive shape provided for interface type: {}",
                     shape.pretty_print()
                 )));
-            }
-
-            ShapeCase::Error(shape::Error { partial, .. }) => {
-                if let Some(partial) = partial {
-                    // Errors with partial shapes still mostly behave like those
-                    // shapes (except for simplification), so we need to
-                    // validate the interface against the partial shape.
-                    self.walk_interface_helper(interface, partial)?;
-                }
             }
         };
 
@@ -771,15 +753,6 @@ impl<'a> TypeShapeWalker<'a> {
                     "Unexpected primitive shape provided for union type: {}",
                     shape.pretty_print()
                 )));
-            }
-
-            ShapeCase::Error(shape::Error { partial, .. }) => {
-                if let Some(partial) = partial {
-                    // Errors with partial shapes still mostly behave like those
-                    // shapes (except for simplification), so we need to
-                    // validate the union against the partial shape.
-                    self.walk_union_helper(union_type, partial)?;
-                }
             }
         }
 

--- a/apollo-federation/src/connectors/json_selection/apply_to.rs
+++ b/apollo-federation/src/connectors/json_selection/apply_to.rs
@@ -562,7 +562,7 @@ impl ApplyToInternal for NamedSelection {
         if let Some(single_output_key) = self.get_single_key() {
             let mut map = Shape::empty_map();
             map.insert(single_output_key.as_string(), path_shape);
-            Shape::record(map, self.shape_location(context.source_id()))
+            Shape::closed_record(map, self.shape_location(context.source_id()))
         } else {
             path_shape
         }
@@ -804,38 +804,57 @@ impl ApplyToInternal for WithRange<PathList> {
         input_shape: Shape,
         dollar_shape: Shape,
     ) -> Shape {
+        // Errors are now stored as metadata on `input_shape` rather than as a
+        // `ShapeCase::Error` variant wrapping a partial. Capture them up-front
+        // so they can be reapplied to whatever the structural recursion below
+        // produces. A pure error (case == Unknown carrying error metadata) has
+        // no partial structure to drive shape computation, so we short-circuit
+        // and return it as-is.
+        let pending_errors: Vec<(String, Vec<Location>)> = if input_shape.has_own_errors() {
+            if matches!(input_shape.case(), ShapeCase::Unknown) {
+                return input_shape;
+            }
+            let locations: Vec<Location> = input_shape.locations().cloned().collect();
+            input_shape
+                .own_errors()
+                .map(|e| (e.message.clone(), locations.clone()))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         match input_shape.case() {
             ShapeCase::One(shapes) => {
-                return Shape::one(
+                let distributed = Shape::one(
                     shapes.iter().map(|shape| {
                         self.compute_output_shape(context, shape.clone(), dollar_shape.clone())
                     }),
                     input_shape.locations().cloned(),
                 );
+                return pending_errors
+                    .into_iter()
+                    .fold(distributed, |acc, (msg, locs)| {
+                        Shape::error_with_partial(msg, acc, locs)
+                    });
             }
             ShapeCase::All(shapes) => {
-                return Shape::all(
+                let distributed = Shape::all(
                     shapes.iter().map(|shape| {
                         self.compute_output_shape(context, shape.clone(), dollar_shape.clone())
                     }),
                     input_shape.locations().cloned(),
                 );
-            }
-            ShapeCase::Error(error) => {
-                return match error.partial.as_ref() {
-                    Some(partial) => Shape::error_with_partial(
-                        error.message.clone(),
-                        self.compute_output_shape(context, partial.clone(), dollar_shape),
-                        input_shape.locations().cloned(),
-                    ),
-                    None => input_shape.clone(),
-                };
+                return pending_errors
+                    .into_iter()
+                    .fold(distributed, |acc, (msg, locs)| {
+                        Shape::error_with_partial(msg, acc, locs)
+                    });
             }
             _ => {}
         };
 
-        // Given the base cases above, we can assume below that input_shape is
-        // neither ::One, ::All, nor ::Error.
+        // Below, input_shape is neither ::One nor ::All; any pending_errors
+        // captured above will be reapplied at the bottom of this function.
 
         let mut extra_vars_opt: Option<Shape> = None;
         let (current_shape, tail_opt) = match self.as_ref() {
@@ -1042,7 +1061,7 @@ impl ApplyToInternal for WithRange<PathList> {
             }
         };
 
-        if let Some(tail) = tail_opt {
+        let tail_result = if let Some(tail) = tail_opt {
             // Recurses over extra_vars_opt, which is usually None, but could be
             // Some(object_shape) (when handling ArrowMethod::As), and might
             // sometimes be Some(error_shape) with an object partial shape.
@@ -1053,7 +1072,13 @@ impl ApplyToInternal for WithRange<PathList> {
                 input_shape: Shape,
                 dollar_shape: Shape,
             ) -> Shape {
-                match extra_vars_opt.as_ref().map(|s| s.case()) {
+                let pending_messages: Vec<String> = extra_vars_opt
+                    .as_ref()
+                    .map(|s| s.own_errors().map(|e| e.message.clone()).collect())
+                    .unwrap_or_default();
+                let tail_location = tail.shape_location(context.source_id());
+
+                let inner_shape = match extra_vars_opt.as_ref().map(|s| s.case()) {
                     Some(ShapeCase::Object { fields, .. }) => {
                         // TODO Refactor the internal ShapeContext
                         // representation to make this cloning
@@ -1066,28 +1091,26 @@ impl ApplyToInternal for WithRange<PathList> {
                         tail.compute_output_shape(&new_context, input_shape, dollar_shape)
                     }
 
-                    Some(ShapeCase::Error(shape::Error { message, partial })) => {
-                        if partial.is_some() {
-                            let tail_shape = compute_tail_shape(
-                                tail,
-                                partial,
-                                context,
-                                input_shape,
-                                dollar_shape,
-                            );
-
-                            Shape::error_with_partial(
-                                message.clone(),
-                                tail_shape,
-                                tail.shape_location(context.source_id()),
-                            )
-                        } else {
-                            Shape::error(message.clone(), tail.shape_location(context.source_id()))
-                        }
+                    // A pure error (case == Unknown carrying error metadata) has
+                    // no partial structure to drive name installation; emit a
+                    // fresh error shape carrying the same messages.
+                    Some(ShapeCase::Unknown) if !pending_messages.is_empty() => {
+                        let mut iter = pending_messages.into_iter();
+                        let first = iter.next().unwrap_or_default();
+                        return iter.fold(Shape::error(first, tail_location), |acc, msg| {
+                            acc.with_error(shape::Error { message: msg })
+                        });
                     }
 
                     _ => tail.compute_output_shape(context, input_shape, dollar_shape),
-                }
+                };
+
+                // Reattach any error metadata that was sitting on
+                // extra_vars_opt, so the structural recursion's output still
+                // surfaces the original error messages.
+                pending_messages.into_iter().fold(inner_shape, |acc, msg| {
+                    Shape::error_with_partial(msg, acc, tail_location.clone())
+                })
             }
 
             compute_tail_shape(
@@ -1101,7 +1124,16 @@ impl ApplyToInternal for WithRange<PathList> {
             )
         } else {
             current_shape
-        }
+        };
+
+        // Reapply any pending errors that were attached to the original
+        // input_shape, so callers see the same error metadata they would have
+        // seen when errors were a dedicated `ShapeCase::Error` variant.
+        pending_errors
+            .into_iter()
+            .fold(tail_result, |acc, (msg, locs)| {
+                Shape::error_with_partial(msg, acc, locs)
+            })
     }
 }
 
@@ -1420,7 +1452,7 @@ impl SubSelection {
         }
 
         if all_shape.is_unknown() {
-            Shape::empty_object(locations)
+            Shape::any_object(locations)
         } else {
             all_shape
         }
@@ -3420,7 +3452,7 @@ mod tests {
         named_shapes.insert(
             "$batch".to_string(),
             Shape::list(
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert("id".to_string(), Shape::int([]));
@@ -3439,7 +3471,7 @@ mod tests {
 
         let computed_batch_id =
             selection!("$batch.id", spec).compute_output_shape(&shape_context, root_shape.clone());
-        assert_eq!(computed_batch_id.pretty_print(), "List<Int>");
+        assert_eq!(computed_batch_id.pretty_print(), "[...Int]");
 
         let computed_first = selection!("$batch.id->first", spec)
             .compute_output_shape(&shape_context, root_shape.clone());
@@ -3522,7 +3554,7 @@ mod tests {
         named_shapes.insert(
             "$batch".to_string(),
             Shape::list(
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert("id".to_string(), Shape::int([]));
@@ -3541,7 +3573,7 @@ mod tests {
 
         let computed_batch_id =
             selection!("$batch.id", spec).compute_output_shape(&shape_context, root_shape.clone());
-        assert_eq!(computed_batch_id.pretty_print(), "List<Int>");
+        assert_eq!(computed_batch_id.pretty_print(), "[...Int]");
 
         let computed_first = selection!("$batch.id->first", spec)
             .compute_output_shape(&shape_context, root_shape.clone());
@@ -3569,35 +3601,35 @@ mod tests {
             selection!("$batch.id->map(@)->echo(@)", spec)
                 .shape()
                 .pretty_print(),
-            "List<$batch.id.*>",
+            "[...$batch.id.*]",
         );
 
         assert_eq!(
             selection!("$batch.id->map(@)->echo([@])", spec)
                 .shape()
                 .pretty_print(),
-            "[List<$batch.id.*>]",
+            "[[...$batch.id.*]]",
         );
 
         assert_eq!(
             selection!("$batch.id->map([@])->echo(@)", spec)
                 .shape()
                 .pretty_print(),
-            "List<[$batch.id.*]>",
+            "[...[$batch.id.*]]",
         );
 
         assert_eq!(
             selection!("$batch.id->map([@])->echo([@])", spec)
                 .shape()
                 .pretty_print(),
-            "[List<[$batch.id.*]>]",
+            "[[...[$batch.id.*]]]",
         );
 
         assert_eq!(
             selection!("$batch.id->map([@])->echo([@])", spec)
                 .compute_output_shape(&shape_context, root_shape,)
                 .pretty_print(),
-            "[List<[Int]>]",
+            "[[...[Int]]]",
         );
     }
 
@@ -4054,7 +4086,7 @@ mod tests {
     fn test_compute_output_shape() {
         let spec = ConnectSpec::V0_3;
 
-        assert_eq!(selection!("", spec).shape().pretty_print(), "{}");
+        assert_eq!(selection!("", spec).shape().pretty_print(), "{...}");
 
         assert_eq!(
             selection!("id name", spec).shape().pretty_print(),
@@ -4118,7 +4150,7 @@ mod tests {
     x: $root.*.arrayOfArrays.*.x,
     y: $root.*.arrayOfArrays.*.y,
   },
-  friends: List<{ id: $root.*.friend_ids.* }>,
+  friends: [...{ id: $root.*.friend_ids.* }],
   id: $root.*.id,
   name: $root.*.name,
   xs: $root.*.arrayOfArrays.x,
@@ -4567,14 +4599,14 @@ mod tests {
             .with_spec(spec)
             .with_named_shapes([(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
                             "unreliableAuthor".to_string(),
                             Shape::one(
                                 [
-                                    Shape::record(
+                                    Shape::closed_record(
                                         {
                                             let mut map = Shape::empty_map();
                                             map.insert("age".to_string(), Shape::int([]));
@@ -5809,7 +5841,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -5877,7 +5909,7 @@ mod tests {
         let shape_context = {
             let mut named_shapes = IndexMap::default();
 
-            let person_shape = Shape::record(
+            let person_shape = Shape::closed_record(
                 {
                     let mut map = Shape::empty_map();
                     map.insert("name".to_string(), Shape::string([]));
@@ -5889,7 +5921,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert("person".to_string(), person_shape);
@@ -5945,7 +5977,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -5985,7 +6017,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -6024,7 +6056,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -6054,7 +6086,7 @@ mod tests {
         );
 
         // The question mark should be applied recursively to the partial shape within the error
-        assert!(result_shape.pretty_print().contains("Error"));
+        assert!(result_shape.pretty_print().contains("(err "));
         assert!(result_shape.pretty_print().contains("None"));
     }
 
@@ -6067,7 +6099,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -6093,7 +6125,7 @@ mod tests {
                     shape_context.named_shapes()["$root"].clone()
                 )
                 .pretty_print(),
-            "Error<\"Something went wrong\">",
+            "Unknown (err \"Something went wrong\")",
         );
     }
 
@@ -6106,7 +6138,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -6152,7 +6184,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -6191,7 +6223,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert("nonNullString".to_string(), Shape::string([]));
@@ -6248,17 +6280,17 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
                             "level1".to_string(),
-                            Shape::record(
+                            Shape::closed_record(
                                 {
                                     let mut inner_map = Shape::empty_map();
                                     inner_map.insert(
                                         "level2".to_string(),
-                                        Shape::record(
+                                        Shape::closed_record(
                                             {
                                                 let mut inner_inner_map = Shape::empty_map();
                                                 inner_inner_map
@@ -6351,7 +6383,7 @@ mod tests {
         let mut named_shapes = IndexMap::default();
         named_shapes.insert(
             "$root".to_string(),
-            Shape::record(
+            Shape::closed_record(
                 {
                     let mut map = Shape::empty_map();
                     map.insert(
@@ -6392,7 +6424,7 @@ mod tests {
         let mut named_shapes = IndexMap::default();
         named_shapes.insert(
             "$root".to_string(),
-            Shape::record(
+            Shape::closed_record(
                 {
                     let mut map = Shape::empty_map();
                     map.insert(
@@ -6432,7 +6464,7 @@ mod tests {
             .with_spec(spec)
             .with_named_shapes([(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(

--- a/apollo-federation/src/connectors/json_selection/apply_to.rs
+++ b/apollo-federation/src/connectors/json_selection/apply_to.rs
@@ -809,7 +809,11 @@ impl ApplyToInternal for WithRange<PathList> {
         // so they can be reapplied to whatever the structural recursion below
         // produces. A pure error (case == Unknown carrying error metadata) has
         // no partial structure to drive shape computation, so we short-circuit
-        // and return it as-is.
+        // and return it as-is. Note: this collapses the distinction between
+        // error_with_partial(msg, Unknown) and error(msg) — both early-return
+        // here — so if a future call site constructs the former and expects
+        // tail computation through the Unknown partial, this path will need
+        // refinement.
         let pending_errors: Vec<(String, Vec<Location>)> = if input_shape.has_own_errors() {
             if matches!(input_shape.case(), ShapeCase::Unknown) {
                 return input_shape;
@@ -1452,7 +1456,7 @@ impl SubSelection {
         }
 
         if all_shape.is_unknown() {
-            Shape::any_object(locations)
+            Shape::empty_object(locations)
         } else {
             all_shape
         }
@@ -4086,7 +4090,7 @@ mod tests {
     fn test_compute_output_shape() {
         let spec = ConnectSpec::V0_3;
 
-        assert_eq!(selection!("", spec).shape().pretty_print(), "{...}");
+        assert_eq!(selection!("", spec).shape().pretty_print(), "{}");
 
         assert_eq!(
             selection!("id name", spec).shape().pretty_print(),

--- a/apollo-federation/src/connectors/json_selection/apply_to.rs
+++ b/apollo-federation/src/connectors/json_selection/apply_to.rs
@@ -4119,10 +4119,10 @@ mod tests {
             .pretty_print(),
             // This output shape is wrong if $root.friend_ids turns out to be an
             // array, and it's tricky to see how to transform the shape to what
-            // it would have been if we knew that, where friends: List<{ id:
-            // $root.friend_ids.* }> (note the * meaning any array index),
+            // it would have been if we knew that, where friends: [...{ id:
+            // $root.friend_ids.* }] (note the * meaning any array index),
             // because who's to say it's not the id field that should become the
-            // List, rather than the friends field?
+            // array, rather than the friends field?
             r#"{
   alias: {
     x: $root.*.arrayOfArrays.*.x,

--- a/apollo-federation/src/connectors/json_selection/apply_to.rs
+++ b/apollo-federation/src/connectors/json_selection/apply_to.rs
@@ -1419,7 +1419,7 @@ impl SubSelection {
     }
 
     /// Shape counterpart of [`Self::apply_selections_no_rebind`]: merge the
-    /// output shapes of each [`NamedSelection`] with [`Shape::all`] without
+    /// output shapes of each [`NamedSelection`] with [`Shape::merge`] without
     /// rebinding `$`. Callers pass the `dollar_shape` they want threaded.
     fn compute_selections_shape_no_rebind(
         &self,
@@ -1428,16 +1428,16 @@ impl SubSelection {
         dollar_shape: Shape,
     ) -> Shape {
         let locations = self.shape_location(context.source_id());
-        let mut all_shape = Shape::unknown([]);
+        let mut merged_shape = Shape::unknown([]);
 
         for named_selection in self.selections.iter() {
-            // Simplifying as we go with Shape::all keeps all_shape relatively
+            // Simplifying as we go with Shape::merge keeps merged_shape relatively
             // small in the common case when all named_selection items return an
             // object shape, since those object shapes can all be merged
             // together into one object.
-            all_shape = Shape::all(
+            merged_shape = Shape::merge(
                 [
-                    all_shape,
+                    merged_shape,
                     named_selection.compute_output_shape(
                         context,
                         input_shape.clone(),
@@ -1450,15 +1450,15 @@ impl SubSelection {
             // If any named_selection item returns null instead of an object,
             // that nullifies the whole object and allows shape computation to
             // bail out early.
-            if all_shape.is_null() {
+            if merged_shape.is_null() {
                 break;
             }
         }
 
-        if all_shape.is_unknown() {
+        if merged_shape.is_unknown() {
             Shape::empty_object(locations)
         } else {
-            all_shape
+            merged_shape
         }
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/and.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/and.rs
@@ -306,11 +306,9 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::Bool(true), None)],
                 Shape::string([])
-            ),
-            Shape::error(
-                "Method ->and can only be applied to boolean values. Got String.".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->and can only be applied to boolean values. Got String.")"#,
         );
     }
 
@@ -320,23 +318,17 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("test".to_string()), None)],
                 Shape::bool([])
-            ),
-            Shape::error(
-                "Method ->and can only accept boolean arguments. Got \"test\" at position 0."
-                    .to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->and can only accept boolean arguments. Got \"test\" at position 0.")"#,
         );
     }
 
     #[test]
     fn and_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::bool([])),
-            Shape::error(
-                "Method ->and requires at least one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::bool([])).pretty_print(),
+            r#"Unknown (err "Method ->and requires at least one argument")"#,
         );
     }
 
@@ -350,11 +342,9 @@ mod shape_tests {
                 None,
                 Shape::bool([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->and requires at least one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->and requires at least one argument")"#,
         );
     }
 
@@ -378,12 +368,9 @@ mod shape_tests {
                 }),
                 Shape::bool([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->and can only accept boolean arguments. Got None at position 0."
-                    .to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->and can only accept boolean arguments. Got None at position 0.")"#,
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/arithmetic.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/arithmetic.rs
@@ -917,11 +917,9 @@ mod shape_tests {
                 "add",
                 vec![WithRange::new(LitExpr::Number(Number::from(1)), None)],
                 Shape::string([]),
-            ),
-            Shape::error(
-                "Method ->add received non-numeric input".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->add received non-numeric input")"#,
         );
     }
 
@@ -935,11 +933,9 @@ mod shape_tests {
                     None,
                 )],
                 Shape::int([]),
-            ),
-            Shape::error(
-                "Method ->add received non-numeric argument 0".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->add received non-numeric argument 0")"#,
         );
     }
 
@@ -1058,11 +1054,9 @@ mod shape_tests {
                 "mul",
                 vec![WithRange::new(LitExpr::Number(Number::from(1)), None)],
                 Shape::string([]),
-            ),
-            Shape::error(
-                "Method ->mul received non-numeric input".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->mul received non-numeric input")"#,
         );
     }
 
@@ -1073,11 +1067,9 @@ mod shape_tests {
                 "div",
                 vec![WithRange::new(LitExpr::String("invalid".to_string()), None)],
                 Shape::int([]),
-            ),
-            Shape::error(
-                "Method ->div received non-numeric argument 0".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->div received non-numeric argument 0")"#,
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/as.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/as.rs
@@ -245,7 +245,7 @@ fn as_shape(
         // computed result shape as the value shape. Although there can be at
         // most one variable in this object for now, we might let ->as define
         // multiple variables in the future.
-        Shape::record(
+        Shape::closed_record(
             [(var_name.clone(), result_shape)].into(),
             // No need for locations, as this is a utility/internal object.
             [],
@@ -323,12 +323,12 @@ mod tests {
 
         assert_eq!(
             selection!("person->as", spec).shape().pretty_print(),
-            "Error<\n  \"Method ->as requires one or two arguments (got 0)\",\n  $root.person,\n>",
+            "$root.person (err \"Method ->as requires one or two arguments (got 0)\")",
         );
 
         assert_eq!(
             selection!("person->as()", spec).shape().pretty_print(),
-            "Error<\n  \"Method ->as requires one or two arguments (got 0)\",\n  $root.person,\n>",
+            "$root.person (err \"Method ->as requires one or two arguments (got 0)\")",
         );
     }
 
@@ -361,7 +361,7 @@ mod tests {
             selection!("person->as($x, @.id, @.name)", spec)
                 .shape()
                 .pretty_print(),
-            "Error<\n  \"Method ->as requires one or two arguments (got 3)\",\n  $root.person,\n>",
+            "$root.person (err \"Method ->as requires one or two arguments (got 3)\")",
         );
     }
 
@@ -421,17 +421,17 @@ mod tests {
 
         assert_eq!(
             selection!("person->as(123)", spec).shape().pretty_print(),
-            "Error<\n  \"First argument to ->as must be a single $variable name\",\n  $root.person,\n>",
+            "$root.person (err \"First argument to ->as must be a single $variable name\")",
         );
 
         assert_eq!(
             selection!("person->as($x.id)", spec).shape().pretty_print(),
-            "Error<\n  \"First argument to ->as must be a single $variable name with no path suffix\",\n  $root.person,\n>",
+            "$root.person (err \"First argument to ->as must be a single $variable name with no path suffix\")",
         );
 
         assert_eq!(
             selection!("person->as(p)", spec).shape().pretty_print(),
-            "Error<\n  \"First argument to ->as must be a single $variable name\",\n  $root.person,\n>",
+            "$root.person (err \"First argument to ->as must be a single $variable name\")",
         );
     }
 
@@ -515,12 +515,12 @@ mod tests {
                     &ShapeContext::new(SourceId::Other("JSONSelection".into()))
                         .with_spec(spec)
                         .with_named_shapes(vars),
-                    Shape::record(
+                    Shape::closed_record(
                         {
                             let mut map = Shape::empty_map();
                             map.insert(
                                 "person".to_string(),
-                                Shape::record(
+                                Shape::closed_record(
                                     {
                                         let mut map = Shape::empty_map();
                                         map.insert("id".to_string(), Shape::int([]));
@@ -597,7 +597,7 @@ mod tests {
             )
             .shape()
             .pretty_print(),
-            "{ listsOfPairs: List<List<[$root.*.xs.*, $root.*.ys.*]>> }",
+            "{ listsOfPairs: [...[...[$root.*.xs.*, $root.*.ys.*]]] }",
         );
 
         assert_eq!(
@@ -609,7 +609,7 @@ mod tests {
             )
             .shape()
             .pretty_print(),
-            "List<List<[$root.xs.*, $root.ys.*]>>",
+            "[...[...[$root.xs.*, $root.ys.*]]]",
         );
     }
 

--- a/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
@@ -126,7 +126,7 @@ fn contains_shape(
     let arg_shape = first_arg.compute_output_shape(context, input_shape.clone(), dollar_shape);
 
     // Ensure input is an array
-    if !Shape::tuple([], []).accepts(&input_shape) && !input_shape.accepts(&Shape::unknown([])) {
+    if !input_shape.is_array() && !input_shape.accepts(&Shape::unknown([])) {
         return Shape::error(
             format!(
                 "Method ->{} requires an array input, but got: {input_shape}",

--- a/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
@@ -521,11 +521,9 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("a".to_string()), None)],
                 Shape::string([])
-            ),
-            Shape::error(
-                "Method ->contains requires an array input, but got: String".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->contains requires an array input, but got: String")"#,
         );
     }
 
@@ -535,13 +533,9 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("a".to_string()), None)],
                 Shape::list(Shape::int([]), [])
-            ),
-            Shape::error_with_partial(
-                "Method ->contains can only compare values of the same type. Got \"a\" == Int."
-                    .to_string(),
-                Shape::bool_value(false, [get_location()]),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"false (err "Method ->contains can only compare values of the same type. Got \"a\" == Int.")"#,
         );
     }
 
@@ -551,24 +545,17 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("a".to_string()), None)],
                 Shape::array([Shape::int([])], Shape::none(), [])
-            ),
-            Shape::error_with_partial(
-                "Method ->contains can only compare values of the same type. Got Int == \"a\"."
-                    .to_string(),
-                Shape::bool_value(false, [get_location()]),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"false (err "Method ->contains can only compare values of the same type. Got Int == \"a\".")"#,
         );
     }
 
     #[test]
     fn contains_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::list(Shape::string([]), [])),
-            Shape::error(
-                "Method ->contains requires one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::list(Shape::string([]), [])).pretty_print(),
+            r#"Unknown (err "Method ->contains requires one argument")"#,
         );
     }
 
@@ -581,11 +568,9 @@ mod shape_tests {
                     WithRange::new(LitExpr::Number(Number::from(43)), None)
                 ],
                 Shape::list(Shape::int([]), [])
-            ),
-            Shape::error(
-                "Method ->contains requires only one argument, but 2 were provided".to_string(),
-                []
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->contains requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -599,11 +584,9 @@ mod shape_tests {
                 None,
                 Shape::list(Shape::string([]), []),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->contains requires one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->contains requires one argument")"#,
         );
     }
 

--- a/apollo-federation/src/connectors/json_selection/methods/public/entries.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/entries.rs
@@ -157,7 +157,7 @@ fn entries_shape(
             entries.insert("key".to_string(), Shape::string([]));
             entries.insert("value".to_string(), Shape::unknown([]));
             Shape::list(
-                Shape::record(entries, method_name.shape_location(context.source_id())),
+                Shape::closed_record(entries, method_name.shape_location(context.source_id())),
                 method_name.shape_location(context.source_id()),
             )
         }

--- a/apollo-federation/src/connectors/json_selection/methods/public/eq.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/eq.rs
@@ -444,24 +444,17 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("a".to_string()), None)],
                 Shape::int([])
-            ),
-            Shape::error_with_partial(
-                "Method ->eq can only compare values of the same type. Got Int == \"a\"."
-                    .to_string(),
-                Shape::bool_value(false, [get_location()]),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"false (err "Method ->eq can only compare values of the same type. Got Int == \"a\".")"#,
         );
     }
 
     #[test]
     fn eq_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::string([])),
-            Shape::error(
-                "Method ->eq requires one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::string([])).pretty_print(),
+            r#"Unknown (err "Method ->eq requires one argument")"#,
         );
     }
 
@@ -474,11 +467,9 @@ mod shape_tests {
                     WithRange::new(LitExpr::Number(Number::from(43)), None)
                 ],
                 Shape::int([])
-            ),
-            Shape::error(
-                "Method ->eq requires only one argument, but 2 were provided".to_string(),
-                []
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->eq requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -492,11 +483,9 @@ mod shape_tests {
                 None,
                 Shape::string([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->eq requires one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->eq requires one argument")"#,
         );
     }
 

--- a/apollo-federation/src/connectors/json_selection/methods/public/filter.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/filter.rs
@@ -524,7 +524,7 @@ mod shape_tests {
             Shape::unknown([]),
         );
         assert!(
-            !matches!(after_first.case(), ShapeCase::Error(_)),
+            !after_first.has_own_errors(),
             "first ->filter unexpectedly errored: {}",
             after_first.pretty_print()
         );
@@ -534,7 +534,7 @@ mod shape_tests {
         // error.
         let after_second = get_shape(vec![parse_condition("@.locNumber->gt(0)")], after_first);
         assert!(
-            !matches!(after_second.case(), ShapeCase::Error(_)),
+            !after_second.has_own_errors(),
             "chained ->filter produced an error shape (regression): {}",
             after_second.pretty_print()
         );

--- a/apollo-federation/src/connectors/json_selection/methods/public/filter.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/filter.rs
@@ -148,10 +148,10 @@ fn filter_shape(
     // so the condition must be shaped against the array's ELEMENT shape, not the
     // whole array. Passing `input_shape` directly only happened to work when the
     // input was `Unknown` (the lenient check below accepts it); for a concrete
-    // list — e.g. the output of a prior `->filter`, which is `List<…>` — a
+    // list — e.g. the output of a prior `->filter`, which is `[...]` — a
     // condition like `@.field->eq(…)` mapped `.field` across the list and then
     // applied the comparison to a list, yielding a non-boolean shape and a
-    // spurious `Error<"->filter condition must return a boolean value">`. That
+    // spurious `(err "->filter condition must return a boolean value")`. That
     // error then propagated into expansion as an empty output object type.
     // `any_item` matches the per-element runtime semantics and is robust to
     // chaining.
@@ -428,22 +428,17 @@ mod shape_tests {
                     None
                 )],
                 Shape::string([])
-            ),
-            Shape::error(
-                "->filter condition must return a boolean value".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "->filter condition must return a boolean value")"#,
         );
     }
 
     #[test]
     fn filter_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::string([])),
-            Shape::error(
-                "Method ->filter requires one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::string([])).pretty_print(),
+            r#"Unknown (err "Method ->filter requires one argument")"#,
         );
     }
 
@@ -456,11 +451,9 @@ mod shape_tests {
                     WithRange::new(LitExpr::Bool(false), None)
                 ],
                 Shape::string([])
-            ),
-            Shape::error(
-                "Method ->filter requires only one argument, but 2 were provided".to_string(),
-                []
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->filter requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -474,11 +467,9 @@ mod shape_tests {
                 None,
                 Shape::string([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->filter requires one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->filter requires one argument")"#,
         );
     }
 
@@ -507,10 +498,10 @@ mod shape_tests {
 
     // Regression: chained `->filter(...)` must shape each condition against the
     // array's element, not the whole array. The first filter turns an `Unknown`
-    // input into a concrete `List<Unknown>`; the second filter then receives that
+    // input into a concrete `[...Unknown]`; the second filter then receives that
     // list. Before the fix, the second filter's condition (`@.field->gt(0)`)
     // mapped `.field` across the list and applied `->gt` to a list, producing
-    // `Error<"->filter condition must return a boolean value">`. The expander
+    // `(err "->filter condition must return a boolean value")`. The expander
     // turned that error shape into an empty output object type, which slipped
     // past release builds (validation skipped) and surfaced downstream as a
     // composition `SATISFIABILITY_ERROR` (e.g. Relay-pagination connectors with

--- a/apollo-federation/src/connectors/json_selection/methods/public/find.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/find.rs
@@ -589,7 +589,7 @@ mod shape_tests {
         let input_shape = Shape::list(Shape::unknown([]), []);
         let result = get_shape(vec![parse_condition("@.rank->gt(0)")], input_shape.clone());
         assert!(
-            !matches!(result.case(), ShapeCase::Error(_)),
+            !result.has_own_errors(),
             "->find over a concrete list produced an error shape (regression): {}",
             result.pretty_print()
         );

--- a/apollo-federation/src/connectors/json_selection/methods/public/find.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/find.rs
@@ -146,10 +146,10 @@ fn find_shape(
     // so the condition must be shaped against the array's ELEMENT shape, not the
     // whole array. Passing `input_shape` directly only happened to work when the
     // input was `Unknown` (the lenient check below accepts it); for a concrete
-    // list — e.g. the output of a prior `->filter`, which is `List<…>` — a
+    // list — e.g. the output of a prior `->filter`, which is `[...]` — a
     // condition like `@.field->gt(…)` mapped `.field` across the list and then
     // applied the comparison to a list, yielding a non-boolean shape and a
-    // spurious `Error<"->find condition must return a boolean value">`. That
+    // spurious `(err "->find condition must return a boolean value")`. That
     // error then propagated into expansion as an empty output object type.
     // Unlike `->filter`, `->find` returns a single item (not a list), so it is
     // only ever the *victim* of this mismatch (as the terminal consumer of a
@@ -490,22 +490,17 @@ mod shape_tests {
                     None
                 )],
                 Shape::string([])
-            ),
-            Shape::error(
-                "->find condition must return a boolean value".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "->find condition must return a boolean value")"#,
         );
     }
 
     #[test]
     fn find_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::string([])),
-            Shape::error(
-                "Method ->find requires one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::string([])).pretty_print(),
+            r#"Unknown (err "Method ->find requires one argument")"#,
         );
     }
 
@@ -518,11 +513,9 @@ mod shape_tests {
                     WithRange::new(LitExpr::Bool(false), None)
                 ],
                 Shape::string([])
-            ),
-            Shape::error(
-                "Method ->find requires only one argument, but 2 were provided".to_string(),
-                []
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->find requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -536,11 +529,9 @@ mod shape_tests {
                 None,
                 Shape::string([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->find requires one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->find requires one argument")"#,
         );
     }
 
@@ -574,9 +565,9 @@ mod shape_tests {
     // not the whole array. Unlike `->filter`, `->find` returns a single item, so
     // it is never the *producer* in a chain — but it is still a *victim* as the
     // terminal consumer of a list-producing method (`->filter`/`->map`), which
-    // hands it a concrete `List<…>`. Before the fix, `->find`'s condition
+    // hands it a concrete `[...]`. Before the fix, `->find`'s condition
     // (`@.field->gt(0)`) mapped `.field` across that list and applied `->gt` to a
-    // list, producing `Error<"->find condition must return a boolean value">`.
+    // list, producing `(err "->find condition must return a boolean value")`.
     // The expander turned that error shape into an empty output object type,
     // which slipped past release builds (validation skipped) and surfaced
     // downstream as a composition `SATISFIABILITY_ERROR`. A bare `->find` over an
@@ -585,7 +576,7 @@ mod shape_tests {
     // See integration fixture `chained_methods_v0_4.graphql`.
     #[test]
     fn find_shape_supports_concrete_list_condition() {
-        // The concrete `List<Unknown>` a prior `->filter`/`->map` produces.
+        // The concrete `[...Unknown]` a prior `->filter`/`->map` produces.
         let input_shape = Shape::list(Shape::unknown([]), []);
         let result = get_shape(vec![parse_condition("@.rank->gt(0)")], input_shape.clone());
         assert!(

--- a/apollo-federation/src/connectors/json_selection/methods/public/get.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/get.rs
@@ -351,9 +351,9 @@ fn get_shape(
 
     if Shape::string([]).accepts(&input_shape) {
         handle_string_shape(method_name, &input_shape, &index_shape, context.source_id())
-    } else if Shape::tuple([], []).accepts(&input_shape) {
+    } else if input_shape.is_array() {
         handle_array_shape(method_name, &input_shape, &index_shape, context.source_id())
-    } else if Shape::empty_object([]).accepts(&input_shape) {
+    } else if input_shape.is_object() {
         handle_object_shape(method_name, &input_shape, &index_shape, context.source_id())
     } else if input_shape.accepts(&Shape::unknown([])) {
         handle_unknown_shape(method_name, &index_shape, context.source_id())

--- a/apollo-federation/src/connectors/json_selection/methods/public/get.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/get.rs
@@ -830,11 +830,9 @@ mod shape_tests {
                 None,
                 Shape::string([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->get requires one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get requires one argument")"#,
         );
     }
 
@@ -847,11 +845,9 @@ mod shape_tests {
                     WithRange::new(LitExpr::Number(Number::from(1)), None)
                 ],
                 Shape::string([])
-            ),
-            Shape::error(
-                "Method ->get requires only one argument, but 2 were provided".to_string(),
-                []
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -894,11 +890,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Number(Number::from(10)), None)],
                 Shape::string_value("hello", [])
-            ),
-            Shape::error(
-                "Method ->get index 10 out of bounds in string of length 5".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get index 10 out of bounds in string of length 5")"#,
         );
     }
 
@@ -908,11 +902,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Number(Number::from(-10)), None)],
                 Shape::string_value("hello", [])
-            ),
-            Shape::error(
-                "Method ->get index -10 out of bounds in string of length 5".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get index -10 out of bounds in string of length 5")"#,
         );
     }
 
@@ -922,11 +914,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Number(Number::from(0)), None)],
                 Shape::string_value("", [])
-            ),
-            Shape::error(
-                "Method ->get index 0 out of bounds in string of length 0".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get index 0 out of bounds in string of length 0")"#,
         );
     }
 
@@ -936,12 +926,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::String("invalid".to_string()), None)],
                 Shape::string([])
-            ),
-            Shape::error(
-                "Method ->get must be provided an integer argument when applied to a string"
-                    .to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get must be provided an integer argument when applied to a string")"#,
         );
     }
 
@@ -1013,11 +1000,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Number(Number::from(5)), None)],
                 Shape::array([Shape::int([]), Shape::string([])], Shape::none(), [])
-            ),
-            Shape::error(
-                "Method ->get index 5 out of bounds in array of length 2".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get index 5 out of bounds in array of length 2")"#,
         );
     }
 
@@ -1027,11 +1012,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Number(Number::from(-5)), None)],
                 Shape::array([Shape::int([]), Shape::string([])], Shape::none(), [])
-            ),
-            Shape::error(
-                "Method ->get index -5 out of bounds in array of length 2".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get index -5 out of bounds in array of length 2")"#,
         );
     }
 
@@ -1041,11 +1024,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Number(Number::from(0)), None)],
                 Shape::array([], Shape::none(), [])
-            ),
-            Shape::error(
-                "Method ->get index 0 out of bounds in array of length 0".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get index 0 out of bounds in array of length 0")"#,
         );
     }
 
@@ -1055,12 +1036,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::String("invalid".to_string()), None)],
                 Shape::array([Shape::int([])], Shape::none(), [])
-            ),
-            Shape::error(
-                "Method ->get must be provided an integer argument when applied to an array"
-                    .to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get must be provided an integer argument when applied to an array")"#,
         );
     }
 
@@ -1121,11 +1099,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::String("missing".to_string()), None)],
                 Shape::object(fields, Shape::none(), [])
-            ),
-            Shape::error(
-                "Method ->get property missing not found in object".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get property missing not found in object")"#,
         );
     }
 
@@ -1137,12 +1113,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Number(Number::from(42)), None)],
                 Shape::object(fields, Shape::none(), [])
-            ),
-            Shape::error(
-                "Method ->get must be provided an string argument when applied to an object"
-                    .to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get must be provided an string argument when applied to an object")"#,
         );
     }
 
@@ -1154,12 +1127,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Bool(false), None)],
                 Shape::object(fields, Shape::none(), [])
-            ),
-            Shape::error(
-                "Method ->get must be provided an string argument when applied to an object"
-                    .to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get must be provided an string argument when applied to an object")"#,
         );
     }
 
@@ -1171,12 +1141,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Null, None)],
                 Shape::object(fields, Shape::none(), [])
-            ),
-            Shape::error(
-                "Method ->get must be provided an string argument when applied to an object"
-                    .to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get must be provided an string argument when applied to an object")"#,
         );
     }
 
@@ -1232,11 +1199,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Bool(true), None)],
                 Shape::unknown([])
-            ),
-            Shape::error(
-                "Method ->get must be provided an integer or string argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get must be provided an integer or string argument")"#,
         );
     }
 
@@ -1266,11 +1231,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Number(Number::from(0)), None)],
                 Shape::bool([])
-            ),
-            Shape::error(
-                "Method ->get must be applied to a string, array, or object".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get must be applied to a string, array, or object")"#,
         );
     }
 
@@ -1280,11 +1243,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Number(Number::from(0)), None)],
                 Shape::null([])
-            ),
-            Shape::error(
-                "Method ->get must be applied to a string, array, or object".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get must be applied to a string, array, or object")"#,
         );
     }
 
@@ -1294,11 +1255,9 @@ mod shape_tests {
             get_test_shape(
                 vec![WithRange::new(LitExpr::Number(Number::from(0)), None)],
                 Shape::int([])
-            ),
-            Shape::error(
-                "Method ->get must be applied to a string, array, or object".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->get must be applied to a string, array, or object")"#,
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/gt.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/gt.rs
@@ -434,24 +434,17 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("a".to_string()), None)],
                 Shape::int([])
-            ),
-            Shape::error_with_partial(
-                "Method ->gt can only compare two numbers or two strings. Found Int > \"a\""
-                    .to_string(),
-                Shape::bool([get_location()]),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Bool (err "Method ->gt can only compare two numbers or two strings. Found Int > \"a\"")"#,
         );
     }
 
     #[test]
     fn gt_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::string([])),
-            Shape::error(
-                "Method ->gt requires one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::string([])).pretty_print(),
+            r#"Unknown (err "Method ->gt requires one argument")"#,
         );
     }
 
@@ -464,11 +457,9 @@ mod shape_tests {
                     WithRange::new(LitExpr::Number(Number::from(42)), None)
                 ],
                 Shape::int([])
-            ),
-            Shape::error(
-                "Method ->gt requires only one argument, but 2 were provided".to_string(),
-                []
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->gt requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -482,11 +473,9 @@ mod shape_tests {
                 None,
                 Shape::string([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->gt requires one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->gt requires one argument")"#,
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/gte.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/gte.rs
@@ -430,24 +430,17 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("a".to_string()), None)],
                 Shape::int([])
-            ),
-            Shape::error_with_partial(
-                "Method ->gte can only compare two numbers or two strings. Found Int >= \"a\""
-                    .to_string(),
-                Shape::bool_value(false, [get_location()]),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"false (err "Method ->gte can only compare two numbers or two strings. Found Int >= \"a\"")"#,
         );
     }
 
     #[test]
     fn gte_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::string([])),
-            Shape::error(
-                "Method ->gte requires one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::string([])).pretty_print(),
+            r#"Unknown (err "Method ->gte requires one argument")"#,
         );
     }
 
@@ -460,11 +453,9 @@ mod shape_tests {
                     WithRange::new(LitExpr::Number(Number::from(42)), None)
                 ],
                 Shape::int([])
-            ),
-            Shape::error(
-                "Method ->gte requires only one argument, but 2 were provided".to_string(),
-                []
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->gte requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -478,11 +469,9 @@ mod shape_tests {
                 None,
                 Shape::string([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->gte requires one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->gte requires one argument")"#,
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/in.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/in.rs
@@ -125,7 +125,7 @@ fn in_shape(
 
     let arg_shape = first_arg.compute_output_shape(context, input_shape.clone(), dollar_shape);
 
-    if !Shape::tuple([], []).accepts(&arg_shape) && !arg_shape.accepts(&Shape::unknown([])) {
+    if !arg_shape.is_array() && !arg_shape.accepts(&Shape::unknown([])) {
         return Shape::error(
             format!(
                 "Method ->{} requires an array argument, but got: {arg_shape}",

--- a/apollo-federation/src/connectors/json_selection/methods/public/in.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/in.rs
@@ -536,11 +536,9 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("a".to_string()), None)],
                 Shape::string([])
-            ),
-            Shape::error(
-                "Method ->in requires an array argument, but got: \"a\"".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->in requires an array argument, but got: \"a\"")"#,
         );
     }
 
@@ -553,24 +551,17 @@ mod shape_tests {
                     None
                 )],
                 Shape::int([])
-            ),
-            Shape::error_with_partial(
-                "Method ->in can only compare values of the same type. Got Int == \"a\"."
-                    .to_string(),
-                Shape::bool_value(false, [get_location()]),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"false (err "Method ->in can only compare values of the same type. Got Int == \"a\".")"#,
         );
     }
 
     #[test]
     fn in_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::string([])),
-            Shape::error(
-                "Method ->in requires one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::string([])).pretty_print(),
+            r#"Unknown (err "Method ->in requires one argument")"#,
         );
     }
 
@@ -595,11 +586,9 @@ mod shape_tests {
                     )
                 ],
                 Shape::int([])
-            ),
-            Shape::error(
-                "Method ->in requires only one argument, but 2 were provided".to_string(),
-                []
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->in requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -613,11 +602,9 @@ mod shape_tests {
                 None,
                 Shape::string([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->in requires one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->in requires one argument")"#,
         );
     }
 

--- a/apollo-federation/src/connectors/json_selection/methods/public/join_not_null.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/join_not_null.rs
@@ -272,11 +272,8 @@ mod tests {
     fn test_join_not_null_shape_no_args() {
         let output_shape = get_shape(vec![], Shape::list(Shape::string([]), []));
         assert_eq!(
-            output_shape,
-            Shape::error(
-                "Method ->joinNotNull requires one argument".to_string(),
-                vec![]
-            )
+            output_shape.pretty_print(),
+            r#"Unknown (err "Method ->joinNotNull requires one argument")"#,
         );
     }
 
@@ -287,11 +284,8 @@ mod tests {
             Shape::list(Shape::string([]), []),
         );
         assert_eq!(
-            output_shape,
-            Shape::error(
-                "Method ->joinNotNull requires a string argument".to_string(),
-                vec![]
-            )
+            output_shape.pretty_print(),
+            r#"Unknown (err "Method ->joinNotNull requires a string argument")"#,
         );
     }
 
@@ -305,11 +299,8 @@ mod tests {
             Shape::list(Shape::string([]), []),
         );
         assert_eq!(
-            output_shape,
-            Shape::error(
-                "Method ->joinNotNull requires only one argument, but 2 were provided".to_string(),
-                vec![]
-            )
+            output_shape.pretty_print(),
+            r#"Unknown (err "Method ->joinNotNull requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -332,11 +323,8 @@ mod tests {
             Shape::list(Shape::list(Shape::string([]), []), []),
         );
         assert_eq!(
-            output_shape,
-            Shape::error(
-                "Method ->joinNotNull requires an array of scalar values as input".to_string(),
-                vec![]
-            )
+            output_shape.pretty_print(),
+            r#"Unknown (err "Method ->joinNotNull requires an array of scalar values as input")"#,
         );
     }
 

--- a/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case.rs
@@ -457,7 +457,7 @@ mod shape_tests {
     #[test]
     fn shape_should_error_on_non_object_input() {
         let result = get_shape(Shape::string([]));
-        assert!(matches!(result.case(), ShapeCase::Error { .. }));
+        assert!(result.has_own_errors());
     }
 
     #[test]
@@ -473,7 +473,7 @@ mod shape_tests {
             Shape::unknown([]),
             Shape::unknown([]),
         );
-        assert!(matches!(result.case(), ShapeCase::Error { .. }));
+        assert!(result.has_own_errors());
     }
 
     #[test]

--- a/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case_deep.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case_deep.rs
@@ -309,7 +309,7 @@ mod shape_tests {
             Shape::unknown([]),
             Shape::unknown([]),
         );
-        assert!(matches!(result.case(), ShapeCase::Error { .. }));
+        assert!(result.has_own_errors());
     }
 
     #[test]
@@ -322,7 +322,7 @@ mod shape_tests {
     #[test]
     fn should_error_on_non_object_input() {
         let result = get_deep_shape(Shape::string([]));
-        assert!(matches!(result.case(), ShapeCase::Error { .. }));
+        assert!(result.has_own_errors());
     }
 
     #[test]

--- a/apollo-federation/src/connectors/json_selection/methods/public/lt.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/lt.rs
@@ -434,24 +434,17 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("a".to_string()), None)],
                 Shape::int([])
-            ),
-            Shape::error_with_partial(
-                "Method ->lt can only compare two numbers or two strings. Found Int < \"a\""
-                    .to_string(),
-                Shape::bool([get_location()]),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Bool (err "Method ->lt can only compare two numbers or two strings. Found Int < \"a\"")"#,
         );
     }
 
     #[test]
     fn lt_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::string([])),
-            Shape::error(
-                "Method ->lt requires one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::string([])).pretty_print(),
+            r#"Unknown (err "Method ->lt requires one argument")"#,
         );
     }
 
@@ -464,11 +457,9 @@ mod shape_tests {
                     WithRange::new(LitExpr::Number(Number::from(42)), None)
                 ],
                 Shape::int([])
-            ),
-            Shape::error(
-                "Method ->lt requires only one argument, but 2 were provided".to_string(),
-                []
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->lt requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -482,11 +473,9 @@ mod shape_tests {
                 None,
                 Shape::string([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->lt requires one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->lt requires one argument")"#,
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/lte.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/lte.rs
@@ -430,24 +430,17 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("a".to_string()), None)],
                 Shape::int([])
-            ),
-            Shape::error_with_partial(
-                "Method ->lte can only compare two numbers or two strings. Found Int <= \"a\""
-                    .to_string(),
-                Shape::bool_value(false, [get_location()]),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"false (err "Method ->lte can only compare two numbers or two strings. Found Int <= \"a\"")"#,
         );
     }
 
     #[test]
     fn lte_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::string([])),
-            Shape::error(
-                "Method ->lte requires one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::string([])).pretty_print(),
+            r#"Unknown (err "Method ->lte requires one argument")"#,
         );
     }
 
@@ -460,11 +453,9 @@ mod shape_tests {
                     WithRange::new(LitExpr::Number(Number::from(42)), None)
                 ],
                 Shape::int([])
-            ),
-            Shape::error(
-                "Method ->lte requires only one argument, but 2 were provided".to_string(),
-                []
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->lte requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -478,11 +469,9 @@ mod shape_tests {
                 None,
                 Shape::string([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->lte requires one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->lte requires one argument")"#,
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/map.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/map.rs
@@ -189,7 +189,7 @@ mod tests {
         //         &IndexMap::default(),
         //         &SourceId::new("test"),
         //     );
-        //     assert_eq!(output_shape.pretty_print(), "List<String>");
+        //     assert_eq!(output_shape.pretty_print(), "[...String]");
         // }
     }*/
 

--- a/apollo-federation/src/connectors/json_selection/methods/public/ne.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/ne.rs
@@ -443,24 +443,17 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("a".to_string()), None)],
                 Shape::int([])
-            ),
-            Shape::error_with_partial(
-                "Method ->ne can only compare values of the same type. Got Int != \"a\"."
-                    .to_string(),
-                Shape::bool_value(true, [get_location()]),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"true (err "Method ->ne can only compare values of the same type. Got Int != \"a\".")"#,
         );
     }
 
     #[test]
     fn ne_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::string([])),
-            Shape::error(
-                "Method ->ne requires one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::string([])).pretty_print(),
+            r#"Unknown (err "Method ->ne requires one argument")"#,
         );
     }
 
@@ -473,11 +466,9 @@ mod shape_tests {
                     WithRange::new(LitExpr::Number(Number::from(43)), None)
                 ],
                 Shape::int([])
-            ),
-            Shape::error(
-                "Method ->ne requires only one argument, but 2 were provided".to_string(),
-                []
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->ne requires only one argument, but 2 were provided")"#,
         );
     }
 
@@ -491,11 +482,9 @@ mod shape_tests {
                 None,
                 Shape::string([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->ne requires one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->ne requires one argument")"#,
         );
     }
 

--- a/apollo-federation/src/connectors/json_selection/methods/public/not.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/not.rs
@@ -194,11 +194,8 @@ mod shape_tests {
     #[test]
     fn not_shape_should_error_on_non_boolean_input() {
         assert_eq!(
-            get_shape(None, Shape::string([])),
-            Shape::error(
-                "Method ->not can only be applied to boolean values. Got String.".to_string(),
-                [get_location()]
-            )
+            get_shape(None, Shape::string([])).pretty_print(),
+            r#"Unknown (err "Method ->not can only be applied to boolean values. Got String.")"#,
         );
     }
 
@@ -211,11 +208,9 @@ mod shape_tests {
                     range: None
                 }),
                 Shape::bool([])
-            ),
-            Shape::error(
-                "Method ->not does not take any arguments".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->not does not take any arguments")"#,
         );
     }
 

--- a/apollo-federation/src/connectors/json_selection/methods/public/or.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/or.rs
@@ -286,11 +286,9 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::Bool(true), None)],
                 Shape::string([])
-            ),
-            Shape::error(
-                "Method ->or can only be applied to boolean values. Got String.".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->or can only be applied to boolean values. Got String.")"#,
         );
     }
 
@@ -300,23 +298,17 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("test".to_string()), None)],
                 Shape::bool([])
-            ),
-            Shape::error(
-                "Method ->or can only accept boolean arguments. Got \"test\" at position 0."
-                    .to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->or can only accept boolean arguments. Got \"test\" at position 0.")"#,
         );
     }
 
     #[test]
     fn or_shape_should_error_on_no_args() {
         assert_eq!(
-            get_shape(vec![], Shape::bool([])),
-            Shape::error(
-                "Method ->or requires at least one argument".to_string(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::bool([])).pretty_print(),
+            r#"Unknown (err "Method ->or requires at least one argument")"#,
         );
     }
 
@@ -330,11 +322,9 @@ mod shape_tests {
                 None,
                 Shape::bool([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->or requires at least one argument".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->or requires at least one argument")"#,
         );
     }
 
@@ -358,12 +348,9 @@ mod shape_tests {
                 }),
                 Shape::bool([]),
                 Shape::none(),
-            ),
-            Shape::error(
-                "Method ->or can only accept boolean arguments. Got None at position 0."
-                    .to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->or can only accept boolean arguments. Got None at position 0.")"#,
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
@@ -918,7 +918,7 @@ mod shape_tests {
     #[test]
     fn parse_int_shape_should_error_for_object_input() {
         assert_eq!(
-            get_shape(vec![], Shape::empty_object([])),
+            get_shape(vec![], Shape::any_object([])),
             Shape::error_with_partial(
                 "Method ->parseInt can only parse strings and numbers. Found: {}".to_string(),
                 Shape::none(),
@@ -930,7 +930,7 @@ mod shape_tests {
     #[test]
     fn parse_int_shape_should_error_for_array_input() {
         assert_eq!(
-            get_shape(vec![], Shape::tuple([], [])),
+            get_shape(vec![], Shape::any_array([])),
             Shape::error_with_partial(
                 "Method ->parseInt can only parse strings and numbers. Found: []".to_string(),
                 Shape::none(),

--- a/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
@@ -832,12 +832,8 @@ mod shape_tests {
     #[test]
     fn parse_int_shape_should_error_for_boolean_input() {
         assert_eq!(
-            get_shape(vec![], Shape::bool([])),
-            Shape::error_with_partial(
-                "Method ->parseInt can only parse strings and numbers. Found: Bool".to_string(),
-                Shape::none(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::bool([])).pretty_print(),
+            r#"None (err "Method ->parseInt can only parse strings and numbers. Found: Bool")"#,
         );
     }
 
@@ -850,12 +846,9 @@ mod shape_tests {
                     WithRange::new(LitExpr::Number(16.into()), None)
                 ],
                 Shape::string([])
-            ),
-            Shape::error(
-                "Method ->parseInt accepts at most one argument (base), but 2 were provided"
-                    .to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->parseInt accepts at most one argument (base), but 2 were provided")"#,
         );
     }
 
@@ -868,13 +861,9 @@ mod shape_tests {
                     None
                 )],
                 Shape::string([])
-            ),
-            Shape::error_with_partial(
-                "Method ->parseInt base argument must be an integer. Found: \"not_a_number\""
-                    .to_string(),
-                Shape::int([get_location()]),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Int (err "Method ->parseInt base argument must be an integer. Found: \"not_a_number\"")"#,
         );
     }
 
@@ -918,24 +907,16 @@ mod shape_tests {
     #[test]
     fn parse_int_shape_should_error_for_object_input() {
         assert_eq!(
-            get_shape(vec![], Shape::any_object([])),
-            Shape::error_with_partial(
-                "Method ->parseInt can only parse strings and numbers. Found: {}".to_string(),
-                Shape::none(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::any_object([])).pretty_print(),
+            r#"None (err "Method ->parseInt can only parse strings and numbers. Found: {...}")"#,
         );
     }
 
     #[test]
     fn parse_int_shape_should_error_for_array_input() {
         assert_eq!(
-            get_shape(vec![], Shape::any_array([])),
-            Shape::error_with_partial(
-                "Method ->parseInt can only parse strings and numbers. Found: []".to_string(),
-                Shape::none(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::any_array([])).pretty_print(),
+            r#"None (err "Method ->parseInt can only parse strings and numbers. Found: [...]")"#,
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
@@ -89,7 +89,7 @@ fn to_string_shape(
     }
 
     // Check if input is an object or array shape
-    if Shape::empty_object([]).accepts(&input_shape) || Shape::tuple([], []).accepts(&input_shape) {
+    if input_shape.is_object() || input_shape.is_array() {
         return Shape::error_with_partial(
             format!(
                 "Method ->{} cannot convert arrays or objects to strings. Use ->jsonStringify or ->joinNotNull instead",
@@ -378,7 +378,7 @@ mod shape_tests {
     #[test]
     fn to_string_shape_should_error_for_object_input() {
         assert_eq!(
-            get_shape(vec![], Shape::empty_object([])),
+            get_shape(vec![], Shape::any_object([])),
             Shape::error_with_partial(
                 "Method ->toString cannot convert arrays or objects to strings. Use ->jsonStringify or ->joinNotNull instead"
                     .to_string(),
@@ -391,7 +391,7 @@ mod shape_tests {
     #[test]
     fn to_string_shape_should_error_for_array_input() {
         assert_eq!(
-            get_shape(vec![], Shape::tuple([], [])),
+            get_shape(vec![], Shape::any_array([])),
             Shape::error_with_partial(
                 "Method ->toString cannot convert arrays or objects to strings. Use ->jsonStringify or ->joinNotNull instead"
                     .to_string(),

--- a/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
@@ -352,11 +352,9 @@ mod shape_tests {
             get_shape(
                 vec![WithRange::new(LitExpr::String("arg".to_string()), None)],
                 Shape::int([])
-            ),
-            Shape::error(
-                "Method ->toString does not accept any arguments, but 1 were provided".to_string(),
-                [get_location()]
             )
+            .pretty_print(),
+            r#"Unknown (err "Method ->toString does not accept any arguments, but 1 were provided")"#,
         );
     }
 
@@ -378,26 +376,16 @@ mod shape_tests {
     #[test]
     fn to_string_shape_should_error_for_object_input() {
         assert_eq!(
-            get_shape(vec![], Shape::any_object([])),
-            Shape::error_with_partial(
-                "Method ->toString cannot convert arrays or objects to strings. Use ->jsonStringify or ->joinNotNull instead"
-                    .to_string(),
-                Shape::none(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::any_object([])).pretty_print(),
+            r#"None (err "Method ->toString cannot convert arrays or objects to strings. Use ->jsonStringify or ->joinNotNull instead")"#,
         );
     }
 
     #[test]
     fn to_string_shape_should_error_for_array_input() {
         assert_eq!(
-            get_shape(vec![], Shape::any_array([])),
-            Shape::error_with_partial(
-                "Method ->toString cannot convert arrays or objects to strings. Use ->jsonStringify or ->joinNotNull instead"
-                    .to_string(),
-                Shape::none(),
-                [get_location()]
-            )
+            get_shape(vec![], Shape::any_array([])).pretty_print(),
+            r#"None (err "Method ->toString cannot convert arrays or objects to strings. Use ->jsonStringify or ->joinNotNull instead")"#,
         );
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/with_error.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/with_error.rs
@@ -1,6 +1,5 @@
 use serde_json_bytes::Value as JSON;
 use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -202,7 +201,10 @@ fn with_error_shape(
     for arg in args {
         let arg_shape =
             arg.compute_output_shape(context, input_shape.clone(), dollar_shape.clone());
-        if matches!(arg_shape.case(), ShapeCase::Error(_)) {
+        // Shape errors are carried as metadata rather than a dedicated
+        // `ShapeCase::Error` variant, so an argument that failed to compute is
+        // recognized by its own errors rather than by its case.
+        if arg_shape.has_own_errors() {
             return arg_shape;
         }
     }

--- a/apollo-federation/src/connectors/schema_type_ref.rs
+++ b/apollo-federation/src/connectors/schema_type_ref.rs
@@ -82,7 +82,7 @@ impl<'schema> SchemaTypeRef<'schema> {
                     );
                 }
 
-                Shape::record(fields, [])
+                Shape::closed_record(fields, [])
             }
             ExtendedType::Scalar(s) => match s.name.as_str() {
                 "String" => Shape::string([]),
@@ -125,7 +125,7 @@ impl<'schema> SchemaTypeRef<'schema> {
                 }),
                 [],
             ),
-            ExtendedType::InputObject(i) => Shape::record(
+            ExtendedType::InputObject(i) => Shape::closed_record(
                 i.fields
                     .iter()
                     .map(|(name, field)| {

--- a/apollo-federation/src/connectors/validation/connect/selection.rs
+++ b/apollo-federation/src/connectors/validation/connect/selection.rs
@@ -603,6 +603,14 @@ impl<'schema> SelectionValidator<'schema> {
         type_ref: SchemaTypeRef<'schema>,
         shape: &Shape,
     ) -> Result<Vec<(Name, Name)>, Message> {
+        // Shape errors are now carried as metadata rather than a dedicated
+        // `ShapeCase::Error` variant. A shape-processing failure is surfaced
+        // through other diagnostics; there is nothing to credit as seen here,
+        // and we must not descend into the (possibly partial) structure, as
+        // that could emit spurious `SelectedFieldNotFound`-style errors.
+        if shape.has_own_errors() {
+            return Ok(Vec::new());
+        }
         match shape.case() {
             ShapeCase::Object { fields, .. } => {
                 for (field_name, field_shape) in fields.iter() {
@@ -792,9 +800,6 @@ impl<'schema> SelectionValidator<'schema> {
             // mask genuine `CONNECTORS_UNRESOLVED_FIELD` errors. A structure-aware
             // policy for these is left to a follow-up.
             ShapeCase::Name(_, _) | ShapeCase::Unknown => Ok(Vec::new()),
-            // A shape-processing failure is surfaced through other diagnostics;
-            // there is nothing to credit as seen here.
-            ShapeCase::Error(_) => Ok(Vec::new()),
         }
     }
 }

--- a/apollo-federation/src/connectors/validation/connect/selection.rs
+++ b/apollo-federation/src/connectors/validation/connect/selection.rs
@@ -604,6 +604,14 @@ impl<'schema> SelectionValidator<'schema> {
         type_ref: SchemaTypeRef<'schema>,
         shape: &Shape,
     ) -> Result<Vec<(Name, Name)>, Message> {
+        // Shape errors are now carried as metadata rather than a dedicated
+        // `ShapeCase::Error` variant. A shape-processing failure is surfaced
+        // through other diagnostics; there is nothing to credit as seen here,
+        // and we must not descend into the (possibly partial) structure, as
+        // that could emit spurious `SelectedFieldNotFound`-style errors.
+        if shape.has_own_errors() {
+            return Ok(Vec::new());
+        }
         match shape.case() {
             ShapeCase::Object { fields, .. } => {
                 for (field_name, field_shape) in fields.iter() {
@@ -833,9 +841,6 @@ impl<'schema> SelectionValidator<'schema> {
             // mask genuine `CONNECTORS_UNRESOLVED_FIELD` errors. A structure-aware
             // policy for these is left to a follow-up.
             ShapeCase::Name(_, _) | ShapeCase::Unknown => Ok(Vec::new()),
-            // A shape-processing failure is surfaced through other diagnostics;
-            // there is nothing to credit as seen here.
-            ShapeCase::Error(_) => Ok(Vec::new()),
         }
     }
 }

--- a/apollo-federation/src/connectors/validation/expression.rs
+++ b/apollo-federation/src/connectors/validation/expression.rs
@@ -33,7 +33,7 @@ use crate::connectors::validation::graphql::subslice_location;
 use crate::connectors::variable::VariableReference;
 
 static REQUEST_SHAPE: LazyLock<Shape> = LazyLock::new(|| {
-    Shape::record(
+    Shape::closed_record(
         [(
             "headers".to_string(),
             Shape::dict(Shape::list(Shape::string([]), []), []),
@@ -44,7 +44,7 @@ static REQUEST_SHAPE: LazyLock<Shape> = LazyLock::new(|| {
 });
 
 static RESPONSE_SHAPE: LazyLock<Shape> = LazyLock::new(|| {
-    Shape::record(
+    Shape::closed_record(
         [(
             "headers".to_string(),
             Shape::dict(Shape::list(Shape::string([]), []), []),
@@ -359,6 +359,17 @@ fn resolve_shape(
     expression: &Expression,
     resolving: &mut HashSet<String>,
 ) -> Result<Shape, Message> {
+    // Shape errors are stored as metadata on the shape itself rather than as a
+    // dedicated `ShapeCase::Error` variant. If any are present, surface the
+    // first message as a validation failure before attempting structural
+    // dispatch on the (possibly partial) case.
+    if let Some(error) = shape.own_errors().next() {
+        return Err(Message {
+            code: context.code,
+            message: error.message.clone(),
+            locations: transform_locations(shape.locations(), context, expression),
+        });
+    }
     match shape.case() {
         ShapeCase::One(shapes) => {
             let mut inners = Vec::new();
@@ -546,11 +557,6 @@ fn resolve_shape(
             }
             result
         }
-        ShapeCase::Error(shape::Error { message, .. }) => Err(Message {
-            code: context.code,
-            message: message.clone(),
-            locations: transform_locations(shape.locations(), context, expression),
-        }),
         ShapeCase::Array { prefix, tail } => {
             let prefix = prefix
                 .iter()
@@ -621,6 +627,9 @@ fn transform_locations<'a>(
 
 /// A simplified shape name for error messages
 fn short_shape_name(shape: &Shape) -> &'static str {
+    if shape.has_own_errors() {
+        return "error";
+    }
     match shape.case() {
         ShapeCase::Bool(_) => "boolean",
         ShapeCase::String(_) => "string",
@@ -634,7 +643,6 @@ fn short_shape_name(shape: &Shape) -> &'static str {
         ShapeCase::Name(_, _) => "named type",
         ShapeCase::Unknown => "unknown",
         ShapeCase::None => "none",
-        ShapeCase::Error(_) => "error",
     }
 }
 

--- a/apollo-federation/src/connectors/validation/schema/keys.rs
+++ b/apollo-federation/src/connectors/validation/schema/keys.rs
@@ -305,13 +305,6 @@ fn extract_concrete_typenames_into(shape: &Shape, in_typename: bool, result: &mu
             }
             extract_concrete_typenames_into(tail, false, result);
         }
-        ShapeCase::Error(shape::Error { partial, .. }) => {
-            // If the error has a partial shape, treat the partial shape
-            // as the root shape to extract from.
-            if let Some(partial) = partial {
-                extract_concrete_typenames_into(partial, in_typename, result);
-            }
-        }
         // Named types, and leaf types - nothing to extract at the root level
         ShapeCase::Name(_, _) => {}
         ShapeCase::None => {}
@@ -419,7 +412,7 @@ mod tests {
             ],
             [],
         );
-        let shape = Shape::record(
+        let shape = Shape::closed_record(
             [
                 ("__typename".to_string(), typename_union),
                 ("id".to_string(), Shape::string([])),
@@ -444,7 +437,7 @@ mod tests {
         use shape::Shape;
 
         // Build shape: { id: String, author: { __typename: "User", id: String } }
-        let nested_object = Shape::record(
+        let nested_object = Shape::closed_record(
             [
                 ("__typename".to_string(), Shape::string_value("User", [])),
                 ("id".to_string(), Shape::string([])),
@@ -452,7 +445,7 @@ mod tests {
             .into(),
             [],
         );
-        let shape = Shape::record(
+        let shape = Shape::closed_record(
             [
                 ("id".to_string(), Shape::string([])),
                 ("author".to_string(), nested_object),
@@ -488,7 +481,7 @@ mod tests {
             ],
             [],
         );
-        let shape = Shape::record(
+        let shape = Shape::closed_record(
             [
                 ("__typename".to_string(), conflicting_typename),
                 ("id".to_string(), Shape::string([])),
@@ -518,7 +511,7 @@ mod tests {
         use shape::Shape;
 
         // Valid object: { __typename: "Cat", id: String }
-        let valid_cat = Shape::record(
+        let valid_cat = Shape::closed_record(
             [
                 ("__typename".to_string(), Shape::string_value("Cat", [])),
                 ("id".to_string(), Shape::string([])),
@@ -528,7 +521,7 @@ mod tests {
         );
 
         // Invalid object: { __typename: All<"Cat", "Dog">, id: String }
-        let conflicting = Shape::record(
+        let conflicting = Shape::closed_record(
             [
                 (
                     "__typename".to_string(),
@@ -547,7 +540,7 @@ mod tests {
         );
 
         // Valid object: { __typename: "Bird", id: String }
-        let valid_bird = Shape::record(
+        let valid_bird = Shape::closed_record(
             [
                 ("__typename".to_string(), Shape::string_value("Bird", [])),
                 ("id".to_string(), Shape::string([])),

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@env-vars.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@env-vars.graphql.snap
@@ -1,12 +1,12 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/env-vars.graphql
 ---
 [
     Message {
         code: InvalidHeader,
-        message: "In `@source(http.headers:)`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `Dict<String>`",
+        message: "In `@source(http.headers:)`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `{...String}`",
         locations: [
             19:36..19:40,
         ],
@@ -22,7 +22,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/env-vars.graph
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.invalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `Dict<String>`",
+        message: "In `GET` in `@connect(http:)` on `Query.invalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `{...String}`",
         locations: [
             36:44..36:48,
         ],

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@headers__expressions_that_evaluate_to_invalid_types_v0_2.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@headers__expressions_that_evaluate_to_invalid_types_v0_2.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/headers/expressions_that_evaluate_to_invalid_types_v0_2.graphql
 ---
 [
@@ -13,7 +13,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/headers/expres
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.blah`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<One<String, null>>, null>`",
+        message: "In `@connect(http.headers:)` on `Query.blah`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...One<String, null>], null>`",
         locations: [
             19:10..19:27,
             21:73..21:80,

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@headers__expressions_that_evaluate_to_invalid_types_v0_3.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@headers__expressions_that_evaluate_to_invalid_types_v0_3.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/headers/expressions_that_evaluate_to_invalid_types_v0_3.graphql
 ---
 [
@@ -29,7 +29,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/headers/expres
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.blah`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<One<String, null>>, null>`",
+        message: "In `@connect(http.headers:)` on `Query.blah`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...One<String, null>], null>`",
         locations: [
             19:10..19:27,
             21:73..21:80,

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@request_headers.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@request_headers.graphql.snap
@@ -1,26 +1,26 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/request_headers.graphql
 ---
 [
     Message {
         code: InvalidHeader,
-        message: "In `@source(http.headers:)`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<String>, None>`",
+        message: "In `@source(http.headers:)`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...String], None>`",
         locations: [
             5:101..5:111,
         ],
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.failOnArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<String>, None>`",
+        message: "In `@connect(http.headers:)` on `Query.failOnArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...String], None>`",
         locations: [
             28:68..28:78,
         ],
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.failOnArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<String>, None>`",
+        message: "In `GET` in `@connect(http:)` on `Query.failOnArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...String], None>`",
         locations: [
             27:61..27:71,
         ],
@@ -43,14 +43,14 @@ input_file: apollo-federation/src/connectors/validation/test_data/request_header
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.failOnInvalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `Dict<List<String>>`",
+        message: "In `@connect(http.headers:)` on `Query.failOnInvalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `{...[...String]}`",
         locations: [
             44:60..44:67,
         ],
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.failOnInvalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `Dict<List<String>>`",
+        message: "In `GET` in `@connect(http:)` on `Query.failOnInvalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `{...[...String]}`",
         locations: [
             43:53..43:60,
         ],

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@uri_templates__invalid_types.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@uri_templates__invalid_types.graphql.snap
@@ -1,12 +1,12 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/uri_templates/invalid_types.graphql
 ---
 [
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.argIsArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<One<String, null>>, null>`",
+        message: "In `GET` in `@connect(http:)` on `Query.argIsArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...One<String, null>], null>`",
         locations: [
             8:16..8:29,
             10:47..10:50,
@@ -24,7 +24,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/uri_templates/
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `This.thisIsArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<One<String, null>>, null>`",
+        message: "In `GET` in `@connect(http:)` on `This.thisIsArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...One<String, null>], null>`",
         locations: [
             25:47..25:54,
         ],

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@url_properties__path.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@url_properties__path.graphql.snap
@@ -1,12 +1,12 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/url_properties/path.graphql
 ---
 [
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v1\")`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `List<One<String, Float, Bool>>` does not accept `[\"good\", 42, true, null, \"\"]`",
+        message: "In `@source(name: \"v1\")`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `[...One<String, Float, Bool>]` does not accept `[\"good\", 42, true, null, \"\"]`",
         locations: [
             10:16..10:44,
         ],
@@ -20,28 +20,28 @@ input_file: apollo-federation/src/connectors/validation/test_data/url_properties
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v3\")`, the `path` argument is invalid: expected array but received incompatible string\nDetails: `List<One<String, Float, Bool>>` does not accept `\"bad\"`",
+        message: "In `@source(name: \"v3\")`, the `path` argument is invalid: expected array but received incompatible string\nDetails: `[...One<String, Float, Bool>]` does not accept `\"bad\"`",
         locations: [
             16:54..16:59,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v4\")`, the `path` argument is invalid: expected array but received incompatible object\nDetails: `List<One<String, Float, Bool>>` does not accept `{ a: \"bad\" }`",
+        message: "In `@source(name: \"v4\")`, the `path` argument is invalid: expected array but received incompatible object\nDetails: `[...One<String, Float, Bool>]` does not accept `{ a: \"bad\" }`",
         locations: [
             20:54..20:66,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `List<One<String, Float, Bool>>` does not accept `[\"good\", 42, true, null, \"\"]`",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `[...One<String, Float, Bool>]` does not accept `[\"good\", 42, true, null, \"\"]`",
         locations: [
             27:34..27:62,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `List<One<String, Float, Bool>>` does not accept `[\n  One<String, null>,\n  One<Int, null>,\n  One<Float, null>,\n  One<Bool, null>,\n]`",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `[...One<String, Float, Bool>]` does not accept `[\n  One<String, null>,\n  One<Int, null>,\n  One<Float, null>,\n  One<Bool, null>,\n]`",
         locations: [
             32:34..32:70,
         ],
@@ -55,21 +55,21 @@ input_file: apollo-federation/src/connectors/validation/test_data/url_properties
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible string\nDetails: `List<One<String, Float, Bool>>` does not accept `\"bad\"`",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible string\nDetails: `[...One<String, Float, Bool>]` does not accept `\"bad\"`",
         locations: [
             36:55..36:60,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible object\nDetails: `List<One<String, Float, Bool>>` does not accept `{ a: \"bad\" }`",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible object\nDetails: `[...One<String, Float, Bool>]` does not accept `{ a: \"bad\" }`",
         locations: [
             39:34..39:46,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible union\nDetails: `List<One<String, Float, Bool>>` does not accept `One<String, null>`",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible union\nDetails: `[...One<String, Float, Bool>]` does not accept `One<String, null>`",
         locations: [
             24:16..24:22,
             24:13..24:22,

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@url_properties__query_params.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@url_properties__query_params.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/url_properties/query_params.graphql
 ---
 [
@@ -13,14 +13,14 @@ input_file: apollo-federation/src/connectors/validation/test_data/url_properties
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v4\")`, the `queryParams` argument is invalid: expected object but received incompatible array\nDetails: `Dict<Unknown>` does not accept `[]`",
+        message: "In `@source(name: \"v4\")`, the `queryParams` argument is invalid: expected object but received incompatible array\nDetails: `{...}` does not accept `[]`",
         locations: [
             23:61..23:63,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v5\")`, the `queryParams` argument is invalid: expected object but received incompatible string\nDetails: `Dict<Unknown>` does not accept `\"bad\"`",
+        message: "In `@source(name: \"v5\")`, the `queryParams` argument is invalid: expected object but received incompatible string\nDetails: `{...}` does not accept `\"bad\"`",
         locations: [
             27:61..27:66,
         ],
@@ -34,21 +34,21 @@ input_file: apollo-federation/src/connectors/validation/test_data/url_properties
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible string\nDetails: `Dict<Unknown>` does not accept `\"bad\"`",
+        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible string\nDetails: `{...}` does not accept `\"bad\"`",
         locations: [
             52:41..52:46,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible array\nDetails: `Dict<Unknown>` does not accept `[\"bad\"]`",
+        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible array\nDetails: `{...}` does not accept `[\"bad\"]`",
         locations: [
             57:41..57:48,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible union\nDetails: `Dict<Unknown>` does not accept `One<String, null>`",
+        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible union\nDetails: `{...}` does not accept `One<String, null>`",
         locations: [
             31:16..31:22,
             31:13..31:22,


### PR DESCRIPTION
Bumps `shape` from `=0.7.0` to `=0.8.3` and updates the connectors code for the new API.

## Impact

Behavior neutral, with one developer-visible exception. `shape` is not used at runtime: it backs composition-time validation of connectors selections and URI templates. The exception is the pretty-printed shape notation that appears in the `Details: ...` portion of some validation errors, which is now terser:

* `List<T>` prints as `[...T]` and `Dict<T>` as `{...T}`
* error shapes print as `<partial> (err "message")` rather than `Error<...>`

Validation snapshots are updated to match, and `apollo-federation/CHANGELOG.md` gains a Maintenance entry for the notation change, since a snapshot or log query matching the old strings will need updating.

## What changed internally

* Errors are no longer a `ShapeCase::Error` variant. They are metadata that can ride on any shape, and `shape::Error` is now just `{ message }` (the shape itself carries what used to be the error's `partial`). Match sites read error state via `has_own_errors()` / `own_errors()` and construct via `Shape::error` / `error_with_partial`.
* `Shape::record` and `Shape::tuple` are deprecated in favor of explicit `closed_*` and `open_*` constructors, so each construction site now states whether extra fields or elements are allowed.
* The old "is this any array/object?" probes were written as `Shape::tuple([], []).accepts(x)` and `Shape::empty_object([]).accepts(x)`. 0.8.0 is where `accepts()` began enforcing closedness, so those probes would have silently gone false for every non-empty container. They now use `is_array()` / `is_object()`, which preserves the 0.7.0 answer and also handles `One`, `All`, and `Name`.

## What 0.8.3 adds on top of 0.8.0

The 0.8.0 to 0.8.3 step needed no source changes at all: the API surface the connectors code touches is unchanged, and no snapshot moved.

* Four `accepts` fixes backported from shape's `lean-model` branch, one of them unsound. Unions are distributed out of field and item positions, so `One<{a: Int}, {a: String}>` now accepts `{a: One<Int, String>}`. Array positions past the received prefix respect absence, so `[Int, Int, ...]` no longer accepts `[Int, ...Int]`, which the value `[5]` refutes. A received field admitting no value is skipped whether the expected shape is open or closed, and `Never` is recognized alongside `None`. The `One<true, false>` covers `Bool` case asks its containment question in the right direction.
* The union splitting search is bounded by structural caps rather than by a count of the product it might walk, so where the search stops is decidable by inspecting the shapes. The depth cap counts a whole comparison instead of restarting at each object level, and rises from 4 to 12. Answers are memoized for the duration of one comparison, which changes how long a comparison takes and never what it answers: a doomed search nested six levels deep goes from 21 seconds to 455 microseconds.
* `Shape::merge` arrives as a public name for the composition operator. It delegates to `Shape::all` and is the same operation for now, so it is available to record composition intent at call sites ahead of the two being given separate implementations.

## Incorporated from #10118

@tninesling opened #10118 as a forward port of this PR to `dev-v3.x`, and @dariuszkuc reviewed it in detail. That PR is closed in favor of this one, and its review-feedback commit is included here with authorship preserved:

* About 76 assertions of the form `assert_eq!(result, Shape::error("msg", []))` were vacuous, because `PartialEq for Shape` compares only the case and ignores the metadata where 0.8.0 moved error state. They now compare `pretty_print()` output, which tests structure and message together. That change caught stale expectations in `parse_int`.
* The `SubSelection` fallback in `apply_to.rs` goes back to `empty_object`. `empty_object` was never deprecated, so widening it to `any_object` was not something the migration required.
* Comments still using the old display notation are updated in `filter.rs`, `find.rs`, `map.rs` and `apply_to.rs`.

Two findings from that review do not survive checking, recorded here so they are not raised again. The claim that `Shape::empty_object([]).accepts(&input)` "was always false for non-empty containers" is true of 0.8.0 and false of 0.7.0, whose object arm iterates only the fields the expected shape declares and never looks for extras. Those probes fired on every object and every array, so `->toString`, `->get`, `->contains` and `->in` behave exactly as they did before this PR, and no schema that composed previously fails now.

## Groundwork for better connect/v0.5 errors

Two of these changes matter beyond the migration. Errors are now metadata carried by the shape they describe rather than a separate `ShapeCase::Error` node, and 0.8.0 keeps error locations that 0.7.0 dropped when an `Unknown` was simplified out of an `All<>` intersection.

That combination is a prerequisite for the diagnostics the reusable selection definitions in #9919 will want. A `defs:` entry or a `@mapping` body is written once and called from many selections, so a useful error has to say both what went wrong inside the definition and which call site provoked it. Locations survive simplification now, and error state rides along on the shape instead of on a wrapper that gets optimized away, so both ends of that story stay available to report. No diagnostic changes here, just the groundwork.

## Testing

* `cargo test -p apollo-federation --lib`: 1949 passing, 0 failing
* `cargo clippy -p apollo-federation --all-targets --all-features -- -D warnings`: clean
* `apollo-router` builds against the bumped `apollo-federation`

No changeset, matching #8616, the equivalent update for 0.7.0.
