### PR TITLE
feat(connectors): `->reduce($acc, <seed>, <update>)` for connect/v0.5

### DIFF
--- a/.changesets/feat_connect_v0_5_reduce_method.md
+++ b/.changesets/feat_connect_v0_5_reduce_method.md
@@ -1,0 +1,28 @@
+### Fold an array into a single value with `->reduce` in Connect v0.5
+
+Connect spec v0.5 (preview, behind `connectors.preview_connect_v0_5: true`) adds `array->reduce($acc, <seed>, <update>)` to the mapping language, for the aggregations that previously had no expression at all:
+
+```graphql
+type Query {
+  order: Order @connect(
+    source: "api"
+    http: { GET: "/order" }
+    selection: """
+    id
+    total: lineItems->reduce($acc, 0, @.price->add($acc))
+    """
+  )
+}
+```
+
+The first argument names the accumulator. The second is its starting value, evaluated once before the fold begins. The third runs once per element, with `@` bound to that element and the accumulator bound to the value so far; each result becomes the next accumulator, and the last one is the answer.
+
+The starting value is also the result for an empty array, so a fold always produces a value rather than failing on empty input. Because it is written explicitly, the accumulator can be a different type than the elements.
+
+The accumulator is visible only inside the update expression — unlike `->as`, it does not remain bound after the method, so nested folds cannot interfere with one another. For that reason `reduce`, like `as`, cannot be redefined by a `methods:` entry: the mapping language decides what the name binds before it can know which definition it resolves to.
+
+**Mind the argument order.** `@->add($acc)` is correct; `$acc->add(@)` is not, and it fails quietly. Leading a path with something other than `@` moves `@` onto that value, so `$acc->add(@)` adds the accumulator to itself and never reads the array.
+
+Composition now warns about exactly that mistake, wherever `@` is written in a per-element argument to `->map`, `->filter`, `->find`, or `->reduce` but cannot reach the element. It catches the same error outside folds — `items->filter($args.ids->contains(@))` asks whether a list contains itself, and filters nothing — and names the fix. An argument that never mentions `@` is left alone, since ignoring the element can be deliberate.
+
+By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/9969

--- a/apollo-federation/src/connectors/json_selection/README.md
+++ b/apollo-federation/src/connectors/json_selection/README.md
@@ -881,6 +881,24 @@ typeOfValue: value->typeof
 doubled: numbers->map(@->mul(2))
 types: values->map(@->typeof)
 
+# ->reduce folds an array into a single value, left to right. The first
+# argument names the accumulator variable, the second is its starting
+# value, and the third runs once per element with `@` bound to that
+# element and the named variable bound to the accumulator so far.
+total: numbers->reduce($acc, 0, @->add($acc))
+orderTotal: orders->reduce($acc, 0, @.total->add($acc))
+#
+# The starting value is also the result for an empty array, so a fold
+# always produces an answer. The accumulator variable is visible only
+# inside the third argument — unlike ->as, it does not remain bound
+# after the method.
+#
+# Mind the order: `@->add($acc)` is correct, but `$acc->add(@)` is not,
+# and it fails quietly. Leading a path with $acc moves `@` onto the
+# accumulator, so both operands become the accumulator, the array is
+# never read, and the result is whatever folding the starting value into
+# itself produces.
+
 # Returns true if the data is deeply equal to the first argument, false
 # otherwise. Equality is solely value-based (all JSON), no references.
 isObject: value->typeof->eq("object")
@@ -974,6 +992,15 @@ arguments. Because argument `LitExpr`s are positional and many of them
 any syntactic delimiter, whitespace-only separation would be ambiguous for
 positional arguments in a way it is not for named object members or array
 elements.
+
+Arguments are ordinarily parsed in the scope of the surrounding selection, but
+`->reduce` is an exception: its first argument declares a variable that is in
+scope for its third argument, and nowhere else. The declaration therefore
+affects how later arguments in the same list parse, and it is discarded at the
+closing parenthesis, so an accumulator can shadow an outer variable of the same
+name without disturbing it. This is also why `reduce`, like `as`, cannot be
+redefined by a `methods:` entry — the parser has to decide what the syntax
+binds before it can know which definition a name resolves to.
 
 ### `Key ::= Identifier | LitString`
 

--- a/apollo-federation/src/connectors/json_selection/apply_to.rs
+++ b/apollo-federation/src/connectors/json_selection/apply_to.rs
@@ -2025,6 +2025,47 @@ mod tests {
     }
 
     #[test]
