### PR TITLE
Introduce `condition->ifThen(then, else)` method

### DIFF
--- a/.changesets/feat_ifthen_arrow_method.md
+++ b/.changesets/feat_ifthen_arrow_method.md
@@ -1,0 +1,51 @@
+### Add `->ifThen` method for conditional mappings without `->match`
+
+Connector mapping expressions can now branch on a boolean with
+`condition->ifThen(then_expr[, else_expr])`. The then branch is taken only when
+the condition is `true`; otherwise the else branch is used, or nothing is
+produced when it is omitted.
+
+```graphql
+status: age->gte(18)->ifThen("adult", "minor")
+discount: isPremium->ifThen(20, 0)
+```
+
+Only the taken branch is evaluated, so the untaken one cannot contribute errors:
+`isValid->ifThen("then", $.missing)` yields `"then"` without complaining about
+`$.missing`. This is what makes `->ifThen` a method rather than syntax sugar.
+
+Omitting the else branch produces no value, which at a named position drops the
+key and under a spread contributes nothing:
+
+```graphql
+before ...condition->ifThen({ optional: "value" }) after
+```
+
+When `condition` is `false`, the result is just `before` and `after`, with no
+error. Previously an inline spread that produced no value always reported
+`Inlined path produced no value`; that error is now raised only when the path
+itself errored.
+
+Conditions must be boolean, consistent with `->and`, `->or`, `->not`, `->filter`
+and `->find`. There is no truthiness: `true` is the only value that takes the
+then branch, so `1` and `"false"` both take the else branch. Anything that is
+neither `true` nor `false` reports `Method ->ifThen can only be applied to
+boolean values.` Unlike the other boolean methods the error is non-fatal:
+because `->ifThen` has a fallback, it still produces a value rather than
+collapsing the selection.
+
+For two-way dispatch this replaces `->match`'s `[candidate, value]` pairs and
+`[@, _]` catch-all with the branches written directly:
+
+```graphql
+# before
+... type->match(["book", { __typename: "Book", title: title }],
+                [@,      { __typename: "Movie", title: title }])
+# after
+... type->eq("book")->ifThen({ __typename: "Book", title: title },
+                             { __typename: "Movie", title: title })
+```
+
+`->match` remains the better fit for dispatch over more than two cases.
+
+By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/9970

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6785,9 +6785,9 @@ dependencies = [
 
 [[package]]
 name = "shape"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68f64918904ec44a5574808ffa986a2a1abf14738ebfc8479eed64d2882b0b1"
+checksum = "8687837087ee58ab3479bbbf80dd7b2c119a523ddf8b439317078fb22265896f"
 dependencies = [
  "apollo-compiler",
  "indexmap 2.14.0",

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -59,7 +59,7 @@ url = "2"
 either = "1.13.0"
 tracing = "0.1.40"
 ron = { version = "0.12.0", optional = true }
-shape = "=0.7.0"
+shape = "=0.8.0"
 form_urlencoded = "1.2.1"
 parking_lot = "0.12.4"
 mime = "0.3.17"

--- a/apollo-federation/src/connectors/expand/visitors/selection.rs
+++ b/apollo-federation/src/connectors/expand/visitors/selection.rs
@@ -436,15 +436,6 @@ impl<'a> TypeShapeWalker<'a> {
                     object.type_name.as_str(),
                 )));
             }
-
-            ShapeCase::Error(shape::Error { partial, .. }) => {
-                if let Some(partial) = partial {
-                    // Errors with partial shapes still mostly behave like those
-                    // shapes (except for simplification), so we need to
-                    // validate the object against the partial shape.
-                    self.walk_object_helper(object, new_object_type, partial)?;
-                }
-            }
         };
 
         Ok(())
@@ -582,15 +573,6 @@ impl<'a> TypeShapeWalker<'a> {
                     "Unexpected primitive shape provided for interface type: {}",
                     shape.pretty_print()
                 )));
-            }
-
-            ShapeCase::Error(shape::Error { partial, .. }) => {
-                if let Some(partial) = partial {
-                    // Errors with partial shapes still mostly behave like those
-                    // shapes (except for simplification), so we need to
-                    // validate the interface against the partial shape.
-                    self.walk_interface_helper(interface, partial)?;
-                }
             }
         };
 
@@ -771,15 +753,6 @@ impl<'a> TypeShapeWalker<'a> {
                     "Unexpected primitive shape provided for union type: {}",
                     shape.pretty_print()
                 )));
-            }
-
-            ShapeCase::Error(shape::Error { partial, .. }) => {
-                if let Some(partial) = partial {
-                    // Errors with partial shapes still mostly behave like those
-                    // shapes (except for simplification), so we need to
-                    // validate the union against the partial shape.
-                    self.walk_union_helper(union_type, partial)?;
-                }
             }
         }
 

--- a/apollo-federation/src/connectors/json_selection/apply_to.rs
+++ b/apollo-federation/src/connectors/json_selection/apply_to.rs
@@ -491,6 +491,7 @@ impl ApplyToInternal for NamedSelection {
         let mut errors = Vec::new();
 
         let (value_opt, apply_errors) = self.path.apply_to_path(data, vars, input_path, spec);
+        let had_errors = !apply_errors.is_empty();
         errors.extend(apply_errors);
 
         match &self.prefix {
@@ -516,12 +517,17 @@ impl ApplyToInternal for NamedSelection {
                         ));
                     }
                     None => {
-                        errors.push(ApplyToError::new(
-                            "Inlined path produced no value".to_string(),
-                            input_path.to_vec(),
-                            self.path.range(),
-                            spec,
-                        ));
+                        // Only produce an error if the None was caused by an error.
+                        // If the path legitimately returned None (no errors), just
+                        // spread nothing silently.
+                        if had_errors {
+                            errors.push(ApplyToError::new(
+                                "Inlined path produced no value".to_string(),
+                                input_path.to_vec(),
+                                self.path.range(),
+                                spec,
+                            ));
+                        }
                     }
                 };
             }

