### PR TITLE
fix(rhai): redact internal error details from client-facing responses

### DIFF
--- a/.changesets/breaking_rohan_b99_redact_rhai_internals_from_client_errors.md
+++ b/.changesets/breaking_rohan_b99_redact_rhai_internals_from_client_errors.md
@@ -26,6 +26,6 @@ Three behaviour changes to be aware of when upgrading:
 
 - Client-facing messages for a thrown string no longer include the `rhai execution error: 'Runtime error: ... (line N, position M)'` wrapper. Only the string you threw is returned. The full error is still in the logs.
 - An error raised by a router Rhai function is now caught as a `RouterError` rather than a string. Interpolating it - `${err}` - reads as it always has, and `err.message` gives the same text. Errors your script raised with `throw` are caught unchanged.
-- Re-throwing an error you caught keeps it redacted, whichever kind it is: a caught router error is opaque rather than an object map you can add a `status` or `message` to, and the object map the Rhai engine gives you for its own failures keeps its `message` out of the response. A `status` you set on either is still honoured. To give a client a specific message, `throw` a new error instead.
+- Re-throwing an error you caught keeps it redacted, whichever kind it is: a caught router error is opaque rather than an object map you can add a `status` or `message` to, and the object map the Rhai engine gives you for its own failures keeps its `message` out of the response. A `status` you set on that object map is still honoured; a caught router error takes no `status` at all - assigning one raises a fresh error that replaces the one you caught. To give a client a specific message, `throw` a new error instead.
 
 By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9956

--- a/.changesets/breaking_rohan_b99_redact_rhai_internals_from_client_errors.md
+++ b/.changesets/breaking_rohan_b99_redact_rhai_internals_from_client_errors.md
@@ -26,6 +26,6 @@ Three behaviour changes to be aware of when upgrading:
 
 - Client-facing messages for a thrown string no longer include the `rhai execution error: 'Runtime error: ... (line N, position M)'` wrapper. Only the string you threw is returned. The full error is still in the logs.
 - An error raised by a router Rhai function is now caught as a `RouterError` rather than a string. Interpolating it - `${err}` - reads as it always has, and `err.message` gives the same text. Errors your script raised with `throw` are caught unchanged.
-- A caught router error is opaque rather than an object map you can add a `status` or `message` to, and re-throwing it keeps it redacted. To give a client a specific message, `throw` a new error instead.
+- Re-throwing an error you caught keeps it redacted, whichever kind it is: a caught router error is opaque rather than an object map you can add a `status` or `message` to, and the object map the Rhai engine gives you for its own failures keeps its `message` out of the response. A `status` you set on either is still honoured. To give a client a specific message, `throw` a new error instead.
 
 By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9956

--- a/.changesets/fix_rohan_b99_redact_rhai_internals_from_client_errors.md
+++ b/.changesets/fix_rohan_b99_redact_rhai_internals_from_client_errors.md
@@ -1,0 +1,31 @@
+### Stop disclosing Rhai internals in client-facing error responses ([PR #9956](https://github.com/apollographql/router/pull/9956))
+
+When a Rhai script failed, the router returned the raw Rhai error to the client, which exposed the fact that the router runs Rhai, the names of the script's callbacks, and the line and position where the failure happened:
+
+```json
+{
+  "errors": [
+    {
+      "message": "rhai execution error: 'Runtime error: failed to convert header to a str (line 25, position 39)\nin call to function 'process_router_request' @ 'process_router_request' (line 6, position 29)'"
+    }
+  ]
+}
+```
+
+Clients now only receive a message the script author chose. A `throw` is returned as written, with the Rhai wrapper stripped:
+
+```rhai
+throw "Invalid request";                          // client sees: Invalid request
+throw #{ status: 403, message: "Forbidden" };     // client sees: Forbidden
+throw #{ status: 403, body: #{ errors: [...] } }; // client sees the custom body
+```
+
+Anything the script did *not* choose is replaced with the status code's reason phrase, and the underlying error is logged at `ERROR` level instead. This covers failures inside the router's own Rhai functions (such as reading a header that isn't present), failures raised by the Rhai engine itself (such as calling an undefined function), and a `throw` carrying only a status - `throw #{ status: 400 }` now reads `Bad Request` rather than dumping the thrown object.
+
+Three behaviour changes to be aware of when upgrading:
+
+- Client-facing messages for a thrown string no longer include the `rhai execution error: 'Runtime error: ... (line N, position M)'` wrapper. Only the string you threw is returned. The full error is still in the logs.
+- An error raised by a router Rhai function is now caught as a `RouterError` rather than a string. Interpolating it - `${err}` - reads as it always has, and `err.message` gives the same text. Errors your script raised with `throw` are caught unchanged.
+- A caught router error is opaque rather than an object map you can add a `status` or `message` to, and re-throwing it keeps it redacted. To give a client a specific message, `throw` a new error instead.
+
+By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/9956

--- a/apollo-router/src/plugins/rhai/engine/error.rs
+++ b/apollo-router/src/plugins/rhai/engine/error.rs
@@ -58,10 +58,26 @@ pub(crate) fn internal_error_message(thrown: &Dynamic) -> Option<String> {
 /// How rhai renders a marked error when it formats the `Dynamic` carrying it with `Display`.
 ///
 /// Rhai's `Display` for a custom value writes [`std::any::type_name`] rather than going through the
-/// `to_string` registered below, so this is the token `process_error` substitutes the real message
-/// back into when it keeps the engine's error text for the logs.
+/// `to_string` registered below, so this is the token [`display_error_for_log`] and `process_error`
+/// substitute the real message back into when they keep the engine's error text for the logs.
 pub(crate) fn displayed_as() -> &'static str {
     std::any::type_name::<RouterInternalError>()
+}
+
+/// Render a whole Rhai error for the logs, with a marked error's message put back where rhai names
+/// its Rust type.
+///
+/// For a callback failure `process_error` does this itself, because it has a client-facing response
+/// to build at the same time. This is for the failures that only ever reach a log.
+pub(super) fn display_error_for_log(error: &EvalAltResult) -> String {
+    let displayed = error.to_string();
+    match error.unwrap_inner() {
+        EvalAltResult::ErrorRuntime(thrown, _) => match internal_error_message(thrown) {
+            Some(message) => displayed.replace(displayed_as(), &message),
+            None => displayed,
+        },
+        _ => displayed,
+    }
 }
 
 /// Render a value a script passed to one of the router's logging functions.
@@ -100,10 +116,11 @@ mod tests {
         }
     }
 
-    // The two places a marked error is rendered outside a script: a router logging function, which
-    // takes a `Dynamic` and formats it with `Display`, and `process_error`, which substitutes the
-    // message back into rhai's own error text. Both rest on `Display` naming the Rust type rather
-    // than calling the `to_string` registered for scripts.
+    // The three places a marked error is rendered outside a script: a router logging function,
+    // which takes a `Dynamic` and formats it with `Display`; `display_error_for_log`, for the
+    // failures that never reach a client; and `process_error`, which substitutes the message back
+    // into rhai's own error text. All rest on `Display` naming the Rust type rather than calling
+    // the `to_string` registered for scripts.
     #[test]
     fn it_renders_a_marked_error_as_its_message_rather_than_its_type() {
         let thrown = thrown_value(*internal_error("environment variable not found"));
@@ -113,6 +130,11 @@ mod tests {
             display_for_log(&thrown),
             "environment variable not found",
             "log_error(err) has to read as the message, not as the marker"
+        );
+        assert_eq!(
+            display_error_for_log(&internal_error("environment variable not found")),
+            "Runtime error: environment variable not found",
+            "a service callback failure has to read as the message, not as the marker"
         );
     }
 

--- a/apollo-router/src/plugins/rhai/engine/error.rs
+++ b/apollo-router/src/plugins/rhai/engine/error.rs
@@ -1,0 +1,70 @@
+//! Errors raised by the router's own Rhai bindings, as opposed to errors a script raised
+//! deliberately with `throw`.
+
+use rhai::Dynamic;
+use rhai::Engine;
+use rhai::EvalAltResult;
+use rhai::Position;
+
+/// The name scripts see for [`RouterInternalError`], in `type_of()` and in Rhai's own error text.
+const SCRIPT_TYPE_NAME: &str = "RouterError";
+
+/// The value carried by a failure inside the router's own Rhai bindings.
+///
+/// Rhai gives us no way to tell such a failure from a `throw` in the script - both arrive as
+/// [`EvalAltResult::ErrorRuntime`] - but only the latter is a message the script author chose to
+/// show to clients. `process_error` looks for this type so that binding failures are logged
+/// server-side and replaced with a generic message in the client-facing response, instead of
+/// disclosing router internals.
+///
+/// It is an opaque Rust type rather than a key in an object map so that a script can neither strip
+/// the marker nor carry it into an error of its own by mutating and re-throwing the value it
+/// caught: a script that wants its own status and message throws a fresh value.
+#[derive(Clone)]
+struct RouterInternalError {
+    message: String,
+}
+
+/// Build the Rhai error to return from a failure inside the router's own Rhai bindings.
+///
+/// Every binding must raise its errors through this helper rather than converting a string into
+/// `Box<EvalAltResult>` directly, otherwise the error text ends up in client-facing responses.
+/// `tests::bindings_raise_their_errors_through_internal_error` enforces that.
+///
+/// Scripts can still `catch` these errors. The caught value stringifies to the message, so
+/// `${err}` in an interpolated string reads as it always has, and exposes it as `err.message`.
+pub(super) fn internal_error(message: impl std::fmt::Display) -> Box<EvalAltResult> {
+    Box::new(EvalAltResult::ErrorRuntime(
+        Dynamic::from(RouterInternalError {
+            message: message.to_string(),
+        }),
+        Position::NONE,
+    ))
+}
+
+/// The unredacted message of a binding failure, or `None` if `thrown` is something the script threw
+/// itself.
+///
+/// The message names router internals - which binding failed and why - so it belongs in the logs
+/// and in a script's `catch` block, never in a client-facing response.
+pub(crate) fn internal_error_message(thrown: &Dynamic) -> Option<String> {
+    thrown
+        .read_lock::<RouterInternalError>()
+        .map(|error| error.message.clone())
+}
+
+/// Give scripts the same access to a binding failure they had when it was a plain string: `${err}`
+/// and `print(err)` yield the message, and so does `err.message`.
+pub(super) fn register(engine: &mut Engine) {
+    engine
+        .register_type_with_name::<RouterInternalError>(SCRIPT_TYPE_NAME)
+        .register_get("message", |error: &mut RouterInternalError| {
+            error.message.clone()
+        })
+        .register_fn("to_string", |error: &mut RouterInternalError| {
+            error.message.clone()
+        })
+        .register_fn("to_debug", |error: &mut RouterInternalError| {
+            error.message.clone()
+        });
+}

--- a/apollo-router/src/plugins/rhai/engine/error.rs
+++ b/apollo-router/src/plugins/rhai/engine/error.rs
@@ -55,8 +55,26 @@ pub(crate) fn internal_error_message(thrown: &Dynamic) -> Option<String> {
         .map(|error| error.message.clone())
 }
 
