### PR TITLE
Return `application/graphql-response+json` when the client asked for it

### DIFF
--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -1456,6 +1456,54 @@ async fn it_errors_on_bad_accept_header() -> Result<(), ApolloRouterError> {
 }
 
 #[test(tokio::test)]
+async fn it_returns_graphql_response_json_content_type_when_accepted()
+-> Result<(), ApolloRouterError> {
+    let expected_response = graphql::Response::builder()
+        .data(json!({"__typename": "Query"}))
+        .build();
+    let example_response = expected_response.clone();
+    let (mock, mut handle) = tower_test::mock::pair::<
+        crate::services::supergraph::Request,
+        crate::services::supergraph::Response,
+    >();
+    let driver = tokio::spawn(async move {
+        let (req, responder) = handle.next_request().await.unwrap();
+        responder.send_response(SupergraphResponse::new_from_graphql_response(
+            example_response,
+            req.context,
+        ));
+    });
+    let router_service = router::service::from_supergraph_mock(mock).await;
+    let (server, client) = init(router_service).await;
+    let url = format!("{}", server.graphql_listen_address().as_ref().unwrap());
+
+    let response = client
+        .post(url.as_str())
+        .header(ACCEPT, "application/graphql-response+json")
+        .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+        .body(json!({ "query": "{ __typename }" }).to_string())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE),
+        Some(&HeaderValue::from_static(
+            "application/graphql-response+json"
+        ))
+    );
+    assert_eq!(
+        response.json::<graphql::Response>().await.unwrap(),
+        expected_response
+    );
+
+    server.shutdown().await?;
+    driver.await.unwrap();
+    Ok(())
+}
+
+#[test(tokio::test)]
 async fn it_displays_homepage() {
     let conf = Arc::new(Configuration::fake_builder().build().unwrap());
 

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -1504,6 +1504,59 @@ async fn it_returns_graphql_response_json_content_type_when_accepted()
 }
 
 #[test(tokio::test)]
+async fn it_prefers_graphql_response_json_when_accepted_alongside_lower_priority_json()
+-> Result<(), ApolloRouterError> {
+    let expected_response = graphql::Response::builder()
+        .data(json!({"__typename": "Query"}))
+        .build();
+    let example_response = expected_response.clone();
+    let (mock, mut handle) = tower_test::mock::pair::<
+        crate::services::supergraph::Request,
+        crate::services::supergraph::Response,
+    >();
+    let driver = tokio::spawn(async move {
+        let (req, responder) = handle.next_request().await.unwrap();
+        responder.send_response(SupergraphResponse::new_from_graphql_response(
+            example_response,
+            req.context,
+        ));
+    });
+    let router_service = router::service::from_supergraph_mock(mock).await;
+    let (server, client) = init(router_service).await;
+    let url = format!("{}", server.graphql_listen_address().as_ref().unwrap());
+
+    // The recommended Accept header for a spec-compliant GraphQL-over-HTTP client: prefer
+    // application/graphql-response+json, but still accept application/json as a fallback.
+    let response = client
+        .post(url.as_str())
+        .header(
+            ACCEPT,
+            "application/graphql-response+json, application/json;q=0.9",
+        )
+        .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+        .body(json!({ "query": "{ __typename }" }).to_string())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE),
+        Some(&HeaderValue::from_static(
+            "application/graphql-response+json"
+        ))
+    );
+    assert_eq!(
+        response.json::<graphql::Response>().await.unwrap(),
+        expected_response
+    );
+
+    server.shutdown().await?;
+    driver.await.unwrap();
+    Ok(())
+}
+
+#[test(tokio::test)]
 async fn it_displays_homepage() {
     let conf = Arc::new(Configuration::fake_builder().build().unwrap());
 

--- a/apollo-router/src/plugins/authorization/authenticated.rs
+++ b/apollo-router/src/plugins/authorization/authenticated.rs
@@ -1708,7 +1708,7 @@ mod tests {
                 multipart_defer: true,
                 multipart_subscription: true,
                 json: true,
-                json_response: false,
+                graphql_response_json: false,
                 wildcard: true,
             })
         });

