### PR TITLE
chore(deps): bump lru to 0.18.2, fixes RUSTSEC-2026-0253

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,9 +4164,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.0",
 ]


### PR DESCRIPTION
## Summary

`lru` 0.18.0's `LruCache::pop()` wasn't panic-safe: if a stored key's `Drop` impl panicked during `pop()`, `detach()` was skipped, leaving dangling pointers in the internal doubly-linked list. A later cache eviction could then dereference these dangling pointers (use-after-free, potential double-free). Fixed upstream in 0.18.2 ([lru-rs#238](https://github.com/jeromefroe/lru-rs/pull/238)).

- RUSTSEC advisory: https://rustsec.org/advisories/RUSTSEC-2026-0253

## Why now

This is currently failing `check_compliance` on #9985 — unrelated to that PR's actual content (the condition-resolver-cache dedup change). `dev-v2.16.x`'s lockfile still pins the vulnerable `lru 0.18.0`; this bumps it to `0.18.2` and nothing else. Verified locally with `cargo xtask check-compliance` (`advisories ok, bans ok, licenses ok, sources ok`).

## Test plan

- [x] `cargo update -p lru` — confirmed the diff is scoped to exactly the `lru` version bump, no other lockfile changes
- [x] `cargo xtask check-compliance` passes locally