+    fn a_method_body_can_fold_with_reduce() {
+        // `->reduce` is the reason a hand-written method wants the array whole.
+        // The fold runs inside the method body, against the method's receiver.
+        let (out, errors) = apply_with_methods(
+            "$->sum",
+            &[("sum", "@->reduce($acc, 0, @->add($acc))")],
+            json!([1, 2, 3, 4]),
+        );
+        assert!(errors.is_empty(), "{errors:?}");
+        assert_eq!(out, Some(json!(10)));
+    }
+
+    #[test]
+    fn a_reducing_method_can_take_its_seed_as_a_parameter() {
+        // The parameter is a caller-scope `Local`, and the fold's own `$acc`
+        // binding must not disturb it — both are visible in the update.
+        let (out, errors) = apply_with_methods(
+            "$->sumFrom(100)",
+            &[(
+                "sumFrom",
+                "($start) => @->reduce($acc, $start, @->add($acc))",
+            )],
+            json!([1, 2, 3]),
+        );
+        assert!(errors.is_empty(), "{errors:?}");
+        assert_eq!(out, Some(json!(106)));
+    }
+
+    #[test]
+    fn a_reducing_method_folds_over_a_field_of_each_element() {
+        // `@` inside the update is the element, so the fold can reach into it.
+        let (out, errors) = apply_with_methods(
+            "$->orderTotal",
+            &[("orderTotal", "@->reduce($acc, 0, @.total->add($acc))")],
+            json!([{ "total": 10 }, { "total": 20 }, { "total": 5 }]),
+        );
+        assert!(errors.is_empty(), "{errors:?}");
+        assert_eq!(out, Some(json!(35)));
+    }
+
+    #[test]
     fn min_and_max_are_expressible_as_methods() {
         for (input, other, min, max) in [(5, 3, 3, 5), (2, 3, 2, 3), (4, 4, 4, 4)] {
             let (out, errors) =

--- a/apollo-federation/src/connectors/json_selection/methods.rs
+++ b/apollo-federation/src/connectors/json_selection/methods.rs
@@ -45,12 +45,21 @@ pub(crate) fn is_builtin_method_name(name: &str) -> bool {
 /// form while dispatch routed elsewhere — parse-time and eval-time would
 /// disagree about what the syntax means.
 ///
+/// `->reduce` qualifies for the same reason and no other: the parser rewrites
+/// `$acc` to a `Local` binding scoped to the update expression, so the binding
+/// form is decided before dispatch ever happens. Note it is the *binding*, not
+/// the iteration, that reserves the name — `->map` and `->filter` bind nothing
+/// and stay shadowable.
+///
 /// Note this is *not* subject to the forward-compatibility argument that makes
 /// ordinary built-ins shadowable: reserved names already mean something today,
 /// so reserving them cannot retroactively break a schema the way newly shipping
 /// an ordinary built-in could.
 pub(crate) fn is_reserved_method_name(name: &str) -> bool {
-    matches!(ArrowMethod::lookup(name), Some(ArrowMethod::As))
+    matches!(
+        ArrowMethod::lookup(name),
+        Some(ArrowMethod::As | ArrowMethod::Reduce)
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,6 +68,7 @@ pub(super) enum ArrowMethod {
     As,
     Echo,
     Map,
+    Reduce,
     Match,
     First,
     Last,
@@ -180,6 +190,7 @@ impl std::ops::Deref for ArrowMethod {
             Self::As => &public::AsMethod,
             Self::Echo => &public::EchoMethod,
             Self::Map => &public::MapMethod,
+            Self::Reduce => &public::ReduceMethod,
             Self::Match => &public::MatchMethod,
             Self::First => &public::FirstMethod,
             Self::Last => &public::LastMethod,
@@ -236,6 +247,7 @@ impl ArrowMethod {
             "as" => Some(Self::As),
             "echo" => Some(Self::Echo),
             "map" => Some(Self::Map),
+            "reduce" => Some(Self::Reduce),
             "eq" => Some(Self::Eq),
             "match" => Some(Self::Match),
             // As this case suggests, we can't necessarily provide a name()
@@ -298,6 +310,7 @@ impl ArrowMethod {
             Self::As
                 | Self::Echo
                 | Self::Map
+                | Self::Reduce
                 | Self::Match
                 | Self::First
                 | Self::Last

--- a/apollo-federation/src/connectors/json_selection/methods/public/mod.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/mod.rs
@@ -20,6 +20,8 @@ mod last;
 pub(crate) use last::LastMethod;
 mod map;
 pub(crate) use map::MapMethod;
+mod reduce;
+pub(crate) use reduce::ReduceMethod;
 mod r#as;
 pub(crate) use r#as::AsMethod;
 mod r#match;

--- a/apollo-federation/src/connectors/json_selection/methods/public/reduce.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/reduce.rs
@@ -1,0 +1,522 @@
+use serde_json_bytes::Value as JSON;
+use serde_json_bytes::json;
+use shape::Shape;
+use shape::ShapeCase;
+
+use crate::connectors::json_selection::ApplyContext;
+use crate::connectors::json_selection::ApplyToError;
+use crate::connectors::json_selection::ApplyToInternal;
+use crate::connectors::json_selection::MethodArgs;
+use crate::connectors::json_selection::PathList;
+use crate::connectors::json_selection::ShapeContext;
+use crate::connectors::json_selection::VarsWithPathsMap;
+use crate::connectors::json_selection::immutable::InputPath;
+use crate::connectors::json_selection::known_var::KnownVariable;
+use crate::connectors::json_selection::lit_expr::LitExpr;
+use crate::connectors::json_selection::location::Ranged;
+use crate::connectors::json_selection::location::WithRange;
+use crate::connectors::spec::ConnectSpec;
+use crate::impl_arrow_method;
+
+impl_arrow_method!(ReduceMethod, reduce_method, reduce_shape);
+/// The `array->reduce($acc, <seed>, <update>)` method folds an array into a
+/// single value, left to right.
+///
+/// The accumulator starts as `<seed>` (evaluated once, in the caller's scope),
+/// and `<update>` is evaluated once per element with `@` bound to that element
+/// and `$acc` bound to the accumulator so far. Each result becomes the next
+/// accumulator, and the last one is the method's output:
+///
+/// ```graphql
+/// $([1, 2, 3, 4])->reduce($acc, 0, @->add($acc))   // 10
+/// orders->reduce($acc, 0, @.total->add($acc))      // sum one field of each element
+/// ```
+///
+/// The seed does three jobs: it is the accumulator's starting value, it is the
+/// result for an empty array (so the fold is *total* — there is always an
+/// answer), and it pins the accumulator's type, which is what lets a fold
+/// return something other than the element type. That last job is latent for
+/// now: folding an array into an object needs a method that builds one key at a
+/// time, which the language does not yet have.
+///
+/// # `$acc` is lexical, `@` is a cursor — mind the argument order
+///
+/// `@->add($acc)` is correct. The mirror image, `$acc->add(@)`, is **not**, and
+/// it fails silently: leading a path with `$acc` retargets the cursor onto the
+/// accumulator (see the `PathList::Var` arm of `apply_to_path`), so the inner
+/// `@` means the accumulator rather than the element. Every step computes
+/// `acc + acc`, the array is never read, and with a seed of `0` the answer is
+/// `0` — no error, no type mismatch.
+///
+/// This is worth knowing precisely because `acc.combine(element)` is how folds
+/// read in most languages, so it is the shape people reach for first. Naming
+/// the element with a fourth argument was considered and rejected in favor of
+/// keeping the signature tight and warning about the trap.
+///
+/// # Recursion is impossible, so the language stays total
+///
+/// The trip count is fixed by the input array's length before the loop starts,
+/// and the accumulator is never the iteration source, so `->reduce` is bounded
+/// iteration over finite data rather than a general loop. Folding is safe in a
+/// way unfolding would not be.
+fn reduce_method(
+    method_name: &WithRange<String>,
+    method_args: Option<&MethodArgs>,
+    data: &JSON,
+    vars: &VarsWithPathsMap,
+    input_path: &InputPath<JSON>,
+    context: &ApplyContext,
+) -> (Option<JSON>, Vec<ApplyToError>) {
+    let spec = context.spec();
+    let (acc_name_opt, mut errors) = check_method_args(method_name, method_args, input_path, spec);
+
+    // Without a validated accumulator name there is nothing to bind the update
+    // expression against, so the fold cannot run at all. `check_method_args`
+    // has already explained why.
+    let (Some(acc_name), Some(args)) = (acc_name_opt, method_args) else {
+        return (None, errors);
+    };
+    let (Some(seed_arg), Some(update_arg)) = (args.args.get(1), args.args.get(2)) else {
+        return (None, errors);
+    };
+
+    // The seed is evaluated once, in the caller's scope, before any binding
+    // exists — so `$acc` is deliberately not in scope here.
+    let (seed_opt, seed_errors) = seed_arg.apply_to_path(data, vars, input_path, context);
+    errors.extend(seed_errors);
+    let Some(mut acc) = seed_opt else {
+        return (None, errors);
+    };
+
+    // A non-array input folds as a one-element array, matching how ->map and
+    // ->filter treat scalars.
+    let singleton;
+    let elements: &[JSON] = match data {
+        JSON::Array(array) => array.as_slice(),
+        other => {
+            singleton = [other.clone()];
+            &singleton
+        }
+    };
+
+    let acc_path = InputPath::empty().append(json!(acc_name));
+
+    for (index, element) in elements.iter().enumerate() {
+        let element_path = input_path.append(JSON::Number(index.into()));
+
+        // Rebind `$acc` for this step only. The frame is scoped to the
+        // iteration so the borrow of `acc` ends before it is reassigned, and
+        // so the binding never escapes to the method's tail — unlike `->as`,
+        // `->reduce` does not leak its variable to what follows.
+        let (updated_opt, update_errors) = {
+            let mut frame = vars.clone();
+            frame.insert(
+                KnownVariable::Local(acc_name.clone()),
+                (&acc, acc_path.clone()),
+            );
+            update_arg.apply_to_path(element, &frame, &element_path, context)
+        };
+        errors.extend(update_errors);
+
+        match updated_opt {
+            Some(updated) => acc = updated,
+            None => {
+                // Carrying the previous accumulator forward would hand back a
+                // plausible-looking number that quietly ignored an element, so
+                // a failed step fails the whole fold. The errors collected
+                // above say which element and why.
+                return (None, errors);
+            }
+        }
+    }
+
+    (Some(acc), errors)
+}
+
+/// Validate `->reduce`'s arguments, shared by [`reduce_method`] and
+/// [`reduce_shape`] so the runtime and the shape pass agree about what is
+/// well-formed. Returns the accumulator variable name (including its leading
+/// `$`) when the first argument is a single bare `$variable`, as `->as` requires
+/// of its own first argument.
+fn check_method_args(
+    method_name: &WithRange<String>,
+    method_args: Option<&MethodArgs>,
+    // Not meaningful for reduce_shape.
+    input_path: &InputPath<JSON>,
+    spec: ConnectSpec,
+) -> (Option<String>, Vec<ApplyToError>) {
+    let mut errors = vec![];
+
+    let arg_count = method_args.map(|args| args.args.len()).unwrap_or_default();
+    if arg_count != 3 {
+        errors.push(ApplyToError::new(
+            format!(
+                "Method ->{} requires three arguments: a $variable for the accumulator, an initial value, and an update expression (got {arg_count})",
+                method_name.as_ref(),
+            ),
+            input_path.to_vec(),
+            method_name.range(),
+            spec,
+        ));
+    }
+
+    let Some(var_arg) = method_args.and_then(|args| args.args.first()) else {
+        return (None, errors);
+    };
+
+    let mut not_a_variable = |suffix: &str| {
+        errors.push(ApplyToError::new(
+            format!(
+                "First argument to ->{} must be a single $variable name{suffix}",
+                method_name.as_ref(),
+            ),
+            input_path.to_vec(),
+            method_name.range(),
+            spec,
+        ));
+    };
+
+    let LitExpr::Path(path_selection) = var_arg.as_ref() else {
+        not_a_variable("");
+        return (None, errors);
+    };
+    let PathList::Var(known_var, tail) = path_selection.path.as_ref() else {
+        not_a_variable("");
+        return (None, errors);
+    };
+    if !matches!(tail.as_ref(), PathList::Empty) {
+        not_a_variable(" with no path suffix");
+        return (None, errors);
+    }
+
+    match known_var.as_ref() {
+        // The parser rewrites this argument to a Local when it sees a
+        // `->reduce` call, exactly as it does for `->as`, so a Local here is
+        // the well-formed case.
+        KnownVariable::Local(var_name) => (Some(var_name.clone()), errors),
+
+        // `@` and `$` are the language's own bindings, and rebinding either
+        // per iteration would make the update expression unreadable.
+        KnownVariable::Dollar | KnownVariable::AtSign => {
+            errors.push(ApplyToError::new(
+                format!(
+                    "First argument to ->{} must be a named $variable, not {}",
+                    method_name.as_ref(),
+                    known_var.as_str(),
+                ),
+                input_path.to_vec(),
+                method_name.range(),
+                spec,
+            ));
+            (None, errors)
+        }
+
+        KnownVariable::External(var_name) => {
+            errors.push(ApplyToError::new(
+                format!(
+                    "Argument {} to ->{} must not be an external variable",
+                    var_name, // Includes the leading $
+                    method_name.as_ref(),
+                ),
+                input_path.to_vec(),
+                method_name.range(),
+                spec,
+            ));
+            (None, errors)
+        }
+    }
+}
+
+/// The accumulator's static shape is a fixpoint: `$acc` starts as the seed, and
+/// every step replaces it with the update's output computed against that same
+/// `$acc`. Rather than iterate to convergence, take one widening step —
+/// `seedShape ⊔ updateOutputShape` — and then *check* that it is the fixpoint by
+/// applying the update once more against it.
+///
+/// The check is what makes the single step safe. It holds for every fold whose
+/// accumulator type settles, which is nearly all of them and exactly what the
+/// seed exists to pin. It fails for an update that grows the accumulator
+/// structurally — `->reduce($acc, 0, [$acc])` wraps it one array deeper per
+/// element — where one step would report `One<0, [0]>` while the runtime
+/// produces arbitrarily deep nesting. That is not an imprecise shape but a wrong
+/// one, so a failed check widens all the way to `Unknown` rather than pretending
+/// to a bound the fold does not respect.
+///
+/// The seed joins the union only when the array might be empty, since the seed
+/// is the result in exactly that case. When the input shape's array prefix
+/// guarantees at least one element, the fold body always runs, and including the
+/// seed would invent a case the caller then has to handle.
+///
+/// The element shape is the union of the input array's item shapes
+/// (`any_item`), so a heterogeneous array widens the update's input rather than
+/// analyzing each position separately — the fold's result comes from the last
+/// element, but nothing here knows which shape that is. A non-array input yields
+/// itself, mirroring the runtime's one-element fold.
+fn reduce_shape(
+    context: &ShapeContext,
+    method_name: &WithRange<String>,
+    method_args: Option<&MethodArgs>,
+    input_shape: Shape,
+    dollar_shape: Shape,
+) -> Shape {
+    let (acc_name_opt, errors) = check_method_args(
+        method_name,
+        method_args,
+        &InputPath::empty(),
+        context.spec(),
+    );
+
+    if !errors.is_empty() {
+        return Shape::error(
+            errors
+                .iter()
+                .map(|e| e.message().to_string())
+                .collect::<Vec<_>>()
+                .join("\n"),
+            method_name.shape_location(context.source_id()),
+        );
+    }
+
+    let (Some(acc_name), Some(args)) = (acc_name_opt, method_args) else {
+        return Shape::error(
+            format!("Method ->{} could not be analyzed", method_name.as_ref()),
+            method_name.shape_location(context.source_id()),
+        );
+    };
+    let (Some(seed_arg), Some(update_arg)) = (args.args.get(1), args.args.get(2)) else {
+        return Shape::error(
+            format!("Method ->{} could not be analyzed", method_name.as_ref()),
+            method_name.shape_location(context.source_id()),
+        );
+    };
+
+    let seed_shape =
+        seed_arg.compute_output_shape(context, input_shape.clone(), dollar_shape.clone());
+    let element_shape = input_shape.any_item([]);
+    let locations = || method_name.shape_location(context.source_id());
+
+    // An array whose static prefix has at least one entry cannot be empty, so
+    // the fold body is guaranteed to run and the seed cannot be the result.
+    let may_be_empty = !matches!(
+        input_shape.case(),
+        ShapeCase::Array { prefix, .. } if !prefix.is_empty()
+    );
+
+    let update_once = |acc_shape: &Shape| {
+        let update_context = context
+            .clone()
+            .with_named_shapes([(acc_name.clone(), acc_shape.clone())]);
+        update_arg.compute_output_shape(
+            &update_context,
+            element_shape.clone(),
+            dollar_shape.clone(),
+        )
+    };
+
+    // One widening step, from the accumulator's initial shape.
+    let first = update_once(&seed_shape);
+    let candidate = if may_be_empty {
+        Shape::one([seed_shape, first], locations())
+    } else {
+        first
+    };
+
+    // Then confirm it is the fixpoint. If feeding the candidate back through the
+    // update yields something it does not already accept, the accumulator grows
+    // without bound and no finite shape describes it.
+    let second = update_once(&candidate);
+    if candidate.accepts(&second) {
+        candidate
+    } else {
+        Shape::unknown(locations())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json_bytes::json;
+
+    use crate::connectors::ConnectSpec;
+    use crate::selection;
+
+    const SPEC: ConnectSpec = ConnectSpec::V0_5;
+
+    #[test]
+    fn sums_an_array_of_numbers() {
+        assert_eq!(
+            selection!("$->reduce($acc, 0, @->add($acc))", SPEC).apply_to(&json!([1, 2, 3, 4])),
+            (Some(json!(10)), vec![]),
+        );
+    }
+
+    #[test]
+    fn returns_the_seed_for_an_empty_array() {
+        // The seed is what makes the fold total: no elements, no problem.
+        assert_eq!(
+            selection!("$->reduce($acc, 0, @->add($acc))", SPEC).apply_to(&json!([])),
+            (Some(json!(0)), vec![]),
+        );
+    }
+
+    #[test]
+    fn folds_over_a_selected_field() {
+        assert_eq!(
+            selection!("total: prices->reduce($acc, 0, @->add($acc))", SPEC).apply_to(&json!({
+                "prices": [10, 20, 5],
+            })),
+            (Some(json!({ "total": 35 })), vec![]),
+        );
+    }
+
+    #[test]
+    fn accumulator_need_not_have_the_element_type() {
+        // Strings in, a number out: the seed pins the accumulator's type
+        // independently of the elements, which is what a seedless reduction
+        // could not do.
+        assert_eq!(
+            selection!("$->reduce($acc, 0, @->size->add($acc))", SPEC)
+                .apply_to(&json!(["a", "bb", "ccc"])),
+            (Some(json!(6)), vec![]),
+        );
+    }
+
+    #[test]
+    fn accumulator_is_visible_to_the_update_only() {
+        // `$acc` does not leak to the method's tail the way `->as` binds do.
+        let (value, errors) =
+            selection!("$->reduce($acc, 0, @->add($acc))->echo($acc)", SPEC).apply_to(&json!([1]));
+        assert_eq!(value, None);
+        assert_eq!(
+            errors
+                .iter()
+                .map(|e| e.message().to_string())
+                .collect::<Vec<_>>(),
+            vec!["Variable $acc not found".to_string()],
+        );
+    }
+
+    #[test]
+    fn non_array_input_folds_as_a_single_element() {
+        assert_eq!(
+            selection!("$->reduce($acc, 100, @->add($acc))", SPEC).apply_to(&json!(5)),
+            (Some(json!(105)), vec![]),
+        );
+    }
+
+    #[test]
+    fn leading_with_the_accumulator_is_the_documented_trap() {
+        // `$acc->add(@)` retargets the cursor onto the accumulator, so `@` is
+        // the accumulator too and the array is never read: 0+0, four times.
+        // This test pins the behavior so a future change to it is deliberate.
+        assert_eq!(
+            selection!("$->reduce($acc, 0, $acc->add(@))", SPEC).apply_to(&json!([1, 2, 3, 4])),
+            (Some(json!(0)), vec![]),
+        );
+    }
+
+    #[test]
+    fn rejects_a_non_variable_first_argument() {
+        let (value, errors) = selection!("$->reduce(123, 0, @)", SPEC).apply_to(&json!([1, 2, 3]));
+        assert_eq!(value, None);
+        assert_eq!(
+            errors
+                .iter()
+                .map(|e| e.message().to_string())
+                .collect::<Vec<_>>(),
+            vec!["First argument to ->reduce must be a single $variable name".to_string()],
+        );
+    }
+
+    #[test]
+    fn rejects_the_wrong_number_of_arguments() {
+        let (value, errors) = selection!("$->reduce($acc, 0)", SPEC).apply_to(&json!([1, 2, 3]));
+        assert_eq!(value, None);
+        assert_eq!(
+            errors
+                .iter()
+                .map(|e| e.message().to_string())
+                .collect::<Vec<_>>(),
+            vec![
+                "Method ->reduce requires three arguments: a $variable for the accumulator, an initial value, and an update expression (got 2)"
+                    .to_string()
+            ],
+        );
+    }
+
+    #[test]
+    fn nested_folds_keep_their_own_accumulators() {
+        assert_eq!(
+            selection!(
+                "$->reduce($outer, 0, @->reduce($inner, $outer, @->add($inner)))",
+                SPEC
+            )
+            .apply_to(&json!([[1, 2], [3, 4]])),
+            (Some(json!(10)), vec![]),
+        );
+    }
+
+    #[test]
+    fn sum_shape_is_the_widened_accumulator() {
+        // `seedShape ⊔ updateOutputShape` = Int ⊔ Float. The union collapses to
+        // Float because Int is subsumed by it — which is the widening step
+        // doing its job, not a loss of precision from skipping the fixpoint.
+        assert_eq!(
+            selection!("$->reduce($acc, 0, @->add($acc))", SPEC)
+                .shape()
+                .pretty_print(),
+            "Float",
+        );
+    }
+
+    #[test]
+    fn shape_omits_the_seed_when_the_array_cannot_be_empty() {
+        // A statically non-empty array always runs the fold, so the seed is not
+        // a possible result and must not appear in the output shape. (The
+        // element shapes are all present because the analysis does not know
+        // which element is last.)
+        assert_eq!(
+            selection!("$([1, 2, 3])->reduce($acc, null, @)", SPEC)
+                .shape()
+                .pretty_print(),
+            "One<1, 2, 3>",
+        );
+    }
+
+    #[test]
+    fn shape_keeps_the_seed_when_the_array_might_be_empty() {
+        // Nothing is known about `list`, so the empty case is live and the seed
+        // is a genuine possibility.
+        assert_eq!(
+            selection!("list->reduce($acc, null, @)", SPEC)
+                .shape()
+                .pretty_print(),
+            "One<null, $root.list.*>",
+        );
+    }
+
+    #[test]
+    fn shape_gives_up_on_an_accumulator_that_grows_each_step() {
+        // `[$acc]` wraps the accumulator one array deeper per element, so no
+        // finite shape describes the result. One widening step would claim
+        // `One<0, [0]>`, which the runtime disproves at three elements
+        // (`[[[0]]]`), so the stability check widens to Unknown instead.
+        let sel = selection!("$->reduce($acc, 0, [$acc])", SPEC);
+        assert_eq!(sel.shape().pretty_print(), "Unknown");
+        assert_eq!(
+            sel.apply_to(&json!([1, 2, 3])),
+            (Some(json!([[[0]]])), vec![]),
+        );
+    }
+
+    #[test]
+    fn shape_reports_a_type_changing_accumulator_as_a_union() {
+        // Seeded with a string, updated to an int: the one widening step keeps
+        // both rather than silently claiming the seed's type.
+        assert_eq!(
+            selection!("$->reduce($acc, '', @->size)", SPEC)
+                .shape()
+                .pretty_print(),
+            "One<\"\", Int>",
+        );
+    }
+}

--- a/apollo-federation/src/connectors/json_selection/parser.rs
+++ b/apollo-federation/src/connectors/json_selection/parser.rs
@@ -646,6 +646,242 @@ impl JSONSelection {
     }
 }
 
+/// The `->` methods that evaluate an argument once per element of an array,
+/// paired with the index of that argument. Their per-element argument is the
+/// only place `@` means "the current element", which is what makes
+/// [`JSONSelection::element_ignoring_calls`] meaningful.
+const PER_ELEMENT_ARGS: &[(&str, usize)] = &[
+    ("map", 0),
+    ("filter", 0),
+    ("find", 0),
+    // `->reduce($acc, <seed>, <update>)`: the seed runs once in the caller's
+    // scope, so only the update is per-element.
+    ("reduce", 2),
+];
+
+impl JSONSelection {
+    /// Collect every per-element `->method(...)` call — `->map`, `->filter`,
+    /// `->find`, `->reduce` — whose per-element argument **writes `@` but does
+    /// not read the element with it**.
+    ///
+    /// That conjunction is the whole check. Writing `@` is the author saying
+    /// *here is where the element goes*; the report fires only when the `@` they
+    /// wrote cannot mean the element, because the cursor was retargeted before
+    /// reaching it. `->reduce($acc, 0, $acc->add(@))` is the case: leading with
+    /// `$acc` moves `@` onto the accumulator, so the array is never read and the
+    /// fold quietly returns the seed folded into itself.
+    ///
+    /// An argument with **no `@` at all** is left alone, because ignoring the
+    /// element can be deliberate — `items->reduce($acc, 0, $acc->add(1))` counts
+    /// elements, `items->filter($args.showAll)` keeps or drops the whole list.
+    /// Neither mentions `@`, so neither is claiming to use an element it does not
+    /// use. Requiring the mention is what separates a stated intent from a
+    /// design choice.
+    ///
+    /// Still a heuristic rather than a proof, so callers raise it as a warning.
+    pub(crate) fn element_ignoring_calls(&self) -> Vec<&WithRange<String>> {
+        let mut out = Vec::new();
+        match &self.inner {
+            TopLevelSelection::Named(sub) => collect_element_ignoring_subselection(sub, &mut out),
+            TopLevelSelection::Value(lit) => collect_element_ignoring_lit(lit, &mut out),
+        }
+        out
+    }
+}
+
+fn collect_element_ignoring_subselection<'a>(
+    sub: &'a SubSelection,
+    out: &mut Vec<&'a WithRange<String>>,
+) {
+    for named in &sub.selections {
+        collect_element_ignoring_lit(&named.path, out);
+    }
+}
+
+fn collect_element_ignoring_lit<'a>(
+    lit: &'a WithRange<LitExpr>,
+    out: &mut Vec<&'a WithRange<String>>,
+) {
+    match lit.as_ref() {
+        LitExpr::String(_) | LitExpr::Number(_) | LitExpr::Bool(_) | LitExpr::Null => {}
+        LitExpr::LegacyObject(map) => {
+            for value in map.values() {
+                collect_element_ignoring_lit(value, out);
+            }
+        }
+        LitExpr::Object(sub) => collect_element_ignoring_subselection(sub, out),
+        LitExpr::Array(items) => {
+            for item in items {
+                collect_element_ignoring_lit(item, out);
+            }
+        }
+        LitExpr::Path(path) => collect_element_ignoring_pathlist(&path.path, out),
+        LitExpr::LitPath(root, tail) => {
+            collect_element_ignoring_lit(root, out);
+            collect_element_ignoring_pathlist(tail, out);
+        }
+        LitExpr::OpChain(_, operands) => {
+            for operand in operands {
+                collect_element_ignoring_lit(operand, out);
+            }
+        }
+    }
+}
+
+fn collect_element_ignoring_pathlist<'a>(
+    path: &'a WithRange<PathList>,
+    out: &mut Vec<&'a WithRange<String>>,
+) {
+    match path.as_ref() {
+        PathList::Var(_, tail) | PathList::Key(_, tail) | PathList::Question(tail) => {
+            collect_element_ignoring_pathlist(tail, out)
+        }
+        PathList::Expr(lit, tail) => {
+            collect_element_ignoring_lit(lit, out);
+            collect_element_ignoring_pathlist(tail, out);
+        }
+        PathList::Method(name, args, tail) => {
+            if let Some(args) = args {
+                if let Some((_, index)) = PER_ELEMENT_ARGS
+                    .iter()
+                    .find(|(method, _)| *method == name.as_ref().as_str())
+                    && let Some(per_element) = args.args.get(*index)
+                {
+                    // Report only when the author wrote `@` and none of those
+                    // `@`s can mean the element. An argument that never
+                    // mentions `@` is ignoring the element on purpose.
+                    let usage = scan_at_usage_lit(per_element, true);
+                    if usage.mentions && !usage.reads_subject {
+                        out.push(name);
+                    }
+                }
+                // Recurse regardless: a nested call inside the argument is
+                // judged on its own element, not this one.
+                for arg in &args.args {
+                    collect_element_ignoring_lit(arg, out);
+                }
+            }
+            collect_element_ignoring_pathlist(tail, out);
+        }
+        PathList::Selection(sub) => collect_element_ignoring_subselection(sub, out),
+        PathList::Empty => {}
+    }
+}
+
+/// What an expression does with `@`, as seen from one particular ambient value.
+#[derive(Clone, Copy, Default)]
+struct AtUsage {
+    /// The expression writes `@` somewhere, anywhere — the author's statement
+    /// that a value flows in here.
+    mentions: bool,
+    /// The expression reads the ambient value under consideration, whether via
+    /// `@` or via a bare key.
+    reads_subject: bool,
+}
+
+impl AtUsage {
+    const NONE: Self = Self {
+        mentions: false,
+        reads_subject: false,
+    };
+
+    /// Combine two positions in the same expression. `reads_subject` is a
+    /// disjunction because one reader anywhere is enough.
+    fn or(self, other: Self) -> Self {
+        Self {
+            mentions: self.mentions || other.mentions,
+            reads_subject: self.reads_subject || other.reads_subject,
+        }
+    }
+
+    /// Keep the mention, discard the read — for a sub-expression evaluated
+    /// against some *other* value, where an `@` is still written but cannot
+    /// mean the subject.
+    fn retargeted(self) -> Self {
+        Self {
+            mentions: self.mentions,
+            reads_subject: false,
+        }
+    }
+}
+
+/// Scan `lit`, evaluated against an ambient value, for its use of `@`.
+///
+/// `ambient_is_subject` tracks whether the ambient value is still the one we are
+/// asking about. It starts true at the root of a per-element argument (where the
+/// ambient value *is* the element) and goes false the moment a path retargets the
+/// cursor — leading with `$var`, or rooting a path in a literal. Everything
+/// downstream of a retarget reads that other value instead, which is exactly the
+/// distinction between `@->add($acc)` and `$acc->add(@)`: both mention `@`, only
+/// the first reads the element with it.
+fn scan_at_usage_lit(lit: &WithRange<LitExpr>, ambient_is_subject: bool) -> AtUsage {
+    match lit.as_ref() {
+        LitExpr::String(_) | LitExpr::Number(_) | LitExpr::Bool(_) | LitExpr::Null => AtUsage::NONE,
+        LitExpr::LegacyObject(map) => map.values().fold(AtUsage::NONE, |acc, value| {
+            acc.or(scan_at_usage_lit(value, ambient_is_subject))
+        }),
+        LitExpr::Object(sub) => sub.selections.iter().fold(AtUsage::NONE, |acc, named| {
+            acc.or(scan_at_usage_lit(&named.path, ambient_is_subject))
+        }),
+        LitExpr::Array(items) => items.iter().fold(AtUsage::NONE, |acc, item| {
+            acc.or(scan_at_usage_lit(item, ambient_is_subject))
+        }),
+        LitExpr::Path(path) => scan_at_usage_pathlist(&path.path, ambient_is_subject),
+        // A literal-rooted path reads the literal, so its tail is evaluated
+        // against that literal rather than the ambient value. The literal itself
+        // may still read the ambient value, as in `[@, 1]->first`.
+        LitExpr::LitPath(root, tail) => scan_at_usage_lit(root, ambient_is_subject)
+            .or(scan_at_usage_pathlist(tail, false).retargeted()),
+        LitExpr::OpChain(_, operands) => operands.iter().fold(AtUsage::NONE, |acc, operand| {
+            acc.or(scan_at_usage_lit(operand, ambient_is_subject))
+        }),
+    }
+}
+
+fn scan_at_usage_pathlist(path: &WithRange<PathList>, ambient_is_subject: bool) -> AtUsage {
+    match path.as_ref() {
+        PathList::Var(known_var, tail) => match known_var.as_ref() {
+            // `@` is the ambient value itself — always a mention, and a read of
+            // the subject only when the ambient value still is the subject.
+            KnownVariable::AtSign => AtUsage {
+                mentions: true,
+                reads_subject: ambient_is_subject,
+            }
+            .or(scan_at_usage_pathlist(tail, false).retargeted()),
+            // Any named variable (or `$`) moves the cursor off the ambient
+            // value for the whole rest of the path.
+            KnownVariable::Dollar | KnownVariable::Local(_) | KnownVariable::External(_) => {
+                scan_at_usage_pathlist(tail, false).retargeted()
+            }
+        },
+        // A bare key reads a property of the ambient value, without mentioning
+        // `@` — `->map(total)` is a read but not a claim about `@`.
+        PathList::Key(_, tail) => AtUsage {
+            mentions: false,
+            reads_subject: ambient_is_subject,
+        }
+        .or(scan_at_usage_pathlist(tail, false).retargeted()),
+        PathList::Question(tail) => scan_at_usage_pathlist(tail, ambient_is_subject),
+        PathList::Expr(lit, tail) => scan_at_usage_lit(lit, ambient_is_subject)
+            .or(scan_at_usage_pathlist(tail, false).retargeted()),
+        // A method's arguments are evaluated against its receiver, so they
+        // inherit whatever the path has reached by this point.
+        PathList::Method(_, args, tail) => args
+            .as_ref()
+            .map(|args| {
+                args.args.iter().fold(AtUsage::NONE, |acc, arg| {
+                    acc.or(scan_at_usage_lit(arg, ambient_is_subject))
+                })
+            })
+            .unwrap_or(AtUsage::NONE)
+            .or(scan_at_usage_pathlist(tail, ambient_is_subject)),
+        PathList::Selection(sub) => sub.selections.iter().fold(AtUsage::NONE, |acc, named| {
+            acc.or(scan_at_usage_lit(&named.path, ambient_is_subject))
+        }),
+        PathList::Empty => AtUsage::NONE,
+    }
+}
+
 fn collect_methods_subselection<'a>(sub: &'a SubSelection, out: &mut Vec<&'a WithRange<String>>) {
     for named in &sub.selections {
         collect_methods_lit(&named.path, out);
@@ -1566,16 +1802,46 @@ impl PathList {
             // method name, so we can unconditionally return based on what
             // parse_identifier tells us. since MethodArgs::parse is optional,
             // the absence of args will never trigger the error case.
-            return match (parse_identifier, opt(MethodArgs::parse)).parse(suffix) {
-                Ok((suffix, (method, args_opt))) => {
+            // The method name has to be parsed before its arguments, because
+            // `->reduce($acc, <seed>, <update>)` binds `$acc` *within* its own
+            // argument list — the update expression is parsed with the
+            // accumulator already in scope. See `MethodArgs::parse_with_binding`.
+            let (suffix, method) = match parse_identifier.parse(suffix) {
+                Ok(parsed) => parsed,
+                Err(_) => {
+                    return Err(nom_fail_message(
+                        input.clone(),
+                        "Method name must follow ->",
+                    ));
+                }
+            };
+            let bind_arg_zero_from =
+                if ArrowMethod::lookup(method.as_ref()) == Some(ArrowMethod::Reduce) {
+                    // Argument 1 is the seed, evaluated in the caller's scope
+                    // before any accumulator exists, so the binding starts at
+                    // argument 2.
+                    Some(2)
+                } else {
+                    None
+                };
+
+            return match opt(|input| MethodArgs::parse_with_binding(input, bind_arg_zero_from))
+                .parse(suffix)
+            {
+                Ok((suffix, args_opt)) => {
                     let mut local_var_name = None;
 
-                    // Convert the first argument of input->as($var) from
-                    // KnownVariable::External (the default for parsed named
-                    // variable references) to KnownVariable::Local, when we know
-                    // we're parsing an ->as($var) method invocation.
+                    // Convert the first argument of input->as($var) — or of
+                    // input->reduce($acc, ...) — from KnownVariable::External
+                    // (the default for parsed named variable references) to
+                    // KnownVariable::Local, now that we know we are parsing one
+                    // of the two methods that bind their first argument.
+                    let binding_method = matches!(
+                        ArrowMethod::lookup(method.as_ref()),
+                        Some(ArrowMethod::As | ArrowMethod::Reduce)
+                    );
                     let args = if let Some(args) = args_opt.as_ref()
-                        && ArrowMethod::lookup(method.as_ref()) == Some(ArrowMethod::As)
+                        && binding_method
                     {
                         let new_args = if let Some(old_first_arg) = args.args.first()
                             && let LitExpr::Path(path_selection) = old_first_arg.as_ref()
@@ -1616,10 +1882,16 @@ impl PathList {
                         args_opt
                     };
 
-                    let suffix_with_local_var = if let Some(var_name) = local_var_name {
-                        suffix.map_extra(|extra| extra.with_local_var(var_name))
-                    } else {
-                        suffix
+                    // `->as($var)` binds for everything that follows it, which
+                    // is the whole point of the method. `->reduce($acc, ...)`
+                    // binds only inside its own update argument (handled during
+                    // argument parsing), so its accumulator must not leak into
+                    // the tail — `$acc` after the fold is an unbound variable.
+                    let suffix_with_local_var = match local_var_name {
+                        Some(var_name) if bind_arg_zero_from.is_none() => {
+                            suffix.map_extra(|extra| extra.with_local_var(var_name))
+                        }
+                        _ => suffix,
                     };
 
                     let (remainder, rest) =
@@ -2272,18 +2544,58 @@ impl Ranged for MethodArgs {
 // the PathSelection::Method will be None, so we can safely define MethodArgs
 // using a Vec<LitExpr> in all cases (possibly empty but never missing).
 impl MethodArgs {
-    fn parse(input: Span) -> ParseResult<Self> {
+    /// Parse a parenthesized method argument list.
+    ///
+    /// When `bind_first_arg_from` is `Some(index)` and the first argument is a
+    /// bare `$variable`, that variable is in scope as a `Local` while parsing
+    /// arguments at `index` and later. This is what makes `$acc` resolve as a
+    /// local inside `->reduce($acc, <seed>, <update>)`'s update expression while
+    /// staying unbound in the seed, which is evaluated once in the caller's
+    /// scope before any accumulator exists.
+    ///
+    /// The binding is confined to this argument list: the span handed back
+    /// carries the caller's original locals, so an accumulator cannot leak into
+    /// whatever follows the method. That is the difference from `->as`, which
+    /// binds for the rest of the path on purpose.
+    fn parse_with_binding(input: Span, bind_first_arg_from: Option<usize>) -> ParseResult<Self> {
         let input = spaces_or_comments(input)?.0;
+        let outer_local_vars = input.extra.local_vars.clone();
         let (mut input, open_paren) = ranged_span("(").parse(input)?;
         input = spaces_or_comments(input)?.0;
 
         let mut args = Vec::new();
         if let Ok((remainder, first)) = LitExpr::parse(input.clone()) {
+            // A bare `$var` first argument is what a binding method declares.
+            // Anything else (a path with a suffix, a literal) is not a binder,
+            // and the method's own argument validation reports it.
+            let bound_var = bind_first_arg_from.and_then(|from| {
+                let LitExpr::Path(path) = first.as_ref() else {
+                    return None;
+                };
+                let PathList::Var(var_name, var_tail) = path.path.as_ref() else {
+                    return None;
+                };
+                if !matches!(var_tail.as_ref(), PathList::Empty) {
+                    return None;
+                }
+                match var_name.as_ref() {
+                    KnownVariable::External(name) | KnownVariable::Local(name) => {
+                        Some((from, name.clone()))
+                    }
+                    KnownVariable::Dollar | KnownVariable::AtSign => None,
+                }
+            });
+
             args.push(first);
             input = remainder;
 
             while let Ok((remainder, _)) = (spaces_or_comments, char(',')).parse(input.clone()) {
                 input = spaces_or_comments(remainder)?.0;
+                if let Some((from, name)) = bound_var.as_ref()
+                    && args.len() >= *from
+                {
+                    input = input.map_extra(|extra| extra.with_local_var(name.clone()));
+                }
                 if let Ok((remainder, arg)) = LitExpr::parse(input.clone()) {
                     args.push(arg);
                     input = remainder;
@@ -2295,6 +2607,13 @@ impl MethodArgs {
 
         input = spaces_or_comments(input.clone())?.0;
         let (input, close_paren) = ranged_span(")").parse(input.clone())?;
+
+        // Drop any binding introduced above, so it cannot escape the argument
+        // list and shadow a caller variable of the same name.
+        let input = input.map_extra(|mut extra| {
+            extra.local_vars = outer_local_vars;
+            extra
+        });
 
         let range = merge_ranges(open_paren.range(), close_paren.range());
         Ok((input, Self { args, range }))

--- a/apollo-federation/src/connectors/validation/methods.rs
+++ b/apollo-federation/src/connectors/validation/methods.rs
@@ -461,6 +461,22 @@ pub(super) fn validate_method_calls(schema: &SchemaInfo) -> Vec<Message> {
                 locations: locations.clone(),
             });
         }
+
+        // A per-element argument that never reads its element is nearly always
+        // the cursor trap: leading a path with `$acc` (or any variable) moves
+        // `@` off the element, so the array goes unread and the result looks
+        // plausible. Reported wherever a mapping can appear, including method
+        // bodies, since a fold is exactly what a hand-written method is for.
+        for method in parsed.element_ignoring_calls() {
+            let name = method.as_ref().as_str();
+            messages.push(Message {
+                code: Code::ElementIgnoredByMethodArgument,
+                message: format!(
+                    "`{coordinate}` calls `->{name}` with an argument that writes `@` but never reaches the element, so the input is ignored. Leading a path with something else moves `@` onto that value instead — `$acc->add(@)` adds the accumulator to itself, and `$args.ids->contains(@)` asks whether a list contains itself. Put the element first: `@->add($acc)`, `@->in($args.ids)`."
+                ),
+                locations: locations.clone(),
+            });
+        }
     };
 
     for (directive_name, arg_name, value) in selections {
@@ -753,6 +769,139 @@ type Query {
         assert!(
             codes(schema).contains(&Code::MethodShadowsReserved),
             "expected MethodShadowsReserved for a method named `as`"
+        );
+    }
+
+    #[test]
+    fn shadowing_reduce_is_an_error_for_the_same_reason_as_as() {
+        // `->reduce($acc, ...)` is the other method the parser reads at parse
+        // time, to scope `$acc` to the update expression. A custom `reduce`
+        // would leave the parser binding a variable for a body that never
+        // receives it.
+        let schema = schema_with_methods("0.5", r#"{ reduce: "id" }"#);
+        assert!(
+            codes(schema).contains(&Code::MethodShadowsReserved),
+            "expected MethodShadowsReserved for a method named `reduce`"
+        );
+    }
+
+    /// A `@connect(selection:)` carrying `mapping`, for exercising checks that
+    /// look at selection contents rather than at `methods:` entries.
+    fn schema_with_selection(mapping: &str) -> String {
+        format!(
+            r#"extend schema
+@link(url: "https://specs.apollo.dev/connect/v0.5", import: ["@connect", "@source"])
+@source(name: "v", http: {{ baseURL: "http://localhost" }})
+
+type Query {{
+  f: JSON @connect(source: "v", http: {{ GET: "/" }}, selection: "{mapping}")
+}}
+
+scalar JSON
+"#
+        )
+    }
+
+    #[test]
+    fn a_fold_that_leads_with_the_accumulator_is_reported() {
+        // The cursor trap: `$acc` retargets `@` onto itself, so the array is
+        // never read and the fold returns the seed folded into the seed.
+        let schema = schema_with_selection("$->reduce($acc, 0, $acc->add(@))");
+        let codes = codes(schema);
+        assert!(
+            codes.contains(&Code::ElementIgnoredByMethodArgument),
+            "expected the element-ignored warning, got {codes:?}"
+        );
+        assert_eq!(
+            Code::ElementIgnoredByMethodArgument.severity(),
+            Severity::Warning,
+            "ignoring the element is sometimes deliberate, so this must not fail composition"
+        );
+    }
+
+    #[test]
+    fn a_fold_that_reads_the_element_is_not_reported() {
+        // The correct spelling of the same fold, and the variants that reach
+        // into the element or wrap the whole thing in another method.
+        for mapping in [
+            "$->reduce($acc, 0, @->add($acc))",
+            "$.orders->reduce($acc, 0, @.total->add($acc))",
+            "$.rows->map(@.name)->filter(@->eq('x'))",
+            "$.rows->find(@.active)",
+        ] {
+            let codes = codes(schema_with_selection(mapping));
+            assert!(
+                !codes.contains(&Code::ElementIgnoredByMethodArgument),
+                "`{mapping}` reads its element, but was reported: {codes:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_argument_that_never_mentions_the_cursor_is_left_alone() {
+        // Ignoring the element without writing `@` is a design choice, not a
+        // mistaken one: the first counts elements, the second keeps or drops
+        // the whole list. Neither claims to use an element it does not use.
+        for mapping in [
+            "$->reduce($acc, 0, $acc->add(1))",
+            "$.rows->filter($args.showAll)",
+            "$.rows->map('x')",
+        ] {
+            let codes = codes(schema_with_selection(mapping));
+            assert!(
+                !codes.contains(&Code::ElementIgnoredByMethodArgument),
+                "`{mapping}` never mentions `@`, so it must not be reported: {codes:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_inner_callback_does_not_excuse_an_outer_one() {
+        // The outer fold ignores its element; the inner `->map` reads its own.
+        // Judging each call against its own element is what makes the outer one
+        // visible here.
+        let schema = schema_with_selection("$->reduce($acc, 0, $acc->map(@->add(1)))");
+        let codes = codes(schema);
+        assert!(
+            codes.contains(&Code::ElementIgnoredByMethodArgument),
+            "expected the outer fold to be reported, got {codes:?}"
+        );
+    }
+
+    #[test]
+    fn the_check_reaches_inside_method_bodies() {
+        // A fold written inside a `methods:` entry is exactly where this is
+        // most likely to hide.
+        let schema = schema_with_methods("0.5", r#"{ sum: "@->reduce($acc, 0, $acc->add(@))" }"#);
+        let codes = codes(schema);
+        assert!(
+            codes.contains(&Code::ElementIgnoredByMethodArgument),
+            "expected the warning for a fold inside a method body, got {codes:?}"
+        );
+    }
+
+    #[test]
+    fn a_method_body_may_fold_its_input_with_reduce() {
+        // The composition this branch exists for: a hand-written method that
+        // takes the array whole and reduces it. Note the receiver is a list and
+        // that is fine — only type-derived methods reject a list receiver.
+        let schema = r#"extend schema
+@link(url: "https://specs.apollo.dev/connect/v0.5", import: ["@connect", "@source"])
+@source(name: "v", http: { baseURL: "http://localhost" }, methods: { sum: "$->reduce($acc, 0, @->add($acc))" })
+
+type Query {
+  total: Float @connect(source: "v", http: { GET: "/" }, selection: "$.prices->sum")
+}
+"#
+        .to_string();
+        let codes = codes(schema);
+        assert!(
+            !codes.contains(&Code::UnknownMethod),
+            "->reduce must resolve inside a method body, got {codes:?}"
+        );
+        assert!(
+            codes.is_empty(),
+            "a folding method should compose cleanly, got {codes:?}"
         );
     }
 

--- a/apollo-federation/src/connectors/validation/mod.rs
+++ b/apollo-federation/src/connectors/validation/mod.rs
@@ -346,6 +346,14 @@ pub enum Code {
     /// an object-typed field. Auto-derive over nested object types is not yet
     /// supported; provide an explicit `selection:`. (Parked co-design item.)
     UnsupportedMethodAutoDerive,
+    /// A per-element argument to `->map`, `->filter`, `->find`, or `->reduce`
+    /// writes `@` but cannot reach the element with it, because the path
+    /// retargets the cursor first: `->reduce($acc, 0, $acc->add(@))` moves `@`
+    /// onto the accumulator, and `->filter($args.ids->contains(@))` moves it
+    /// onto `$args.ids`. Both read as ordinary code and both silently ignore
+    /// the array. An argument that never writes `@` is not reported — see
+    /// [`Code::severity`].
+    ElementIgnoredByMethodArgument,
 }
 
 impl Code {
@@ -363,6 +371,14 @@ impl Code {
             // that an error retroactively would break them on upgrade; warn
             // instead, and reserve the error for v0.5+.
             Self::UnknownMethodLegacySpec => Severity::Warning,
+            // Requiring a written `@` already excludes the deliberate cases
+            // (`->reduce($acc, 0, $acc->add(1))` counts elements;
+            // `->filter($args.showAll)` keeps or drops the whole list), so what
+            // remains is nearly always a mistake. It stays a warning because
+            // "nearly" is not "always" — an argument may legitimately refer to
+            // its own receiver — and because this is a heuristic about intent
+            // rather than a rule the language enforces.
+            Self::ElementIgnoredByMethodArgument => Severity::Warning,
             _ => Severity::Error,
         }
     }


### PR DESCRIPTION
Stacked on #9919 (`benjamn/connect-v0.5-defs-pr`). Review that one first; the diff here is a single commit.

Adds `array->reduce($acc, <seed>, <update>)` to the connectors mapping language — the one iteration form the language could not express, and the reason a hand-written `methods:` method wants an array whole.

```graphql
total: numbers->reduce($acc, 0, @->add($acc))
orderTotal: orders->reduce($acc, 0, @.total->add($acc))
```

The seed is evaluated once in the caller's scope and does three jobs: it starts the accumulator, it fixes the accumulator's type, and it is the result for an empty array — so the fold is total. The update runs once per element with `@` bound to that element and the named accumulator bound to the value so far.

## The accumulator binding is contained

`->as` binds for the rest of the path by construction: it marks the tail scope, so `$p` still means something after `->as($p)->…`. `->reduce` is the opposite, and it can afford to be. `MethodArgs::parse_with_binding` puts the accumulator in scope for the update argument only, then restores the caller's locals at the closing parenthesis. The seed does not see it, the tail does not see it, and nested folds cannot collide.

That containment also means the engine needs no caller-side special case. `->as` requires the `ArrowMethod::As` arm in `apply_to.rs`, where the *caller* writes the returned bindings into `updated_vars`. `->reduce` clones `vars`, inserts the accumulator, and evaluates the update itself, in a frame that dies with the iteration.

## Why `reduce` is a reserved name

The parser rewrites the first argument from `External` to `Local` before the method registry exists, so it cannot know whether `reduce` resolves to a built-in or to a `methods:` entry. Allowing a custom method to take the name would let the parser bind a variable for a body that never receives it, and silently capture a genuine external variable of that name. So `reduce` joins `as` in `is_reserved_method_name` — the only two built-ins a `methods:` author cannot shadow.

This is a real cost against the "methods win over built-ins" policy that PR #9919 establishes deliberately. It is forced by the parse-time binding rather than chosen.

## Shapes: one widening step, then check it

`reduce_shape` computes `seedShape ⊔ updateOutputShape`, then applies the update once more against that candidate to confirm it is the fixpoint.

The check is what makes one step safe. Without it, `$->reduce($acc, 0, [$acc])` reports `One<0, [0]>` while the runtime returns `[[[0]]]` — not an imprecise shape but one that excludes the actual value. A fold whose accumulator settles reports that type; one that grows the accumulator structurally reports `Unknown`. A test asserts the shape and the runtime value together, so reintroducing an unsound bound fails.

The seed joins the union only when the array might be empty. `$([1,2,3])->reduce($acc, null, @)` is `One<1, 2, 3>`, not `One<null, 1, 2, 3>` — a statically non-empty array always runs the fold, so the seed cannot be the result and should not force callers to handle a case that never occurs.

## New warning: an argument that writes `@` but cannot reach the element

`Code::ElementIgnoredByMethodArgument` covers the four methods whose argument runs per element — `->map`, `->filter`, `->find`, `->reduce`.

Leading a path with anything other than `@` moves the cursor onto that value, so a later `@` means the receiver rather than the element:

```graphql
items->reduce($acc, 0, $acc->add(@))     # adds the accumulator to itself; the array is never read
items->filter($args.ids->contains(@))    # asks whether a list contains itself; filters nothing
```

Both run without error and return plausible results, which is what makes them worth catching at composition. The fixes are `@->add($acc)` and `@->in($args.ids)`, and the message says so.

The check fires only when the argument **writes `@` and none of those `@`s can reach the element**. Requiring the mention is what keeps deliberate code quiet: `->reduce($acc, 0, $acc->add(1))` counts elements, `->filter($args.showAll)` keeps or drops the whole list, and neither claims to use an element it does not use. Warning severity, since an argument may legitimately refer to its own receiver.

It fires on nothing in the existing test corpus.

## Tests

24 tests: runtime and shape behavior in `methods/public/reduce.rs`, folds inside custom `methods:` bodies in `apply_to.rs`, and the warning plus the reserved-name rule in `validation/methods.rs`. Notable behaviors pinned deliberately — an empty array returns the seed, a non-array folds as one element, a failed update step fails the whole fold rather than carrying a stale accumulator forward, and the `$acc->add(@)` trap is pinned at its actual (wrong-looking) result so changing it has to be a decision.

## Checklist

Complete the following:

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