--- a/apollo-router/src/plugins/authorization/authenticated.rs
+++ b/apollo-router/src/plugins/authorization/authenticated.rs
@@ -1708,6 +1708,7 @@ mod tests {
                 multipart_defer: true,
                 multipart_subscription: true,
                 json: true,
+                json_response: false,
                 wildcard: true,
             })
         });

--- a/apollo-router/src/services/layers/content_negotiation.rs
+++ b/apollo-router/src/services/layers/content_negotiation.rs
@@ -5,6 +5,7 @@
 use std::ops::ControlFlow;
 
 use http::HeaderMap;
+use http::HeaderValue;
 use http::Method;
 use http::StatusCode;
 use http::header::ACCEPT;
@@ -39,6 +40,10 @@ use crate::services::router::service::MULTIPART_SUBSCRIPTION_CONTENT_TYPE_HEADER
 use crate::services::supergraph;
 
 pub(crate) const GRAPHQL_JSON_RESPONSE_HEADER_VALUE: &str = "application/graphql-response+json";
+
+#[allow(clippy::declare_interior_mutable_const)]
+pub(crate) static GRAPHQL_JSON_RESPONSE_CONTENT_TYPE_HEADER_VALUE: HeaderValue =
+    HeaderValue::from_static(GRAPHQL_JSON_RESPONSE_HEADER_VALUE);
 
 /// A layer for the router service that rejects requests that do not have an expected Content-Type,
 /// or that have an Accept header that is not supported by the router.
