### PR TITLE
fix(file_uploads): bound multipart framing overhead with max_overhead_size

### DIFF
--- a/.changesets/fix_caroline_router_881.md
+++ b/.changesets/fix_caroline_router_881.md
@@ -1,0 +1,20 @@
+### Bound multipart framing in file upload requests ([PR #PULL_NUMBER](https://github.com/apollographql/router/pull/PULL_NUMBER))
+
+The file uploads plugin bounded the *content* of a `multipart/form-data` request — per-file bytes via `max_file_size`, the GraphQL operation via `http_max_request_bytes`, and the `map` field via an internal cap — but not the framing around it. A `multipart/form-data` body may also carry a preamble before the first boundary, a header block per part, boundary delimiters, and transport padding, and the parser has to buffer the preamble and each header block in full before it can act on them. Neither was subject to any limit, so a single request with an endless preamble, or one part carrying an enormous `Content-Disposition`, could grow router memory until the process was terminated.
+
+A new limit, `preview_file_uploads.protocols.multipart.limits.max_overhead_size`, bounds how much framing a single upload request may contain. It defaults to `2mb`:
+
+```yaml
+preview_file_uploads:
+  enabled: true
+  protocols:
+    multipart:
+      limits:
+        max_overhead_size: 2mb
+```
+
+Because the multipart parser cannot distinguish a framing byte from a content byte, the router adds this allowance to the content the other limits already permit and enforces the sum as a limit on the total request; exceeding it returns `413 Payload Too Large`. The total therefore scales with `max_file_size` and `max_files`, as you would expect, and a request that fits within the configured file and operation limits cannot trip it.
+
+One behavior change to note: parts that the `map` field never references were previously skipped without any size limit at all. They now count toward the total, so a request cannot use unreferenced parts to stream unbounded data through the router.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/PULL_NUMBER

--- a/.changesets/fix_caroline_router_881.md
+++ b/.changesets/fix_caroline_router_881.md
@@ -1,4 +1,4 @@
-### Bound multipart framing in file upload requests ([PR #PULL_NUMBER](https://github.com/apollographql/router/pull/PULL_NUMBER))
+### Bound multipart framing in file upload requests ([PR #9959](https://github.com/apollographql/router/pull/9959))
 
 The file uploads plugin bounded the *content* of a `multipart/form-data` request — per-file bytes via `max_file_size`, the GraphQL operation via `http_max_request_bytes`, and the `map` field via an internal cap — but not the framing around it. A `multipart/form-data` body may also carry a preamble before the first boundary, a header block per part, boundary delimiters, and transport padding, and the parser has to buffer the preamble and each header block in full before it can act on them. Neither was subject to any limit, so a single request with an endless preamble, or one part carrying an enormous `Content-Disposition`, could grow router memory until the process was terminated.
 
@@ -17,4 +17,4 @@ Because the multipart parser cannot distinguish a framing byte from a content by
 
 One behavior change to note: parts that the `map` field never references were previously skipped without any size limit at all. They now count toward the total, so a request cannot use unreferenced parts to stream unbounded data through the router.
 
-By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/PULL_NUMBER
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/9959

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -405,7 +405,9 @@ impl InstrumentData {
             opt.limits.max_file_size,
             "$.limits.max_file_size",
             opt.limits.max_files,
-            "$.limits.max_files"
+            "$.limits.max_files",
+            opt.limits.max_overhead_size,
+            "$.limits.max_overhead_size"
         );
 
         populate_config_instrument!(

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@file_uploads.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@file_uploads.router.yaml.snap
@@ -9,3 +9,4 @@ expression: "&metrics.non_zero()"
         attributes:
           opt.limits.max_file_size: 1mb
           opt.limits.max_files: 10
+          opt.limits.max_overhead_size: 64kb

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -7546,7 +7546,7 @@ expression: "&schema"
         },
         "max_overhead_size": {
           "default": "2.0 MB",
-          "description": "The maximum amount of multipart framing — the preamble, part headers, boundary delimiters,\nand transport padding — permitted in a single upload request.\n\nThis allowance is added to the content the other limits permit, and the sum is enforced\nas a limit on the total request. Requests exceeding it are rejected with\n`413 Payload Too Large`.",
+          "description": "The maximum amount of multipart framing — the preamble, part headers, boundary delimiters,\nand transport padding — permitted in a single upload request.\n\nThe parser cannot tell a framing byte from a content byte. The router therefore adds this\nallowance to the content the other limits already permit. It enforces the sum as a limit on\nthe whole request. A request over that sum gets a `413 Payload Too Large`. The sum grows\nwith `max_files` and `max_file_size`.",
           "type": "string"
         },
         "operation_body_timeout": {

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -7544,6 +7544,11 @@ expression: "&schema"
           "minimum": 0,
           "type": "integer"
         },