--- a/apollo-federation/src/connectors/json_selection/apply_to.rs
+++ b/apollo-federation/src/connectors/json_selection/apply_to.rs
@@ -562,7 +562,7 @@ impl ApplyToInternal for NamedSelection {
         if let Some(single_output_key) = self.get_single_key() {
             let mut map = Shape::empty_map();
             map.insert(single_output_key.as_string(), path_shape);
-            Shape::record(map, self.shape_location(context.source_id()))
+            Shape::closed_record(map, self.shape_location(context.source_id()))
         } else {
             path_shape
         }
@@ -804,38 +804,57 @@ impl ApplyToInternal for WithRange<PathList> {
         input_shape: Shape,
         dollar_shape: Shape,
     ) -> Shape {
+        // Errors are now stored as metadata on `input_shape` rather than as a
+        // `ShapeCase::Error` variant wrapping a partial. Capture them up-front
+        // so they can be reapplied to whatever the structural recursion below
+        // produces. A pure error (case == Unknown carrying error metadata) has
+        // no partial structure to drive shape computation, so we short-circuit
+        // and return it as-is.
+        let pending_errors: Vec<(String, Vec<Location>)> = if input_shape.has_own_errors() {
+            if matches!(input_shape.case(), ShapeCase::Unknown) {
+                return input_shape;
+            }
+            let locations: Vec<Location> = input_shape.locations().cloned().collect();
+            input_shape
+                .own_errors()
+                .map(|e| (e.message.clone(), locations.clone()))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         match input_shape.case() {
             ShapeCase::One(shapes) => {
-                return Shape::one(
+                let distributed = Shape::one(
                     shapes.iter().map(|shape| {
                         self.compute_output_shape(context, shape.clone(), dollar_shape.clone())
                     }),
                     input_shape.locations().cloned(),
                 );
+                return pending_errors
+                    .into_iter()
+                    .fold(distributed, |acc, (msg, locs)| {
+                        Shape::error_with_partial(msg, acc, locs)
+                    });
             }
             ShapeCase::All(shapes) => {
-                return Shape::all(
+                let distributed = Shape::all(
                     shapes.iter().map(|shape| {
                         self.compute_output_shape(context, shape.clone(), dollar_shape.clone())
                     }),
                     input_shape.locations().cloned(),
                 );
-            }
-            ShapeCase::Error(error) => {
-                return match error.partial.as_ref() {
-                    Some(partial) => Shape::error_with_partial(
-                        error.message.clone(),
-                        self.compute_output_shape(context, partial.clone(), dollar_shape),
-                        input_shape.locations().cloned(),
-                    ),
-                    None => input_shape.clone(),
-                };
+                return pending_errors
+                    .into_iter()
+                    .fold(distributed, |acc, (msg, locs)| {
+                        Shape::error_with_partial(msg, acc, locs)
+                    });
             }
             _ => {}
         };
 
-        // Given the base cases above, we can assume below that input_shape is
-        // neither ::One, ::All, nor ::Error.
+        // Below, input_shape is neither ::One nor ::All; any pending_errors
+        // captured above will be reapplied at the bottom of this function.
 
         let mut extra_vars_opt: Option<Shape> = None;
         let (current_shape, tail_opt) = match self.as_ref() {
@@ -1042,7 +1061,7 @@ impl ApplyToInternal for WithRange<PathList> {
             }
         };
 
-        if let Some(tail) = tail_opt {
+        let tail_result = if let Some(tail) = tail_opt {
             // Recurses over extra_vars_opt, which is usually None, but could be
             // Some(object_shape) (when handling ArrowMethod::As), and might
             // sometimes be Some(error_shape) with an object partial shape.
@@ -1053,7 +1072,13 @@ impl ApplyToInternal for WithRange<PathList> {
                 input_shape: Shape,
                 dollar_shape: Shape,
             ) -> Shape {
-                match extra_vars_opt.as_ref().map(|s| s.case()) {
+                let pending_messages: Vec<String> = extra_vars_opt
+                    .as_ref()
+                    .map(|s| s.own_errors().map(|e| e.message.clone()).collect())
+                    .unwrap_or_default();
+                let tail_location = tail.shape_location(context.source_id());
+
+                let inner_shape = match extra_vars_opt.as_ref().map(|s| s.case()) {
                     Some(ShapeCase::Object { fields, .. }) => {
                         // TODO Refactor the internal ShapeContext
                         // representation to make this cloning
@@ -1066,28 +1091,26 @@ impl ApplyToInternal for WithRange<PathList> {
                         tail.compute_output_shape(&new_context, input_shape, dollar_shape)
                     }
 
-                    Some(ShapeCase::Error(shape::Error { message, partial })) => {
-                        if partial.is_some() {
-                            let tail_shape = compute_tail_shape(
-                                tail,
-                                partial,
-                                context,
-                                input_shape,
-                                dollar_shape,
-                            );
-
-                            Shape::error_with_partial(
-                                message.clone(),
-                                tail_shape,
-                                tail.shape_location(context.source_id()),
-                            )
-                        } else {
-                            Shape::error(message.clone(), tail.shape_location(context.source_id()))
-                        }
+                    // A pure error (case == Unknown carrying error metadata) has
+                    // no partial structure to drive name installation; emit a
+                    // fresh error shape carrying the same messages.
+                    Some(ShapeCase::Unknown) if !pending_messages.is_empty() => {
+                        let mut iter = pending_messages.into_iter();
+                        let first = iter.next().unwrap_or_default();
+                        return iter.fold(Shape::error(first, tail_location), |acc, msg| {
+                            acc.with_error(shape::Error { message: msg })
+                        });
                     }
 
                     _ => tail.compute_output_shape(context, input_shape, dollar_shape),
-                }
+                };
+
+                // Reattach any error metadata that was sitting on
+                // extra_vars_opt, so the structural recursion's output still
+                // surfaces the original error messages.
+                pending_messages.into_iter().fold(inner_shape, |acc, msg| {
+                    Shape::error_with_partial(msg, acc, tail_location.clone())
+                })
             }
 
             compute_tail_shape(
@@ -1101,7 +1124,16 @@ impl ApplyToInternal for WithRange<PathList> {
             )
         } else {
             current_shape
-        }
+        };
+
+        // Reapply any pending errors that were attached to the original
+        // input_shape, so callers see the same error metadata they would have
+        // seen when errors were a dedicated `ShapeCase::Error` variant.
+        pending_errors
+            .into_iter()
+            .fold(tail_result, |acc, (msg, locs)| {
+                Shape::error_with_partial(msg, acc, locs)
+            })
     }
 }
 
@@ -1420,7 +1452,7 @@ impl SubSelection {
         }
 
         if all_shape.is_unknown() {
-            Shape::empty_object(locations)
+            Shape::any_object(locations)
         } else {
             all_shape
         }
@@ -3420,7 +3452,7 @@ mod tests {
         named_shapes.insert(
             "$batch".to_string(),
             Shape::list(
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert("id".to_string(), Shape::int([]));
@@ -3439,7 +3471,7 @@ mod tests {
 
         let computed_batch_id =
             selection!("$batch.id", spec).compute_output_shape(&shape_context, root_shape.clone());
-        assert_eq!(computed_batch_id.pretty_print(), "List<Int>");
+        assert_eq!(computed_batch_id.pretty_print(), "[...Int]");
 
         let computed_first = selection!("$batch.id->first", spec)
             .compute_output_shape(&shape_context, root_shape.clone());
@@ -3522,7 +3554,7 @@ mod tests {
         named_shapes.insert(
             "$batch".to_string(),
             Shape::list(
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert("id".to_string(), Shape::int([]));
@@ -3541,7 +3573,7 @@ mod tests {
 
         let computed_batch_id =
             selection!("$batch.id", spec).compute_output_shape(&shape_context, root_shape.clone());
-        assert_eq!(computed_batch_id.pretty_print(), "List<Int>");
+        assert_eq!(computed_batch_id.pretty_print(), "[...Int]");
 
         let computed_first = selection!("$batch.id->first", spec)
             .compute_output_shape(&shape_context, root_shape.clone());
@@ -3569,35 +3601,35 @@ mod tests {
             selection!("$batch.id->map(@)->echo(@)", spec)
                 .shape()
                 .pretty_print(),
-            "List<$batch.id.*>",
+            "[...$batch.id.*]",
         );
 
         assert_eq!(
             selection!("$batch.id->map(@)->echo([@])", spec)
                 .shape()
                 .pretty_print(),
-            "[List<$batch.id.*>]",
+            "[[...$batch.id.*]]",
         );
 
         assert_eq!(
             selection!("$batch.id->map([@])->echo(@)", spec)
                 .shape()
                 .pretty_print(),
-            "List<[$batch.id.*]>",
+            "[...[$batch.id.*]]",
         );
 
         assert_eq!(
             selection!("$batch.id->map([@])->echo([@])", spec)
                 .shape()
                 .pretty_print(),
-            "[List<[$batch.id.*]>]",
+            "[[...[$batch.id.*]]]",
         );
 
         assert_eq!(
             selection!("$batch.id->map([@])->echo([@])", spec)
                 .compute_output_shape(&shape_context, root_shape,)
                 .pretty_print(),
-            "[List<[Int]>]",
+            "[[...[Int]]]",
         );
     }
 
@@ -4054,7 +4086,7 @@ mod tests {
     fn test_compute_output_shape() {
         let spec = ConnectSpec::V0_3;
 
-        assert_eq!(selection!("", spec).shape().pretty_print(), "{}");
+        assert_eq!(selection!("", spec).shape().pretty_print(), "{...}");
 
         assert_eq!(
             selection!("id name", spec).shape().pretty_print(),
@@ -4118,7 +4150,7 @@ mod tests {
     x: $root.*.arrayOfArrays.*.x,
     y: $root.*.arrayOfArrays.*.y,
   },
-  friends: List<{ id: $root.*.friend_ids.* }>,
+  friends: [...{ id: $root.*.friend_ids.* }],
   id: $root.*.id,
   name: $root.*.name,
   xs: $root.*.arrayOfArrays.x,
@@ -4567,14 +4599,14 @@ mod tests {
             .with_spec(spec)
             .with_named_shapes([(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
                             "unreliableAuthor".to_string(),
                             Shape::one(
                                 [
-                                    Shape::record(
+                                    Shape::closed_record(
                                         {
                                             let mut map = Shape::empty_map();
                                             map.insert("age".to_string(), Shape::int([]));
@@ -5809,7 +5841,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -5877,7 +5909,7 @@ mod tests {
         let shape_context = {
             let mut named_shapes = IndexMap::default();
 
-            let person_shape = Shape::record(
+            let person_shape = Shape::closed_record(
                 {
                     let mut map = Shape::empty_map();
                     map.insert("name".to_string(), Shape::string([]));
@@ -5889,7 +5921,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert("person".to_string(), person_shape);
@@ -5945,7 +5977,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -5985,7 +6017,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -6024,7 +6056,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -6054,7 +6086,7 @@ mod tests {
         );
 
         // The question mark should be applied recursively to the partial shape within the error
-        assert!(result_shape.pretty_print().contains("Error"));
+        assert!(result_shape.pretty_print().contains("(err "));
         assert!(result_shape.pretty_print().contains("None"));
     }
 
@@ -6067,7 +6099,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -6093,7 +6125,7 @@ mod tests {
                     shape_context.named_shapes()["$root"].clone()
                 )
                 .pretty_print(),
-            "Error<\"Something went wrong\">",
+            "Unknown (err \"Something went wrong\")",
         );
     }
 
@@ -6106,7 +6138,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -6152,7 +6184,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
@@ -6191,7 +6223,7 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert("nonNullString".to_string(), Shape::string([]));
@@ -6248,17 +6280,17 @@ mod tests {
 
             named_shapes.insert(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(
                             "level1".to_string(),
-                            Shape::record(
+                            Shape::closed_record(
                                 {
                                     let mut inner_map = Shape::empty_map();
                                     inner_map.insert(
                                         "level2".to_string(),
-                                        Shape::record(
+                                        Shape::closed_record(
                                             {
                                                 let mut inner_inner_map = Shape::empty_map();
                                                 inner_inner_map
@@ -6351,7 +6383,7 @@ mod tests {
         let mut named_shapes = IndexMap::default();
         named_shapes.insert(
             "$root".to_string(),
-            Shape::record(
+            Shape::closed_record(
                 {
                     let mut map = Shape::empty_map();
                     map.insert(
@@ -6392,7 +6424,7 @@ mod tests {
         let mut named_shapes = IndexMap::default();
         named_shapes.insert(
             "$root".to_string(),
-            Shape::record(
+            Shape::closed_record(
                 {
                     let mut map = Shape::empty_map();
                     map.insert(
@@ -6432,7 +6464,7 @@ mod tests {
             .with_spec(spec)
             .with_named_shapes([(
                 "$root".to_string(),
-                Shape::record(
+                Shape::closed_record(
                     {
                         let mut map = Shape::empty_map();
                         map.insert(

--- a/apollo-federation/src/connectors/json_selection/methods.rs
+++ b/apollo-federation/src/connectors/json_selection/methods.rs
@@ -67,6 +67,7 @@ pub(super) enum ArrowMethod {
     Trim,
     TrimStart,
     TrimEnd,
+    IfThen,
 
     // Future methods:
     TypeOf,
@@ -188,6 +189,7 @@ impl std::ops::Deref for ArrowMethod {
             Self::Trim => &public::TrimMethod,
             Self::TrimStart => &public::TrimStartMethod,
             Self::TrimEnd => &public::TrimEndMethod,
+            Self::IfThen => &public::IfThenMethod,
 
             // Future methods:
             Self::TypeOf => &future::TypeOfMethod,
@@ -252,6 +254,7 @@ impl ArrowMethod {
             "trim" => Some(Self::Trim),
             "trimStart" => Some(Self::TrimStart),
             "trimEnd" => Some(Self::TrimEnd),
+            "ifThen" => Some(Self::IfThen),
             _ => None,
         };
 
@@ -306,6 +309,7 @@ impl ArrowMethod {
                 | Self::Trim
                 | Self::TrimStart
                 | Self::TrimEnd
+                | Self::IfThen
         )
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/as.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/as.rs
@@ -245,7 +245,7 @@ fn as_shape(
         // computed result shape as the value shape. Although there can be at
         // most one variable in this object for now, we might let ->as define
         // multiple variables in the future.
-        Shape::record(
+        Shape::closed_record(
             [(var_name.clone(), result_shape)].into(),
             // No need for locations, as this is a utility/internal object.
             [],
@@ -323,12 +323,12 @@ mod tests {
 
         assert_eq!(
             selection!("person->as", spec).shape().pretty_print(),
-            "Error<\n  \"Method ->as requires one or two arguments (got 0)\",\n  $root.person,\n>",
+            "$root.person (err \"Method ->as requires one or two arguments (got 0)\")",
         );
 
         assert_eq!(
             selection!("person->as()", spec).shape().pretty_print(),
-            "Error<\n  \"Method ->as requires one or two arguments (got 0)\",\n  $root.person,\n>",
+            "$root.person (err \"Method ->as requires one or two arguments (got 0)\")",
         );
     }
 
@@ -361,7 +361,7 @@ mod tests {
             selection!("person->as($x, @.id, @.name)", spec)
                 .shape()
                 .pretty_print(),
-            "Error<\n  \"Method ->as requires one or two arguments (got 3)\",\n  $root.person,\n>",
+            "$root.person (err \"Method ->as requires one or two arguments (got 3)\")",
         );
     }
 
@@ -421,17 +421,17 @@ mod tests {
 
         assert_eq!(
             selection!("person->as(123)", spec).shape().pretty_print(),
-            "Error<\n  \"First argument to ->as must be a single $variable name\",\n  $root.person,\n>",
+            "$root.person (err \"First argument to ->as must be a single $variable name\")",
         );
 
         assert_eq!(
             selection!("person->as($x.id)", spec).shape().pretty_print(),
-            "Error<\n  \"First argument to ->as must be a single $variable name with no path suffix\",\n  $root.person,\n>",
+            "$root.person (err \"First argument to ->as must be a single $variable name with no path suffix\")",
         );
 
         assert_eq!(
             selection!("person->as(p)", spec).shape().pretty_print(),
-            "Error<\n  \"First argument to ->as must be a single $variable name\",\n  $root.person,\n>",
+            "$root.person (err \"First argument to ->as must be a single $variable name\")",
         );
     }
 
@@ -515,12 +515,12 @@ mod tests {
                     &ShapeContext::new(SourceId::Other("JSONSelection".into()))
                         .with_spec(spec)
                         .with_named_shapes(vars),
-                    Shape::record(
+                    Shape::closed_record(
                         {
                             let mut map = Shape::empty_map();
                             map.insert(
                                 "person".to_string(),
-                                Shape::record(
+                                Shape::closed_record(
                                     {
                                         let mut map = Shape::empty_map();
                                         map.insert("id".to_string(), Shape::int([]));
@@ -597,7 +597,7 @@ mod tests {
             )
             .shape()
             .pretty_print(),
-            "{ listsOfPairs: List<List<[$root.*.xs.*, $root.*.ys.*]>> }",
+            "{ listsOfPairs: [...[...[$root.*.xs.*, $root.*.ys.*]]] }",
         );
 
         assert_eq!(
@@ -609,7 +609,7 @@ mod tests {
             )
             .shape()
             .pretty_print(),
-            "List<List<[$root.xs.*, $root.ys.*]>>",
+            "[...[...[$root.xs.*, $root.ys.*]]]",
         );
     }
 

--- a/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
@@ -126,7 +126,7 @@ fn contains_shape(
     let arg_shape = first_arg.compute_output_shape(context, input_shape.clone(), dollar_shape);
 
     // Ensure input is an array
-    if !Shape::tuple([], []).accepts(&input_shape) && !input_shape.accepts(&Shape::unknown([])) {
+    if !input_shape.is_array() && !input_shape.accepts(&Shape::unknown([])) {
         return Shape::error(
             format!(
                 "Method ->{} requires an array input, but got: {input_shape}",

--- a/apollo-federation/src/connectors/json_selection/methods/public/entries.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/entries.rs
@@ -157,7 +157,7 @@ fn entries_shape(
             entries.insert("key".to_string(), Shape::string([]));
             entries.insert("value".to_string(), Shape::unknown([]));
             Shape::list(
-                Shape::record(entries, method_name.shape_location(context.source_id())),
+                Shape::closed_record(entries, method_name.shape_location(context.source_id())),
                 method_name.shape_location(context.source_id()),
             )
         }

--- a/apollo-federation/src/connectors/json_selection/methods/public/filter.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/filter.rs
@@ -524,7 +524,7 @@ mod shape_tests {
             Shape::unknown([]),
         );
         assert!(
-            !matches!(after_first.case(), ShapeCase::Error(_)),
+            !after_first.has_own_errors(),
             "first ->filter unexpectedly errored: {}",
             after_first.pretty_print()
         );
@@ -534,7 +534,7 @@ mod shape_tests {
         // error.
         let after_second = get_shape(vec![parse_condition("@.locNumber->gt(0)")], after_first);
         assert!(
-            !matches!(after_second.case(), ShapeCase::Error(_)),
+            !after_second.has_own_errors(),
             "chained ->filter produced an error shape (regression): {}",
             after_second.pretty_print()
         );

--- a/apollo-federation/src/connectors/json_selection/methods/public/find.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/find.rs
@@ -589,7 +589,7 @@ mod shape_tests {
         let input_shape = Shape::list(Shape::unknown([]), []);
         let result = get_shape(vec![parse_condition("@.rank->gt(0)")], input_shape.clone());
         assert!(
-            !matches!(result.case(), ShapeCase::Error(_)),
+            !result.has_own_errors(),
             "->find over a concrete list produced an error shape (regression): {}",
             result.pretty_print()
         );

--- a/apollo-federation/src/connectors/json_selection/methods/public/get.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/get.rs
@@ -351,9 +351,9 @@ fn get_shape(
 
     if Shape::string([]).accepts(&input_shape) {
         handle_string_shape(method_name, &input_shape, &index_shape, context.source_id())
-    } else if Shape::tuple([], []).accepts(&input_shape) {
+    } else if input_shape.is_array() {
         handle_array_shape(method_name, &input_shape, &index_shape, context.source_id())
-    } else if Shape::empty_object([]).accepts(&input_shape) {
+    } else if input_shape.is_object() {
         handle_object_shape(method_name, &input_shape, &index_shape, context.source_id())
     } else if input_shape.accepts(&Shape::unknown([])) {
         handle_unknown_shape(method_name, &index_shape, context.source_id())

--- a/apollo-federation/src/connectors/json_selection/methods/public/if_then.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/if_then.rs
@@ -1,0 +1,509 @@
+use serde_json_bytes::Value as JSON;
+use shape::Shape;
+
+use crate::connectors::json_selection::ApplyToError;
+use crate::connectors::json_selection::ApplyToInternal;
+use crate::connectors::json_selection::MethodArgs;
+use crate::connectors::json_selection::ShapeContext;
+use crate::connectors::json_selection::VarsWithPathsMap;
+use crate::connectors::json_selection::immutable::InputPath;
+use crate::connectors::json_selection::location::Ranged;
+use crate::connectors::json_selection::location::WithRange;
+use crate::connectors::json_selection::location::merge_ranges;
+use crate::connectors::spec::ConnectSpec;
+use crate::impl_arrow_method;
+
+impl_arrow_method!(IfThenMethod, if_then_method, if_then_shape);
+
+/// The ifThen method evaluates a condition and returns one of two expressions based on the result.
+///
+/// Syntax: `condition->ifThen(then_expr[, else_expr])`
+///
+/// If the condition (the input data) evaluates to true, returns then_expr.
+/// Otherwise, returns else_expr if provided, or None if omitted.
+///
+/// Example: `age->gte(18)->ifThen('adult', 'minor')`
+fn if_then_method(
+    method_name: &WithRange<String>,
+    method_args: Option<&MethodArgs>,
+    data: &JSON,
+    vars: &VarsWithPathsMap,
+    input_path: &InputPath<JSON>,
+    spec: ConnectSpec,
+) -> (Option<JSON>, Vec<ApplyToError>) {
+    let Some(MethodArgs { args, .. }) = method_args else {
+        return (
+            None,
+            vec![ApplyToError::new(
+                format!(
+                    "Method ->{} requires 1-2 arguments: then_expr[, else_expr]",
+                    method_name.as_ref(),
+                ),
+                input_path.to_vec(),
+                method_name.range(),
+                spec,
+            )],
+        );
+    };
+
+    if args.is_empty() || args.len() > 2 {
+        return (
+            None,
+            vec![ApplyToError::new(
+                format!(
+                    "Method ->{} requires 1-2 arguments, got {}",
+                    method_name.as_ref(),
+                    args.len(),
+                ),
+                input_path.to_vec(),
+                merge_ranges(
+                    method_name.range(),
+                    method_args.and_then(|args| args.range()),
+                ),
+                spec,
+            )],
+        );
+    }
+
+    // There is no notion of truthiness in this mapping language: ->and/->or/->not
+    // and ->filter/->find all require a strict boolean. ->ifThen keeps that
+    // invariant — `true` is the only value that reaches the then branch, and
+    // anything that is neither `true` nor `false` is reported. The error is
+    // non-fatal, unlike those methods, because ->ifThen has a defined fallback
+    // (the else branch, or nothing) and so can complain and still produce a
+    // value rather than collapsing the whole selection.
+    let mut errors = Vec::new();
+    if data.as_bool().is_none() {
+        errors.push(ApplyToError::new(
+            format!(
+                "Method ->{} can only be applied to boolean values.",
+                method_name.as_ref()
+            ),
+            input_path.to_vec(),
+            method_name.range(),
+            spec,
+        ));
+    }
+
+    // Check if condition is true
+    let (value_opt, branch_errors) = if data == &JSON::Bool(true) {
+        // Evaluate and return then_expr (first argument)
+        if let Some(then_arg) = args.first() {
+            then_arg.apply_to_path(data, vars, input_path, spec)
+        } else {
+            unreachable!("args validation ensures at least 1 argument")
+        }
+    } else {
+        // Return else_expr if provided (second argument), otherwise None
+        if let Some(else_arg) = args.get(1) {
+            else_arg.apply_to_path(data, vars, input_path, spec)
+        } else {
+            (None, vec![])
+        }
+    };
+    errors.extend(branch_errors);
+
+    (value_opt, errors)
+}
+
+#[allow(dead_code)] // method type-checking disabled until we add name resolution
+pub(crate) fn if_then_shape(
+    context: &ShapeContext,
+    method_name: &WithRange<String>,
+    method_args: Option<&MethodArgs>,
+    input_shape: Shape,
+    dollar_shape: Shape,
+) -> Shape {
+    let Some(MethodArgs { args, .. }) = method_args else {
+        return Shape::error(
+            format!(
+                "Method ->{} requires 1-2 arguments: then_expr[, else_expr]",
+                method_name.as_ref(),
+            ),
+            method_name.shape_location(context.source_id()),
+        );
+    };
+
+    if args.is_empty() || args.len() > 2 {
+        return Shape::error(
+            format!(
+                "Method ->{} requires 1-2 arguments, got {}",
+                method_name.as_ref(),
+                args.len(),
+            ),
+            merge_ranges(
+                method_name.range(),
+                method_args.and_then(|args| args.range()),
+            )
+            .map(|range| context.source_id().location(range)),
+        );
+    }
+
+    // Compute shape for then branch
+    let then_shape = if let Some(then_arg) = args.first() {
+        then_arg.compute_output_shape(context, input_shape.clone(), dollar_shape.clone())
+    } else {
+        unreachable!("args validation ensures at least 1 argument")
+    };
+
+    // Compute shape for else branch (or None if omitted)
+    let else_shape = if let Some(else_arg) = args.get(1) {
+        else_arg.compute_output_shape(context, input_shape.clone(), dollar_shape)
+    } else {
+        Shape::none()
+    };
+
+    // Mirror the runtime's non-fatal complaint about non-boolean conditions.
+    // Anything bool-like, or unknown/named (not yet resolved), is accepted. For
+    // anything else the partial is the else branch alone rather than the union:
+    // since `true` is the only value that reaches the then branch, a shape known
+    // not to be boolean can never take it, so narrowing here is sound.
+    if !(Shape::bool([]).accepts(&input_shape) || input_shape.accepts(&Shape::unknown([]))) {
+        return Shape::error_with_partial(
+            format!(
+                "Method ->{} can only be applied to boolean values. Got {input_shape}.",
+                method_name.as_ref()
+            ),
+            else_shape,
+            method_name.shape_location(context.source_id()),
+        );
+    }
+
+    // Return union of both branches
+    Shape::one(
+        vec![then_shape, else_shape],
+        method_name.shape_location(context.source_id()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json_bytes::json;
+
+    use crate::connectors::ConnectSpec;
+    use crate::selection;
+
+    #[test]
+    fn if_then_should_return_then_expr_when_condition_is_true() {
+        assert_eq!(
+            selection!(
+                r#"
+                result: condition->ifThen('yes', 'no')
+                "#
+            )
+            .apply_to(&json!({
+                "condition": true,
+            })),
+            (
+                Some(json!({
+                    "result": "yes",
+                })),
+                vec![],
+            ),
+        );
+    }
+
+    #[test]
+    fn if_then_should_return_else_expr_when_condition_is_false() {
+        assert_eq!(
+            selection!(
+                r#"
+                result: condition->ifThen('yes', 'no')
+                "#
+            )
+            .apply_to(&json!({
+                "condition": false,
+            })),
+            (
+                Some(json!({
+                    "result": "no",
+                })),
+                vec![],
+            ),
+        );
+    }
+
+    #[test]
+    fn if_then_should_return_none_when_condition_is_false_and_no_else() {
+        assert_eq!(
+            selection!(
+                r#"
+                result: condition->ifThen('yes')
+                "#
+            )
+            .apply_to(&json!({
+                "condition": false,
+            })),
+            (Some(json!({})), vec![]),
+        );
+    }
+
+    #[test]
+    fn if_then_should_work_with_complex_expressions() {
+        assert_eq!(
+            selection!(
+                r#"
+                status: age->gte(18)->ifThen('adult', 'minor')
+                "#
+            )
+            .apply_to(&json!({
+                "age": 25,
+            })),
+            (
+                Some(json!({
+                    "status": "adult",
+                })),
+                vec![],
+            ),
+        );
+    }
+
+    #[test]
+    fn if_then_should_work_with_nested_data() {
+        assert_eq!(
+            selection!(
+                r#"
+                discount: isPremium->ifThen(20, 0)
+                "#
+            )
+            .apply_to(&json!({
+                "isPremium": true,
+            })),
+            (
+                Some(json!({
+                    "discount": 20,
+                })),
+                vec![],
+            ),
+        );
+    }
+
+    #[rstest::rstest]
+    // No truthiness: `true` is the only value that reaches the then branch, so
+    // every one of these takes the else branch. Notably `"false"` and `1` are
+    // not special — a language with truthiness would disagree about both.
+    #[case::null(json!(null))]
+    #[case::zero(json!(0))]
+    #[case::one(json!(1))]
+    #[case::negative(json!(-1))]
+    #[case::empty_string(json!(""))]
+    #[case::non_empty_string(json!("not a boolean"))]
+    #[case::true_string(json!("true"))]
+    #[case::false_string(json!("false"))]
+    #[case::empty_array(json!([]))]
+    #[case::empty_object(json!({}))]
+    fn if_then_should_take_else_branch_and_report_non_booleans(
+        #[case] value: serde_json_bytes::Value,
+    ) {
+        let result = selection!(
+            r#"
+                result: value->ifThen('yes', 'no')
+                "#
+        )
+        .apply_to(&json!({ "value": value }));
+
+        // The selection still produces a value — the error is non-fatal...
+        assert_eq!(result.0, Some(json!({ "result": "no" })));
+
+        // ...but anything that is neither `true` nor `false` is reported.
+        assert_eq!(result.1.len(), 1);
+        assert!(
+            result.1[0]
+                .message()
+                .contains("Method ->ifThen can only be applied to boolean values.")
+        );
+    }
+
+    #[test]
+    fn if_then_branch_args_are_applied_to_the_condition_not_the_receiver() {
+        // The then/else expressions are applied to the *condition* value, so a
+        // bare `@` inside them is the boolean, not the value being tested. This
+        // is why ->as is needed to carry the receiver into a branch.
+        assert_eq!(
+            selection!("$.n->gt(1)->ifThen(@, 'no')", ConnectSpec::V0_5).apply_to(&json!({
+                "n": 5,
+            })),
+            (Some(json!(true)), vec![]),
+        );
+
+        // Binding the receiver first makes it reachable from either branch.
+        assert_eq!(
+            selection!(
+                "$.n->as($self)->gt(1)->ifThen($self, 'no')",
+                ConnectSpec::V0_5
+            )
+            .apply_to(&json!({
+                "n": 5,
+            })),
+            (Some(json!(5)), vec![]),
+        );
+    }
+
+    #[rstest::rstest]
+    // ->ifThen expresses min/max over the receiver and an argument, which
+    // otherwise needs ->match's [true, x] pair plus an `@` catch-all. The
+    // receiver is bound with ->as so both branches can name it, since a bare
+    // `@` there would be the comparison's result. These bodies are the
+    // ->ifThen form of the min/max defs.
+    #[case::min_receiver_smaller(json!(3), json!(7), 3)]
+    #[case::min_arg_smaller(json!(7), json!(3), 3)]
+    #[case::min_equal(json!(4), json!(4), 4)]
+    #[case::min_negative(json!(-2), json!(1), -2)]
+    fn if_then_can_express_min(
+        #[case] receiver: serde_json_bytes::Value,
+        #[case] arg: serde_json_bytes::Value,
+        #[case] expected: i64,
+    ) {
+        assert_eq!(
+            selection!(
+                "$.n->as($self)->lte($.arg)->ifThen($self, $.arg)",
+                ConnectSpec::V0_5
+            )
+            .apply_to(&json!({
+                "n": receiver,
+                "arg": arg,
+            })),
+            (Some(json!(expected)), vec![]),
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::max_receiver_larger(json!(7), json!(3), 7)]
+    #[case::max_arg_larger(json!(3), json!(7), 7)]
+    #[case::max_equal(json!(4), json!(4), 4)]
+    #[case::max_negative(json!(-2), json!(1), 1)]
+    fn if_then_can_express_max(
+        #[case] receiver: serde_json_bytes::Value,
+        #[case] arg: serde_json_bytes::Value,
+        #[case] expected: i64,
+    ) {
+        assert_eq!(
+            selection!(
+                "$.n->as($self)->gte($.arg)->ifThen($self, $.arg)",
+                ConnectSpec::V0_5
+            )
+            .apply_to(&json!({
+                "n": receiver,
+                "arg": arg,
+            })),
+            (Some(json!(expected)), vec![]),
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::bool_true(json!(true), "yes")]
+    #[case::bool_false(json!(false), "no")]
+    fn if_then_should_not_warn_on_actual_booleans(
+        #[case] value: serde_json_bytes::Value,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(
+            selection!(
+                r#"
+                result: value->ifThen('yes', 'no')
+                "#
+            )
+            .apply_to(&json!({ "value": value })),
+            (Some(json!({ "result": expected })), vec![]),
+        );
+    }
+
+    #[test]
+    fn if_then_non_boolean_spread_reports_both_cause_and_consequence() {
+        // A non-boolean condition takes the else branch, which is absent here,
+        // so the spread contributes nothing and adds its usual note after the
+        // root cause — the same pairing apply_to.rs asserts for any errored
+        // inline path. Neither error is fatal: the selection still resolves.
+        let result = selection!(
+            "before ...value->ifThen({ optional: 'value' }) after",
+            ConnectSpec::V0_5
+        )
+        .apply_to(&json!({
+            "before": "before value",
+            "after": "after value",
+            "value": "not a boolean",
+        }));
+
+        assert_eq!(
+            result.0,
+            Some(json!({
+                "before": "before value",
+                "after": "after value",
+            })),
+        );
+        assert_eq!(
+            result.1.iter().map(|e| e.message()).collect::<Vec<_>>(),
+            vec![
+                "Method ->ifThen can only be applied to boolean values.",
+                "Inlined path produced no value",
+            ],
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_2(ConnectSpec::V0_2)]
+    #[case::v0_3(ConnectSpec::V0_3)]
+    #[case::v0_4(ConnectSpec::V0_4)]
+    #[case::v0_5(ConnectSpec::V0_5)]
+    fn if_then_should_evaluate_lazily(#[case] spec: ConnectSpec) {
+        // When condition is true, else_expr should not be evaluated
+        assert_eq!(
+            selection!("$.isValid->ifThen('then', $.missing)", spec).apply_to(&json!({
+                "isValid": true,
+            })),
+            (Some(json!("then")), vec![]),
+        );
+
+        // When condition is false, then_expr should not be evaluated
+        assert_eq!(
+            selection!("$.isValid->ifThen($.missing, 'else')", spec).apply_to(&json!({
+                "isValid": false,
+            })),
+            (Some(json!("else")), vec![]),
+        );
+    }
+
+    #[rstest::rstest]
+    #[case::v0_4(ConnectSpec::V0_4)]
+    #[case::v0_5(ConnectSpec::V0_5)]
+    fn if_then_spread_with_none_should_spread_nothing(#[case] spec: ConnectSpec) {
+        let sel = selection!(
+            "before ...condition->ifThen({ optional: 'value' }) after",
+            spec
+        );
+
+        // When condition is true, spread should include the optional field
+        assert_eq!(
+            sel.apply_to(&json!({
+                "before": "before value",
+                "after": "after value",
+                "condition": true,
+            })),
+            (
+                Some(json!({
+                    "before": "before value",
+                    "after": "after value",
+                    "optional": "value",
+                })),
+                vec![],
+            ),
+        );
+
+        // When condition is false (no else clause), ifThen returns None
+        // which should spread nothing (no error, no fields)
+        assert_eq!(
+            sel.apply_to(&json!({
+                "before": "before value",
+                "after": "after value",
+                "condition": false,
+            })),
+            (
+                Some(json!({
+                    "before": "before value",
+                    "after": "after value",
+                })),
+                vec![],
+            ),
+        );
+    }
+}

--- a/apollo-federation/src/connectors/json_selection/methods/public/in.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/in.rs
@@ -125,7 +125,7 @@ fn in_shape(
 
     let arg_shape = first_arg.compute_output_shape(context, input_shape.clone(), dollar_shape);
 
-    if !Shape::tuple([], []).accepts(&arg_shape) && !arg_shape.accepts(&Shape::unknown([])) {
+    if !arg_shape.is_array() && !arg_shape.accepts(&Shape::unknown([])) {
         return Shape::error(
             format!(
                 "Method ->{} requires an array argument, but got: {arg_shape}",

--- a/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case.rs
@@ -457,7 +457,7 @@ mod shape_tests {
     #[test]
     fn shape_should_error_on_non_object_input() {
         let result = get_shape(Shape::string([]));
-        assert!(matches!(result.case(), ShapeCase::Error { .. }));
+        assert!(result.has_own_errors());
     }
 
     #[test]
@@ -473,7 +473,7 @@ mod shape_tests {
             Shape::unknown([]),
             Shape::unknown([]),
         );
-        assert!(matches!(result.case(), ShapeCase::Error { .. }));
+        assert!(result.has_own_errors());
     }
 
     #[test]

--- a/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case_deep.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case_deep.rs
@@ -309,7 +309,7 @@ mod shape_tests {
             Shape::unknown([]),
             Shape::unknown([]),
         );
-        assert!(matches!(result.case(), ShapeCase::Error { .. }));
+        assert!(result.has_own_errors());
     }
 
     #[test]
@@ -322,7 +322,7 @@ mod shape_tests {
     #[test]
     fn should_error_on_non_object_input() {
         let result = get_deep_shape(Shape::string([]));
-        assert!(matches!(result.case(), ShapeCase::Error { .. }));
+        assert!(result.has_own_errors());
     }
 
     #[test]

--- a/apollo-federation/src/connectors/json_selection/methods/public/mod.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/mod.rs
@@ -71,3 +71,5 @@ pub(crate) use arithmetic::DivMethod;
 pub(crate) use arithmetic::ModMethod;
 pub(crate) use arithmetic::MulMethod;
 pub(crate) use arithmetic::SubMethod;
+mod if_then;
+pub(crate) use if_then::IfThenMethod;

--- a/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
@@ -918,7 +918,7 @@ mod shape_tests {
     #[test]
     fn parse_int_shape_should_error_for_object_input() {
         assert_eq!(
-            get_shape(vec![], Shape::empty_object([])),
+            get_shape(vec![], Shape::any_object([])),
             Shape::error_with_partial(
                 "Method ->parseInt can only parse strings and numbers. Found: {}".to_string(),
                 Shape::none(),
@@ -930,7 +930,7 @@ mod shape_tests {
     #[test]
     fn parse_int_shape_should_error_for_array_input() {
         assert_eq!(
-            get_shape(vec![], Shape::tuple([], [])),
+            get_shape(vec![], Shape::any_array([])),
             Shape::error_with_partial(
                 "Method ->parseInt can only parse strings and numbers. Found: []".to_string(),
                 Shape::none(),

--- a/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
@@ -89,7 +89,7 @@ fn to_string_shape(
     }
 
     // Check if input is an object or array shape
-    if Shape::empty_object([]).accepts(&input_shape) || Shape::tuple([], []).accepts(&input_shape) {
+    if input_shape.is_object() || input_shape.is_array() {
         return Shape::error_with_partial(
             format!(
                 "Method ->{} cannot convert arrays or objects to strings. Use ->jsonStringify or ->joinNotNull instead",
@@ -378,7 +378,7 @@ mod shape_tests {
     #[test]
     fn to_string_shape_should_error_for_object_input() {
         assert_eq!(
-            get_shape(vec![], Shape::empty_object([])),
+            get_shape(vec![], Shape::any_object([])),
             Shape::error_with_partial(
                 "Method ->toString cannot convert arrays or objects to strings. Use ->jsonStringify or ->joinNotNull instead"
                     .to_string(),
@@ -391,7 +391,7 @@ mod shape_tests {
     #[test]
     fn to_string_shape_should_error_for_array_input() {
         assert_eq!(
-            get_shape(vec![], Shape::tuple([], [])),
+            get_shape(vec![], Shape::any_array([])),
             Shape::error_with_partial(
                 "Method ->toString cannot convert arrays or objects to strings. Use ->jsonStringify or ->joinNotNull instead"
                     .to_string(),

--- a/apollo-federation/src/connectors/json_selection/mod.rs
+++ b/apollo-federation/src/connectors/json_selection/mod.rs
@@ -69,11 +69,29 @@ mod test {
     #[case::spread_match_with_default       ("... rootField->match(['nomatch', { x: $(1) }], [@, { default: $(true) }])", Some(json!({"default": true})), "0.4")]
     #[case::spread_multiple_spreads         ("rootField ... $({ first: $(1) }) ... $({ second: $(2) })", Some(json!({"rootField": "hello", "first": 1, "second": 2})), "0.4")]
     #[case::spread_multiple_with_match      ("... rootField->match(['hello', { a: $(1) }]) ... $({ b: $(2) })", Some(json!({"a": 1, "b": 2})), "0.4")]
+    // The ->ifThen counterparts of the ->match spreads above. Each pairs a
+    // boolean-producing comparison with the branches directly, instead of
+    // encoding "if true" as a [candidate, value] pair and a default as an [@, _]
+    // catch-all. Same expected output, so the two forms are interchangeable
+    // wherever the dispatch is two-way.
+    #[case::spread_with_ifthen               ("rootField ... rootField->eq('hello')->ifThen({ matched: $(true) })", Some(json!({"rootField": "hello", "matched": true})), "0.4")]
+    #[case::spread_with_ifthen_no_match      ("rootField ... rootField->eq('goodbye')->ifThen({ matched: $(true) }, null)", Some(json!(null)), "0.4")]
+    #[case::spread_ifthen_with_default       ("... rootField->eq('nomatch')->ifThen({ x: $(1) }, { default: $(true) })", Some(json!({"default": true})), "0.4")]
+    #[case::spread_multiple_with_ifthen      ("... rootField->eq('hello')->ifThen({ a: $(1) }) ... $({ b: $(2) })", Some(json!({"a": 1, "b": 2})), "0.4")]
+    // With no else branch, a false condition spreads nothing at all — the case
+    // ->match cannot express without an explicit [@, {}] arm.
+    #[case::spread_ifthen_false_spreads_nothing("rootField ... rootField->eq('goodbye')->ifThen({ matched: $(true) })", Some(json!({"rootField": "hello"})), "0.4")]
     fn kitchen_sink(
         #[case] selection: &str,
         #[case] expected: Option<Value>,
         #[case] minimum_version: &str,
-        #[values(ConnectSpec::V0_2, ConnectSpec::V0_3, ConnectSpec::V0_4)] version: ConnectSpec,
+        #[values(
+            ConnectSpec::V0_2,
+            ConnectSpec::V0_3,
+            ConnectSpec::V0_4,
+            ConnectSpec::V0_5
+        )]
+        version: ConnectSpec,
     ) {
         // We're effectively skipping the test but it will be reported as passed because Rust has no runtime "mark as skipped" capability
         if version.as_str() < minimum_version {

--- a/apollo-federation/src/connectors/schema_type_ref.rs
+++ b/apollo-federation/src/connectors/schema_type_ref.rs
@@ -82,7 +82,7 @@ impl<'schema> SchemaTypeRef<'schema> {
                     );
                 }
 
-                Shape::record(fields, [])
+                Shape::closed_record(fields, [])
             }
             ExtendedType::Scalar(s) => match s.name.as_str() {
                 "String" => Shape::string([]),
@@ -125,7 +125,7 @@ impl<'schema> SchemaTypeRef<'schema> {
                 }),
                 [],
             ),
-            ExtendedType::InputObject(i) => Shape::record(
+            ExtendedType::InputObject(i) => Shape::closed_record(
                 i.fields
                     .iter()
                     .map(|(name, field)| {

--- a/apollo-federation/src/connectors/validation/connect/selection.rs
+++ b/apollo-federation/src/connectors/validation/connect/selection.rs
@@ -603,6 +603,14 @@ impl<'schema> SelectionValidator<'schema> {
         type_ref: SchemaTypeRef<'schema>,
         shape: &Shape,
     ) -> Result<Vec<(Name, Name)>, Message> {
+        // Shape errors are now carried as metadata rather than a dedicated
+        // `ShapeCase::Error` variant. A shape-processing failure is surfaced
+        // through other diagnostics; there is nothing to credit as seen here,
+        // and we must not descend into the (possibly partial) structure, as
+        // that could emit spurious `SelectedFieldNotFound`-style errors.
+        if shape.has_own_errors() {
+            return Ok(Vec::new());
+        }
         match shape.case() {
             ShapeCase::Object { fields, .. } => {
                 for (field_name, field_shape) in fields.iter() {
@@ -832,9 +840,6 @@ impl<'schema> SelectionValidator<'schema> {
             // mask genuine `CONNECTORS_UNRESOLVED_FIELD` errors. A structure-aware
             // policy for these is left to a follow-up.
             ShapeCase::Name(_, _) | ShapeCase::Unknown => Ok(Vec::new()),
-            // A shape-processing failure is surfaced through other diagnostics;
-            // there is nothing to credit as seen here.
-            ShapeCase::Error(_) => Ok(Vec::new()),
         }
     }
 }

--- a/apollo-federation/src/connectors/validation/expression.rs
+++ b/apollo-federation/src/connectors/validation/expression.rs
@@ -33,7 +33,7 @@ use crate::connectors::validation::graphql::subslice_location;
 use crate::connectors::variable::VariableReference;
 
 static REQUEST_SHAPE: LazyLock<Shape> = LazyLock::new(|| {
-    Shape::record(
+    Shape::closed_record(
         [(
             "headers".to_string(),
             Shape::dict(Shape::list(Shape::string([]), []), []),
@@ -44,7 +44,7 @@ static REQUEST_SHAPE: LazyLock<Shape> = LazyLock::new(|| {
 });
 
 static RESPONSE_SHAPE: LazyLock<Shape> = LazyLock::new(|| {
-    Shape::record(
+    Shape::closed_record(
         [(
             "headers".to_string(),
             Shape::dict(Shape::list(Shape::string([]), []), []),
@@ -359,6 +359,17 @@ fn resolve_shape(
     expression: &Expression,
     resolving: &mut HashSet<String>,
 ) -> Result<Shape, Message> {
+    // Shape errors are stored as metadata on the shape itself rather than as a
+    // dedicated `ShapeCase::Error` variant. If any are present, surface the
+    // first message as a validation failure before attempting structural
+    // dispatch on the (possibly partial) case.
+    if let Some(error) = shape.own_errors().next() {
+        return Err(Message {
+            code: context.code,
+            message: error.message.clone(),
+            locations: transform_locations(shape.locations(), context, expression),
+        });
+    }
     match shape.case() {
         ShapeCase::One(shapes) => {
             let mut inners = Vec::new();
@@ -546,11 +557,6 @@ fn resolve_shape(
             }
             result
         }
-        ShapeCase::Error(shape::Error { message, .. }) => Err(Message {
-            code: context.code,
-            message: message.clone(),
-            locations: transform_locations(shape.locations(), context, expression),
-        }),
         ShapeCase::Array { prefix, tail } => {
             let prefix = prefix
                 .iter()
@@ -621,6 +627,9 @@ fn transform_locations<'a>(
 
 /// A simplified shape name for error messages
 fn short_shape_name(shape: &Shape) -> &'static str {
+    if shape.has_own_errors() {
+        return "error";
+    }
     match shape.case() {
         ShapeCase::Bool(_) => "boolean",
         ShapeCase::String(_) => "string",
@@ -634,7 +643,6 @@ fn short_shape_name(shape: &Shape) -> &'static str {
         ShapeCase::Name(_, _) => "named type",
         ShapeCase::Unknown => "unknown",
         ShapeCase::None => "none",
-        ShapeCase::Error(_) => "error",
     }
 }
 

--- a/apollo-federation/src/connectors/validation/schema/keys.rs
+++ b/apollo-federation/src/connectors/validation/schema/keys.rs
@@ -305,13 +305,6 @@ fn extract_concrete_typenames_into(shape: &Shape, in_typename: bool, result: &mu
             }
             extract_concrete_typenames_into(tail, false, result);
         }
-        ShapeCase::Error(shape::Error { partial, .. }) => {
-            // If the error has a partial shape, treat the partial shape
-            // as the root shape to extract from.
-            if let Some(partial) = partial {
-                extract_concrete_typenames_into(partial, in_typename, result);
-            }
-        }
         // Named types, and leaf types - nothing to extract at the root level
         ShapeCase::Name(_, _) => {}
         ShapeCase::None => {}
@@ -419,7 +412,7 @@ mod tests {
             ],
             [],
         );
-        let shape = Shape::record(
+        let shape = Shape::closed_record(
             [
                 ("__typename".to_string(), typename_union),
                 ("id".to_string(), Shape::string([])),
@@ -444,7 +437,7 @@ mod tests {
         use shape::Shape;
 
         // Build shape: { id: String, author: { __typename: "User", id: String } }
-        let nested_object = Shape::record(
+        let nested_object = Shape::closed_record(
             [
                 ("__typename".to_string(), Shape::string_value("User", [])),
                 ("id".to_string(), Shape::string([])),
@@ -452,7 +445,7 @@ mod tests {
             .into(),
             [],
         );
-        let shape = Shape::record(
+        let shape = Shape::closed_record(
             [
                 ("id".to_string(), Shape::string([])),
                 ("author".to_string(), nested_object),
@@ -488,7 +481,7 @@ mod tests {
             ],
             [],
         );
-        let shape = Shape::record(
+        let shape = Shape::closed_record(
             [
                 ("__typename".to_string(), conflicting_typename),
                 ("id".to_string(), Shape::string([])),
@@ -518,7 +511,7 @@ mod tests {
         use shape::Shape;
 
         // Valid object: { __typename: "Cat", id: String }
-        let valid_cat = Shape::record(
+        let valid_cat = Shape::closed_record(
             [
                 ("__typename".to_string(), Shape::string_value("Cat", [])),
                 ("id".to_string(), Shape::string([])),
@@ -528,7 +521,7 @@ mod tests {
         );
 
         // Invalid object: { __typename: All<"Cat", "Dog">, id: String }
-        let conflicting = Shape::record(
+        let conflicting = Shape::closed_record(
             [
                 (
                     "__typename".to_string(),
@@ -547,7 +540,7 @@ mod tests {
         );
 
         // Valid object: { __typename: "Bird", id: String }
-        let valid_bird = Shape::record(
+        let valid_bird = Shape::closed_record(
             [
                 ("__typename".to_string(), Shape::string_value("Bird", [])),
                 ("id".to_string(), Shape::string([])),

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@env-vars.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@env-vars.graphql.snap
@@ -1,12 +1,12 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/env-vars.graphql
 ---
 [
     Message {
         code: InvalidHeader,
-        message: "In `@source(http.headers:)`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `Dict<String>`",
+        message: "In `@source(http.headers:)`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `{...String}`",
         locations: [
             19:36..19:40,
         ],
@@ -22,7 +22,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/env-vars.graph
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.invalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `Dict<String>`",
+        message: "In `GET` in `@connect(http:)` on `Query.invalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `{...String}`",
         locations: [
             36:44..36:48,
         ],

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@headers__expressions_that_evaluate_to_invalid_types_v0_2.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@headers__expressions_that_evaluate_to_invalid_types_v0_2.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/headers/expressions_that_evaluate_to_invalid_types_v0_2.graphql
 ---
 [
@@ -13,7 +13,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/headers/expres
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.blah`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<One<String, null>>, null>`",
+        message: "In `@connect(http.headers:)` on `Query.blah`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...One<String, null>], null>`",
         locations: [
             19:10..19:27,
             21:73..21:80,

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@headers__expressions_that_evaluate_to_invalid_types_v0_3.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@headers__expressions_that_evaluate_to_invalid_types_v0_3.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/headers/expressions_that_evaluate_to_invalid_types_v0_3.graphql
 ---
 [
@@ -29,7 +29,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/headers/expres
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.blah`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<One<String, null>>, null>`",
+        message: "In `@connect(http.headers:)` on `Query.blah`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...One<String, null>], null>`",
         locations: [
             19:10..19:27,
             21:73..21:80,

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@request_headers.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@request_headers.graphql.snap
@@ -1,26 +1,26 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/request_headers.graphql
 ---
 [
     Message {
         code: InvalidHeader,
-        message: "In `@source(http.headers:)`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<String>, None>`",
+        message: "In `@source(http.headers:)`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...String], None>`",
         locations: [
             5:101..5:111,
         ],
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.failOnArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<String>, None>`",
+        message: "In `@connect(http.headers:)` on `Query.failOnArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...String], None>`",
         locations: [
             28:68..28:78,
         ],
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.failOnArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<String>, None>`",
+        message: "In `GET` in `@connect(http:)` on `Query.failOnArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...String], None>`",
         locations: [
             27:61..27:71,
         ],
@@ -43,14 +43,14 @@ input_file: apollo-federation/src/connectors/validation/test_data/request_header
     },
     Message {
         code: InvalidHeader,
-        message: "In `@connect(http.headers:)` on `Query.failOnInvalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `Dict<List<String>>`",
+        message: "In `@connect(http.headers:)` on `Query.failOnInvalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `{...[...String]}`",
         locations: [
             44:60..44:67,
         ],
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.failOnInvalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `Dict<List<String>>`",
+        message: "In `GET` in `@connect(http:)` on `Query.failOnInvalidObject`: expected union but received incompatible object\nDetails: `One<Float, Bool, String, null, None>` does not accept `{...[...String]}`",
         locations: [
             43:53..43:60,
         ],

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@uri_templates__invalid_types.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@uri_templates__invalid_types.graphql.snap
@@ -1,12 +1,12 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/uri_templates/invalid_types.graphql
 ---
 [
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.argIsArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<One<String, null>>, null>`",
+        message: "In `GET` in `@connect(http:)` on `Query.argIsArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...One<String, null>], null>`",
         locations: [
             8:16..8:29,
             10:47..10:50,
@@ -24,7 +24,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/uri_templates/
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `This.thisIsArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<List<One<String, null>>, null>`",
+        message: "In `GET` in `@connect(http:)` on `This.thisIsArray`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<[...One<String, null>], null>`",
         locations: [
             25:47..25:54,
         ],

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@url_properties__path.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@url_properties__path.graphql.snap
@@ -1,12 +1,12 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/url_properties/path.graphql
 ---
 [
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v1\")`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `List<One<String, Float, Bool>>` does not accept `[\"good\", 42, true, null, \"\"]`",
+        message: "In `@source(name: \"v1\")`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `[...One<String, Float, Bool>]` does not accept `[\"good\", 42, true, null, \"\"]`",
         locations: [
             10:16..10:44,
         ],
@@ -20,28 +20,28 @@ input_file: apollo-federation/src/connectors/validation/test_data/url_properties
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v3\")`, the `path` argument is invalid: expected array but received incompatible string\nDetails: `List<One<String, Float, Bool>>` does not accept `\"bad\"`",
+        message: "In `@source(name: \"v3\")`, the `path` argument is invalid: expected array but received incompatible string\nDetails: `[...One<String, Float, Bool>]` does not accept `\"bad\"`",
         locations: [
             16:54..16:59,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v4\")`, the `path` argument is invalid: expected array but received incompatible object\nDetails: `List<One<String, Float, Bool>>` does not accept `{ a: \"bad\" }`",
+        message: "In `@source(name: \"v4\")`, the `path` argument is invalid: expected array but received incompatible object\nDetails: `[...One<String, Float, Bool>]` does not accept `{ a: \"bad\" }`",
         locations: [
             20:54..20:66,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `List<One<String, Float, Bool>>` does not accept `[\"good\", 42, true, null, \"\"]`",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `[...One<String, Float, Bool>]` does not accept `[\"good\", 42, true, null, \"\"]`",
         locations: [
             27:34..27:62,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `List<One<String, Float, Bool>>` does not accept `[\n  One<String, null>,\n  One<Int, null>,\n  One<Float, null>,\n  One<Bool, null>,\n]`",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible array\nDetails: `[...One<String, Float, Bool>]` does not accept `[\n  One<String, null>,\n  One<Int, null>,\n  One<Float, null>,\n  One<Bool, null>,\n]`",
         locations: [
             32:34..32:70,
         ],
@@ -55,21 +55,21 @@ input_file: apollo-federation/src/connectors/validation/test_data/url_properties
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible string\nDetails: `List<One<String, Float, Bool>>` does not accept `\"bad\"`",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible string\nDetails: `[...One<String, Float, Bool>]` does not accept `\"bad\"`",
         locations: [
             36:55..36:60,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible object\nDetails: `List<One<String, Float, Bool>>` does not accept `{ a: \"bad\" }`",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible object\nDetails: `[...One<String, Float, Bool>]` does not accept `{ a: \"bad\" }`",
         locations: [
             39:34..39:46,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible union\nDetails: `List<One<String, Float, Bool>>` does not accept `One<String, null>`",
+        message: "In `@connect` on `Query.resources`, the `path` argument is invalid: expected array but received incompatible union\nDetails: `[...One<String, Float, Bool>]` does not accept `One<String, null>`",
         locations: [
             24:16..24:22,
             24:13..24:22,

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@url_properties__query_params.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@url_properties__query_params.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/connectors/validation/mod.rs
-expression: "format!(\"{:#?}\", result.errors)"
+expression: result.errors
 input_file: apollo-federation/src/connectors/validation/test_data/url_properties/query_params.graphql
 ---
 [
@@ -13,14 +13,14 @@ input_file: apollo-federation/src/connectors/validation/test_data/url_properties
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v4\")`, the `queryParams` argument is invalid: expected object but received incompatible array\nDetails: `Dict<Unknown>` does not accept `[]`",
+        message: "In `@source(name: \"v4\")`, the `queryParams` argument is invalid: expected object but received incompatible array\nDetails: `{...}` does not accept `[]`",
         locations: [
             23:61..23:63,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@source(name: \"v5\")`, the `queryParams` argument is invalid: expected object but received incompatible string\nDetails: `Dict<Unknown>` does not accept `\"bad\"`",
+        message: "In `@source(name: \"v5\")`, the `queryParams` argument is invalid: expected object but received incompatible string\nDetails: `{...}` does not accept `\"bad\"`",
         locations: [
             27:61..27:66,
         ],
@@ -34,21 +34,21 @@ input_file: apollo-federation/src/connectors/validation/test_data/url_properties
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible string\nDetails: `Dict<Unknown>` does not accept `\"bad\"`",
+        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible string\nDetails: `{...}` does not accept `\"bad\"`",
         locations: [
             52:41..52:46,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible array\nDetails: `Dict<Unknown>` does not accept `[\"bad\"]`",
+        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible array\nDetails: `{...}` does not accept `[\"bad\"]`",
         locations: [
             57:41..57:48,
         ],
     },
     Message {
         code: InvalidUrlProperty,
-        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible union\nDetails: `Dict<Unknown>` does not accept `One<String, null>`",
+        message: "In `@connect` on `Query.resources`, the `queryParams` argument is invalid: expected object but received incompatible union\nDetails: `{...}` does not accept `One<String, null>`",
         locations: [
             31:16..31:22,
             31:13..31:22,


### PR DESCRIPTION
Adds a `->ifThen` method to the connectors mapping language:

```
condition->ifThen(then_expr[, else_expr])
```

Revived from `1931ca4db` on `benjamn/conditional-ifThen-arrow-method`, a branch that had drifted 914 commits behind `dev`. Only the ifThen commit was taken; the shape-driven rewrites beneath it on that branch were left there.

Stacked on #9947, so this targets `benjamn/shape-0.8.0` to keep the diff free of the shape bump. It needs retargeting to `dev` once #9947 lands. The rebase onto shape 0.8.0 required no changes to `if_then_shape`.

### Semantics

Only the taken branch is evaluated, so the untaken one cannot contribute errors. `isValid->ifThen('then', $.missing)` yields `'then'` with no complaint about `$.missing`, which is what makes this a method rather than syntax sugar.

Omitting `else_expr` produces no value. At a named position that drops the key; under a spread it contributes nothing:

```
before ...condition->ifThen({ optional: 'value' }) after
```

With `condition: false` the result is just `before` and `after`, and no error.

### Conditions must be boolean

`true` is the only value that takes the then branch, consistent with `->and`, `->or`, `->not`, `->filter` and `->find`, none of which recognize truthiness. So `1` and `"false"` both take the else branch.

Anything that is neither `true` nor `false` reports `Method ->ifThen can only be applied to boolean values.` The error is **non-fatal**, which is the one deliberate divergence from those methods: they return `None` and collapse the selection, whereas `->ifThen` has a fallback and so still produces a value alongside the complaint.

`if_then_shape` mirrors this with `Shape::error_with_partial`, narrowing the partial to the else branch. That narrowing is sound precisely because the rule is strict `true`: a shape known not to be boolean can never take the then branch.

### Relationship to `->match`

For two-way dispatch this replaces `->match`'s `[candidate, value]` pairs and its `[@, _]` catch-all with the branches written directly:

```
# before
... type->match(["book", { __typename: "Book", title }],
                [@,      { __typename: "Movie", title }])
# after
... type->eq("book")->ifThen({ __typename: "Book", title },
                             { __typename: "Movie", title })
```

`->match` remains the better fit for dispatch over more than two cases. `->ifThen` also expresses `min`/`max` without it:

```
min: "($arg) => @->as($self)->lte($arg)->ifThen($self, $arg)"
max: "($arg) => @->as($self)->gte($arg)->ifThen($self, $arg)"
```

`->as` is required because the branch expressions are applied to the *condition* value, so a bare `@` inside a branch is the boolean, not the receiver.

### Note on the `apply_to.rs` change

An inline spread whose path produces no value previously always reported `Inlined path produced no value`. That is now raised only when the path itself errored. ifThen's no-else case depends on it, but it is a behavior change reaching any spread of a legitimately empty path, so it is worth reviewing on its own terms. Happy to split it into a separate PR if preferred.

### Tests

- 33 tests in `if_then.rs`: branch selection, laziness across V0_2 through V0_5, the strict-boolean rule over 10 non-boolean inputs including `1` and `"false"`, the spread cases, and the `min`/`max` idiom verified on values
- 5 `->ifThen` cases added to the `kitchen_sink` table, each mirroring a `->match` case above it with identical expected output
- `ConnectSpec::V0_5` added to `kitchen_sink`'s version matrix, which also gives the 27 pre-existing `->match` and spread cases their first V0_5 coverage

`apollo-federation` is green across every target (1990 lib, 834 integration), and `cargo xtask lint` passes. The `apollo-router` crate's suite has not been run.
