### PR TITLE
fix(telemetry): preserve valid W3C trace context when custom trace-id header is absent

### DIFF
--- a/.changesets/fix_custom_trace_id_propagator_preserve_context.md
+++ b/.changesets/fix_custom_trace_id_propagator_preserve_context.md
@@ -1,0 +1,15 @@
+### Preserve valid W3C trace context when the custom trace ID header is absent ([PR #9984](https://github.com/apollographql/router/pull/9984))
+
+When `telemetry.exporters.tracing.propagation.request.header_name` is
+configured, the router registers `CustomTraceIdPropagator` as the last
+propagator in the chain so it can override earlier ones when its own header
+is present. Previously, when that header was absent on a given request, it
+unconditionally reset the trace context to an empty one, discarding a valid
+context an earlier propagator (e.g. W3C `trace_context`) had already
+extracted from an incoming `traceparent` header — forcing a new root trace
+on every such request.
+
+The propagator now leaves the context untouched when its header is missing,
+so a context extracted by an earlier propagator is preserved.
+
+By [@OriginLeon](https://github.com/OriginLeon) in https://github.com/apollographql/router/pull/9984

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -2094,10 +2094,10 @@ impl TextMapPropagator for CustomTraceIdPropagator {
         cx: &opentelemetry::Context,
         extractor: &dyn Extractor,
     ) -> opentelemetry::Context {
-        cx.with_remote_span_context(
-            self.extract_span_context(extractor)
-                .unwrap_or_else(SpanContext::empty_context),
-        )
+        match self.extract_span_context(extractor) {
+            Some(span_context) => cx.with_remote_span_context(span_context),
+            None => cx.clone(),
+        }
     }
 
     fn fields(&self) -> FieldIter<'_> {
@@ -3429,6 +3429,71 @@ mod tests {
         ));
 
         assert!(tracing_test::logs_contain(&invalid_trace_id));
+    }
+
+    #[test]
+    fn test_extract_with_context_preserves_existing_context_when_header_absent() {
+        let header = String::from("x-trace-id");
+        let propagator = CustomTraceIdPropagator::new(header, TraceIdFormat::Uuid);
+
+        let existing_span_context = SpanContext::new(
+            TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap(),
+            SpanId::from_hex("00f067aa0ba902b7").unwrap(),
+            TraceFlags::default().with_sampled(true),
+            true,
+            TraceState::default(),
+        );
+        let cx =
+            opentelemetry::Context::new().with_remote_span_context(existing_span_context.clone());
+
+        let headers: HashMap<String, String> = HashMap::new();
+
+        let result_cx = propagator.extract_with_context(&cx, &headers);
+
+        assert_eq!(result_cx.span().span_context(), &existing_span_context);
+    }
+
+    #[test]
+    fn test_extract_with_context_stays_empty_when_header_absent_and_no_prior_context() {
+        let header = String::from("x-trace-id");
+        let propagator = CustomTraceIdPropagator::new(header, TraceIdFormat::Uuid);
+
+        let cx = opentelemetry::Context::new(); // no propagator has extracted anything yet
+        let headers: HashMap<String, String> = HashMap::new(); // custom header absent
+
+        let result_cx = propagator.extract_with_context(&cx, &headers);
+
+        assert_eq!(
+            result_cx.span().span_context(),
+            &SpanContext::empty_context()
+        );
+    }
+
+    #[test]
+    fn test_extract_with_context_overrides_when_header_present() {
+        let header = String::from("x-trace-id");
+        let propagator = CustomTraceIdPropagator::new(header.clone(), TraceIdFormat::Uuid);
+
+        // Prior context, as if W3C had already extracted a different traceparent.
+        let previous_span_context = SpanContext::new(
+            TraceId::from_hex("4bf92f3577b34da6a3ce929d0e0e4736").unwrap(),
+            SpanId::from_hex("00f067aa0ba902b7").unwrap(),
+            TraceFlags::default().with_sampled(true),
+            true,
+            TraceState::default(),
+        );
+        let cx = opentelemetry::Context::new().with_remote_span_context(previous_span_context);
+
+        // Custom header is present and must take precedence.
+        let mut headers: HashMap<String, String> = HashMap::new();
+        headers.insert(header, "04f9e396-465c-4840-bc2b-f493b8b1a7fc".to_string());
+
+        let result_cx = propagator.extract_with_context(&cx, &headers);
+
+        assert_eq!(
+            result_cx.span().span_context().trace_id().to_string(),
+            "04f9e396465c4840bc2bf493b8b1a7fc"
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- [ROUTER-2055] -->
## Problem

When `telemetry.exporters.tracing.propagation.request.header_name` is configured, the router registers a `CustomTraceIdPropagator` as the last propagator in the composite chain, specifically so it can override earlier propagators when its own header is present. When that header is absent from an incoming request, `extract_with_context` was unconditionally resetting the OTel context to `SpanContext::empty_context()` — discarding a valid parent context an earlier propagator (e.g. W3C `trace_context`) had already extracted from an incoming `traceparent` header. This forced the router to start a brand-new, non-deterministic root trace on every request that didn't carry the custom header.

Reported by a customer using both `trace_context: true` and `propagation.request.header_name` together (see [TSH-23849](https://apollographql.atlassian.net/browse/TSH-23849)); traffic without the custom header lost its upstream trace context on every single call.

## Fix

`CustomTraceIdPropagator::extract_with_context` now only replaces the context when its own header successfully yields a trace ID. When the header is absent (or invalid), it returns the incoming context unchanged, so whatever an earlier propagator already extracted survives.

## Testing

Added unit tests covering the three relevant branches of `extract_with_context`:
- header absent, valid context already present → context is preserved (the regression test for this bug)
- header absent, no prior context → stays empty (unchanged behavior)
- header present → still overrides (unchanged override behavior)

Ran `cargo xtask lint` (fmt, clippy `--all --all-targets --all-features -D warnings`, doc) clean.

[ROUTER-2055]: https://apollographql.atlassian.net/browse/ROUTER-2055

[TSH-23849]: https://apollographql.atlassian.net/browse/TSH-23849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