### PR TITLE
perf(query-planner): share equal path trees across condition cache entries

### DIFF
--- a/.changesets/perf_condition_cache_share_path_trees.md
+++ b/.changesets/perf_condition_cache_share_path_trees.md
@@ -1,0 +1,17 @@
+### Share equal path trees across condition cache entries ([PR #9975](https://github.com/apollographql/router/pull/9975))
+
+The condition resolver cache stores one entry per `(context,
+excluded_destinations, excluded_conditions)` combination per edge.
+Exclusion sets change on each key-edge attempt during path exploration,
+so an edge commonly accumulates many entries whose resolutions are
+structurally identical path trees, each independently allocated by a
+separate nested traversal.
+
+Cache inserts now compare the new resolution against the edge's
+existing entries and, when an equal resolution is already cached, store
+a shared reference to the existing path tree instead of retaining
+another copy. This reduces the query planner's peak heap usage during
+planning. Cache lookup behavior and generated query plans are
+unchanged.
+
+By [@tninesling](https://github.com/tninesling) in https://github.com/apollographql/router/pull/9975

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -193,7 +193,7 @@ impl ConditionResolverCache {
                 context_map: None,
             } = &entry.resolution
                 && cached_cost == cost
-                && (Arc::ptr_eq(tree, cached_tree) || tree == cached_tree)
+                && tree.equals_same_root(cached_tree)
             {
                 return entry.resolution.clone();
             }

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -193,7 +193,7 @@ impl ConditionResolverCache {
                 context_map: None,
             } = &entry.resolution
                 && cached_cost == cost
-                && tree.equals_same_root(cached_tree)
+                && (Arc::ptr_eq(tree, cached_tree) || tree == cached_tree)
             {
                 return entry.resolution.clone();
             }

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -161,15 +161,44 @@ impl ConditionResolverCache {
         excluded_destinations: ExcludedDestinations,
         excluded_conditions: ExcludedConditions,
     ) {
-        self.edge_states
-            .entry(edge)
-            .or_default()
-            .push(CachedConditionEntry {
-                resolution,
-                context,
-                excluded_destinations,
-                excluded_conditions,
-            });
+        let entries = self.edge_states.entry(edge).or_default();
+        let resolution = Self::dedupe_resolution(entries, resolution);
+        entries.push(CachedConditionEntry {
+            resolution,
+            context,
+            excluded_destinations,
+            excluded_conditions,
+        });
+    }
+
+    /// Many cache entries for the same edge (differing only by context/exclusions) resolve to
+    /// structurally identical path trees, each independently allocated. Share the first equal
+    /// tree's `Arc` instead of storing another copy.
+    fn dedupe_resolution(
+        entries: &[CachedConditionEntry],
+        resolution: ConditionResolution,
+    ) -> ConditionResolution {
+        let ConditionResolution::Satisfied {
+            cost,
+            path_tree: Some(tree),
+            context_map: None,
+        } = &resolution
+        else {
+            return resolution;
+        };
+        for entry in entries {
+            if let ConditionResolution::Satisfied {
+                cost: cached_cost,
+                path_tree: Some(cached_tree),
+                context_map: None,
+            } = &entry.resolution
+            {
+                if cached_cost == cost && (Arc::ptr_eq(tree, cached_tree) || tree == cached_tree) {
+                    return entry.resolution.clone();
+                }
+            }
+        }
+        resolution
     }
 }
 

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -192,10 +192,10 @@ impl ConditionResolverCache {
                 path_tree: Some(cached_tree),
                 context_map: None,
             } = &entry.resolution
+                && cached_cost == cost
+                && (Arc::ptr_eq(tree, cached_tree) || tree == cached_tree)
             {
-                if cached_cost == cost && (Arc::ptr_eq(tree, cached_tree) || tree == cached_tree) {
-                    return entry.resolution.clone();
-                }
+                return entry.resolution.clone();
             }
         }
         resolution

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -366,9 +366,10 @@ where
     }
 
     /// May have false negatives (see comment about `Arc::ptr_eq`)
-    fn equals_same_root(self: &Arc<Self>, other: &Arc<Self>) -> bool {
+    pub(crate) fn equals_same_root(self: &Arc<Self>, other: &Arc<Self>) -> bool {
         Arc::ptr_eq(self, other)
-            || self.childs.iter().zip(&other.childs).all(|(a, b)| {
+            || self.childs.len() == other.childs.len()
+                && self.childs.iter().zip(&other.childs).all(|(a, b)| {
                 a.edge == b.edge
                     // `Arc::ptr_eq` instead of `==` is faster and good enough.
                     // This method is all about avoid unnecessary merging

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -114,6 +114,8 @@ where
             && self.trigger == other.trigger
             && self.conditions == other.conditions
             && self.tree == other.tree
+            && self.matching_context_ids == other.matching_context_ids
+            && self.arguments_to_context_usages == other.arguments_to_context_usages
     }
 }
 
@@ -411,9 +413,6 @@ where
             self.node, other.node,
             "Cannot merge path trees rooted different nodes"
         );
-        if self == other {
-            return;
-        }
         if other.childs.is_empty() {
             return;
         }


### PR DESCRIPTION
## Summary

The condition resolver cache stores one entry per `(context, excluded_destinations, excluded_conditions)` combination per edge. Exclusion sets change on each key-edge attempt during path exploration, so an edge commonly accumulates many entries whose resolutions are structurally identical path trees — each independently allocated by a separate nested traversal, since a cache miss always runs a fresh `QueryPlanningTraversal` that builds its own `OpPathTree`.

This change dedupes at insert time: compare the new resolution against the edge's existing entries and, when an equal resolution is already cached, store a clone of the existing entry's `Arc<OpPathTree>` instead of retaining another copy of the same tree. The freshly computed tree is then dropped when the caller's copy goes out of scope rather than being held for the remainder of planning.

This reduces the planner's peak heap usage during planning. Cache lookup behavior, hit/miss outcomes, and generated query plans are unchanged.

## Notes for reviewers

- The equality check only runs on cache inserts (misses), immediately after the nested traversal that computed the resolution — the lookup path is untouched.
- `Arc::ptr_eq` short-circuits the deep compare where possible, and `PathTree`'s `PartialEq` compares children via `Arc`-backed structures.
- Resolutions with a `context_map` (`@fromContext`) are excluded from sharing and stored as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)