-/// Give scripts the same access to a binding failure they had when it was a plain string: `${err}`
-/// and `print(err)` yield the message, and so does `err.message`.
+/// How rhai renders a marked error when it formats the `Dynamic` carrying it with `Display`.
+///
+/// Rhai's `Display` for a custom value writes [`std::any::type_name`] rather than going through the
+/// `to_string` registered below, so this is the token `process_error` substitutes the real message
+/// back into when it keeps the engine's error text for the logs.
+pub(crate) fn displayed_as() -> &'static str {
+    std::any::type_name::<RouterInternalError>()
+}
+
+/// Render a value a script passed to one of the router's logging functions.
+///
+/// Those take a `Dynamic` and format it with `Display`, which renders a marked error as
+/// [`displayed_as`] rather than through the registered `to_string` - so a script logging the error
+/// itself, `log_error(err)`, has to be routed past that the way an interpolated one already is.
+pub(super) fn display_for_log(value: &Dynamic) -> String {
+    internal_error_message(value).unwrap_or_else(|| value.to_string())
+}
+
+/// Give scripts the same access to a binding failure they had when it was a plain string: `${err}`,
+/// `print(err)` and `log_error(err)` yield the message, and so does `err.message`.
 pub(super) fn register(engine: &mut Engine) {
     engine
         .register_type_with_name::<RouterInternalError>(SCRIPT_TYPE_NAME)
@@ -69,4 +87,39 @@ pub(super) fn register(engine: &mut Engine) {
         .register_fn("to_debug", |error: &mut RouterInternalError| {
             error.message.clone()
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn thrown_value(error: EvalAltResult) -> Dynamic {
+        match error {
+            EvalAltResult::ErrorRuntime(thrown, _) => thrown,
+            other => panic!("expected a runtime error, got: {other}"),
+        }
+    }
+
+    // The two places a marked error is rendered outside a script: a router logging function, which
+    // takes a `Dynamic` and formats it with `Display`, and `process_error`, which substitutes the
+    // message back into rhai's own error text. Both rest on `Display` naming the Rust type rather
+    // than calling the `to_string` registered for scripts.
+    #[test]
+    fn it_renders_a_marked_error_as_its_message_rather_than_its_type() {
+        let thrown = thrown_value(*internal_error("environment variable not found"));
+
+        assert_eq!(thrown.to_string(), displayed_as());
+        assert_eq!(
+            display_for_log(&thrown),
+            "environment variable not found",
+            "log_error(err) has to read as the message, not as the marker"
+        );
+    }
+
+    #[test]
+    fn it_renders_everything_else_as_it_always_did() {
+        let thrown = thrown_value("a message the script threw".into());
+
+        assert_eq!(display_for_log(&thrown), "a message the script threw");
+    }
 }

--- a/apollo-router/src/plugins/rhai/engine/error.rs
+++ b/apollo-router/src/plugins/rhai/engine/error.rs
@@ -27,9 +27,11 @@ struct RouterInternalError {
 
 /// Build the Rhai error to return from a failure inside the router's own Rhai bindings.
 ///
-/// Every binding must raise its errors through this helper rather than converting a string into
-/// `Box<EvalAltResult>` directly, otherwise the error text ends up in client-facing responses.
-/// `tests::bindings_raise_their_errors_through_internal_error` enforces that.
+/// Every binding must raise its errors through this helper - both the ones it builds itself, rather
+/// than converting a string into `Box<EvalAltResult>` directly, and the ones rhai's own conversions
+/// hand it already built, rather than propagating those unchanged - otherwise the error text ends up
+/// in client-facing responses. `tests::bindings_raise_their_errors_through_internal_error` enforces
+/// that.
 ///
 /// Scripts can still `catch` these errors. The caught value stringifies to the message, so
 /// `${err}` in an interpolated string reads as it always has, and exposes it as `err.message`.

--- a/apollo-router/src/plugins/rhai/engine/mod.rs
+++ b/apollo-router/src/plugins/rhai/engine/mod.rs
@@ -75,6 +75,7 @@ const CANNOT_ACCESS_STATUS_CODE_ON_A_DEFERRED_RESPONSE: &str =
 
 const CANNOT_GET_ENVIRONMENT_VARIABLE: &str = "environment variable not found";
 
+pub(super) use error::displayed_as as internal_error_displayed_as;
 use error::internal_error;
 pub(super) use error::internal_error_message;
 pub(crate) use types::OptionDance;
@@ -279,9 +280,13 @@ mod router_header_map {
         x: &mut HeaderMap,
         key: &str,
     ) -> Result<String, Box<EvalAltResult>> {
+        // Parse the key before naming it in an error: `HeaderMap::remove` accepts any `&str` and
+        // simply finds nothing, so an unparsed key would put whatever the script passed - which may
+        // be a value it read off the request - into the log line verbatim.
+        let search_name = HeaderName::from_str(key).map_err(internal_error)?;
         let removed = x
-            .remove(key)
-            .ok_or_else(|| internal_error(format!("header not found: {key}")))?;
+            .remove(&search_name)
+            .ok_or_else(|| internal_error(format!("header not found: {search_name}")))?;
         Ok(String::from_utf8_lossy(removed.as_bytes()).to_string())
     }
 
@@ -1364,13 +1369,13 @@ impl Rhai {
                         function_name,
                         (rhai_service, name.to_string()),
                     )
-                    .map_err(|err| err.to_string())?;
+                    .map_err(|err| err.to_string())?; // not a rhai binding
             }
             None => {
                 let _ = self
                     .engine
                     .call_fn::<Dynamic>(&mut guard, &self.ast, function_name, (rhai_service,))
-                    .map_err(|err| err.to_string())?;
+                    .map_err(|err| err.to_string())?; // not a rhai binding
             }
         }
 
@@ -1452,19 +1457,28 @@ impl Rhai {
                 tracing::info!(%message, target = %print_main);
             })
             // Register a series of logging functions
+            //
+            // Note: these render their argument with `error::display_for_log` rather than with
+            // `Display`, so that `log_error(err)` on a caught binding failure reads as its message
+            // and not as the Rust type rhai's `Display` would name.
             .register_fn("log_trace", move |message: Dynamic| {
+                let message = error::display_for_log(&message);
                 tracing::trace!(%message, target = %trace_main);
             })
             .register_fn("log_debug", move |message: Dynamic| {
+                let message = error::display_for_log(&message);
                 tracing::debug!(%message, target = %debug_main);
             })
             .register_fn("log_info", move |message: Dynamic| {
+                let message = error::display_for_log(&message);
                 tracing::info!(%message, target = %info_main);
             })
             .register_fn("log_warn", move |message: Dynamic| {
+                let message = error::display_for_log(&message);
                 tracing::warn!(%message, target = %warn_main);
             })
             .register_fn("log_error", move |message: Dynamic| {
+                let message = error::display_for_log(&message);
                 tracing::error!(%message, target = %error_main);
             });
 

--- a/apollo-router/src/plugins/rhai/engine/mod.rs
+++ b/apollo-router/src/plugins/rhai/engine/mod.rs
@@ -1068,7 +1068,7 @@ mod router_plugin {
         x: &mut Request,
         om: Map,
     ) -> Result<(), Box<EvalAltResult>> {
-        x.variables = from_dynamic(&om.into())?;
+        x.variables = from_dynamic(&om.into()).map_err(internal_error)?;
         Ok(())
     }
 
@@ -1083,7 +1083,7 @@ mod router_plugin {
         x: &mut Request,
         om: Map,
     ) -> Result<(), Box<EvalAltResult>> {
-        x.extensions = from_dynamic(&om.into())?;
+        x.extensions = from_dynamic(&om.into()).map_err(internal_error)?;
         Ok(())
     }
 
@@ -1204,7 +1204,7 @@ mod router_plugin {
 
     #[rhai_fn(set = "data", return_raw)]
     pub(crate) fn response_data_set(x: &mut Response, om: Map) -> Result<(), Box<EvalAltResult>> {
-        x.data = from_dynamic(&om.into())?;
+        x.data = from_dynamic(&om.into()).map_err(internal_error)?;
         Ok(())
     }
 
@@ -1220,7 +1220,7 @@ mod router_plugin {
         x: &mut Response,
         value: Dynamic,
     ) -> Result<(), Box<EvalAltResult>> {
-        x.errors = from_dynamic(&value)?;
+        x.errors = from_dynamic(&value).map_err(internal_error)?;
         Ok(())
     }
 
@@ -1235,7 +1235,7 @@ mod router_plugin {
         x: &mut Response,
         om: Map,
     ) -> Result<(), Box<EvalAltResult>> {
-        x.extensions = from_dynamic(&om.into())?;
+        x.extensions = from_dynamic(&om.into()).map_err(internal_error)?;
         Ok(())
     }
 

--- a/apollo-router/src/plugins/rhai/engine/mod.rs
+++ b/apollo-router/src/plugins/rhai/engine/mod.rs
@@ -1369,13 +1369,13 @@ impl Rhai {
                         function_name,
                         (rhai_service, name.to_string()),
                     )
-                    .map_err(|err| err.to_string())?; // not a rhai binding
+                    .map_err(|err| error::display_error_for_log(&err))?; // not a rhai binding
             }
             None => {
                 let _ = self
                     .engine
                     .call_fn::<Dynamic>(&mut guard, &self.ast, function_name, (rhai_service,))
-                    .map_err(|err| err.to_string())?; // not a rhai binding
+                    .map_err(|err| error::display_error_for_log(&err))?; // not a rhai binding
             }
         }
 

--- a/apollo-router/src/plugins/rhai/engine/mod.rs
+++ b/apollo-router/src/plugins/rhai/engine/mod.rs
@@ -1,3 +1,4 @@
+mod error;
 mod registration;
 mod types;
 
@@ -12,13 +13,11 @@ use base64::prelude::BASE64_STANDARD_NO_PAD;
 use base64::prelude::BASE64_URL_SAFE;
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use http::HeaderMap;
-use http::header::InvalidHeaderName;
 use http::uri::Authority;
 use http::uri::Parts;
 use http::uri::PathAndQuery;
 use http::uri::Scheme;
 use parking_lot::Mutex;
-use tower::BoxError;
 use uuid::Uuid;
 
 use super::Rhai;
@@ -76,6 +75,8 @@ const CANNOT_ACCESS_STATUS_CODE_ON_A_DEFERRED_RESPONSE: &str =
 
 const CANNOT_GET_ENVIRONMENT_VARIABLE: &str = "environment variable not found";
 
+use error::internal_error;
+pub(super) use error::internal_error_message;
 pub(crate) use types::OptionDance;
 pub(crate) use types::SharedMut;
 
@@ -113,9 +114,9 @@ mod router_base64 {
         String::from_utf8(
             BASE64_STANDARD
                 .decode(input.as_bytes())
-                .map_err(|e| e.to_string())?,
+                .map_err(internal_error)?,
         )
-        .map_err(|e| e.to_string().into())
+        .map_err(internal_error)
     }
 
     #[rhai_fn(pure, name = "decode", return_raw)]
@@ -124,8 +125,8 @@ mod router_base64 {
         alphabet: Alphabet,
     ) -> Result<String, Box<EvalAltResult>> {
         let engine = get_engine(&alphabet);
-        String::from_utf8(engine.decode(input.as_bytes()).map_err(|e| e.to_string())?)
-            .map_err(|e| e.to_string().into())
+        String::from_utf8(engine.decode(input.as_bytes()).map_err(internal_error)?)
+            .map_err(internal_error)
     }
 
     #[rhai_fn(pure)]
@@ -157,12 +158,12 @@ mod router_json {
 
     #[rhai_fn(pure, return_raw)]
     pub(crate) fn encode(input: &mut Dynamic) -> Result<String, Box<EvalAltResult>> {
-        serde_json::to_string(input).map_err(|e| e.to_string().into())
+        serde_json::to_string(input).map_err(internal_error)
     }
 
     #[rhai_fn(pure, return_raw)]
     pub(crate) fn decode(input: &mut ImmutableString) -> Result<Dynamic, Box<EvalAltResult>> {
-        serde_json::from_str(input).map_err(|e| e.to_string().into())
+        serde_json::from_str(input).map_err(internal_error)
     }
 }
 
@@ -183,11 +184,11 @@ mod router_expansion {
 
     #[rhai_fn(name = "get", return_raw)]
     pub(crate) fn expansion_env(key: &str) -> Result<String, Box<EvalAltResult>> {
-        let expander = Expansion::default_rhai().map_err(|e| e.to_string())?;
+        let expander = Expansion::default_rhai().map_err(internal_error)?;
         expander
             .expand_env(key)
-            .map_err(|e| e.to_string())?
-            .ok_or(CANNOT_GET_ENVIRONMENT_VARIABLE.into())
+            .map_err(internal_error)?
+            .ok_or_else(|| internal_error(CANNOT_GET_ENVIRONMENT_VARIABLE))
     }
 }
 
