### PR TITLE
fix(connectors): handle union/interface types in nested group selections

### DIFF
--- a/apollo-federation/CHANGELOG.md
+++ b/apollo-federation/CHANGELOG.md
@@ -22,6 +22,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🐛 Fixes
 
+### Fix `GROUP_SELECTION_IS_NOT_OBJECT` for union/interface fields in nested `@connect` selections ([PR #9990](https://github.com/apollographql/router/pull/9990))
+
+Connectors validation rejected `->match` results assigned to union- or
+interface-typed fields nested inside another object (e.g. `Stop.location:
+StopLocation` where `StopLocation` is a union). The top-level validation path
+already expanded abstract types to their concrete members, but the recursive
+`walk_selection_with_shape` did not, causing a spurious
+`GROUP_SELECTION_IS_NOT_OBJECT` error. The recursive path now mirrors the
+top-level expansion for both union and interface types.
+
+By [@tninesling](https://github.com/tninesling) in <https://github.com/apollographql/router/pull/9990>
+
 ### Upgrading federation 1 subgraphs no longer clones subgraph metadata once per type ([PR #9946](https://github.com/apollographql/router/pull/9946))
 
 Composition constructs a schema upgrader as soon as **one** input subgraph is a

--- a/apollo-federation/src/connectors/validation/connect/selection.rs
+++ b/apollo-federation/src/connectors/validation/connect/selection.rs
@@ -683,8 +683,54 @@ impl<'schema> SelectionValidator<'schema> {
                                     // Valid: object field with subselection
                                     self.walk_selection_with_shape(field_type_ref, field_shape)?;
                                 }
+                                (ExtendedType::Union(union_type), true) => {
+                                    // Expand union to concrete member types and
+                                    // validate against each, mirroring the top-level
+                                    // expansion in type_check_shape_based.
+                                    let concrete_refs: Vec<_> = union_type
+                                        .members
+                                        .iter()
+                                        .filter_map(|member_name| {
+                                            SchemaTypeRef::new(self.schema, member_name)
+                                        })
+                                        .collect();
+                                    for concrete_ref in concrete_refs {
+                                        self.walk_selection_with_shape(
+                                            concrete_ref,
+                                            field_shape,
+                                        )?;
+                                    }
+                                }
+                                (ExtendedType::Interface(interface_type), true) => {
+                                    // Expand interface to concrete implementing
+                                    // types and validate against each.
+                                    let concrete_refs: Vec<_> = self
+                                        .schema
+                                        .types
+                                        .values()
+                                        .filter_map(|t| {
+                                            if let ExtendedType::Object(o) = t {
+                                                if o.implements_interfaces
+                                                    .contains(&interface_type.name)
+                                                {
+                                                    SchemaTypeRef::new(self.schema, &o.name)
+                                                } else {
+                                                    None
+                                                }
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .collect();
+                                    for concrete_ref in concrete_refs {
+                                        self.walk_selection_with_shape(
+                                            concrete_ref,
+                                            field_shape,
+                                        )?;
+                                    }
+                                }
                                 (_, true) => {
-                                    // Invalid: non-object field with subselection (group selection)
+                                    // Invalid: non-composite field with subselection (group selection)
                                     return Err(Message {
                                         code: Code::GroupSelectionIsNotObject,
                                         message: format!(

--- a/apollo-federation/src/connectors/validation/connect/selection.rs
+++ b/apollo-federation/src/connectors/validation/connect/selection.rs
@@ -695,10 +695,7 @@ impl<'schema> SelectionValidator<'schema> {
                                         })
                                         .collect();
                                     for concrete_ref in concrete_refs {
-                                        self.walk_selection_with_shape(
-                                            concrete_ref,
-                                            field_shape,
-                                        )?;
+                                        self.walk_selection_with_shape(concrete_ref, field_shape)?;
                                     }
                                 }
                                 (ExtendedType::Interface(interface_type), true) => {
@@ -723,10 +720,7 @@ impl<'schema> SelectionValidator<'schema> {
                                         })
                                         .collect();
                                     for concrete_ref in concrete_refs {
-                                        self.walk_selection_with_shape(
-                                            concrete_ref,
-                                            field_shape,
-                                        )?;
+                                        self.walk_selection_with_shape(concrete_ref, field_shape)?;
                                     }
                                 }
                                 (_, true) => {

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@nested_interface_in_selection.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@nested_interface_in_selection.graphql.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-federation/src/connectors/validation/mod.rs
+assertion_line: 335
+expression: result.errors
+input_file: apollo-federation/src/connectors/validation/test_data/nested_interface_in_selection.graphql
+---
+[]

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@nested_union_in_selection.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@nested_union_in_selection.graphql.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-federation/src/connectors/validation/mod.rs
+assertion_line: 335
+expression: result.errors
+input_file: apollo-federation/src/connectors/validation/test_data/nested_union_in_selection.graphql
+---
+[]

--- a/apollo-federation/src/connectors/validation/test_data/nested_interface_in_selection.graphql
+++ b/apollo-federation/src/connectors/validation/test_data/nested_interface_in_selection.graphql
@@ -1,0 +1,46 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.11")
+  @link(
+    url: "https://specs.apollo.dev/connect/v0.4"
+    import: ["@connect", "@source"]
+  )
+  @source(
+    name: "api"
+    http: { baseURL: "https://api.example.com/" }
+  )
+
+interface Detail {
+  text: String!
+}
+
+type Summary implements Detail {
+  text: String!
+}
+
+type FullText implements Detail {
+  text: String!
+}
+
+type Item {
+  detail: Detail
+}
+
+type Query {
+  item: Item
+    @connect(
+      source: "api"
+      http: { GET: "/item" }
+      selection: """
+        detail: kind->match(
+          ["short", {
+            __typename: "Summary",
+            text: text
+          }],
+          [@, {
+            __typename: "FullText",
+            text: text
+          }]
+        )
+      """
+    )
+}

--- a/apollo-federation/src/connectors/validation/test_data/nested_union_in_selection.graphql
+++ b/apollo-federation/src/connectors/validation/test_data/nested_union_in_selection.graphql
@@ -1,0 +1,44 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.11")
+  @link(
+    url: "https://specs.apollo.dev/connect/v0.4"
+    import: ["@connect", "@source"]
+  )
+  @source(
+    name: "api"
+    http: { baseURL: "https://api.example.com/" }
+  )
+
+type Summary {
+  brief: String!
+}
+
+type FullText {
+  content: String!
+}
+
+union Detail = Summary | FullText
+
+type Item {
+  detail: Detail
+}
+
+type Query {
+  item: Item
+    @connect(
+      source: "api"
+      http: { GET: "/item" }
+      selection: """
+        detail: kind->match(
+          ["short", {
+            __typename: "Summary",
+            brief: text
+          }],
+          [@, {
+            __typename: "FullText",
+            content: text
+          }]
+        )
+      """
+    )
+}


### PR DESCRIPTION
## Summary

- `walk_selection_with_shape` rejected union/interface-typed fields with `GROUP_SELECTION_IS_NOT_OBJECT` when they appeared as nested fields (e.g. `Stop.location: StopLocation` where `StopLocation` is a union populated via `->match`)
- The top-level `type_check_shape_based` already expanded abstract types to concrete members, but the recursive walk did not — this adds the same expansion
- Adds test cases for both nested unions and nested interfaces in `@connect` selections

<!-- FED-1082 -->

## Test plan

- [x] New `nested_union_in_selection.graphql` test — validates union-typed field in nested `->match` selection produces no errors
- [x] New `nested_interface_in_selection.graphql` test — same for interface-typed fields
- [x] Both tests produce `GROUP_SELECTION_IS_NOT_OBJECT` without the fix, `[]` with it
- [x] All 86 existing validation tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)