### PR TITLE
fix(query-planner): stop discarding a node's own @requires dependency on merge

### DIFF
--- a/.changesets/fix_query_planner_requires_merge_drop.md
+++ b/.changesets/fix_query_planner_requires_merge_drop.md
@@ -1,0 +1,7 @@
+### Fix query planner silently dropping a field's own `@requires` when merged into a same-subgraph ancestor
+
+When a field with its own `@requires` was reached from an ancestor fetch node in the same subgraph, the planner's merge optimization could fold that field directly into the ancestor without checking whether it still had other pending dependencies -- such as a fetch created specifically to satisfy its `@requires`. The dependency was silently discarded: the ancestor's fetch would request the field without first fetching the data it required, producing incomplete or incorrect results with no error or warning.
+
+The query planner's node-merging logic now rejects merging a node into an ancestor unless every other dependency of that node is already satisfied by (i.e., is an ancestor of) the merge target, preserving the correct fetch ordering.
+
+By [@briannafugate408](https://github.com/briannafugate408) in https://github.com/apollographql/router/pull/9967

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2314,6 +2314,13 @@ impl FetchDependencyGraph {
         // selection into `node_id`'s, which silently drops the dependency edge from any other
         // parent unless `node_id` already (transitively) depends on it. Without this check, an
         // unsatisfied `@requires` on `child` can be merged away entirely (RH-1396).
+        //
+        // Note this is conservative: some of those other parents may just be fetching `@key`
+        // fields (potentially a compound `@key`) for the very subgraph jump this merge would
+        // remove, in which case merging would still be safe and this rejects an optimization we
+        // could otherwise make. There's no cheap way to distinguish that case from a genuine
+        // unsatisfied dependency today, and it's a niche case -- plan correctness matters more
+        // than plan optimality here, so we accept the missed optimization.
         for other_parent_id in self.parents_of(child_id) {
             if other_parent_id != node_id && !self.is_descendant_of(node_id, other_parent_id) {
                 return Ok(false);

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2302,9 +2302,25 @@ impl FetchDependencyGraph {
         let parent_relation = self.parent_relation(child_id, node_id);
 
         // we compare the subgraph names last because on average it improves performance
-        Ok(parent_relation.is_some_and(|r| r.path_in_parent.is_some())
+        if !(parent_relation.is_some_and(|r| r.path_in_parent.is_some())
             && node.defer_ref == child.defer_ref
             && node.subgraph_name == child.subgraph_name)
+        {
+            return Ok(false);
+        }
+
+        // `child` may have other parents besides `node_id` -- for instance, a node created to
+        // satisfy `child`'s own `@requires`. Merging `child` into `node_id` collapses `child`'s
+        // selection into `node_id`'s, which silently drops the dependency edge from any other
+        // parent unless `node_id` already (transitively) depends on it. Without this check, an
+        // unsatisfied `@requires` on `child` can be merged away entirely (RH-1396).
+        for other_parent_id in self.parents_of(child_id) {
+            if other_parent_id != node_id && !self.is_descendant_of(node_id, other_parent_id) {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
     }
 
     /// We only allow merging sibling on the same subgraph, same "merge_at" and when the common parent is their only parent:

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
@@ -2275,3 +2275,553 @@ fn handles_requires_when_key_conditions_are_fetched_below_the_entity() {
     "#
     );
 }
+
+#[test]
+fn rh1396_transitive_require_with_own_require() {
+    let planner = planner!(
+        hotelpage: r#"
+          type Query { t: T }
+          type T @key(fields: "id") {
+            id: ID!
+            property: Property
+          }
+          type Property @key(fields: "id") {
+            id: ID!
+            location: String
+            rooms: Int
+          }
+        "#,
+        room_details: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            property: Property @external
+            availableOffers: Offer @requires(fields: "property { location rooms }")
+          }
+          type Property @key(fields: "id") {
+            id: ID!
+            location: String @external
+            rooms: Int @external
+          }
+          type Offer {
+            price: Int
+            property: Property
+          }
+        "#,
+        value_merchandising: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            availableOffers: Offer @external
+            vMPricingData: Int @requires(fields: "availableOffers { price property { location rooms } }")
+          }
+          type Offer {
+            price: Int @external
+            property: Property @external
+          }
+          type Property @key(fields: "id") {
+            id: ID!
+            location: String @external
+            rooms: Int @external
+          }
+        "#
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          { t { vMPricingData } }
+        "#,
+        @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "hotelpage") {
+          {
+            t {
+              __typename
+              id
+              property {
+                location
+                rooms
+              }
+            }
+          }
+        },
+        Flatten(path: "t") {
+          Fetch(service: "room_details") {
+            {
+              ... on T {
+                __typename
+                property {
+                  location
+                  rooms
+                }
+                id
+              }
+            } =>
+            {
+              ... on T {
+                availableOffers {
+                  price
+                  property {
+                    __typename
+                    id
+                  }
+                }
+              }
+            }
+          },
+        },
+        Flatten(path: "t.availableOffers.property") {
+          Fetch(service: "hotelpage") {
+            {
+              ... on Property {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on Property {
+                location
+                rooms
+              }
+            }
+          },
+        },
+        Flatten(path: "t") {
+          Fetch(service: "value_merchandising") {
+            {
+              ... on T {
+                __typename
+                availableOffers {
+                  price
+                  property {
+                    location
+                    rooms
+                  }
+                }
+                id
+              }
+            } =>
+            {
+              ... on T {
+                vMPricingData
+              }
+            }
+          },
+        },
+      },
+    }
+    "#
+    );
+}
+
+// Same shape as `rh1396_transitive_require_with_own_require`, but with the ROOT
+// field `t` owned by `room_details` — the same subgraph that owns
+// `availableOffers` (the field carrying the nested `@requires`). Hypothesis
+// (RH-1396): when the nested-`@requires` field is co-located in the entry
+// subgraph, the planner resolves it in the initial fetch and drops its own
+// `@requires` (on `property`), instead of sequencing the hotelpage fetch first.
+#[test]
+fn rh1396_nested_require_when_root_is_colocated() {
+    let planner = planner!(
+        room_details: r#"
+          type Query { t: T }
+          type T @key(fields: "id") {
+            id: ID!
+            property: Property @external
+            availableOffers: Offer @requires(fields: "property { location rooms }")
+          }
+          type Property @key(fields: "id") {
+            id: ID!
+            location: String @external
+            rooms: Int @external
+          }
+          type Offer {
+            price: Int
+          }
+        "#,
+        hotelpage: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            property: Property
+          }
+          type Property @key(fields: "id") {
+            id: ID!
+            location: String
+            rooms: Int
+          }
+        "#,
+        value_merchandising: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            availableOffers: Offer @external
+            vMPricingData: Int @requires(fields: "availableOffers { price }")
+          }
+          type Offer {
+            price: Int @external
+          }
+        "#
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          { t { vMPricingData } }
+        "#,
+        @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "room_details") {
+          {
+            t {
+              __typename
+              id
+            }
+          }
+        },
+        Flatten(path: "t") {
+          Fetch(service: "hotelpage") {
+            {
+              ... on T {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on T {
+                property {
+                  location
+                  rooms
+                }
+              }
+            }
+          },
+        },
+        Flatten(path: "t") {
+          Fetch(service: "room_details") {
+            {
+              ... on T {
+                __typename
+                property {
+                  location
+                  rooms
+                }
+                id
+              }
+            } =>
+            {
+              ... on T {
+                availableOffers {
+                  price
+                }
+              }
+            }
+          },
+        },
+        Flatten(path: "t") {
+          Fetch(service: "value_merchandising") {
+            {
+              ... on T {
+                __typename
+                availableOffers {
+                  price
+                }
+                id
+              }
+            } =>
+            {
+              ... on T {
+                vMPricingData
+              }
+            }
+          },
+        },
+      },
+    }
+    "#
+    );
+}
+
+// RH-1396 generalization probe: same co-location trigger as
+// `rh1396_nested_require_when_root_is_colocated`, but with the nested `@requires`
+// chain THREE levels deep instead of two: `vMPricingData` requires `availableOffers`
+// (room_details, co-located with the root), which requires `property` (hotelpage),
+// which in turn requires `geoCoords` (geo). This checks whether the ancestor check
+// in `can_merge_child_in` still correctly blocks the wrongful merge when the
+// dependency chain is longer than the minimal repro.
+#[test]
+fn rh1396_three_level_nested_require_when_root_is_colocated() {
+    let planner = planner!(
+        room_details: r#"
+          type Query { t: T }
+          type T @key(fields: "id") {
+            id: ID!
+            property: Property @external
+            availableOffers: Offer @requires(fields: "property { location rooms }")
+          }
+          type Property @key(fields: "id") {
+            id: ID!
+            location: String @external
+            rooms: Int @external
+          }
+          type Offer {
+            price: Int
+          }
+        "#,
+        hotelpage: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            geoCoords: Coords @external
+            property: Property @requires(fields: "geoCoords { lat lng }")
+          }
+          type Coords {
+            lat: Float @external
+            lng: Float @external
+          }
+          type Property @key(fields: "id") {
+            id: ID!
+            location: String
+            rooms: Int
+          }
+        "#,
+        geo: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            geoCoords: Coords
+          }
+          type Coords {
+            lat: Float
+            lng: Float
+          }
+        "#,
+        value_merchandising: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            availableOffers: Offer @external
+            vMPricingData: Int @requires(fields: "availableOffers { price }")
+          }
+          type Offer {
+            price: Int @external
+          }
+        "#
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          { t { vMPricingData } }
+        "#,
+        @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "room_details") {
+          {
+            t {
+              __typename
+              id
+            }
+          }
+        },
+        Flatten(path: "t") {
+          Fetch(service: "geo") {
+            {
+              ... on T {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on T {
+                geoCoords {
+                  lat
+                  lng
+                }
+              }
+            }
+          },
+        },
+        Flatten(path: "t") {
+          Fetch(service: "hotelpage") {
+            {
+              ... on T {
+                __typename
+                geoCoords {
+                  lat
+                  lng
+                }
+                id
+              }
+            } =>
+            {
+              ... on T {
+                property {
+                  location
+                  rooms
+                }
+              }
+            }
+          },
+        },
+        Flatten(path: "t") {
+          Fetch(service: "room_details") {
+            {
+              ... on T {
+                __typename
+                property {
+                  location
+                  rooms
+                }
+                id
+              }
+            } =>
+            {
+              ... on T {
+                availableOffers {
+                  price
+                }
+              }
+            }
+          },
+        },
+        Flatten(path: "t") {
+          Fetch(service: "value_merchandising") {
+            {
+              ... on T {
+                __typename
+                availableOffers {
+                  price
+                }
+                id
+              }
+            } =>
+            {
+              ... on T {
+                vMPricingData
+              }
+            }
+          },
+        },
+      },
+    }
+    "#
+    );
+}
+
+// RH-1396 generalization probe: same co-location trigger, but the root field
+// returns a LIST of entities (`ts: [T]`) rather than a single `T`. Checks whether
+// the fix holds when fetch node `merge_at` paths include a list index.
+#[test]
+fn rh1396_nested_require_when_root_is_colocated_list_entity() {
+    let planner = planner!(
+        room_details: r#"
+          type Query { ts: [T] }
+          type T @key(fields: "id") {
+            id: ID!
+            property: Property @external
+            availableOffers: Offer @requires(fields: "property { location rooms }")
+          }
+          type Property @key(fields: "id") {
+            id: ID!
+            location: String @external
+            rooms: Int @external
+          }
+          type Offer {
+            price: Int
+          }
+        "#,
+        hotelpage: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            property: Property
+          }
+          type Property @key(fields: "id") {
+            id: ID!
+            location: String
+            rooms: Int
+          }
+        "#,
+        value_merchandising: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            availableOffers: Offer @external
+            vMPricingData: Int @requires(fields: "availableOffers { price }")
+          }
+          type Offer {
+            price: Int @external
+          }
+        "#
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          { ts { vMPricingData } }
+        "#,
+        @r#"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "room_details") {
+          {
+            ts {
+              __typename
+              id
+            }
+          }
+        },
+        Flatten(path: "ts.@") {
+          Fetch(service: "hotelpage") {
+            {
+              ... on T {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on T {
+                property {
+                  location
+                  rooms
+                }
+              }
+            }
+          },
+        },
+        Flatten(path: "ts.@") {
+          Fetch(service: "room_details") {
+            {
+              ... on T {
+                __typename
+                property {
+                  location
+                  rooms
+                }
+                id
+              }
+            } =>
+            {
+              ... on T {
+                availableOffers {
+                  price
+                }
+              }
+            }
+          },
+        },
+        Flatten(path: "ts.@") {
+          Fetch(service: "value_merchandising") {
+            {
+              ... on T {
+                __typename
+                availableOffers {
+                  price
+                }
+                id
+              }
+            } =>
+            {
+              ... on T {
+                vMPricingData
+              }
+            }
+          },
+        },
+      },
+    }
+    "#
+    );
+}