@@ -175,6 +180,7 @@ where
                 let ClientRequestAccepts {
                     wildcard: accepts_wildcard,
                     json: accepts_json,
+                    json_response: accepts_json_response,
                     multipart_defer: accepts_multipart_defer,
                     multipart_subscription: accepts_multipart_subscription,
                 } = context.extensions().with_lock(|lock| {
@@ -184,9 +190,12 @@ where
                 });
 
                 if !res.has_next.unwrap_or_default() && (accepts_json || accepts_wildcard) {
-                    parts
-                        .headers
-                        .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone());
+                    let content_type = if accepts_json_response {
+                        GRAPHQL_JSON_RESPONSE_CONTENT_TYPE_HEADER_VALUE.clone()
+                    } else {
+                        APPLICATION_JSON_HEADER_VALUE.clone()
+                    };
+                    parts.headers.insert(CONTENT_TYPE, content_type);
                 } else if accepts_multipart_defer {
                     parts.headers.insert(
                         CONTENT_TYPE,
@@ -261,13 +270,17 @@ fn parse_accept(headers: &HeaderMap) -> ClientRequestAccepts {
         if let Ok(str) = value.to_str() {
             for result in MediaTypeList::new(str) {
                 if let Ok(mime) = result {
+                    let is_graphql_response_json = mime.ty == APPLICATION
+                        && mime.subty.as_str() == "graphql-response"
+                        && mime.suffix == Some(JSON);
                     if !accepts.json
                         && ((mime.ty == APPLICATION && mime.subty == JSON)
-                            || (mime.ty == APPLICATION
-                                && mime.subty.as_str() == "graphql-response"
-                                && mime.suffix == Some(JSON)))
+                            || is_graphql_response_json)
                     {
                         accepts.json = true
+                    }
+                    if !accepts.json_response && is_graphql_response_json {
+                        accepts.json_response = true
                     }
                     if !accepts.wildcard && (mime.ty == _STAR && mime.subty == _STAR) {
                         accepts.wildcard = true
@@ -340,6 +353,7 @@ mod tests {
         default_headers.append(ACCEPT, HeaderValue::from_static("foo/bar"));
         let accepts = parse_accept(&default_headers);
         assert!(accepts.json);
+        assert!(!accepts.json_response);
 
         let mut default_headers = HeaderMap::new();
         default_headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
@@ -361,6 +375,7 @@ mod tests {
         default_headers.append(ACCEPT, HeaderValue::from_static("foo/bar"));
         let accepts = parse_accept(&default_headers);
         assert!(accepts.json);
+        assert!(accepts.json_response);
 
         let mut default_headers = HeaderMap::new();
         default_headers.insert(

--- a/apollo-router/src/services/layers/content_negotiation.rs
+++ b/apollo-router/src/services/layers/content_negotiation.rs
@@ -180,7 +180,7 @@ where
                 let ClientRequestAccepts {
                     wildcard: accepts_wildcard,
                     json: accepts_json,
-                    json_response: accepts_json_response,
+                    graphql_response_json: accepts_json_response,
                     multipart_defer: accepts_multipart_defer,
                     multipart_subscription: accepts_multipart_subscription,
                 } = context.extensions().with_lock(|lock| {
@@ -279,8 +279,8 @@ fn parse_accept(headers: &HeaderMap) -> ClientRequestAccepts {
                     {
                         accepts.json = true
                     }
-                    if !accepts.json_response && is_graphql_response_json {
-                        accepts.json_response = true
+                    if !accepts.graphql_response_json && is_graphql_response_json {
+                        accepts.graphql_response_json = true
                     }
                     if !accepts.wildcard && (mime.ty == _STAR && mime.subty == _STAR) {
                         accepts.wildcard = true
@@ -353,7 +353,7 @@ mod tests {
         default_headers.append(ACCEPT, HeaderValue::from_static("foo/bar"));
         let accepts = parse_accept(&default_headers);
         assert!(accepts.json);
-        assert!(!accepts.json_response);
+        assert!(!accepts.graphql_response_json);
 
         let mut default_headers = HeaderMap::new();
         default_headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
@@ -375,7 +375,7 @@ mod tests {
         default_headers.append(ACCEPT, HeaderValue::from_static("foo/bar"));
         let accepts = parse_accept(&default_headers);
         assert!(accepts.json);
-        assert!(accepts.json_response);
+        assert!(accepts.graphql_response_json);
 
         let mut default_headers = HeaderMap::new();
         default_headers.insert(
@@ -394,5 +394,16 @@ mod tests {
         );
         let accepts = parse_accept(&default_headers);
         assert!(accepts.multipart_subscription);
+
+        // A spec-compliant GraphQL-over-HTTP client accepting both, with application/json as a
+        // lower-priority fallback: application/graphql-response+json should still be preferred.
+        let mut default_headers = HeaderMap::new();
+        default_headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/graphql-response+json, application/json;q=0.9"),
+        );
+        let accepts = parse_accept(&default_headers);
+        assert!(accepts.json);
+        assert!(accepts.graphql_response_json);
     }
 }

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -462,7 +462,12 @@ impl Response {
 pub(crate) struct ClientRequestAccepts {
     pub(crate) multipart_defer: bool,
     pub(crate) multipart_subscription: bool,
+    /// True if the client accepts `application/json` or `application/graphql-response+json`.
     pub(crate) json: bool,
+    /// True if the client accepts `application/graphql-response+json` specifically. When this is
+    /// true, that media type should be preferred over `application/json` in the response's
+    /// `Content-Type` header.
+    pub(crate) json_response: bool,
     pub(crate) wildcard: bool,
 }
 

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -467,7 +467,7 @@ pub(crate) struct ClientRequestAccepts {
     /// True if the client accepts `application/graphql-response+json` specifically. When this is
     /// true, that media type should be preferred over `application/json` in the response's
     /// `Content-Type` header.
-    pub(crate) json_response: bool,
+    pub(crate) graphql_response_json: bool,
     pub(crate) wildcard: bool,
 }
 

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -70,6 +70,7 @@ use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
 use crate::services::layers::apq::APQLayer;
 use crate::services::layers::content_negotiation;
+use crate::services::layers::content_negotiation::GRAPHQL_JSON_RESPONSE_CONTENT_TYPE_HEADER_VALUE;
 use crate::services::layers::content_negotiation::GRAPHQL_JSON_RESPONSE_HEADER_VALUE;
 use crate::services::layers::persisted_queries::EnforceSafelistLayer;
 use crate::services::layers::persisted_queries::ExpandIdsLayer;
@@ -421,6 +422,7 @@ where
         let ClientRequestAccepts {
             wildcard: accepts_wildcard,
             json: accepts_json,
+            json_response: accepts_json_response,
             multipart_defer: accepts_multipart_defer,
             multipart_subscription: accepts_multipart_subscription,
         } = context
@@ -459,9 +461,14 @@ where
                 {
                     let errors = response.errors.clone();
 
-                    parts
-                        .headers
-                        .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone());
+                    parts.headers.insert(
+                        CONTENT_TYPE,
+                        if accepts_json_response {
+                            GRAPHQL_JSON_RESPONSE_CONTENT_TYPE_HEADER_VALUE.clone()
+                        } else {
+                            APPLICATION_JSON_HEADER_VALUE.clone()
+                        },
+                    );
                     let body: Result<String, BoxError> = tracing::trace_span!("serialize_response")
                         .in_scope(|| {
                             let body = serde_json::to_string(&response)?;

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -422,7 +422,7 @@ where
         let ClientRequestAccepts {
             wildcard: accepts_wildcard,
             json: accepts_json,
-            json_response: accepts_json_response,
+            graphql_response_json: accepts_graphql_response_json,
             multipart_defer: accepts_multipart_defer,
             multipart_subscription: accepts_multipart_subscription,
         } = context
@@ -463,7 +463,9 @@ where
 
                     parts.headers.insert(
                         CONTENT_TYPE,
-                        if accepts_json_response {
+                        // If the client specifically accepts `application/graphql-response+json`, we prefer that over `application/json` in the response's `Content-Type` header.
+                        // `q=` is not parsed at the moment
+                        if accepts_graphql_response_json {
                             GRAPHQL_JSON_RESPONSE_CONTENT_TYPE_HEADER_VALUE.clone()
                         } else {
                             APPLICATION_JSON_HEADER_VALUE.clone()

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -90,7 +90,7 @@ const GRAPHQL_RESPONSE: mediatype::Name = mediatype::Name::new_unchecked("graphq
 #[allow(clippy::declare_interior_mutable_const)]
 pub(crate) static APPLICATION_JSON_HEADER_VALUE: HeaderValue =
     HeaderValue::from_static("application/json");
-static ACCEPT_GRAPHQL_JSON: HeaderValue =
+static ACCEPT_ALL_JSON_HEADER_VALUE: HeaderValue =
     HeaderValue::from_static("application/json, application/graphql-response+json");
 
 enum APQError {
@@ -360,7 +360,7 @@ pub(crate) async fn process_batch(
         .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone());
     request
         .headers_mut()
-        .append(ACCEPT, ACCEPT_GRAPHQL_JSON.clone());
+        .append(ACCEPT, ACCEPT_ALL_JSON_HEADER_VALUE.clone());
 
     let schema_uri = request.uri();
     let (host, port, path) = get_uri_details(schema_uri);
@@ -825,7 +825,7 @@ pub(crate) async fn call_single_http(
         .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone());
     request
         .headers_mut()
-        .append(ACCEPT, ACCEPT_GRAPHQL_JSON.clone());
+        .append(ACCEPT, ACCEPT_ALL_JSON_HEADER_VALUE.clone());
 
     let schema_uri = request.uri();
     let (host, port, path) = get_uri_details(schema_uri);


### PR DESCRIPTION
Fixes #6851 

It's not 100% perfect because the `q=` parameter is not parsed so a (weird) client sending `Accept: application/json, application/graphql-response+json;q=0.9` will see `application/graphql-response+json` prioritized but that would be quite a weird thing to do TBH