### PR TITLE
fix(telemetry): preserve existing trace context when custom header is absent or invalid

### DIFF
--- a/.changesets/fix_preserve_context_when_custom_trace_header_absent_or_invalid.md
+++ b/.changesets/fix_preserve_context_when_custom_trace_header_absent_or_invalid.md
@@ -1,0 +1,11 @@
+### Preserve existing trace context when custom trace header is absent or invalid
+
+When `propagation.request.header_name` is configured alongside `trace_context: true`,
+requests that send only a standard `traceparent` header (without the custom header)
+would have their trace context silently overwritten with an empty context.
+
+This fix ensures that when the custom header is absent or contains an invalid value,
+the existing trace context (e.g. extracted from `traceparent`) is preserved instead
+of being overwritten with an empty context.
+
+By [@p623](https://github.com/p623) in https://github.com/apollographql/router/pull/9971

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -3435,21 +3435,22 @@ mod tests {
     fn test_custom_trace_id_propagator_preserves_context_when_header_absent() {
         let header = String::from("x-trace-id");
         let existing_trace_id = TraceId::from(0x04f9e396465c4840bc2bf493b8b1a7fc);
-        let cx = opentelemetry::Context::new().with_remote_span_context(
-            SpanContext::new(
-                existing_trace_id,
-                SpanId::from(0x1234567890abcdef),
-                TraceFlags::SAMPLED,
-                true,
-                TraceState::default(),
-            )
-        );
+        let cx = opentelemetry::Context::new().with_remote_span_context(SpanContext::new(
+            existing_trace_id,
+            SpanId::from(0x1234567890abcdef),
+            TraceFlags::SAMPLED,
+            true,
+            TraceState::default(),
+        ));
 
         let propagator = CustomTraceIdPropagator::new(header.clone(), TraceIdFormat::Uuid);
         let headers: HashMap<String, String> = HashMap::new();
         let result_cx = propagator.extract_with_context(&cx, &headers);
 
-        assert_eq!(result_cx.span().span_context().trace_id(), existing_trace_id);
+        assert_eq!(
+            result_cx.span().span_context().trace_id(),
+            existing_trace_id
+        );
     }
 
     #[test]
@@ -3457,22 +3458,23 @@ mod tests {
         let header = String::from("x-trace-id");
         let invalid_trace_id = String::from("");
         let existing_trace_id = TraceId::from(0x04f9e396465c4840bc2bf493b8b1a7fc);
-        let cx = opentelemetry::Context::new().with_remote_span_context(
-            SpanContext::new(
-                existing_trace_id,
-                SpanId::from(0x1234567890abcdef),
-                TraceFlags::SAMPLED,
-                true,
-                TraceState::default(),
-            )
-        );
+        let cx = opentelemetry::Context::new().with_remote_span_context(SpanContext::new(
+            existing_trace_id,
+            SpanId::from(0x1234567890abcdef),
+            TraceFlags::SAMPLED,
+            true,
+            TraceState::default(),
+        ));
 
         let propagator = CustomTraceIdPropagator::new(header.clone(), TraceIdFormat::Uuid);
         let mut headers: HashMap<String, String> = HashMap::new();
         headers.insert(header, invalid_trace_id.clone());
         let result_cx = propagator.extract_with_context(&cx, &headers);
 
-        assert_eq!(result_cx.span().span_context().trace_id(), existing_trace_id);
+        assert_eq!(
+            result_cx.span().span_context().trace_id(),
+            existing_trace_id
+        );
     }
 
     #[test]

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -2094,10 +2094,10 @@ impl TextMapPropagator for CustomTraceIdPropagator {
         cx: &opentelemetry::Context,
         extractor: &dyn Extractor,
     ) -> opentelemetry::Context {
-        cx.with_remote_span_context(
-            self.extract_span_context(extractor)
-                .unwrap_or_else(SpanContext::empty_context),
-        )
+        match self.extract_span_context(extractor) {
+            Some(span_context) => cx.with_remote_span_context(span_context),
+            None => cx.clone(),
+        }
     }
 
     fn fields(&self) -> FieldIter<'_> {
@@ -3429,6 +3429,50 @@ mod tests {
         ));
 
         assert!(tracing_test::logs_contain(&invalid_trace_id));
+    }
+
+    #[test]
+    fn test_custom_trace_id_propagator_preserves_context_when_header_absent() {
+        let header = String::from("x-trace-id");
+        let existing_trace_id = TraceId::from(0x04f9e396465c4840bc2bf493b8b1a7fc);
+        let cx = opentelemetry::Context::new().with_remote_span_context(
+            SpanContext::new(
+                existing_trace_id,
+                SpanId::from(0x1234567890abcdef),
+                TraceFlags::SAMPLED,
+                true,
+                TraceState::default(),
+            )
+        );
+
+        let propagator = CustomTraceIdPropagator::new(header.clone(), TraceIdFormat::Uuid);
+        let headers: HashMap<String, String> = HashMap::new();
+        let result_cx = propagator.extract_with_context(&cx, &headers);
+
+        assert_eq!(result_cx.span().span_context().trace_id(), existing_trace_id);
+    }
+
+    #[test]
+    fn test_custom_trace_id_propagator_preserves_context_when_header_invalid() {
+        let header = String::from("x-trace-id");
+        let invalid_trace_id = String::from("");
+        let existing_trace_id = TraceId::from(0x04f9e396465c4840bc2bf493b8b1a7fc);
+        let cx = opentelemetry::Context::new().with_remote_span_context(
+            SpanContext::new(
+                existing_trace_id,
+                SpanId::from(0x1234567890abcdef),
+                TraceFlags::SAMPLED,
+                true,
+                TraceState::default(),
+            )
+        );
+
+        let propagator = CustomTraceIdPropagator::new(header.clone(), TraceIdFormat::Uuid);
+        let mut headers: HashMap<String, String> = HashMap::new();
+        headers.insert(header, invalid_trace_id.clone());
+        let result_cx = propagator.extract_with_context(&cx, &headers);
+
+        assert_eq!(result_cx.span().span_context().trace_id(), existing_trace_id);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix `CustomTraceIdPropagator::extract_with_context` to preserve the existing trace context when the configured `propagation.request.header_name` header is absent or contains an invalid value.

## Problem

When `propagation.request.header_name` is configured alongside `trace_context: true`,
the `CustomTraceIdPropagator` is registered last in the composite propagator chain (by design, to allow override). However, when the custom header is absent or invalid, `extract_span_context` returns `None`, and the previous implementation called `.unwrap_or_else(SpanContext::empty_context)`, which **overwrites** any trace context
already extracted by earlier propagators (e.g. `TraceContextPropagator` from `traceparent`).

This means that even with `trace_context: true` enabled, if a client sends only a `traceparent` header without the custom header, the trace context is lost.

## Fix

Return the incoming context unchanged (`cx.clone()`) when `extract_span_context` returns `None`, instead of overwriting with an empty span context.

```
// Before
fn extract_with_context(
        &self,
        cx: &opentelemetry::Context,
        extractor: &dyn Extractor,
    ) -> opentelemetry::Context {
        cx.with_remote_span_context(
            self.extract_span_context(extractor)
                .unwrap_or_else(SpanContext::empty_context),
        )
    }

// After
fn extract_with_context(
        &self,
        cx: &opentelemetry::Context,
        extractor: &dyn Extractor,
    ) -> opentelemetry::Context {
        match self.extract_span_context(extractor) {
            Some(span_context) => cx.with_remote_span_context(span_context),
            None => cx.clone(),
        }
    }
```


## Testing

Added unit tests covering:
- Context is preserved when the custom header is absent
- Context is preserved when the custom header contains an invalid value

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

- **Tickets**: No existing issue found for this bug. This PR itself serves as the bug report.
- **Documentation**: No configuration changes introduced. N/A.
- **Metrics and logs**: No new metrics or logs required. Existing error log is unchanged. N/A.
- **Integration tests**: Bug is localized to a single propagator method. Unit tests cover all affected code paths. N/A.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