--- a/apollo-federation/tests/query_plan/supergraphs/rh1396_nested_require_when_root_is_colocated.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/rh1396_nested_require_when_root_is_colocated.graphql
@@ -1,0 +1,91 @@
+# Composed from subgraphs with hash: e6fea3b12b57404f87d3062929c3f9a7f9ff6cb5
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  HOTELPAGE @join__graph(name: "hotelpage", url: "none")
+  ROOM_DETAILS @join__graph(name: "room_details", url: "none")
+  VALUE_MERCHANDISING @join__graph(name: "value_merchandising", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Offer
+  @join__type(graph: ROOM_DETAILS)
+  @join__type(graph: VALUE_MERCHANDISING)
+{
+  price: Int @join__field(graph: ROOM_DETAILS) @join__field(graph: VALUE_MERCHANDISING, external: true)
+}
+
+type Property
+  @join__type(graph: HOTELPAGE, key: "id")
+  @join__type(graph: ROOM_DETAILS, key: "id")
+{
+  id: ID!
+  location: String @join__field(graph: HOTELPAGE) @join__field(graph: ROOM_DETAILS, external: true)
+  rooms: Int @join__field(graph: HOTELPAGE) @join__field(graph: ROOM_DETAILS, external: true)
+}
+
+type Query
+  @join__type(graph: HOTELPAGE)
+  @join__type(graph: ROOM_DETAILS)
+  @join__type(graph: VALUE_MERCHANDISING)
+{
+  t: T @join__field(graph: ROOM_DETAILS)
+}
+
+type T
+  @join__type(graph: HOTELPAGE, key: "id")
+  @join__type(graph: ROOM_DETAILS, key: "id")
+  @join__type(graph: VALUE_MERCHANDISING, key: "id")
+{
+  id: ID!
+  property: Property @join__field(graph: HOTELPAGE) @join__field(graph: ROOM_DETAILS, external: true)
+  availableOffers: Offer @join__field(graph: ROOM_DETAILS, requires: "property { location rooms }") @join__field(graph: VALUE_MERCHANDISING, external: true)
+  vMPricingData: Int @join__field(graph: VALUE_MERCHANDISING, requires: "availableOffers { price }")
+}

--- a/apollo-federation/tests/query_plan/supergraphs/rh1396_nested_require_when_root_is_colocated_list_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/rh1396_nested_require_when_root_is_colocated_list_entity.graphql
@@ -1,0 +1,91 @@
+# Composed from subgraphs with hash: 65555345f1ef923d69570f656e4669a440fd564c
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  HOTELPAGE @join__graph(name: "hotelpage", url: "none")
+  ROOM_DETAILS @join__graph(name: "room_details", url: "none")
+  VALUE_MERCHANDISING @join__graph(name: "value_merchandising", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Offer
+  @join__type(graph: ROOM_DETAILS)
+  @join__type(graph: VALUE_MERCHANDISING)
+{
+  price: Int @join__field(graph: ROOM_DETAILS) @join__field(graph: VALUE_MERCHANDISING, external: true)
+}
+
+type Property
+  @join__type(graph: HOTELPAGE, key: "id")
+  @join__type(graph: ROOM_DETAILS, key: "id")
+{
+  id: ID!
+  location: String @join__field(graph: HOTELPAGE) @join__field(graph: ROOM_DETAILS, external: true)
+  rooms: Int @join__field(graph: HOTELPAGE) @join__field(graph: ROOM_DETAILS, external: true)
+}
+
+type Query
+  @join__type(graph: HOTELPAGE)
+  @join__type(graph: ROOM_DETAILS)
+  @join__type(graph: VALUE_MERCHANDISING)
+{
+  ts: [T] @join__field(graph: ROOM_DETAILS)
+}
+
+type T
+  @join__type(graph: HOTELPAGE, key: "id")
+  @join__type(graph: ROOM_DETAILS, key: "id")
+  @join__type(graph: VALUE_MERCHANDISING, key: "id")
+{
+  id: ID!
+  property: Property @join__field(graph: HOTELPAGE) @join__field(graph: ROOM_DETAILS, external: true)
+  availableOffers: Offer @join__field(graph: ROOM_DETAILS, requires: "property { location rooms }") @join__field(graph: VALUE_MERCHANDISING, external: true)
+  vMPricingData: Int @join__field(graph: VALUE_MERCHANDISING, requires: "availableOffers { price }")
+}

--- a/apollo-federation/tests/query_plan/supergraphs/rh1396_three_level_nested_require_when_root_is_colocated.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/rh1396_three_level_nested_require_when_root_is_colocated.graphql
@@ -1,0 +1,103 @@
+# Composed from subgraphs with hash: addd870b594a53491e0df18d52125fe7a77f49f2
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Coords
+  @join__type(graph: GEO)
+  @join__type(graph: HOTELPAGE)
+{
+  lat: Float @join__field(graph: GEO) @join__field(graph: HOTELPAGE, external: true)
+  lng: Float @join__field(graph: GEO) @join__field(graph: HOTELPAGE, external: true)
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  GEO @join__graph(name: "geo", url: "none")
+  HOTELPAGE @join__graph(name: "hotelpage", url: "none")
+  ROOM_DETAILS @join__graph(name: "room_details", url: "none")
+  VALUE_MERCHANDISING @join__graph(name: "value_merchandising", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Offer
+  @join__type(graph: ROOM_DETAILS)
+  @join__type(graph: VALUE_MERCHANDISING)
+{
+  price: Int @join__field(graph: ROOM_DETAILS) @join__field(graph: VALUE_MERCHANDISING, external: true)
+}
+
+type Property
+  @join__type(graph: HOTELPAGE, key: "id")
+  @join__type(graph: ROOM_DETAILS, key: "id")
+{
+  id: ID!
+  location: String @join__field(graph: HOTELPAGE) @join__field(graph: ROOM_DETAILS, external: true)
+  rooms: Int @join__field(graph: HOTELPAGE) @join__field(graph: ROOM_DETAILS, external: true)
+}
+
+type Query
+  @join__type(graph: GEO)
+  @join__type(graph: HOTELPAGE)
+  @join__type(graph: ROOM_DETAILS)
+  @join__type(graph: VALUE_MERCHANDISING)
+{
+  t: T @join__field(graph: ROOM_DETAILS)
+}
+
+type T
+  @join__type(graph: GEO, key: "id")
+  @join__type(graph: HOTELPAGE, key: "id")
+  @join__type(graph: ROOM_DETAILS, key: "id")
+  @join__type(graph: VALUE_MERCHANDISING, key: "id")
+{
+  id: ID!
+  geoCoords: Coords @join__field(graph: GEO) @join__field(graph: HOTELPAGE, external: true)
+  property: Property @join__field(graph: HOTELPAGE, requires: "geoCoords { lat lng }") @join__field(graph: ROOM_DETAILS, external: true)
+  availableOffers: Offer @join__field(graph: ROOM_DETAILS, requires: "property { location rooms }") @join__field(graph: VALUE_MERCHANDISING, external: true)
+  vMPricingData: Int @join__field(graph: VALUE_MERCHANDISING, requires: "availableOffers { price }")
+}

--- a/apollo-federation/tests/query_plan/supergraphs/rh1396_transitive_require_with_own_require.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/rh1396_transitive_require_with_own_require.graphql
@@ -1,0 +1,93 @@
+# Composed from subgraphs with hash: f0a9676dd7135e7d48c29c4371ef0dd905d723c7
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  HOTELPAGE @join__graph(name: "hotelpage", url: "none")
+  ROOM_DETAILS @join__graph(name: "room_details", url: "none")
+  VALUE_MERCHANDISING @join__graph(name: "value_merchandising", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Offer
+  @join__type(graph: ROOM_DETAILS)
+  @join__type(graph: VALUE_MERCHANDISING)
+{
+  price: Int @join__field(graph: ROOM_DETAILS) @join__field(graph: VALUE_MERCHANDISING, external: true)
+  property: Property @join__field(graph: ROOM_DETAILS) @join__field(graph: VALUE_MERCHANDISING, external: true)
+}
+
+type Property
+  @join__type(graph: HOTELPAGE, key: "id")
+  @join__type(graph: ROOM_DETAILS, key: "id")
+  @join__type(graph: VALUE_MERCHANDISING, key: "id")
+{
+  id: ID!
+  location: String @join__field(graph: HOTELPAGE) @join__field(graph: ROOM_DETAILS, external: true) @join__field(graph: VALUE_MERCHANDISING, external: true)
+  rooms: Int @join__field(graph: HOTELPAGE) @join__field(graph: ROOM_DETAILS, external: true) @join__field(graph: VALUE_MERCHANDISING, external: true)
+}
+
+type Query
+  @join__type(graph: HOTELPAGE)
+  @join__type(graph: ROOM_DETAILS)
+  @join__type(graph: VALUE_MERCHANDISING)
+{
+  t: T @join__field(graph: HOTELPAGE)
+}
+
+type T
+  @join__type(graph: HOTELPAGE, key: "id")
+  @join__type(graph: ROOM_DETAILS, key: "id")
+  @join__type(graph: VALUE_MERCHANDISING, key: "id")
+{
+  id: ID!
+  property: Property @join__field(graph: HOTELPAGE) @join__field(graph: ROOM_DETAILS, external: true)
+  availableOffers: Offer @join__field(graph: ROOM_DETAILS, requires: "property { location rooms }") @join__field(graph: VALUE_MERCHANDISING, external: true)
+  vMPricingData: Int @join__field(graph: VALUE_MERCHANDISING, requires: "availableOffers { price property { location rooms } }")
+}


### PR DESCRIPTION
## Summary

Fixes a query-planner bug where a field with its own `@requires` could be resolved *before* the data it required was actually fetched -- silently, with no error and no warning.

**Trigger:** a field `B` has `@requires(fields: "C")`, where `C` lives in a different subgraph than `B`. When `B` itself is reached from an ancestor fetch node in the *same subgraph* as `B`, the planner's merge-optimization pass folds `B`'s node into that ancestor without checking whether `B` has other pending dependencies (like the node that resolves `C`). The dependency edge for `C` is silently dropped, and the ancestor's fetch ends up requesting `B` without the data `B` needs.

## Root cause

`can_merge_child_in` (`apollo-federation/src/query_plan/fetch_dependency_graph.rs`) decides whether a fetch-dependency node can be merged into an ancestor. It only checked:
1. a parent relation with a known path exists,
2. same `defer_ref`,
3. same `subgraph_name`.

It never checked whether the child node had *other* parents -- e.g. a node created specifically to satisfy the child's own `@requires`. `merge_child_in` merges with `merge_parent_dependencies: false`, so any such edge is discarded, not relocated, when the merge proceeds.

## The fix

Reject the merge unless every other parent of the child is already a (transitive) ancestor of the merge target:

```rust
for other_parent_id in self.parents_of(child_id) {
    if other_parent_id != node_id && !self.is_descendant_of(node_id, other_parent_id) {
        return Ok(false);
    }
}
```

An earlier candidate fix (requiring input-selection containment) also fixed the repro but regressed 17 other passing snapshot tests where a same-subgraph merge is legitimately safe even though the ancestor has no recorded `.inputs`. The topological ancestor check is the minimal correct condition and introduces zero regressions.

## Testing

- `rh1396_nested_require_when_root_is_colocated` -- minimal repro of the reported shape, produces the correct 4-fetch sequenced plan.
- `rh1396_transitive_require_with_own_require` -- negative control (same shape, but the nested-`@requires` field is *not* co-located with the root); confirms the fix doesn't change already-correct behavior.
- `rh1396_three_level_nested_require_when_root_is_colocated` -- generalization probe: three levels of nested `@requires` across four subgraphs. Confirmed to reproduce the same bug pre-fix, plans correctly post-fix.
- `rh1396_nested_require_when_root_is_colocated_list_entity` -- generalization probe: same shape with a list-typed root field, to check `merge_at` path handling with a list index. Also confirmed buggy pre-fix, correct post-fix.

Full `apollo-federation` suite: 1908 lib tests + 836 integration tests passing, no regressions beyond the four tests above (which previously had `SEE_OUTPUT` placeholders or asserted the incorrect plan).

## Note on scope

This PR intentionally excludes a fifth test built from a real customer's (anonymized-in-spirit but structurally derived) schema, which was used during initial diagnosis but isn't appropriate to commit here. The four generic tests above fully cover the bug and its fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)