@@ -219,7 +220,7 @@ mod status_code {
 
     #[rhai_fn(return_raw)]
     pub(crate) fn status_code_from_int(number: INT) -> Result<StatusCode, Box<EvalAltResult>> {
-        let code = StatusCode::from_u16(number as u16).map_err(|e| e.to_string())?;
+        let code = StatusCode::from_u16(number as u16).map_err(internal_error)?;
         Ok(code)
     }
 
@@ -278,7 +279,10 @@ mod router_header_map {
         x: &mut HeaderMap,
         key: &str,
     ) -> Result<String, Box<EvalAltResult>> {
-        Ok(String::from_utf8_lossy(x.remove(key).ok_or("")?.as_bytes()).to_string())
+        let removed = x
+            .remove(key)
+            .ok_or_else(|| internal_error(format!("header not found: {key}")))?;
+        Ok(String::from_utf8_lossy(removed.as_bytes()).to_string())
     }
 
     // Register a HeaderMap indexer so we can get/set headers
@@ -294,9 +298,11 @@ mod router_header_map {
         x: &mut HeaderMap,
         key: &str,
     ) -> Result<String, Box<EvalAltResult>> {
-        let search_name =
-            HeaderName::from_str(key).map_err(|e: InvalidHeaderName| e.to_string())?;
-        Ok(String::from_utf8_lossy(x.get(search_name).ok_or("")?.as_bytes()).to_string())
+        let search_name = HeaderName::from_str(key).map_err(internal_error)?;
+        let value = x
+            .get(search_name)
+            .ok_or_else(|| internal_error(format!("header not found: {key}")))?;
+        Ok(String::from_utf8_lossy(value.as_bytes()).to_string())
     }
 
     #[rhai_fn(index_set, return_raw)]
@@ -306,8 +312,8 @@ mod router_header_map {
         value: &str,
     ) -> Result<(), Box<EvalAltResult>> {
         x.insert(
-            HeaderName::from_str(key).map_err(|e| e.to_string())?,
-            HeaderValue::from_str(value).map_err(|e| e.to_string())?,
+            HeaderName::from_str(key).map_err(internal_error)?,
+            HeaderValue::from_str(value).map_err(internal_error)?,
         );
         Ok(())
     }
@@ -320,11 +326,12 @@ mod router_header_map {
         key: &str,
         value: Array,
     ) -> Result<(), Box<EvalAltResult>> {
-        let h_key = HeaderName::from_str(key).map_err(|e| e.to_string())?;
+        let h_key = HeaderName::from_str(key).map_err(internal_error)?;
         for v in value {
             x.append(
                 h_key.clone(),
-                HeaderValue::from_str(&v.into_string()?).map_err(|e| e.to_string())?,
+                HeaderValue::from_str(&v.into_string().map_err(internal_error)?)
+                    .map_err(internal_error)?,
             );
         }
         Ok(())
@@ -341,8 +348,7 @@ mod router_header_map {
         x: &mut HeaderMap,
         key: &str,
     ) -> Result<Array, Box<EvalAltResult>> {
-        let search_name =
-            HeaderName::from_str(key).map_err(|e: InvalidHeaderName| e.to_string())?;
+        let search_name = HeaderName::from_str(key).map_err(internal_error)?;
         let mut response = Array::new();
         for value in x.get_all(search_name).iter() {
             response.push(String::from_utf8_lossy(value.as_bytes()).to_string().into())
@@ -411,7 +417,7 @@ mod router_context {
     pub(crate) fn context_get(x: &mut Context, key: &str) -> Result<Dynamic, Box<EvalAltResult>> {
         x.get(key)
             .map(|v: Option<Dynamic>| v.unwrap_or(Dynamic::UNIT))
-            .map_err(|e: BoxError| e.to_string().into())
+            .map_err(internal_error)
     }
 
     #[rhai_fn(index_set, return_raw)]
@@ -423,7 +429,7 @@ mod router_context {
         let _ = x
             .insert(key, value)
             .map(|v: Option<Dynamic>| v.unwrap_or(Dynamic::UNIT))
-            .map_err(|e: BoxError| e.to_string())?;
+            .map_err(internal_error)?;
         Ok(())
     }
 
@@ -443,7 +449,7 @@ mod router_context {
                 .call_within_context(&context, (v.clone(),))
                 .unwrap_or(v)
         })
-        .map_err(|e: BoxError| e.to_string().into())
+        .map_err(internal_error)
     }
 
     #[rhai_fn(name = "to_string", pure)]
@@ -694,14 +700,16 @@ mod router_plugin {
     pub(crate) fn get_originating_headers_router_deferred_response(
         _obj: &mut SharedMut<router::DeferredResponse>,
     ) -> Result<HeaderMap, Box<EvalAltResult>> {
-        Err(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE.into())
+        Err(internal_error(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE))
     }
 
     #[rhai_fn(get = "status_code", pure, return_raw)]
     pub(crate) fn get_status_code_router_deferred_response(
         _obj: &mut SharedMut<router::DeferredResponse>,
     ) -> Result<HeaderMap, Box<EvalAltResult>> {
-        Err(CANNOT_ACCESS_STATUS_CODE_ON_A_DEFERRED_RESPONSE.into())
+        Err(internal_error(
+            CANNOT_ACCESS_STATUS_CODE_ON_A_DEFERRED_RESPONSE,
+        ))
     }
 
     #[rhai_fn(name = "is_primary", pure)]
@@ -729,7 +737,7 @@ mod router_plugin {
     pub(crate) fn get_originating_headers_supergraph_deferred_response(
         _obj: &mut SharedMut<supergraph::DeferredResponse>,
     ) -> Result<HeaderMap, Box<EvalAltResult>> {
-        Err(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE.into())
+        Err(internal_error(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE))
     }
 
     #[rhai_fn(name = "is_primary", pure)]
@@ -757,7 +765,7 @@ mod router_plugin {
     pub(crate) fn get_originating_headers_execution_deferred_response(
         _obj: &mut SharedMut<execution::DeferredResponse>,
     ) -> Result<HeaderMap, Box<EvalAltResult>> {
-        Err(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE.into())
+        Err(internal_error(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE))
     }
 
     #[rhai_fn(name = "is_primary", pure)]
@@ -823,7 +831,7 @@ mod router_plugin {
             Ok::<Bytes, Box<EvalAltResult>>(bytes)
         })?;
 
-        String::from_utf8(bytes.to_vec()).map_err(|err| err.to_string().into())
+        String::from_utf8(bytes.to_vec()).map_err(internal_error)
     }*/
 
     #[rhai_fn(get = "body", pure, return_raw)]
@@ -854,7 +862,7 @@ mod router_plugin {
         _obj: &mut SharedMut<router::DeferredResponse>,
         _headers: HeaderMap,
     ) -> Result<(), Box<EvalAltResult>> {
-        Err(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE.into())
+        Err(internal_error(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE))
     }
 
     #[rhai_fn(set = "headers", return_raw)]
@@ -871,7 +879,7 @@ mod router_plugin {
         _obj: &mut SharedMut<supergraph::DeferredResponse>,
         _headers: HeaderMap,
     ) -> Result<(), Box<EvalAltResult>> {
-        Err(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE.into())
+        Err(internal_error(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE))
     }
 
     #[rhai_fn(set = "headers", return_raw)]
@@ -888,7 +896,7 @@ mod router_plugin {
         _obj: &mut SharedMut<execution::DeferredResponse>,
         _headers: HeaderMap,
     ) -> Result<(), Box<EvalAltResult>> {
-        Err(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE.into())
+        Err(internal_error(CANNOT_ACCESS_HEADERS_ON_A_DEFERRED_RESPONSE))
     }
 
     #[rhai_fn(set = "headers", return_raw)]
@@ -987,9 +995,7 @@ mod router_plugin {
 
     #[rhai_fn(pure, return_raw)]
     pub(crate) fn urldecode(x: &mut ImmutableString) -> Result<String, Box<EvalAltResult>> {
-        Ok(urlencoding::decode(x)
-            .map_err(|e| e.to_string())?
-            .into_owned())
+        Ok(urlencoding::decode(x).map_err(internal_error)?.into_owned())
     }
 
     #[rhai_fn(name = "headers_are_available", pure)]
@@ -1054,7 +1060,7 @@ mod router_plugin {
     // Request.variables
     #[rhai_fn(get = "variables", pure, return_raw)]
     pub(crate) fn request_variables_get(x: &mut Request) -> Result<Dynamic, Box<EvalAltResult>> {
-        to_dynamic(x.variables.clone())
+        to_dynamic(x.variables.clone()).map_err(internal_error)
     }
 
     #[rhai_fn(set = "variables", return_raw)]
@@ -1069,7 +1075,7 @@ mod router_plugin {
     // Request.extensions
     #[rhai_fn(get = "extensions", pure, return_raw)]
     pub(crate) fn request_extensions_get(x: &mut Request) -> Result<Dynamic, Box<EvalAltResult>> {
-        to_dynamic(x.extensions.clone())
+        to_dynamic(x.extensions.clone()).map_err(internal_error)
     }
 
     #[rhai_fn(set = "extensions", return_raw)]
@@ -1084,7 +1090,7 @@ mod router_plugin {
     // Uri.path
     #[rhai_fn(get = "path", pure, return_raw)]
     pub(crate) fn uri_path_get(x: &mut Uri) -> Result<Dynamic, Box<EvalAltResult>> {
-        to_dynamic(x.path())
+        to_dynamic(x.path()).map_err(internal_error)
     }
 
     #[rhai_fn(set = "path", return_raw)]
@@ -1096,23 +1102,23 @@ mod router_plugin {
         let mut parts: Parts = x.clone().into_parts();
         parts.path_and_query = match parts
             .path_and_query
-            .ok_or("path and query are missing")?
+            .ok_or_else(|| internal_error("path and query are missing"))?
             .query()
         {
             Some(query) => Some(
                 PathAndQuery::from_maybe_shared(format!("{value}?{query}"))
-                    .map_err(|e| e.to_string())?,
+                    .map_err(internal_error)?,
             ),
-            None => Some(PathAndQuery::from_str(value).map_err(|e| e.to_string())?),
+            None => Some(PathAndQuery::from_str(value).map_err(internal_error)?),
         };
-        *x = Uri::from_parts(parts).map_err(|e| e.to_string())?;
+        *x = Uri::from_parts(parts).map_err(internal_error)?;
         Ok(())
     }
 
     // Uri.host
     #[rhai_fn(get = "host", pure, return_raw)]
     pub(crate) fn uri_host_get(x: &mut Uri) -> Result<Dynamic, Box<EvalAltResult>> {
-        to_dynamic(x.host())
+        to_dynamic(x.host()).map_err(internal_error)
     }
 
     #[rhai_fn(set = "host", return_raw)]
@@ -1126,22 +1132,22 @@ mod router_plugin {
             Some(old_authority) => {
                 if let Some(port) = old_authority.port() {
                     Authority::from_maybe_shared(format!("{value}:{port}"))
-                        .map_err(|e| e.to_string())?
+                        .map_err(internal_error)?
                 } else {
-                    Authority::from_str(value).map_err(|e| e.to_string())?
+                    Authority::from_str(value).map_err(internal_error)?
                 }
             }
-            None => Authority::from_str(value).map_err(|e| e.to_string())?,
+            None => Authority::from_str(value).map_err(internal_error)?,
         };
         parts.authority = Some(new_authority);
-        *x = Uri::from_parts(parts).map_err(|e| e.to_string())?;
+        *x = Uri::from_parts(parts).map_err(internal_error)?;
         Ok(())
     }
 
     // Uri.port
     #[rhai_fn(get = "port", pure, return_raw)]
     pub(crate) fn uri_port_get(x: &mut Uri) -> Result<Dynamic, Box<EvalAltResult>> {
-        to_dynamic(x.port().map(|p| p.as_u16()))
+        to_dynamic(x.port().map(|p| p.as_u16())).map_err(internal_error)
     }
 
     #[rhai_fn(set = "port", return_raw)]
@@ -1155,27 +1161,27 @@ mod router_plugin {
             Some(old_authority) => {
                 let host = old_authority.host();
                 let new_authority = Authority::from_maybe_shared(format!("{host}:{value}"))
-                    .map_err(|e| e.to_string())?;
+                    .map_err(internal_error)?;
                 parts.authority = Some(new_authority);
-                *x = Uri::from_parts(parts).map_err(|e| e.to_string())?;
+                *x = Uri::from_parts(parts).map_err(internal_error)?;
                 Ok(())
             }
-            None => Err("invalid URI; unable to set port".into()),
+            None => Err(internal_error("invalid URI; unable to set port")),
         }
     }
 
     // Uri.scheme
     #[rhai_fn(get = "scheme", pure, return_raw)]
     pub(crate) fn uri_scheme_get(x: &mut Uri) -> Result<Dynamic, Box<EvalAltResult>> {
-        to_dynamic(x.scheme_str())
+        to_dynamic(x.scheme_str()).map_err(internal_error)
     }
 
     #[rhai_fn(set = "scheme", return_raw)]
     pub(crate) fn uri_scheme_set(x: &mut Uri, value: &str) -> Result<(), Box<EvalAltResult>> {
         let mut parts: Parts = x.clone().into_parts();
-        let new_scheme = Scheme::from_str(value).map_err(|e| e.to_string())?;
+        let new_scheme = Scheme::from_str(value).map_err(internal_error)?;
         parts.scheme = Some(new_scheme);
-        *x = Uri::from_parts(parts).map_err(|e| e.to_string())?;
+        *x = Uri::from_parts(parts).map_err(internal_error)?;
         Ok(())
     }
 
@@ -1193,7 +1199,7 @@ mod router_plugin {
     // Response.data
     #[rhai_fn(get = "data", pure, return_raw)]
     pub(crate) fn response_data_get(x: &mut Response) -> Result<Dynamic, Box<EvalAltResult>> {
-        to_dynamic(x.data.clone())
+        to_dynamic(x.data.clone()).map_err(internal_error)
     }
 
     #[rhai_fn(set = "data", return_raw)]
@@ -1206,7 +1212,7 @@ mod router_plugin {
     // Response.errors
     #[rhai_fn(get = "errors", pure, return_raw)]
     pub(crate) fn response_errors_get(x: &mut Response) -> Result<Dynamic, Box<EvalAltResult>> {
-        to_dynamic(x.errors.clone())
+        to_dynamic(x.errors.clone()).map_err(internal_error)
     }
 
     #[rhai_fn(set = "errors", return_raw)]
@@ -1221,7 +1227,7 @@ mod router_plugin {
     // Response.extensions
     #[rhai_fn(get = "extensions", pure, return_raw)]
     pub(crate) fn response_extensions_get(x: &mut Response) -> Result<Dynamic, Box<EvalAltResult>> {
-        to_dynamic(x.extensions.clone())
+        to_dynamic(x.extensions.clone()).map_err(internal_error)
     }
 
     #[rhai_fn(set = "extensions", return_raw)]
@@ -1238,7 +1244,7 @@ mod router_plugin {
     pub(crate) fn traceid() -> Result<TraceId, Box<EvalAltResult>> {
         TraceId::maybe_new()
             .or_else(TraceId::current)
-            .ok_or_else(|| "trace unavailable".into())
+            .ok_or_else(|| internal_error("trace unavailable"))
     }
 
     #[rhai_fn(name = "to_string")]
@@ -1283,7 +1289,7 @@ mod router_plugin {
     pub(crate) fn unix_now() -> Result<i64, Box<EvalAltResult>> {
         SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .map_err(|e| e.to_string().into())
+            .map_err(internal_error)
             .map(|x| x.as_secs() as i64)
     }
 
@@ -1291,7 +1297,7 @@ mod router_plugin {
     pub(crate) fn unix_ms_now() -> Result<i64, Box<EvalAltResult>> {
         SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .map_err(|e| e.to_string().into())
+            .map_err(internal_error)
             .map(|x| x.as_millis() as i64)
     }
 
@@ -1400,6 +1406,9 @@ impl Rhai {
             .register_static_module("env", expansion_module.into())
             // Register HeaderMap as an iterator so we can loop over contents
             .register_iterator::<HeaderMap>();
+
+        // Let scripts read the errors the modules registered above raise on failure
+        error::register(engine);
     }
 
     pub(super) fn new_rhai_engine(

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -18,6 +18,7 @@ use rhai::EvalAltResult;
 use rhai::FnPtr;
 use rhai::FuncArgs;
 use rhai::Instant;
+use rhai::Map;
 use rhai::Scope;
 use rhai::Shared;
 use schemars::JsonSchema;
@@ -726,7 +727,7 @@ impl ServiceStep {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug)]
 struct Position {
     line: Option<usize>,
     pos: Option<usize>,
@@ -751,12 +752,14 @@ impl From<&rhai::Position> for Position {
     }
 }
 
-#[derive(Deserialize, Debug)]
+/// What a failed Rhai callback turns into: the response the client gets, and the reason an operator
+/// needs.
+///
+/// This is built by `process_error`, never deserialized from a script's value - `process_error`
+/// reads the keys of a thrown object map one at a time instead, so that a key it cannot use does
+/// not take the rest of the author's intent down with it.
+#[derive(Debug)]
 struct ErrorDetails {
-    #[serde(
-        with = "http_serde::status_code",
-        default = "default_thrown_status_code"
-    )]
     status: StatusCode,
     message: Option<String>,
     position: Option<Position>,
@@ -765,14 +768,8 @@ struct ErrorDetails {
     ///
     /// This holds Rhai implementation details - engine error text, script line numbers and the
     /// names of the callbacks involved - so it must never be copied into `message` or into a
-    /// client-facing response. It is skipped during deserialization because it describes the
-    /// failure, not something a script can throw.
-    #[serde(skip)]
+    /// client-facing response.
     internal_detail: Option<String>,
-}
-
-fn default_thrown_status_code() -> StatusCode {
-    StatusCode::INTERNAL_SERVER_ERROR
 }
 
 /// The client-facing message for a failure the script author did not choose, i.e. anything the
@@ -791,17 +788,31 @@ fn redacted_message(status: StatusCode) -> String {
         .to_string()
 }
 
+/// Whether a thrown object map is one rhai handed a `catch` block for an engine failure, rather
+/// than one the script wrote itself.
+///
+/// `EvalAltResult::dump_fields` stamps every such map with an `error` key naming the variant -
+/// `"ErrorFunctionNotFound"` and the like. A script's own throw never picks that key up, because
+/// rhai passes a thrown value to `catch` unchanged rather than rebuilding it, so the key tells the
+/// two apart. It matters because the `message` on an engine map is the engine's own error text: a
+/// script re-throwing that map, with or without a status set on it first, would put back exactly
+/// what `process_error` redacts everywhere else.
+fn is_caught_engine_error(thrown_map: &Map) -> bool {
+    thrown_map
+        .get("error")
+        .is_some_and(|variant| variant.is_string())
+}
+
 fn process_error(error: Box<EvalAltResult>) -> ErrorDetails {
     let mut error_details = ErrorDetails {
         status: StatusCode::INTERNAL_SERVER_ERROR,
         message: None,
         position: None,
         body: None,
-        internal_detail: None,
+        // Rendered before `error` is taken apart below: this is the only place the whole Rhai
+        // error is available, including the chain of script callbacks it came up through.
+        internal_detail: Some(format!("rhai execution error: '{error}'")),
     };
-    // Captured before `error` is consumed below: this is the only chance to keep the full Rhai
-    // error text for the logs.
-    error_details.internal_detail = Some(format!("rhai execution error: '{error}'"));
 
     let inner_error = error.unwrap_inner();
     // A script's `throw` is the usual source of `ErrorRuntime`, and the only source that carries a
@@ -820,29 +831,42 @@ fn process_error(error: Box<EvalAltResult>) -> ErrorDetails {
         if let Some(internal_message) = engine::internal_error_message(thrown) {
             // A router Rhai binding failed rather than the script throwing, so the message
             // describes router internals: it stays out of the response and goes to the logs. Rhai
-            // displays a marked error as its Rust type name rather than as its message, so the
-            // detail captured above has to be rebuilt here to keep the message in the logs.
-            error_details.internal_detail = Some(format!(
-                "rhai execution error: 'Runtime error: {internal_message}{}'",
-                if pos.is_none() {
-                    String::new()
-                } else {
-                    format!(" ({pos})")
-                }
-            ));
-        } else if let Ok(thrown_details) = rhai::serde::from_dynamic::<ErrorDetails>(thrown) {
-            // `throw #{ status: ..., message: ..., body: ... }`
-            error_details.status = thrown_details.status;
+            // renders a marked error as its Rust type rather than as its message, so put the
+            // message back where that type was named - rebuilding the detail from this error alone
+            // would drop the `in call to function` chain around it.
+            if let Some(detail) = &mut error_details.internal_detail {
+                *detail = detail.replace(engine::internal_error_displayed_as(), &internal_message);
+            }
+        } else if let Some(thrown_map) = thrown.read_lock::<Map>() {
+            // `throw #{ status: ..., message: ..., body: ... }`, read one key at a time. A script
+            // is free to throw a map carrying keys of its own - rhai gives a `catch` block `line`
+            // and `position` integers alongside the message - and a key we cannot use must not
+            // discard the status and message the author did choose.
+            let thrown_value = |key: &str| thrown_map.get(key).filter(|value| !value.is_unit());
+            if let Some(status) = thrown_value("status")
+                .and_then(|value| value.as_int().ok())
+                .and_then(|code| u16::try_from(code).ok())
+                .and_then(|code| StatusCode::from_u16(code).ok())
+            {
+                error_details.status = status;
+            }
+            let message = thrown_value("message")
+                .filter(|_| !is_caught_engine_error(&thrown_map))
+                .and_then(|value| value.as_immutable_string_ref().ok())
+                .map(|message| message.to_string());
+            let body = thrown_value("body").and_then(|value| {
+                rhai::serde::from_dynamic::<crate::graphql::Response>(value).ok()
+            });
             // A throw carrying only a status - `throw #{ status: 400 }` - gets the status it asked
             // for and a redacted message, because there is no author-provided message to return.
-            if thrown_details.message.is_some() || thrown_details.body.is_some() {
-                error_details.message = thrown_details.message;
-                error_details.body = thrown_details.body;
+            if message.is_some() || body.is_some() {
+                error_details.message = message;
+                error_details.body = body;
             }
-        } else if let Ok(thrown_message) = thrown.clone().into_string() {
+        } else if let Ok(thrown_message) = thrown.as_immutable_string_ref() {
             // `throw "some message"`. The author wrote this string, so it is theirs to return - but
             // only the string itself, not the Rhai wrapper around it.
-            error_details.message = Some(thrown_message);
+            error_details.message = Some(thrown_message.to_string());
         }
     }
 

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -791,16 +791,22 @@ fn redacted_message(status: StatusCode) -> String {
 /// Whether a thrown object map is one rhai handed a `catch` block for an engine failure, rather
 /// than one the script wrote itself.
 ///
-/// `EvalAltResult::dump_fields` stamps every such map with an `error` key naming the variant -
-/// `"ErrorFunctionNotFound"` and the like. A script's own throw never picks that key up, because
-/// rhai passes a thrown value to `catch` unchanged rather than rebuilding it, so the key tells the
-/// two apart. It matters because the `message` on an engine map is the engine's own error text: a
-/// script re-throwing that map, with or without a status set on it first, would put back exactly
-/// what `process_error` redacts everywhere else.
+/// `EvalAltResult::dump_fields` stamps every such map with an `error` key naming the variant, and
+/// every variant a script can catch is named `ErrorSomething` - `"ErrorFunctionNotFound"` and the
+/// like. A script's own throw never picks that key up, because rhai passes a thrown value to
+/// `catch` unchanged rather than rebuilding it, so the key tells the two apart. It matters because
+/// the `message` on an engine map is the engine's own error text: a script re-throwing that map,
+/// with or without a status set on it first, would put back exactly what `process_error` redacts
+/// everywhere else.
+///
+/// The value is matched as well as the key, because `error` is an obvious name for a code of the
+/// script's own - `throw #{ message: "Email is invalid", error: "INVALID_EMAIL" }` is a message the
+/// author wrote and has to be returned.
 fn is_caught_engine_error(thrown_map: &Map) -> bool {
     thrown_map
         .get("error")
-        .is_some_and(|variant| variant.is_string())
+        .and_then(|variant| variant.as_immutable_string_ref().ok())
+        .is_some_and(|variant| variant.starts_with("Error"))
 }
 
 fn process_error(error: Box<EvalAltResult>) -> ErrorDetails {

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -537,10 +537,12 @@ macro_rules! gen_map_deferred_response {
                     if first.is_none() {
                         let error_details = ErrorDetails {
                             status: StatusCode::INTERNAL_SERVER_ERROR,
-                            message: Some("rhai execution error: empty response".to_string()),
+                            message: Some(redacted_message(StatusCode::INTERNAL_SERVER_ERROR)),
                             position: None,
-                            body: None
+                            body: None,
+                            internal_detail: Some("rhai execution error: empty response".to_string()),
                         };
+                        tracing::error!("map_response callback failed: {error_details:#?}");
                         return Ok($base::response_failure(
                             context,
                             error_details
@@ -759,31 +761,92 @@ struct ErrorDetails {
     message: Option<String>,
     position: Option<Position>,
     body: Option<crate::graphql::Response>,
+    /// The unredacted Rhai error, kept for server-side logging only.
+    ///
+    /// This holds Rhai implementation details - engine error text, script line numbers and the
+    /// names of the callbacks involved - so it must never be copied into `message` or into a
+    /// client-facing response. It is skipped during deserialization because it describes the
+    /// failure, not something a script can throw.
+    #[serde(skip)]
+    internal_detail: Option<String>,
 }
 
 fn default_thrown_status_code() -> StatusCode {
     StatusCode::INTERNAL_SERVER_ERROR
 }
 
+/// The client-facing message for a failure the script author did not choose, i.e. anything the
+/// script did not explicitly `throw`.
+///
+/// Returning the Rhai error itself discloses that the router runs Rhai, which script functions are
+/// registered, and where in the script the failure happened, so clients get the status code's
+/// reason phrase instead and the real error is logged.
+fn redacted_message(status: StatusCode) -> String {
+    // A script is free to throw a status code that has no reason phrase - `throw #{ status: 599 }`
+    // - so there has to be a fallback. It is deliberately as vague as the status is: saying
+    // "Internal Server Error" alongside a 599 would be a lie.
+    status
+        .canonical_reason()
+        .unwrap_or("Unknown Error")
+        .to_string()
+}
+
 fn process_error(error: Box<EvalAltResult>) -> ErrorDetails {
     let mut error_details = ErrorDetails {
         status: StatusCode::INTERNAL_SERVER_ERROR,
-        message: Some(format!("rhai execution error: '{error}'")),
+        message: None,
         position: None,
         body: None,
+        internal_detail: None,
     };
+    // Captured before `error` is consumed below: this is the only chance to keep the full Rhai
+    // error text for the logs.
+    error_details.internal_detail = Some(format!("rhai execution error: '{error}'"));
 
     let inner_error = error.unwrap_inner();
-    // We only want to process runtime errors
-    if let EvalAltResult::ErrorRuntime(obj, pos) = inner_error {
-        if let Ok(temp_error_details) = rhai::serde::from_dynamic::<ErrorDetails>(obj) {
-            if temp_error_details.message.is_some() || temp_error_details.body.is_some() {
-                error_details = temp_error_details;
-            } else {
-                error_details.status = temp_error_details.status;
-            }
-        }
+    // A script's `throw` is the usual source of `ErrorRuntime`, and the only source that carries a
+    // message the author chose to show a client, so this is the one variant whose text can be
+    // returned. Every other variant is an engine failure - unknown function, type mismatch, script
+    // recursion limit - whose text describes the script's internals, so those stay redacted.
+    //
+    // Rhai raises `ErrorRuntime` with a string of its own in two places - a `sort` comparer that
+    // fails, and a serialization failure - and nothing in the value distinguishes those from a
+    // `throw`, so they are returned like one. Router bindings, which we do control, mark their
+    // errors instead: see `engine::internal_error`.
+    if let EvalAltResult::ErrorRuntime(thrown, pos) = inner_error {
         error_details.position = Some(pos.into());
+
+        if let Some(internal_message) = engine::internal_error_message(thrown) {
+            // A router Rhai binding failed rather than the script throwing, so the message
+            // describes router internals: it stays out of the response and goes to the logs. Rhai
+            // displays a marked error as its Rust type name rather than as its message, so the
+            // detail captured above has to be rebuilt here to keep the message in the logs.
+            error_details.internal_detail = Some(format!(
+                "rhai execution error: 'Runtime error: {internal_message}{}'",
+                if pos.is_none() {
+                    String::new()
+                } else {
+                    format!(" ({pos})")
+                }
+            ));
+        } else if let Ok(thrown_details) = rhai::serde::from_dynamic::<ErrorDetails>(thrown) {
+            // `throw #{ status: ..., message: ..., body: ... }`
+            error_details.status = thrown_details.status;
+            // A throw carrying only a status - `throw #{ status: 400 }` - gets the status it asked
+            // for and a redacted message, because there is no author-provided message to return.
+            if thrown_details.message.is_some() || thrown_details.body.is_some() {
+                error_details.message = thrown_details.message;
+                error_details.body = thrown_details.body;
+            }
+        } else if let Ok(thrown_message) = thrown.clone().into_string() {
+            // `throw "some message"`. The author wrote this string, so it is theirs to return - but
+            // only the string itself, not the Rhai wrapper around it.
+            error_details.message = Some(thrown_message);
+        }
+    }
+
+    if error_details.message.is_none() {
+        error_details.message = Some(redacted_message(error_details.status));
     }
     error_details
 }

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -810,9 +810,10 @@ fn process_error(error: Box<EvalAltResult>) -> ErrorDetails {
     // recursion limit - whose text describes the script's internals, so those stay redacted.
     //
     // Rhai raises `ErrorRuntime` with a string of its own in two places - a `sort` comparer that
-    // fails, and a serialization failure - and nothing in the value distinguishes those from a
-    // `throw`, so they are returned like one. Router bindings, which we do control, mark their
-    // errors instead: see `engine::internal_error`.
+    // fails, and a serialization failure in `to_dynamic` - and nothing in the value distinguishes
+    // those from a `throw`, so they are returned like one. (Its deserialization failures in
+    // `from_dynamic` are `ErrorParsing`, so they stay redacted here.) Router bindings, which we do
+    // control, mark their errors instead: see `engine::internal_error`.
     if let EvalAltResult::ErrorRuntime(thrown, pos) = inner_error {
         error_details.position = Some(pos.into());
 

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__execution_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__execution_error_logging_without_body@logs.snap
@@ -4,7 +4,7 @@ expression: yaml
 ---
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n}"
   span:
     name: rhai_plugin
     otel.kind: INTERNAL
@@ -15,4 +15,4 @@ expression: yaml
       rhai service: "execution :: Request"
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n}"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_redacts_binding_errors_from_client_responses@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_redacts_binding_errors_from_client_responses@logs.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"Internal Server Error\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                18,\n            ),\n            pos: Some(\n                32,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: header not found: x-header-that-is-not-there (line 18, position 32)'\",\n    ),\n}"
+  span:
+    name: rhai_plugin
+    otel.kind: INTERNAL
+    rhai service: "supergraph :: Request"
+  spans:
+    - name: rhai_plugin
+      otel.kind: INTERNAL
+      rhai service: "supergraph :: Request"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_redacts_engine_errors_from_client_responses@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_redacts_engine_errors_from_client_responses@logs.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"Internal Server Error\",\n    ),\n    position: None,\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Function not found: this_function_does_not_exist () (line 23, position 5)'\",\n    ),\n}"
+  span:
+    name: rhai_plugin
+    otel.kind: INTERNAL
+    rhai service: "execution :: Request"
+  spans:
+    - name: rhai_plugin
+      otel.kind: INTERNAL
+      rhai service: "execution :: Request"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__router_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__router_error_logging_without_body@logs.snap
@@ -4,7 +4,7 @@ expression: yaml
 ---
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n}"
   span:
     name: rhai_plugin
     otel.kind: INTERNAL
@@ -15,4 +15,4 @@ expression: yaml
       rhai service: "router :: Request"
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n}"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__subgraph_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__subgraph_error_logging_without_body@logs.snap
@@ -4,7 +4,7 @@ expression: yaml
 ---
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n}"
   span:
     name: rhai_plugin
     otel.kind: INTERNAL
@@ -15,4 +15,4 @@ expression: yaml
       rhai service: "subgraph :: Request"
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n}"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__supergraph_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__supergraph_error_logging_without_body@logs.snap
@@ -4,7 +4,7 @@ expression: yaml
 ---
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n}"
   span:
     name: rhai_plugin
     otel.kind: INTERNAL
@@ -15,4 +15,4 @@ expression: yaml
       rhai service: "supergraph :: Request"
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n}"

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -1351,18 +1351,72 @@ fn bindings_raise_their_errors_through_internal_error() {
         );
 
         for (index, line) in source.lines().enumerate() {
-            let produces_an_error = ["Err(", "map_err(", "ok_or(", "ok_or_else("]
+            // The `.into()` has to come after the producer to be the thing the producer is raising:
+            // an earlier one is converting an argument, as in `from_dynamic(&om.into())`.
+            let converts_into_an_error = ["Err(", "map_err(", "ok_or(", "ok_or_else("]
                 .iter()
-                .any(|producer| line.contains(producer));
+                .filter_map(|producer| line.find(producer))
+                .min()
+                .zip(line.rfind(".into()"))
+                .is_some_and(|(producer, conversion)| conversion > producer);
             assert!(
-                !(produces_an_error && line.contains(".into()")),
+                !converts_into_an_error,
                 "{path}:{} converts a value into a Rhai error. Raise it with \
                  `engine::internal_error` instead, or `process_error` will return its text to \
                  clients:\n{line}",
                 index + 1
             );
+
+            // Rhai's own conversions fail with a `Box<EvalAltResult>` already built, so a bare `?`
+            // on one raises an unmarked error without naming `EvalAltResult` or `.into()` - neither
+            // rule above sees it.
+            let converts_from_rhai = ["from_dynamic(", "to_dynamic("]
+                .iter()
+                .any(|conversion| line.contains(conversion))
+                && !line.contains("internal_error");
+            assert!(
+                !(converts_from_rhai && line.contains(")?")),
+                "{path}:{} propagates a Rhai conversion failure unchanged. Add \
+                 `.map_err(internal_error)` before the `?`, or `process_error` may return its text \
+                 to clients:\n{line}",
+                index + 1
+            );
         }
     }
+}
+
+// A setter that deserializes a script's value - `response.body.errors` here, given a path element
+// that is neither a key nor an index - fails with an error rhai built rather than one the binding
+// wrote, and its text names Rust types (`untagged enum PathElement`).
+//
+// Rhai's two serde directions do not agree on which error they raise: its serializer's
+// `Error::custom` builds `ErrorRuntime` from a plain string, which `process_error` cannot tell from
+// a `throw` and would return, while its deserializer's builds `ErrorParsing`, which stays redacted
+// whether or not the binding marks it. So the `to_dynamic` getters are the leak and the
+// `from_dynamic` setters are safe by rhai's choice rather than by ours - a choice this test pins, so
+// that if rhai aligns the two directions the setters are already marked.
+#[tokio::test]
+async fn it_redacts_deserialization_failures_in_binding_setters() {
+    let error = call_property_mutation_test(
+        "test_malformed_response_errors",
+        RhaiSupergraphResponse::default(),
+    )
+    .await
+    .expect_err("deserializing the malformed error path fails");
+
+    let processed_error = process_error(error);
+    let message = processed_error.message.expect("the failure has a message");
+    assert_eq!(message, "Internal Server Error");
+    assert_message_discloses_nothing(&message);
+
+    // The other half: what the client no longer sees still has to be available to an operator.
+    let internal_detail = processed_error
+        .internal_detail
+        .expect("the unredacted failure is kept for the logs");
+    assert!(
+        internal_detail.contains("untagged enum PathElement"),
+        "the unredacted failure has to reach the logs: {internal_detail}"
+    );
 }
 
 // Helper for calling property mutation test functions

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -1131,24 +1131,6 @@ async fn test_subgraph_error_logging_with_body() -> Result<(), BoxError> {
         .await
 }
 
-/// Anything that could tell a client the router runs Rhai, which functions its script registers,
-/// or where in that script a failure happened.
-fn assert_message_discloses_nothing(message: &str) {
-    for disclosure in [
-        "rhai",
-        "Rhai",
-        "Runtime error",
-        "line ",
-        "position ",
-        "in call to function",
-    ] {
-        assert!(
-            !message.contains(disclosure),
-            "client-facing message leaks {disclosure:?}: {message}"
-        );
-    }
-}
-
 // A failure inside the router's own Rhai bindings - here, reading a header that isn't present -
 // used to reach the client as `rhai execution error: 'Runtime error: <binding error> (line N,
 // position M)'`.
@@ -1172,7 +1154,6 @@ async fn it_redacts_binding_errors_from_client_responses() -> Result<(), BoxErro
         let body = response.next_response().await.expect("there is a response");
         let message = &body.errors.first().expect("the request failed").message;
         assert_eq!(message, "Internal Server Error");
-        assert_message_discloses_nothing(message);
 
         crate::plugin::test::assert_no_mock_calls(handle).await;
         Ok(())
@@ -1209,7 +1190,6 @@ async fn it_redacts_engine_errors_from_client_responses() -> Result<(), BoxError
         let body = response.next_response().await.expect("there is a response");
         let message = &body.errors.first().expect("the request failed").message;
         assert_eq!(message, "Internal Server Error");
-        assert_message_discloses_nothing(message);
 
         crate::plugin::test::assert_no_mock_calls(handle).await;
         Ok(())
@@ -1220,8 +1200,8 @@ async fn it_redacts_engine_errors_from_client_responses() -> Result<(), BoxError
 
 // Scripts can still `catch` a binding failure, so the router must not have made these errors
 // uncatchable in the course of marking them internal.
-#[tokio::test]
-async fn it_can_catch_binding_errors_in_a_script() {
+#[test]
+fn it_can_catch_binding_errors_in_a_script() {
     let engine = new_rhai_test_engine();
     let caught: String = engine
         .eval(
@@ -1306,16 +1286,94 @@ fn it_redacts_a_throw_with_an_unrecognised_status() {
     assert_eq!(processed_error.message, Some("Unknown Error".to_string()));
 }
 
+// A thrown object map is read a key at a time, so a key the router has no use for - the value a
+// `catch` sees for an engine error carries `line` and `position` integers, and re-throwing it with
+// a status set is an obvious thing to write - does not take the author's status and message with
+// it.
+#[test]
+fn it_returns_a_throw_that_carries_keys_of_its_own() {
+    let engine = new_rhai_test_engine();
+    let error = engine
+        .eval::<()>(r#"throw #{ status: 400, message: "Invalid request", position: 3 };"#)
+        .expect_err("the script throws");
+
+    let processed_error = process_error(error);
+    assert_eq!(processed_error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        processed_error.message,
+        Some("Invalid request".to_string()),
+        "a key the router cannot use must not discard the author's message"
+    );
+}
+
+// Re-throwing the value a `catch` block was handed for an engine failure must not put the engine's
+// error text into the response, however the script dresses it up first. Its status is still the
+// author's to choose - only the message rhai wrote is redacted.
+#[test]
+fn it_redacts_a_re_thrown_engine_error() {
+    let engine = new_rhai_test_engine();
+    let error = engine
+        .eval::<()>(
+            r#"
+            try {
+                this_function_does_not_exist();
+            } catch(err) {
+                err.status = 400;
+                throw err;
+            }"#,
+        )
+        .expect_err("the script re-throws what it caught");
+
+    let processed_error = process_error(error);
+    assert_eq!(processed_error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        processed_error.message,
+        Some("Bad Request".to_string()),
+        "the engine's own error text is not the script author's to return"
+    );
+    // The operator still gets it.
+    let internal_detail = processed_error
+        .internal_detail
+        .expect("the real error is logged");
+    assert!(
+        internal_detail.contains("this_function_does_not_exist"),
+        "expected the unredacted error in the logs, got: {internal_detail}"
+    );
+}
+
+// ...and a key it *can* use but cannot read - a body that isn't a GraphQL response - only costs the
+// author that key, not the status they asked for.
+#[test]
+fn it_keeps_the_status_of_a_throw_whose_body_is_malformed() {
+    let engine = new_rhai_test_engine();
+    let error = engine
+        .eval::<()>(r#"throw #{ status: 403, body: "not a graphql response" };"#)
+        .expect_err("the script throws");
+
+    let processed_error = process_error(error);
+    assert_eq!(processed_error.status, StatusCode::FORBIDDEN);
+    assert!(processed_error.body.is_none());
+    // There is no author-provided message left to return, so the status' reason phrase stands in.
+    assert_eq!(processed_error.message, Some("Forbidden".to_string()));
+}
+
 // `engine::internal_error` is the only way a router binding may raise an error: a plain
 // `Err("...".into())` produces an `ErrorRuntime` that `process_error` cannot tell apart from a
 // script's own `throw`, so its text would be returned to clients. Nothing in the type system
 // prevents that - rhai fixes the error type of a fallible binding as `Box<EvalAltResult>` - so it
 // is checked here instead.
 //
-// A binding that raises an error some way these two rules don't describe slips through; they cover
-// the ways a `Box<EvalAltResult>` can be built at all, which is what makes them worth having.
+// A binding that raises an error some way these rules don't describe slips through; they cover the
+// three ways this code has ever produced one - naming `EvalAltResult`, converting a value with
+// `.into()`, and leaning on a `?` to do that conversion implicitly - which is what makes them worth
+// having.
 #[test]
 fn bindings_raise_their_errors_through_internal_error() {
+    // Not everything in `engine/` is a binding: `run_rhai_service` raises `String`s that only ever
+    // reach a log, never `process_error`. The few such lines say so, rather than the rules below
+    // guessing which functions rhai calls.
+    const NOT_A_BINDING: &str = "not a rhai binding";
+
     // Read the directory rather than listing the files, so a binding added later is checked too.
     let engine_dir =
         std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/plugins/rhai/engine");
@@ -1351,14 +1409,27 @@ fn bindings_raise_their_errors_through_internal_error() {
         );
 
         for (index, line) in source.lines().enumerate() {
-            // The `.into()` has to come after the producer to be the thing the producer is raising:
-            // an earlier one is converting an argument, as in `from_dynamic(&om.into())`.
+            if line.contains(NOT_A_BINDING) {
+                continue;
+            }
+
+            // A producer raises what follows it as a Rhai error either explicitly, with an `.into()`
+            // after it, or implicitly, with a `?` leaning on `impl From<T: AsRef<str>> for
+            // Box<EvalAltResult>`. The `.into()` has to come after the producer to be the thing
+            // being raised: an earlier one is converting an argument, as in
+            // `from_dynamic(&om.into())`. The `?` form names neither `EvalAltResult` nor `.into()`,
+            // and is how `.map_err(|e| e.to_string())?` and `.ok_or("...")?` - the shapes every
+            // disclosure fixed alongside this test was written in - get past a reader.
             let converts_into_an_error = ["Err(", "map_err(", "ok_or(", "ok_or_else("]
                 .iter()
                 .filter_map(|producer| line.find(producer))
                 .min()
-                .zip(line.rfind(".into()"))
-                .is_some_and(|(producer, conversion)| conversion > producer);
+                .is_some_and(|producer| {
+                    line.rfind(".into()")
+                        .is_some_and(|conversion| conversion > producer)
+                        || line.contains(")?")
+                })
+                && !line.contains("internal_error");
             assert!(
                 !converts_into_an_error,
                 "{path}:{} converts a value into a Rhai error. Raise it with \
@@ -1367,18 +1438,19 @@ fn bindings_raise_their_errors_through_internal_error() {
                 index + 1
             );
 
-            // Rhai's own conversions fail with a `Box<EvalAltResult>` already built, so a bare `?`
-            // on one raises an unmarked error without naming `EvalAltResult` or `.into()` - neither
-            // rule above sees it.
+            // Rhai's own conversions fail with a `Box<EvalAltResult>` already built, so propagating
+            // one unchanged raises an unmarked error without naming `EvalAltResult` or `.into()` -
+            // the rule above never sees it. That propagation does not need a `?` either: every
+            // `to_dynamic` getter here returns the `Result` as its tail expression.
             let converts_from_rhai = ["from_dynamic(", "to_dynamic("]
                 .iter()
                 .any(|conversion| line.contains(conversion))
                 && !line.contains("internal_error");
             assert!(
-                !(converts_from_rhai && line.contains(")?")),
+                !converts_from_rhai,
                 "{path}:{} propagates a Rhai conversion failure unchanged. Add \
-                 `.map_err(internal_error)` before the `?`, or `process_error` may return its text \
-                 to clients:\n{line}",
+                 `.map_err(internal_error)` to it, or `process_error` may return its text to \
+                 clients:\n{line}",
                 index + 1
             );
         }
@@ -1407,7 +1479,6 @@ async fn it_redacts_deserialization_failures_in_binding_setters() {
     let processed_error = process_error(error);
     let message = processed_error.message.expect("the failure has a message");
     assert_eq!(message, "Internal Server Error");
-    assert_message_discloses_nothing(&message);
 
     // The other half: what the client no longer sees still has to be available to an operator.
     let internal_detail = processed_error

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -1306,6 +1306,26 @@ fn it_returns_a_throw_that_carries_keys_of_its_own() {
     );
 }
 
+// `error` is the key rhai stamps its own error maps with, and also an obvious name for a code of
+// the script's own. Telling the two apart is what keeps a throw of the second kind returnable.
+#[test]
+fn it_returns_a_throw_that_carries_an_error_code_of_its_own() {
+    let engine = new_rhai_test_engine();
+    let error = engine
+        .eval::<()>(
+            r#"throw #{ status: 400, message: "Email is invalid", error: "INVALID_EMAIL" };"#,
+        )
+        .expect_err("the script throws");
+
+    let processed_error = process_error(error);
+    assert_eq!(processed_error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        processed_error.message,
+        Some("Email is invalid".to_string()),
+        "an error code of the author's own must not be mistaken for rhai's own error map"
+    );
+}
+
 // Re-throwing the value a `catch` block was handed for an engine failure must not put the engine's
 // error text into the response, however the script dresses it up first. Its status is still the
 // author's to choose - only the message rhai wrote is redacted.

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -228,9 +228,11 @@ async fn rhai_plugin_execution_service_error() -> Result<(), BoxError> {
             );
         }
 
+        // The thrown message reaches the client, but the Rhai wrapper around it - which would name
+        // the engine and point at a line in the script - does not.
         assert_eq!(
             body.errors.first().unwrap().message.as_str(),
-            "rhai execution error: 'Runtime error: An error occured (line 30, position 5)'"
+            "An error occured"
         );
         crate::plugin::test::assert_no_mock_calls(handle).await;
         Ok(())
@@ -697,7 +699,21 @@ async fn it_can_process_string_subgraph_forbidden() {
     if let Err(error) = call_rhai_function("process_subgraph_response_string").await {
         let processed_error = process_error(error);
         assert_eq!(processed_error.status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(processed_error.message, Some("rhai execution error: 'Runtime error: I have raised an error (line 257, position 5)'".to_string()));
+        // The thrown string is returned as-is: the script author wrote it, so it is theirs to
+        // show. The Rhai wrapper around it - "rhai execution error", "Runtime error" and the
+        // script's line and position - is not.
+        assert_eq!(
+            processed_error.message,
+            Some("I have raised an error".to_string())
+        );
+        // ...but an operator still gets the whole thing in the logs.
+        assert_eq!(
+            processed_error.internal_detail,
+            Some(
+                "rhai execution error: 'Runtime error: I have raised an error (line 257, position 5)'"
+                    .to_string()
+            )
+        );
     } else {
         // Test failed
         panic!("error processed incorrectly");
@@ -722,13 +738,10 @@ async fn it_cannot_process_om_subgraph_missing_message_and_body() {
     if let Err(error) = call_rhai_function("process_subgraph_response_om_missing_message").await {
         let processed_error = process_error(error);
         assert_eq!(processed_error.status, StatusCode::BAD_REQUEST);
-        assert_eq!(
-            processed_error.message,
-            Some(
-                "rhai execution error: 'Runtime error: #{\"status\": 400} (line 268, position 5)'"
-                    .to_string()
-            )
-        );
+        // `throw #{ status: 400 }` gets the status it asked for, but there is no author-provided
+        // message to return, so the client gets the status' reason phrase rather than a dump of
+        // the thrown object.
+        assert_eq!(processed_error.message, Some("Bad Request".to_string()));
     } else {
         // Test failed
         panic!("error processed incorrectly");
@@ -752,18 +765,32 @@ async fn it_mentions_source_when_syntax_error_occurs() {
 }
 
 #[test]
-#[should_panic(
-    expected = "can use env: ErrorRuntime(\"could not expand variable: THIS_SHOULD_NOT_EXIST, environment variable not found\", none)"
-)]
 fn it_cannot_expand_missing_environment_variable() {
     assert!(std::env::var("THIS_SHOULD_NOT_EXIST").is_err());
     let engine = new_rhai_test_engine();
-    let _: String = engine
-        .eval(
+    let error = engine
+        .eval::<String>(
             r#"
         env::get("THIS_SHOULD_NOT_EXIST")"#,
         )
-        .expect("can use env");
+        .expect_err("cannot expand a variable that isn't set");
+
+    // A binding failing is not a message the script chose to show a client, so it is redacted from
+    // the response...
+    let processed_error = process_error(error);
+    assert_eq!(processed_error.status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        processed_error.message,
+        Some("Internal Server Error".to_string())
+    );
+    // ...and kept for the logs instead.
+    let internal_detail = processed_error
+        .internal_detail
+        .expect("the real error is logged");
+    assert!(
+        internal_detail.contains("could not expand variable: THIS_SHOULD_NOT_EXIST"),
+        "expected the unredacted error in the logs, got: {internal_detail}"
+    );
 }
 
 // POSIX specifies HOME is always set
@@ -955,16 +982,11 @@ async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError>
 
     // Removing a non-UTF-8 header should be OK
     let body = service_response.next_response().await.unwrap();
-    if body.errors.is_empty() {
-        // yay, no errors
-    } else {
-        let rhai_error = body
-            .errors
-            .iter()
-            .find(|e| e.message.contains("rhai execution error"))
-            .expect("unexpected non-rhai error");
-        panic!("Got an unexpected rhai error: {rhai_error:?}");
-    }
+    assert!(
+        body.errors.is_empty(),
+        "removing a non-UTF-8 header should not fail: {:?}",
+        body.errors
+    );
 
     // Check that the header was actually removed
     let headers = service_response.response.headers().clone();
@@ -1107,6 +1129,240 @@ async fn test_subgraph_error_logging_with_body() -> Result<(), BoxError> {
     test_subgraph_error_logging("error_with_body.rhai")
         .with_subscriber(assert_snapshot_subscriber!())
         .await
+}
+
+/// Anything that could tell a client the router runs Rhai, which functions its script registers,
+/// or where in that script a failure happened.
+fn assert_message_discloses_nothing(message: &str) {
+    for disclosure in [
+        "rhai",
+        "Rhai",
+        "Runtime error",
+        "line ",
+        "position ",
+        "in call to function",
+    ] {
+        assert!(
+            !message.contains(disclosure),
+            "client-facing message leaks {disclosure:?}: {message}"
+        );
+    }
+}
+
+// A failure inside the router's own Rhai bindings - here, reading a header that isn't present -
+// used to reach the client as `rhai execution error: 'Runtime error: <binding error> (line N,
+// position M)'`.
+#[tokio::test]
+async fn it_redacts_binding_errors_from_client_responses() -> Result<(), BoxError> {
+    async {
+        let (mock_service, handle) =
+            tower_test::mock::pair::<SupergraphRequest, SupergraphResponse>();
+        let dyn_plugin = create_plugin("rhai_internal_error.rhai").await?;
+        let mut service = dyn_plugin.supergraph_service(mock_service.boxed());
+        let req = SupergraphRequest::fake_builder()
+            .context(Context::new())
+            .build()?;
+
+        let mut response = service.ready().await?.call(req).await?;
+        assert_eq!(
+            response.response.status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        let body = response.next_response().await.expect("there is a response");
+        let message = &body.errors.first().expect("the request failed").message;
+        assert_eq!(message, "Internal Server Error");
+        assert_message_discloses_nothing(message);
+
+        crate::plugin::test::assert_no_mock_calls(handle).await;
+        Ok(())
+    }
+    // The snapshot is the other half of this test: the error the client no longer sees has to still
+    // be in the logs, unredacted, for an operator to debug the script with.
+    .with_subscriber(assert_snapshot_subscriber!())
+    .await
+}
+
+// Same as above for a failure raised by the Rhai engine rather than by a router binding: those
+// never carried an author-written message in the first place.
+#[tokio::test]
+async fn it_redacts_engine_errors_from_client_responses() -> Result<(), BoxError> {
+    async {
+        let (mock_service, handle) =
+            tower_test::mock::pair::<execution::Request, execution::Response>();
+        let dyn_plugin = create_plugin("rhai_internal_error.rhai").await?;
+        let mut service = dyn_plugin.execution_service(mock_service.boxed());
+        let fake_req = http_ext::Request::fake_builder()
+            .body(Request::builder().query(String::new()).build())
+            .build()?;
+        let req = ExecutionRequest::fake_builder()
+            .context(Context::new())
+            .supergraph_request(fake_req)
+            .build();
+
+        let mut response = service.ready().await?.call(req).await?;
+        assert_eq!(
+            response.response.status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        let body = response.next_response().await.expect("there is a response");
+        let message = &body.errors.first().expect("the request failed").message;
+        assert_eq!(message, "Internal Server Error");
+        assert_message_discloses_nothing(message);
+
+        crate::plugin::test::assert_no_mock_calls(handle).await;
+        Ok(())
+    }
+    .with_subscriber(assert_snapshot_subscriber!())
+    .await
+}
+
+// Scripts can still `catch` a binding failure, so the router must not have made these errors
+// uncatchable in the course of marking them internal.
+#[tokio::test]
+async fn it_can_catch_binding_errors_in_a_script() {
+    let engine = new_rhai_test_engine();
+    let caught: String = engine
+        .eval(
+            r#"
+            let caught = "not reached";
+            try {
+                env::get("THIS_SHOULD_NOT_EXIST");
+            } catch(err) {
+                caught = `caught: ${err.message}`;
+            }
+            caught"#,
+        )
+        .expect("the script catches the error itself");
+
+    assert_eq!(
+        caught,
+        "caught: could not expand variable: THIS_SHOULD_NOT_EXIST, environment variable not found"
+    );
+}
+
+// A caught binding error used to be a plain string, so scripts and our own docs interpolate the
+// whole error rather than reading `err.message`. Marking it must not turn `${err}` into a dump of
+// however the marker is represented.
+#[test]
+fn it_interpolates_a_caught_binding_error_as_its_message() {
+    let engine = new_rhai_test_engine();
+    let caught: String = engine
+        .eval(
+            r#"
+            let caught = "not reached";
+            try {
+                env::get("THIS_SHOULD_NOT_EXIST");
+            } catch(err) {
+                caught = `${err}`;
+            }
+            caught"#,
+        )
+        .expect("the script catches the error itself");
+
+    assert_eq!(
+        caught,
+        "could not expand variable: THIS_SHOULD_NOT_EXIST, environment variable not found"
+    );
+}
+
+// The documented way to give a client a specific message for a binding failure: catch it and throw
+// your own. The router's own error must not linger on the thrown value and keep it redacted.
+#[test]
+fn it_lets_a_script_replace_a_binding_error_with_its_own() {
+    let engine = new_rhai_test_engine();
+    let error = engine
+        .eval::<()>(
+            r#"
+            try {
+                env::get("THIS_SHOULD_NOT_EXIST");
+            } catch(err) {
+                throw #{ status: 400, message: "Invalid request" };
+            }"#,
+        )
+        .expect_err("the script throws an error of its own");
+
+    let processed_error = process_error(error);
+    assert_eq!(processed_error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        processed_error.message,
+        Some("Invalid request".to_string()),
+        "a script's own throw is returned even when it replaces a binding error"
+    );
+}
+
+// A status code with no reason phrase still needs a message, and it has to read like the other
+// redacted messages rather than contradicting the status it accompanies.
+#[test]
+fn it_redacts_a_throw_with_an_unrecognised_status() {
+    let engine = new_rhai_test_engine();
+    let error = engine
+        .eval::<()>("throw #{ status: 599 };")
+        .expect_err("the script throws");
+
+    let processed_error = process_error(error);
+    assert_eq!(processed_error.status.as_u16(), 599);
+    assert_eq!(processed_error.message, Some("Unknown Error".to_string()));
+}
+
+// `engine::internal_error` is the only way a router binding may raise an error: a plain
+// `Err("...".into())` produces an `ErrorRuntime` that `process_error` cannot tell apart from a
+// script's own `throw`, so its text would be returned to clients. Nothing in the type system
+// prevents that - rhai fixes the error type of a fallible binding as `Box<EvalAltResult>` - so it
+// is checked here instead.
+//
+// A binding that raises an error some way these two rules don't describe slips through; they cover
+// the ways a `Box<EvalAltResult>` can be built at all, which is what makes them worth having.
+#[test]
+fn bindings_raise_their_errors_through_internal_error() {
+    // Read the directory rather than listing the files, so a binding added later is checked too.
+    let engine_dir =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/plugins/rhai/engine");
+    let mut sources = Vec::new();
+    let mut directories = vec![engine_dir.clone()];
+    while let Some(directory) = directories.pop() {
+        for entry in std::fs::read_dir(&directory).expect("the engine's sources are readable") {
+            let path = entry.expect("the engine's sources are readable").path();
+            if path.is_dir() {
+                directories.push(path);
+            // `error.rs` is where the one legitimate construction lives.
+            } else if path.extension().is_some_and(|extension| extension == "rs")
+                && path.file_name().is_some_and(|name| name != "error.rs")
+            {
+                let source = std::fs::read_to_string(&path).expect("the source is readable");
+                sources.push((path, source));
+            }
+        }
+    }
+    assert!(
+        sources.len() > 1,
+        "expected to scan the engine's sources, found {} in {}",
+        sources.len(),
+        engine_dir.display()
+    );
+
+    for (path, source) in sources {
+        let path = path.display();
+        assert!(
+            !source.contains("EvalAltResult::"),
+            "{path} builds a Rhai error directly. Raise it with `engine::internal_error` instead, \
+             or `process_error` will return its text to clients."
+        );
+
+        for (index, line) in source.lines().enumerate() {
+            let produces_an_error = ["Err(", "map_err(", "ok_or(", "ok_or_else("]
+                .iter()
+                .any(|producer| line.contains(producer));
+            assert!(
+                !(produces_an_error && line.contains(".into()")),
+                "{path}:{} converts a value into a Rhai error. Raise it with \
+                 `engine::internal_error` instead, or `process_error` will return its text to \
+                 clients:\n{line}",
+                index + 1
+            );
+        }
+    }
 }
 
 // Helper for calling property mutation test functions

--- a/apollo-router/tests/fixtures/rhai_internal_error.rhai
+++ b/apollo-router/tests/fixtures/rhai_internal_error.rhai
@@ -1,0 +1,24 @@
+// Scripts that fail without throwing. Neither failure below is a message the script author chose
+// to show a client, so neither should appear in a client-facing response.
+
+fn router_service(service) {
+    service.map_request(Fn("read_missing_header"));
+}
+
+fn supergraph_service(service) {
+    service.map_request(Fn("read_missing_header"));
+}
+
+fn execution_service(service) {
+    service.map_request(Fn("call_undefined_function"));
+}
+
+// Fails inside the router's own Rhai functions: reading an absent header throws an exception.
+fn read_missing_header(request) {
+    let value = request.headers["x-header-that-is-not-there"];
+}
+
+// Fails inside the Rhai engine itself, before any router function is reached.
+fn call_undefined_function(request) {
+    this_function_does_not_exist();
+}

--- a/apollo-router/tests/fixtures/test_property_mutations.rhai
+++ b/apollo-router/tests/fixtures/test_property_mutations.rhai
@@ -81,3 +81,11 @@ fn test_complex_property_chain(request) {
     let first = cookies[0];
     let first_cookie = first.trim();
 }
+
+// Assigns an error whose `path` is neither a key nor an index, so the router's own deserialization
+// of the script's value fails. The failure text names Rust types, so it must not reach a client.
+fn test_malformed_response_errors(response) {
+    let body = response.body;
+    body.errors = [#{ message: "boom", path: [#{}] }];
+    response.body = body;
+}

--- a/apollo-router/tests/integration/batching.rs
+++ b/apollo-router/tests/integration/batching.rs
@@ -391,12 +391,12 @@ async fn it_handles_cancelled_by_rhai() -> Result<(), BoxError> {
         entryA:
           index: 0
     - errors:
-        - message: "rhai execution error: 'Runtime error: cancelled expected failure (line 5, position 13)'"
+        - message: cancelled expected failure
     - data:
         entryA:
           index: 1
     - errors:
-        - message: "rhai execution error: 'Runtime error: cancelled expected failure (line 5, position 13)'"
+        - message: cancelled expected failure
     "###);
     }
 
@@ -485,7 +485,7 @@ async fn it_handles_single_request_cancelled_by_rhai() -> Result<(), BoxError> {
         entryA:
           index: 1
     - errors:
-        - message: "rhai execution error: 'Runtime error: cancelled expected failure (line 5, position 13)'"
+        - message: cancelled expected failure
     "###);
     }
 

--- a/apollo-router/tests/integration/rhai.rs
+++ b/apollo-router/tests/integration/rhai.rs
@@ -58,6 +58,66 @@ rhai:
     router.graceful_shutdown().await;
 }
 
+// A script that fails used to report the Rhai error verbatim to the client, disclosing that the
+// router runs Rhai, the name of the failing callback, and where in the script it failed.
+#[tokio::test(flavor = "multi_thread")]
+async fn client_errors_omit_rhai_internals() {
+    let config = r#"
+rhai:
+  scripts: tests/fixtures
+  main: rhai_internal_error.rhai
+"#;
+
+    let mut router = IntegrationTest::builder()
+        .config(config)
+        .supergraph(PathBuf::from("tests/fixtures/supergraph.graphql"))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let (_trace_id, response) = router
+        .execute_query(
+            Query::builder()
+                .body(json!({"query": "{ topProducts { name } }", "variables": {}}))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR
+    );
+    let body = response.text().await.expect("a response body");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&body).expect("a GraphQL response")["errors"][0]
+            ["message"],
+        json!("Internal Server Error")
+    );
+    for disclosure in [
+        "rhai",
+        "Rhai",
+        "Runtime error",
+        "line ",
+        "position ",
+        "x-header-that-is-not-there",
+    ] {
+        assert!(
+            !body.contains(disclosure),
+            "client response leaks {disclosure:?}: {body}"
+        );
+    }
+
+    // The reason the client no longer sees has to be in the router's logs instead, otherwise this
+    // is just a silent failure.
+    router
+        .wait_for_log_message("header not found: x-header-that-is-not-there")
+        .await;
+
+    router.graceful_shutdown().await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_rhai_hot_reload_works() {
     let (sender, receiver) = tokio::sync::oneshot::channel();

--- a/docs/source/routing/customization/rhai/index.mdx
+++ b/docs/source/routing/customization/rhai/index.mdx
@@ -624,6 +624,7 @@ The log output includes:
 - HTTP status code (defaults to <code>500</code>)
 - Error message
 - Line number and position where the error occurred
+- The underlying Rhai error, including the callback that failed
 
 #### Errors with custom body
 
@@ -645,6 +646,46 @@ fn supergraph_service(service) {
             }
         };
     });
+}
+```
+
+### What clients see when a script fails
+
+Only a message your script chose is returned to clients. A script that throws is in control of its own error:
+
+```rhai
+fn supergraph_service(service) {
+    service.map_request(|request| {
+        // The client receives exactly: {"errors": [{"message": "Invalid request"}]}
+        throw "Invalid request";
+    });
+}
+```
+
+Throwing an object map works the same way, and additionally lets you pick the status code and the
+full GraphQL response body, as shown in the sections above.
+
+Every _other_ kind of failure is replaced with the status code's reason phrase - such as
+`Internal Server Error` - and the real error is written to the router's logs instead. This covers:
+
+- Failures inside the router's own Rhai functions, such as reading a header that isn't present.
+- Failures raised by the Rhai engine itself, such as calling an undefined function or a type mismatch.
+- A `throw` that carries only a status, like `throw #{ status: 400 }`, which the client sees as `Bad Request`.
+
+This keeps script line numbers, callback names and router internals out of client-facing responses.
+If you want a client to see a specific message for one of these cases, catch the error and throw a
+new one. The error you caught is opaque - it has no `status` or `message` you can set - and
+re-throwing it as-is stays redacted:
+
+```rhai
+fn process_request(request) {
+    try {
+        let value = request.headers["x-custom-header"];
+    } catch(err) {
+        // Log the router's error, return your own.
+        log_error(`missing header: ${err}`);
+        throw #{ status: 400, message: "Invalid request" };
+    }
 }
 ```
 

--- a/docs/source/routing/customization/rhai/index.mdx
+++ b/docs/source/routing/customization/rhai/index.mdx
@@ -676,10 +676,10 @@ This keeps script line numbers, callback names and router internals out of clien
 If you want a client to see a specific message for one of these cases, catch the error and throw a
 new one. Re-throwing the error you caught stays redacted - both the opaque `RouterError` a router
 function raises and the object map the Rhai engine hands you, whose `message` is the engine's own
-error text. The object map still honours a `status` you set on it before re-throwing; only the
-message you did not write is replaced. A `RouterError` has no `status` or `message` you can set at
-all - assigning one raises a fresh error that replaces the one you caught, so it is your own throw
-you want here:
+error text. The object map still honours a `status` you set on it before re-throwing, but its
+`message` is always replaced - overwriting it first does not make it yours to return. A
+`RouterError` has no `status` or `message` you can set at all - assigning one raises a fresh error
+that replaces the one you caught, so it is your own throw you want here:
 
 ```rhai
 fn process_request(request) {

--- a/docs/source/routing/customization/rhai/index.mdx
+++ b/docs/source/routing/customization/rhai/index.mdx
@@ -674,8 +674,10 @@ Every _other_ kind of failure is replaced with the status code's reason phrase -
 
 This keeps script line numbers, callback names and router internals out of client-facing responses.
 If you want a client to see a specific message for one of these cases, catch the error and throw a
-new one. The error you caught is opaque - it has no `status` or `message` you can set - and
-re-throwing it as-is stays redacted:
+new one. Re-throwing the error you caught stays redacted - both the opaque `RouterError` a router
+function raises, which has no `status` or `message` you can set, and the object map the Rhai engine
+hands you, whose `message` is the engine's own error text. A `status` you set on either is still
+honoured; only the message you did not write is replaced.
 
 ```rhai
 fn process_request(request) {

--- a/docs/source/routing/customization/rhai/index.mdx
+++ b/docs/source/routing/customization/rhai/index.mdx
@@ -675,9 +675,11 @@ Every _other_ kind of failure is replaced with the status code's reason phrase -
 This keeps script line numbers, callback names and router internals out of client-facing responses.
 If you want a client to see a specific message for one of these cases, catch the error and throw a
 new one. Re-throwing the error you caught stays redacted - both the opaque `RouterError` a router
-function raises, which has no `status` or `message` you can set, and the object map the Rhai engine
-hands you, whose `message` is the engine's own error text. A `status` you set on either is still
-honoured; only the message you did not write is replaced.
+function raises and the object map the Rhai engine hands you, whose `message` is the engine's own
+error text. The object map still honours a `status` you set on it before re-throwing; only the
+message you did not write is replaced. A `RouterError` has no `status` or `message` you can set at
+all - assigning one raises a fresh error that replaces the one you caught, so it is your own throw
+you want here:
 
 ```rhai
 fn process_request(request) {

--- a/docs/source/routing/customization/rhai/reference.mdx
+++ b/docs/source/routing/customization/rhai/reference.mdx
@@ -191,6 +191,22 @@ fn supergraph_service(service) {
 }
 ```
 
+## Handling errors from router functions
+
+When one of the router's own Rhai functions fails, the error you catch is a `RouterError`. Interpolating it gives you the reason, and so does its `message` property:
+
+```rhai
+catch(err) {
+    log_error(`failed: ${err}`);
+    // Equivalent to the line above
+    log_error(`failed: ${err.message}`);
+}
+```
+
+An error your own script raised with `throw` is caught unchanged, so a `catch` block that can see both should interpolate `err` directly - a thrown string has no `message` property.
+
+Router errors are never returned to clients - see [what clients see when a script fails](/graphos/routing/customization/rhai#what-clients-see-when-a-script-fails). If you want a client to see a specific message, throw a new error rather than re-throwing the one you caught, which stays redacted.
+
 ## Accessing a TraceId
 
 Your Rhai customization can use the function `traceid()` to retrieve an opentelemetry span id. This will throw an exception if a span is not available, so always handle exceptions when using this function.


### PR DESCRIPTION
Rhai execution failures previously leaked internal details (script callback names, line/position, "rhai execution error" wrapper) to clients. Now only script-chosen throw messages reach the client; everything else falls back to the status code's reason phrase while the full error is still logged at ERROR level.

<!-- start metadata -->

<!-- [ROUTER-2050] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

See changeset for user facing changes. Outstanding question is if these should be for router 3.0 instead

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-2050]: https://apollographql.atlassian.net/browse/ROUTER-2050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