+        "max_overhead_size": {
+          "default": "2.0 MB",
+          "description": "The maximum amount of multipart framing — the preamble, part headers, boundary delimiters,\nand transport padding — permitted in a single upload request.\n\nThis allowance is added to the content the other limits permit, and the sum is enforced\nas a limit on the total request. Requests exceeding it are rejected with\n`413 Payload Too Large`.",
+          "type": "string"
+        },
         "operation_body_timeout": {
           "default": null,
           "description": "Maximum time allowed for the client to deliver the GraphQL operation (query and variables)\nwithin the multipart body. This timeout does not apply to reading the file contents\nthemselves. If the operation part of the request is too slow to arrive, the request is\nrejected with a `504 Gateway Timeout` error.\n\nIf not set, no operation body timeout is applied.",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -7535,11 +7535,11 @@ expression: "&schema"
       "description": "Request limits for a multipart request",
       "properties": {
         "max_file_size": {
-          "description": "The maximum size of each file, in bytes (default: 5MB)",
+          "description": "The maximum size of each file (default: 1MB)",
           "type": "string"
         },
         "max_files": {
-          "description": "The maximum amount of files allowed for a single query (default: 4)",
+          "description": "The maximum amount of files allowed for a single query (default: 5)",
           "format": "uint",
           "minimum": 0,
           "type": "integer"

--- a/apollo-router/src/configuration/testdata/metrics/file_uploads.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/file_uploads.router.yaml
@@ -7,4 +7,5 @@ preview_file_uploads:
         limits:
             max_file_size: 1mb
             max_files: 10
+            max_overhead_size: 64kb
 

--- a/apollo-router/src/plugins/file_uploads/config.rs
+++ b/apollo-router/src/plugins/file_uploads/config.rs
@@ -29,9 +29,10 @@ pub(crate) struct MultipartRequestLimits {
     /// The maximum amount of multipart framing — the preamble, part headers, boundary delimiters,
     /// and transport padding — permitted in a single upload request.
     ///
-    /// This allowance is added to the content the other limits permit, and the sum is enforced
-    /// as a limit on the total request. Requests exceeding it are rejected with
-    /// `413 Payload Too Large`.
+    /// The parser cannot tell a framing byte from a content byte. The router therefore adds this
+    /// allowance to the content the other limits already permit. It enforces the sum as a limit on
+    /// the whole request. A request over that sum gets a `413 Payload Too Large`. The sum grows
+    /// with `max_files` and `max_file_size`.
     #[serde(
         deserialize_with = "bytesize::ByteSize::deserialize",
         default = "default_max_overhead_size"
@@ -40,13 +41,19 @@ pub(crate) struct MultipartRequestLimits {
     pub(crate) max_overhead_size: ByteSize,
 }
 
-/// Deliberately generous. This allowance sets the floor on the total-request budget, and that
-/// budget is counted at a different point in the pipeline than `max_file_size`: multer counts bytes
-/// as they arrive off the socket, before parsing, while `max_file_size` counts a file's bytes as
-/// they are handed to the subgraph after parsing. The arriving count therefore runs ahead, and
-/// below a small enough budget it trips first. That answer isn't wrong — the body really is over
-/// the total — but "request too large" tells a client less than being pointed at `max_file_size`
-/// does. A megabyte-scale allowance keeps the two apart.
+/// Deliberately generous. The whole-request budget this allowance feeds and `max_file_size` count
+/// bytes at different points:
+///
+/// - multer counts every byte as it arrives off the socket, before it parses anything.
+/// - `max_file_size` counts a file's bytes as the router hands them to the subgraph.
+///
+/// The first count leads the second by whatever multer holds in its buffer. A single read of the
+/// connection can deliver ~400 KB, the default for `limits.router.http1_max_request_buf_size`.
+/// multer keeps reading until the body gives it nothing, so the gap can reach several times that.
+///
+/// With a budget that small, one oversized file breaks the whole-request budget before it breaks
+/// `max_file_size`. The client gets a "request too large" error instead of a "max file size
+/// exceeded" error. A megabyte-scale allowance keeps the budget clear of the gap.
 fn default_max_overhead_size() -> ByteSize {
     ByteSize::mb(2)
 }

--- a/apollo-router/src/plugins/file_uploads/config.rs
+++ b/apollo-router/src/plugins/file_uploads/config.rs
@@ -8,10 +8,10 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Copy, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct MultipartRequestLimits {
-    /// The maximum amount of files allowed for a single query (default: 4)
+    /// The maximum amount of files allowed for a single query (default: 5)
     pub(crate) max_files: usize,
 
-    /// The maximum size of each file, in bytes (default: 5MB)
+    /// The maximum size of each file (default: 1MB)
     #[serde(deserialize_with = "bytesize::ByteSize::deserialize")]
     #[schemars(with = "String")]
     pub(crate) max_file_size: ByteSize,

--- a/apollo-router/src/plugins/file_uploads/config.rs
+++ b/apollo-router/src/plugins/file_uploads/config.rs
@@ -25,6 +25,30 @@ pub(crate) struct MultipartRequestLimits {
     #[serde(deserialize_with = "humantime_serde::deserialize", default)]
     #[schemars(with = "Option<String>", default)]
     pub(crate) operation_body_timeout: Option<Duration>,
+
+    /// The maximum amount of multipart framing — the preamble, part headers, boundary delimiters,
+    /// and transport padding — permitted in a single upload request.
+    ///
+    /// This allowance is added to the content the other limits permit, and the sum is enforced
+    /// as a limit on the total request. Requests exceeding it are rejected with
+    /// `413 Payload Too Large`.
+    #[serde(
+        deserialize_with = "bytesize::ByteSize::deserialize",
+        default = "default_max_overhead_size"
+    )]
+    #[schemars(with = "String", default = "default_max_overhead_size")]
+    pub(crate) max_overhead_size: ByteSize,
+}
+
+/// Deliberately generous. This allowance sets the floor on the total-request budget, and that
+/// budget is counted at a different point in the pipeline than `max_file_size`: multer counts bytes
+/// as they arrive off the socket, before parsing, while `max_file_size` counts a file's bytes as
+/// they are handed to the subgraph after parsing. The arriving count therefore runs ahead, and
+/// below a small enough budget it trips first. That answer isn't wrong — the body really is over
+/// the total — but "request too large" tells a client less than being pointed at `max_file_size`
+/// does. A megabyte-scale allowance keeps the two apart.
+fn default_max_overhead_size() -> ByteSize {
+    ByteSize::mb(2)
 }
 
 impl Default for MultipartRequestLimits {
@@ -33,6 +57,7 @@ impl Default for MultipartRequestLimits {
             max_files: 5,
             max_file_size: ByteSize::mb(1),
             operation_body_timeout: None,
+            max_overhead_size: default_max_overhead_size(),
         }
     }
 }

--- a/apollo-router/src/plugins/file_uploads/error.rs
+++ b/apollo-router/src/plugins/file_uploads/error.rs
@@ -67,11 +67,15 @@ pub(super) enum FileUploadError {
 impl FileUploadError {
     pub(super) fn http_status_code(&self) -> StatusCode {
         match self {
-            // Only "operations" and "map" have multer SizeLimits configured; file parts are
-            // checked separately in SubgraphFileProxyStream and return MaxFileSizeLimitExceeded.
-            FileUploadError::InvalidMultipartRequest(multer::Error::FieldSizeExceeded {
-                ..
-            }) => StatusCode::PAYLOAD_TOO_LARGE,
+            // FieldSizeExceeded: only "operations" and "map" have multer per-field SizeLimits
+            // configured; file parts are checked separately in SubgraphFileProxyStream and return
+            // MaxFileSizeLimitExceeded.
+            //
+            // StreamSizeExceeded: the whole-stream budget derived from the configured limits, which
+            // bounds multipart framing. See `whole_stream_size_limit` in multipart_request.rs.
+            FileUploadError::InvalidMultipartRequest(
+                multer::Error::FieldSizeExceeded { .. } | multer::Error::StreamSizeExceeded { .. },
+            ) => StatusCode::PAYLOAD_TOO_LARGE,
             _ => StatusCode::BAD_REQUEST,
         }
     }
@@ -88,6 +92,9 @@ impl From<FileUploadError> for graphql::Error {
                 FileUploadError::MaxFileSizeLimitExceeded { .. } => {
                     "FILE_UPLOADS_LIMITS_MAX_FILE_SIZE_EXCEEDED".to_string()
                 }
+                FileUploadError::InvalidMultipartRequest(multer::Error::StreamSizeExceeded {
+                    ..
+                }) => "FILE_UPLOADS_LIMITS_MAX_REQUEST_SIZE_EXCEEDED".to_string(),
                 _ => "FILE_UPLOADS_OPERATION_CANNOT_STREAM".to_string(),
             })
             .build()

--- a/apollo-router/src/plugins/file_uploads/multipart_request.rs
+++ b/apollo-router/src/plugins/file_uploads/multipart_request.rs
@@ -68,6 +68,29 @@ impl Drop for MultipartRequestState {
     }
 }
 
+/// The budget for multer's `whole_stream` limit, which is the only limit that bounds the bytes
+/// the parser buffers outside of field content: the preamble, per-part header blocks, boundary
+/// delimiters and transport padding. multer's per-field limits count content bytes only, so
+/// without this those regions are unbounded and a single request can exhaust router memory.
+///
+/// Budgeted as "everything the other limits already permit, plus the configured framing
+/// allowance", since multer cannot tell a framing byte from a content byte. See
+/// `max_overhead_size` in config.rs for what that does and does not guarantee.
+///
+/// Saturating throughout, because `max_files * max_file_size` overflows `u64` for configurations
+/// operators plausibly write — `max_file_size` is legitimately set in gigabytes. Saturating is a
+/// real loss of enforcement rather than a sentinel: multer compares `bytes_pulled > limit`, and
+/// `multer::constants::DEFAULT_WHOLE_STREAM_SIZE_LIMIT` is itself `u64::MAX`, so a saturated budget
+/// is simply unreachable and the limit stops applying. It takes an absurd configuration to get
+/// there — see the unit tests below, which pin both that `large.router.yaml`-scale limits do *not*
+/// saturate and that extreme ones degrade to unlimited rather than wrapping to a tiny budget.
+fn whole_stream_size_limit(limits: &MultipartRequestLimits, operations_size_limit: u64) -> u64 {
+    operations_size_limit
+        .saturating_add(MAP_SIZE_LIMIT)
+        .saturating_add((limits.max_files as u64).saturating_mul(limits.max_file_size.as_u64()))
+        .saturating_add(limits.max_overhead_size.as_u64())
+}
+
 impl MultipartRequest {
     pub(super) fn new(
         request_body: RouterBody,
@@ -80,6 +103,7 @@ impl MultipartRequest {
             boundary,
             Constraints::new().size_limit(
                 SizeLimit::new()
+                    .whole_stream(whole_stream_size_limit(&limits, operations_size_limit))
                     .for_field("map", MAP_SIZE_LIMIT)
                     .for_field("operations", operations_size_limit),
             ),
@@ -275,5 +299,59 @@ where
             Poll::Ready(None) => self.poll_next_field(cx),
             _ => field_result,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytesize::ByteSize;
+
+    use super::*;
+    use crate::plugins::limits::RouterLimitsConfig;
+
+    /// The value the router passes as `operations_size_limit` for a default configuration.
+    fn default_operations_size_limit() -> u64 {
+        RouterLimitsConfig::default().http_max_request_bytes as u64
+    }
+
+    #[test]
+    fn whole_stream_budget_sums_the_configured_limits() {
+        let limits = MultipartRequestLimits::default();
+
+        assert_eq!(
+            whole_stream_size_limit(&limits, default_operations_size_limit()),
+            // http_max_request_bytes + map cap + max_files * max_file_size + max_overhead_size
+            default_operations_size_limit() + MAP_SIZE_LIMIT + 5 * 1_000_000 + 2_000_000,
+        );
+    }
+
+    /// An absurd configuration must degrade to "effectively unlimited" rather than panicking in
+    /// debug or wrapping around to a tiny budget in release. `u64::MAX` is not a sentinel in multer
+    /// — it is just a threshold `bytes_pulled > limit` can never cross — so this is a documented
+    /// loss of enforcement, not a special case.
+    #[test]
+    fn whole_stream_budget_saturates_instead_of_overflowing() {
+        let limits = MultipartRequestLimits {
+            max_files: usize::MAX,
+            max_file_size: ByteSize::b(u64::MAX),
+            ..MultipartRequestLimits::default()
+        };
+
+        assert_eq!(whole_stream_size_limit(&limits, u64::MAX), u64::MAX);
+    }
+
+    /// A large-but-real configuration must not saturate, or the limit silently stops applying.
+    #[test]
+    fn whole_stream_budget_does_not_saturate_for_realistic_large_limits() {
+        // Matches tests/fixtures/file_upload/large.router.yaml.
+        let limits = MultipartRequestLimits {
+            max_files: 10,
+            max_file_size: ByteSize::gb(15),
+            ..MultipartRequestLimits::default()
+        };
+
+        let budget = whole_stream_size_limit(&limits, default_operations_size_limit());
+        assert!(budget < u64::MAX);
+        assert!(budget > 150_000_000_000);
     }
 }

--- a/apollo-router/src/plugins/file_uploads/multipart_request.rs
+++ b/apollo-router/src/plugins/file_uploads/multipart_request.rs
@@ -73,17 +73,17 @@ impl Drop for MultipartRequestState {
 /// delimiters and transport padding. multer's per-field limits count content bytes only, so
 /// without this those regions are unbounded and a single request can exhaust router memory.
 ///
-/// Budgeted as "everything the other limits already permit, plus the configured framing
-/// allowance", since multer cannot tell a framing byte from a content byte. See
-/// `max_overhead_size` in config.rs for what that does and does not guarantee.
+/// The budget is the content the other limits already permit, plus `max_overhead_size`. multer
+/// cannot tell a framing byte from a content byte, so the two cannot be limited separately. See
+/// `max_overhead_size` in config.rs for what this does and does not guarantee.
 ///
-/// Saturating throughout, because `max_files * max_file_size` overflows `u64` for configurations
-/// operators plausibly write — `max_file_size` is legitimately set in gigabytes. Saturating is a
-/// real loss of enforcement rather than a sentinel: multer compares `bytes_pulled > limit`, and
-/// `multer::constants::DEFAULT_WHOLE_STREAM_SIZE_LIMIT` is itself `u64::MAX`, so a saturated budget
-/// is simply unreachable and the limit stops applying. It takes an absurd configuration to get
-/// there — see the unit tests below, which pin both that `large.router.yaml`-scale limits do *not*
-/// saturate and that extreme ones degrade to unlimited rather than wrapping to a tiny budget.
+/// The arithmetic saturates. `max_files * max_file_size` overflows `u64` for limits operators
+/// really write, because `max_file_size` is often set in gigabytes.
+///
+/// A saturated budget is `u64::MAX`, which is not a sentinel for "no limit". multer tests
+/// `bytes_pulled > limit`, so the test never passes and the limit stops working. Only an absurd
+/// configuration saturates. The unit tests below pin both halves: `large.router.yaml`-scale limits
+/// must not saturate, and extreme ones must degrade to no limit rather than wrap to a tiny budget.
 fn whole_stream_size_limit(limits: &MultipartRequestLimits, operations_size_limit: u64) -> u64 {
     operations_size_limit
         .saturating_add(MAP_SIZE_LIMIT)

--- a/apollo-router/tests/fixtures/file_upload/max_overhead_size.router.yaml
+++ b/apollo-router/tests/fixtures/file_upload/max_overhead_size.router.yaml
@@ -1,0 +1,19 @@
+preview_file_uploads:
+  enabled: true
+  protocols:
+    multipart:
+      enabled: true
+      mode: stream
+      limits:
+        max_file_size: 1kb
+        max_files: 5
+        # Deliberately tiny so the derived whole-stream budget stays small enough to blow with
+        # a few KB of framing:
+        #   http_max_request_bytes (500) + map cap (10kb) + max_files * max_file_size (5kb)
+        #   + max_overhead_size (4kb) = ~20kb
+        max_overhead_size: 4kb
+limits:
+  router:
+    http_max_request_bytes: 500
+include_subgraph_errors:
+  all: true

--- a/apollo-router/tests/integration/file_upload.rs
+++ b/apollo-router/tests/integration/file_upload.rs
@@ -1142,6 +1142,9 @@ mod body_limits {
     const OVERHEAD_CONFIG: &str =
         include_str!("../fixtures/file_upload/max_overhead_size.router.yaml");
     const BOUNDARY: &str = "testboundary";
+    /// Line terminator for multipart framing: boundary lines, header lines, and the blank line
+    /// that ends a part's header block.
+    const CRLF: &[u8; 2] = b"\r\n";
 
     /// Non-content regions of a `multipart/form-data` body. RFC 2046 permits all of these; the
     /// GraphQL multipart spec has no use for any of them and real clients emit none, but the
@@ -1165,45 +1168,75 @@ mod body_limits {
     }
 
     fn build_multipart_body_with(operations: &str, file_data: &[u8], framing: Framing) -> Vec<u8> {
-        let map = r#"{"0":["variables.file"]}"#;
-        let mut body = Vec::new();
-        body.extend_from_slice(&framing.preamble);
-        for (name, content) in [
-            ("operations", operations.as_bytes()),
-            ("map", map.as_bytes()),
-        ] {
-            body.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
-            body.extend_from_slice(
-                format!("Content-Disposition: form-data; name=\"{name}\"\r\n").as_bytes(),
-            );
-            if name == "operations"
-                && let Some(extra) = &framing.operations_extra_header
-            {
-                body.extend_from_slice(extra.as_bytes());
-                body.extend_from_slice(b"\r\n");
+        #[derive(Default)]
+        struct MultipartBody(Vec<u8>);
+        impl MultipartBody {
+            fn push<S: AsRef<[u8]>>(&mut self, content: S) {
+                self.0.extend_from_slice(content.as_ref());
+                self.0.extend_from_slice(CRLF);
             }
-            body.extend_from_slice(b"\r\n");
-            body.extend_from_slice(content);
-            body.extend_from_slice(b"\r\n");
+
+            fn push_boundary_start(&mut self) {
+                self.push(format!("--{BOUNDARY}"));
+            }
+
+            fn push_boundary_end(&mut self) {
+                self.push(format!("--{BOUNDARY}--"));
+            }
+
+            fn push_headers_end(&mut self) {
+                self.0.extend_from_slice(CRLF);
+            }
+
+            fn push_content_disposition(&mut self, name: &str, filename: Option<&str>) {
+                let mut disposition = format!("Content-Disposition: form-data; name=\"{name}\"");
+                if let Some(filename) = filename {
+                    disposition += &format!("; filename=\"{filename}\"");
+                }
+                self.push(disposition);
+            }
         }
+
+        let mut body = MultipartBody::default();
+
+        // preamble
+        body.push(&framing.preamble);
+
+        // operations
+        body.push_boundary_start();
+        body.push_content_disposition("operations", None);
+        if let Some(extra_header) = &framing.operations_extra_header {
+            body.push(extra_header);
+        }
+        body.push_headers_end();
+        body.push(operations);
+
+        // map
+        body.push_boundary_start();
+        body.push_content_disposition("map", None);
+        body.push_headers_end();
+        body.push(r#"{"0":["variables.file"]}"#);
+
+        // extraneous parts
         for (name, content) in &framing.extraneous_parts {
-            body.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
-            body.extend_from_slice(
-                format!("Content-Disposition: form-data; name=\"{name}\"; filename=\"{name}.bin\"\r\n\r\n")
-                    .as_bytes(),
-            );
-            body.extend_from_slice(content);
-            body.extend_from_slice(b"\r\n");
+            body.push_boundary_start();
+            body.push_content_disposition(name, Some(&format!("{name}.bin")));
+            body.push_headers_end();
+            body.push(content);
         }
-        body.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
-        body.extend_from_slice(
-            b"Content-Disposition: form-data; name=\"0\"; filename=\"test.bin\"\r\n\r\n",
-        );
-        body.extend_from_slice(file_data);
-        body.extend_from_slice(b"\r\n");
-        body.extend_from_slice(format!("--{BOUNDARY}--\r\n").as_bytes());
-        body.extend_from_slice(&framing.epilogue);
-        body
+
+        // file
+        body.push_boundary_start();
+        body.push_content_disposition("0", Some("test.bin"));
+        body.push_headers_end();
+        body.push(file_data);
+
+        // epilogue
+        body.push_boundary_end();
+        body.push(&framing.epilogue);
+
+        // all parts complete
+        body.0
     }
 
     /// Send `body_bytes` to a router backed by a real subgraph handler.

--- a/apollo-router/tests/integration/file_upload.rs
+++ b/apollo-router/tests/integration/file_upload.rs
@@ -1139,18 +1139,58 @@ mod body_limits {
     use crate::integration::common::graph_os_enabled;
 
     const CONFIG: &str = include_str!("../fixtures/file_upload/small_body_limit.router.yaml");
+    const OVERHEAD_CONFIG: &str =
+        include_str!("../fixtures/file_upload/max_overhead_size.router.yaml");
     const BOUNDARY: &str = "testboundary";
 
+    /// Non-content regions of a `multipart/form-data` body. RFC 2046 permits all of these; the
+    /// GraphQL multipart spec has no use for any of them and real clients emit none, but the
+    /// router still has to bound them because the parser buffers them.
+    #[derive(Default)]
+    struct Framing {
+        /// Bytes before the first boundary delimiter.
+        preamble: Vec<u8>,
+        /// Bytes after the closing boundary delimiter.
+        epilogue: Vec<u8>,
+        /// Extra header line injected into the `operations` part's header block, without the
+        /// trailing CRLF. Used to grow a single part's header section.
+        operations_extra_header: Option<String>,
+        /// Parts that the `map` field never references. The router skips these by name
+        /// (see `SubgraphFileProxyStream::poll_next_field`) but still reads their bytes.
+        extraneous_parts: Vec<(String, Vec<u8>)>,
+    }
+
     fn build_multipart_body(operations: &str, file_data: &[u8]) -> Vec<u8> {
+        build_multipart_body_with(operations, file_data, Framing::default())
+    }
+
+    fn build_multipart_body_with(operations: &str, file_data: &[u8], framing: Framing) -> Vec<u8> {
         let map = r#"{"0":["variables.file"]}"#;
         let mut body = Vec::new();
+        body.extend_from_slice(&framing.preamble);
         for (name, content) in [
             ("operations", operations.as_bytes()),
             ("map", map.as_bytes()),
         ] {
             body.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
             body.extend_from_slice(
-                format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+                format!("Content-Disposition: form-data; name=\"{name}\"\r\n").as_bytes(),
+            );
+            if name == "operations"
+                && let Some(extra) = &framing.operations_extra_header
+            {
+                body.extend_from_slice(extra.as_bytes());
+                body.extend_from_slice(b"\r\n");
+            }
+            body.extend_from_slice(b"\r\n");
+            body.extend_from_slice(content);
+            body.extend_from_slice(b"\r\n");
+        }
+        for (name, content) in &framing.extraneous_parts {
+            body.extend_from_slice(format!("--{BOUNDARY}\r\n").as_bytes());
+            body.extend_from_slice(
+                format!("Content-Disposition: form-data; name=\"{name}\"; filename=\"{name}.bin\"\r\n\r\n")
+                    .as_bytes(),
             );
             body.extend_from_slice(content);
             body.extend_from_slice(b"\r\n");
@@ -1162,6 +1202,7 @@ mod body_limits {
         body.extend_from_slice(file_data);
         body.extend_from_slice(b"\r\n");
         body.extend_from_slice(format!("--{BOUNDARY}--\r\n").as_bytes());
+        body.extend_from_slice(&framing.epilogue);
         body
     }
 
@@ -1169,12 +1210,20 @@ mod body_limits {
     /// `chunk_size` controls HTTP chunking: `None` sends the entire body as one frame
     /// (reproducing curl's default chunked-upload behavior), `Some(n)` splits into n-byte chunks.
     async fn run(body_bytes: Vec<u8>, chunk_size: Option<usize>) -> (StatusCode, Value) {
+        run_with_config(CONFIG, body_bytes, chunk_size).await
+    }
+
+    async fn run_with_config(
+        config: &str,
+        body_bytes: Vec<u8>,
+        chunk_size: Option<usize>,
+    ) -> (StatusCode, Value) {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
         let bound = TcpListener::bind(addr).await.unwrap();
         let bound_url = format!("http://{}", bound.local_addr().unwrap());
 
         let mut router = IntegrationTest::builder()
-            .config(CONFIG)
+            .config(config)
             .subgraph_overrides([("uploads".to_string(), format!("{bound_url}/"))].into())
             .supergraph(PathBuf::from_iter([
                 "tests",
@@ -1318,6 +1367,134 @@ mod body_limits {
         let (status, _body) = run(body_bytes, chunk_size).await;
 
         assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+
+        Ok(())
+    }
+
+    /// A multipart preamble is buffered by the parser while it hunts for the first boundary, and
+    /// charges against no per-field limit. Without a whole-stream budget it grows router memory
+    /// without bound; with one it is a 413.
+    ///
+    /// These tests assert on the status only, not on the error extension code. The limits plugin
+    /// wraps the file uploads plugin and rewrites the body of *any* downstream 413 into its own
+    /// `INVALID_GRAPHQL_REQUEST` / "Request body payload too large" error
+    /// (`plugins::limits::LimitsPlugin::map_error_to_graphql`), so file-uploads-specific codes for
+    /// 413s are not observable at the edge. `rejects_oversized_operations_field` above is limited
+    /// the same way.
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rejects_oversized_preamble(
+        #[values(None, Some(100))] chunk_size: Option<usize>,
+    ) -> Result<(), BoxError> {
+        if !graph_os_enabled() {
+            return Ok(());
+        }
+
+        let body_bytes = build_multipart_body_with(
+            OPS,
+            b"tiny",
+            Framing {
+                // Comfortably past the ~20kb budget the fixture derives, but small enough that a
+                // router without the limit merely accepts it rather than exhausting the test host.
+                preamble: vec![b'A'; 64 * 1024],
+                ..Default::default()
+            },
+        );
+        let (status, body) = run_with_config(OVERHEAD_CONFIG, body_bytes, chunk_size).await;
+
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "body: {body}");
+
+        Ok(())
+    }
+
+    /// A part's header block is buffered whole before it is parsed, so an enormous
+    /// `Content-Disposition` is the same memory-exhaustion vector as a preamble.
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rejects_oversized_part_headers(
+        #[values(None, Some(100))] chunk_size: Option<usize>,
+    ) -> Result<(), BoxError> {
+        if !graph_os_enabled() {
+            return Ok(());
+        }
+
+        let body_bytes = build_multipart_body_with(
+            OPS,
+            b"tiny",
+            Framing {
+                operations_extra_header: Some(format!("X-Padding: {}", "A".repeat(64 * 1024))),
+                ..Default::default()
+            },
+        );
+        let (status, body) = run_with_config(OVERHEAD_CONFIG, body_bytes, chunk_size).await;
+
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "body: {body}");
+
+        Ok(())
+    }
+
+    /// Parts the `map` never references are skipped by name rather than rejected, and no per-field
+    /// limit applies to them — so before the whole-stream budget existed, a client could stream
+    /// unbounded data through the router under cover of a small, valid upload.
+    ///
+    /// This is a deliberate consequence of budgeting the whole stream rather than the framing
+    /// alone. It cannot fire for a legitimate request: real content is bounded by
+    /// `http_max_request_bytes + map cap + max_files * max_file_size`, which is the budget minus
+    /// the framing allowance.
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rejects_extraneous_parts_beyond_total_budget(
+        #[values(None, Some(100))] chunk_size: Option<usize>,
+    ) -> Result<(), BoxError> {
+        if !graph_os_enabled() {
+            return Ok(());
+        }
+
+        let body_bytes = build_multipart_body_with(
+            OPS,
+            b"tiny",
+            Framing {
+                extraneous_parts: vec![("unreferenced".to_string(), vec![b'C'; 64 * 1024])],
+                ..Default::default()
+            },
+        );
+        let (status, body) = run_with_config(OVERHEAD_CONFIG, body_bytes, chunk_size).await;
+
+        // The extraneous part is consumed while streaming to the subgraph, i.e. after the router
+        // has already committed to a 200 GraphQL response, so this surfaces as a GraphQL error
+        // rather than a 413 — the same way `max_file_size` violations do mid-stream.
+        assert!(
+            status == StatusCode::PAYLOAD_TOO_LARGE || !body["errors"].is_null(),
+            "expected the request to be rejected, got {status}: {body}"
+        );
+
+        Ok(())
+    }
+
+    /// Guards against over-rejection: framing that RFC 2046 permits and that fits inside the
+    /// allowance must still upload successfully.
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn succeeds_with_small_preamble_and_epilogue(
+        #[values(None, Some(100))] chunk_size: Option<usize>,
+    ) -> Result<(), BoxError> {
+        if !graph_os_enabled() {
+            return Ok(());
+        }
+
+        let body_bytes = build_multipart_body_with(
+            OPS,
+            &vec![0xBBu8; 500],
+            Framing {
+                preamble: b"this is a legal preamble\r\n".to_vec(),
+                epilogue: b"this is a legal epilogue\r\n".to_vec(),
+                ..Default::default()
+            },
+        );
+        let (status, body) = run_with_config(OVERHEAD_CONFIG, body_bytes, chunk_size).await;
+
+        assert_eq!(status, StatusCode::OK, "body: {body}");
+        assert!(body["errors"].is_null(), "body: {body}");
 
         Ok(())
     }

--- a/docs/shared/config/preview_file_uploads.mdx
+++ b/docs/shared/config/preview_file_uploads.mdx
@@ -9,6 +9,7 @@ preview_file_uploads:
       limits:
         max_file_size: example_max_file_size
         max_files: 0
+        max_overhead_size: example_max_overhead_size
         operation_body_timeout: 30s
       mode: stream
 ```

--- a/docs/source/routing/operations/file-upload.mdx
+++ b/docs/source/routing/operations/file-upload.mdx
@@ -209,7 +209,7 @@ If this limit is exceeded, the router rejects the entire request.
 </td>
 <td>
 
-`512kb`
+`1mb`
 
 </td>
 <td>

--- a/docs/source/routing/operations/file-upload.mdx
+++ b/docs/source/routing/operations/file-upload.mdx
@@ -130,6 +130,8 @@ If a request exceeds a limit, the router rejects the request.
 The `limits.router.http_max_request_bytes` setting applies to the GraphQL operations field (the query and variables) of the multipart request, not to the uploaded file data itself.
 Limit file data using `protocols.multipart.limits.max_file_size`.
 
+A `multipart/form-data` body also carries framing that is neither file data nor the GraphQL operation: a preamble before the first boundary, a header block for each part, boundary delimiters, and transport padding. The router has to buffer some of that framing to parse the request, so `protocols.multipart.limits.max_overhead_size` bounds how much of it a single request may contain. Because the parser cannot tell a framing byte from a content byte, the router adds this allowance to the content the other limits permit and enforces the sum as a limit on the total request. Raising `max_file_size` or `max_files` therefore raises the total size a request may reach.
+
 Unlike other GraphQL requests, file upload requests stream their body through the router's plugin layer so the multipart body can be parsed before query planning begins. This means a slow or stalled client can hold a connection open until the global router `timeout` fires. Use `operation_body_timeout` to set a tighter deadline specifically for receiving the GraphQL operation (query and variables) at the start of the upload, while still allowing the full router `timeout` for subgraph round-trips. `operation_body_timeout` covers only the time to receive the operation — it does not apply to the time taken to upload the files themselves.
 
 #### Configuration reference
@@ -250,6 +252,27 @@ unset
 <td>
 
 duration string, for example `5s` or `30s`
+
+</td>
+</tr>
+<tr>
+<td>
+
+##### `protocols.multipart.limits.max_overhead_size`
+
+The maximum amount of multipart framing to accept in a single request: the preamble, part headers, boundary delimiters, and transport padding.
+
+This allowance is added to the content the other limits permit, and the router enforces the sum as a limit on the total request. If a request exceeds that total, the router rejects it with a `413 Payload Too Large` error.
+
+</td>
+<td>
+
+`2mb`
+
+</td>
+<td>
+
+values in a [human-readable format](https://crates.io/crates/bytesize), for example, `5kb` and `99mb`
 
 </td>
 </tr>


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-881] -->
---

## Motivation

The file uploads plugin bounds the *content* of a `multipart/form-data` request — per-file bytes via `max_file_size`, the GraphQL operation via `http_max_request_bytes`, and the `map` field via an internal 10 KB cap — but nothing bounds the framing around it.

A `multipart/form-data` body may also carry a preamble before the first boundary, a header block per part, boundary delimiters, and transport padding. multer has to buffer two of those in full before it can act on them:

- **Preamble.** While in `StreamingStage::FindingFirstBoundary`, `buffer.read_to("--boundary")` accumulates into `StreamBuffer.buf` until the boundary arrives.
- **Per-part header blocks.** `read_until(CRLF_CRLF)` buffers the entire header section before httparse runs, so one multi-GB `Content-Disposition` is buffered whole.

multer's `SizeLimit::whole_stream` is the only knob that covers either, and the router never set it, so it defaulted to `u64::MAX`. The `for_field` limits the router does set count **content bytes only** — preamble, headers and boundaries never charge against them.

The path is reachable because `router_layer` raises `BodyLimitControl` to `usize::MAX` for any `multipart/form-data` request before multer reads anything. The eager `Content-Length` check in the limits plugin still rejects oversized *declared* lengths, so an attack needs chunked transfer-encoding — which every large upload already uses. The result is that one chunked request with an endless preamble grows router memory without bound, before query parsing, with only the default-off `operation_body_timeout` as a backstop.

Mitigating factor: `preview_file_uploads.enabled` defaults to `false`.

## What changed

A new limit, `preview_file_uploads.protocols.multipart.limits.max_overhead_size`, defaulting to `2mb`:

```yaml
preview_file_uploads:
  enabled: true
  protocols:
    multipart:
      limits:
        max_overhead_size: 2mb
```

`whole_stream_size_limit` sets multer's `whole_stream` limit to the content the other limits already permit plus that allowance, with saturating arithmetic throughout (`max_files * max_file_size` overflows `u64` for limits operators really write — `large.router.yaml` uses `15gb`). multer's `StreamSizeExceeded` now maps to `413 Payload Too Large`, and the option is registered on the existing `apollo.router.config.file_uploads.multipart` gauge.

Because the parser cannot tell a framing byte from a content byte, the enforced bound is a total: permitted content plus the allowance. A request that fits the configured file and operation limits cannot trip it.

## Notes for reviewers

**Why the default is 2 MB rather than something tighter.** The whole-stream budget and `max_file_size` count bytes at different points: multer counts every byte as it arrives off the socket, before parsing, while `max_file_size` counts a file's bytes as the router hands them to the subgraph. The first count leads the second by whatever multer holds in its buffer, and a single read can deliver ~400 KB (the default for `limits.router.http1_max_request_buf_size`). With a budget below that gap, one oversized file breaks the whole-request budget before it breaks `max_file_size`, and the client gets a "request too large" error instead of a "max file size exceeded" error. This reasoning is recorded on `default_max_overhead_size`.

**One deliberate behavior change.** Parts that the `map` field never references are skipped by name without any size limit (matching `graphql-upload`), so today a client can stream unbounded data through the router under cover of a small, valid upload. Those bytes now count toward the total and the request is rejected. `rejects_extraneous_parts_beyond_total_budget` pins this.

**Known limitation.** The bound is a total, so it scales with `max_file_size` and `max_files`. A deployment running `max_file_size: 15gb` can still be sent a very large preamble before rejection. A tight, non-scaling bound would need a counting adapter between the body and multer that credits back bytes accounted as field content — materially more plumbing, and fuzzy by one socket-read cycle. Not attempted here; the default config is safe and operators can tighten `max_overhead_size` independently.

**Extension codes on 413s are not observable at the edge.** `LimitsPlugin::map_error_to_graphql` rewrites the body of *any* downstream 413 into its own `INVALID_GRAPHQL_REQUEST` / "Request body payload too large" error, and file_uploads is the only downstream producer of a 413. So `FILE_UPLOADS_LIMITS_MAX_REQUEST_SIZE_EXCEEDED` is correct but never reaches a client, as is already true of the existing operations-field 413. That is why the new tests assert on status only. The `Ok(r)` branch that does this looks vestigial — both of the limits plugin's own rejection paths return `Err` and are downcast properly — and removing it locally passed 124 tests. Left for a separate PR rather than widened into this one.

## Verification

- `cargo test -p apollo-router --test integration_tests -- integration::file_upload` — 36 passing.
- Each of the four new rejection tests was confirmed to **fail** with the `whole_stream` limit forced back to `u64::MAX`, so they capture the new behavior rather than passing incidentally.
- `it_uploads_a_massive_file` (`#[ignore]`, `max_file_size: 15gb`, uploads 10GB) run explicitly and passing — exercises the saturating arithmetic against a real large-limits config.
- `cargo fmt --check` and `cargo clippy` clean.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [x] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

- **No manual testing.** I have not run a built router against a hand-crafted chunked request to watch RSS stay flat while the 413 returns. The behavior is covered by integration tests that exercise the real router process, but the memory claim itself is reasoned from multer's buffering rather than measured.
- **Compatibility** is ticked with one caveat: the new option is optional with a default, so existing configuration keeps parsing unchanged, and a request within the configured content limits cannot be rejected. The exception is the unreferenced-parts case described above, which is an intentional tightening of out-of-spec requests.
- **Performance impact** is one `u64` comparison per chunk pulled off the body, on a counter multer already maintained; the budget itself is computed once per request in `MultipartRequest::new`.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-881]: https://apollographql.atlassian.net/browse/ROUTER-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