### PR TITLE
fix: remove unsupported cargo-about filter-noassertion option

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -18,9 +18,6 @@ accepted = [
     "CDLA-Permissive-2.0", # webpki-roots
 ]
 
-# See https://github.com/EmbarkStudios/cargo-about/pull/216
-filter-noassertion = true
-
 # Ignore non plublished crates, such as xtask for example
 private = { ignore = true }
 # Ignore dependencies used in tests only, test-log for example


### PR DESCRIPTION
As of #9299, this option is no longer supported.

The option was introduced back in #3178. I seem to be able to generate the licenses just fine without it, so we may no longer rely on this, or a different cargo-about change has made it obsolete.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- Tests added and passing[^4]
    - [x] Manual tests, as necessary

**Exceptions**

Ran `cargo xtask licenses` locally to confirm it works.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
