### PR TITLE
fix(state_machine): stop retrying reloads that cannot succeed

### DIFF
--- a/.changesets/fix_reload_error_classification.md
+++ b/.changesets/fix_reload_error_classification.md
@@ -1,0 +1,9 @@
+### Stop retrying schema, configuration, and license reloads that can never succeed ([PR #10000](https://github.com/apollographql/router/pull/10000))
+
+When the router hot reloads — because a new schema or license arrived from GraphOS, or because its configuration file changed — it now distinguishes failures that a retry might fix from ones it cannot. A schema that fails to parse, a configuration that violates license enforcement, or a schema using preview features that configuration hasn't enabled will fail in exactly the same way on every attempt, so the router no longer retries them on a timer — it keeps serving the last good state and waits for new inputs instead. Failures that could plausibly clear on their own, such as a plugin failing to reach a dependency while pipelines are being built, are retried as before.
+
+This only changes what happens on the retry timer. Whatever the failure, the router keeps serving the previously committed schema, configuration and license, and the next publish always gets an immediate attempt with a fresh retry budget.
+
+A new metric, `apollo.router.state.reload.attempt`, counts reload attempts. Its `is_success` attribute records whether the attempt built, and `error_kind` records why it didn't: `transient`, `permanent`, or `fatal`.
+
+By [@carodewig](https://github.com/carodewig) in https://github.com/apollographql/router/pull/10000

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -168,7 +168,9 @@ enum State<FA: RouterSuperServiceFactory> {
         license: PendingChange<Arc<LicenseState>>,
         retry_after: Instant,
         /// Retries remaining for the current pending (configuration, schema, license).
-        /// `None` means unlimited; `Some(0)` means exhausted.
+        /// `None` means unlimited; `Some(0)` means no further timer-driven attempt,
+        /// either because the budget ran out or because the last failure was permanent
+        /// (see `ReloadError`) and retrying the same inputs cannot help.
         /// Reset to the configured `max_retries` whenever a new publish is received
         /// so that each publish gets a fresh budget of attempts.
         retries_remaining: Option<u32>,
@@ -185,6 +187,54 @@ impl<FA: RouterSuperServiceFactory> Debug for State<FA> {
             Reloading { .. } => write!(f, "Reloading"),
             Stopped => write!(f, "Stopped"),
             Errored(_) => write!(f, "Errored"),
+        }
+    }
+}
+
+/// Why a reload attempt failed, classified by whether retrying the *same* inputs
+/// could ever succeed.
+///
+/// A permanent failure is a property of the inputs themselves — a schema that does
+/// not parse, or a configuration the current license forbids — so every attempt
+/// fails in exactly the same place. Retrying those on a timer burns CPU and floods
+/// logs without ever converging, so `attempt_reload` disarms the retry timer and
+/// keeps serving the last good state until the inputs change. Anything else is
+/// transient (a resource or network blip while building the new pipelines) and is
+/// retried as before.
+///
+/// Note that "permanent" is scoped to one set of inputs, not to the router: a new
+/// publish resets the retry budget in `accumulate_inputs`, so the next schema,
+/// configuration or license still gets an immediate attempt.
+enum ReloadError {
+    Transient(ApolloRouterError),
+    Permanent(ApolloRouterError),
+}
+
+impl ReloadError {
+    /// The value recorded as the `error_kind` attribute of
+    /// `apollo.router.state.reload.attempt`.
+    ///
+    /// This covers only what is intrinsic to the error. Whether a failure is *fatal*
+    /// is positional rather than intrinsic — it depends on whether `try_start` had
+    /// already consumed the server handle — so `attempt_reload` supplies that label
+    /// from the arm that knows.
+    fn error_kind(&self) -> &'static str {
+        match self {
+            Self::Transient(_) => "transient",
+            Self::Permanent(_) => "permanent",
+        }
+    }
+
+    /// True when a later attempt with the same inputs might succeed.
+    fn is_transient(&self) -> bool {
+        matches!(self, Self::Transient(_))
+    }
+
+    /// The underlying error, discarding the classification. Used once the retry
+    /// decision has been made and the failure is reported or becomes terminal.
+    fn into_inner(self) -> ApolloRouterError {
+        match self {
+            Self::Transient(err) | Self::Permanent(err) => err,
         }
     }
 }
@@ -225,7 +275,8 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
 
     /// Returns the scheduled retry instant if the state machine is in `Reloading`
     /// with at least one attempt remaining.  Returns `None` when not reloading or
-    /// when the retry budget is exhausted (`retries_remaining == Some(0)`).
+    /// when no timer-driven attempt should be made (`retries_remaining == Some(0)`,
+    /// set either by exhausting the budget or by a permanent failure).
     fn retry_after(&self) -> Option<Instant> {
         match self {
             Reloading {
@@ -408,7 +459,9 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                     &mut listen_addresses_guard,
                     vec![],
                 )
-                .map_ok_or_else(Errored, |f| f.0)
+                // Nothing is serving yet, so any startup failure is terminal and the
+                // classification does not apply.
+                .map_ok_or_else(|e| Errored(e.into_inner()), |f| f.0)
                 .await
             }
 
@@ -450,6 +503,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                             event = STATE_CHANGE,
                             "reload complete"
                         );
+                        record_reload_attempt(None);
                         // Explicitly drop the old factory before broadcasting notifications so
                         // that its resources (connections, background tasks) are fully torn down
                         // before any listeners act on the reload-complete signal.
@@ -471,11 +525,24 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                         new_state
                     }
                     Err(e) if server_handle.is_some() => {
-                        // Decrement the retry budget (saturating so it stops at 0, not wrapping).
-                        let retries_remaining = retries_remaining.map(|n| n.saturating_sub(1));
+                        let error_kind = e.error_kind();
+                        record_reload_attempt(Some(error_kind));
+
+                        let retries_remaining = if e.is_transient() {
+                            // Decrement the retry budget (saturating so it stops at 0, not wrapping).
+                            retries_remaining.map(|n| n.saturating_sub(1))
+                        } else {
+                            // Retrying will not help. Pin the budget at 0 to disarm the
+                            // timer — not a dead end, since `accumulate_inputs` resets it
+                            // on the next publish, which also gets an immediate attempt.
+                            Some(0)
+                        };
+
+                        let e = e.into_inner();
 
                         tracing::error!(
                             error = %e,
+                            error_kind,
                             retries_remaining = retries_remaining
                                 .map_or("unlimited".to_string(), |n| n.to_string()),
                             event = STATE_CHANGE,
@@ -501,8 +568,13 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                         }
                     }
                     // The point of no return was passed — server handle consumed
-                    // before the failure. Fatal.
+                    // before the failure. Fatal, whatever the classification.
                     Err(e) => {
+                        // Fatal is a property of this arm, not of the error: whatever kind
+                        // of failure it was, the server handle is gone and the router
+                        // cannot keep serving.
+                        record_reload_attempt(Some("fatal"));
+                        let e = e.into_inner();
                         tracing::error!(
                             error = %e,
                             event = STATE_CHANGE,
@@ -560,14 +632,17 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         license: Arc<LicenseState>,
         listen_addresses_guard: &mut OwnedRwLockWriteGuard<ListenAddresses>,
         mut all_connections_stopped_signals: Vec<mpsc::Receiver<()>>,
-    ) -> Result<(State<FA>, Arc<Schema>), ApolloRouterError>
+    ) -> Result<(State<FA>, Arc<Schema>), ReloadError>
     where
         S: HttpServerFactory,
         FA: RouterSuperServiceFactory,
     {
         let schema = Arc::new(
-            Schema::parse_arc(schema_state.clone(), &configuration)
-                .map_err(|e| ServiceCreationError(e.to_string().into()))?,
+            Schema::parse_arc(schema_state.clone(), &configuration).map_err(|e| {
+                // The same SDL and the same configuration parse identically every
+                // time, so there is nothing for a retry to fix.
+                ReloadError::Permanent(ServiceCreationError(e.to_string().into()))
+            })?,
         );
         // Check the license
         let report = LicenseEnforcementReport::build(&configuration, &schema, &license);
@@ -579,9 +654,13 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                         "The router is using features not available for your license:\n\n{}",
                         report
                     );
-                    return Err(ApolloRouterError::LicenseViolation(
+                    // Enforcement is a pure function of the configuration, schema and
+                    // license, so a retry of these three re-derives the same violation.
+                    // A newly published license arrives as its own event and gets its
+                    // own attempt.
+                    return Err(ReloadError::Permanent(ApolloRouterError::LicenseViolation(
                         report.restricted_features_in_use(),
-                    ));
+                    )));
                 } else {
                     tracing::debug!("A valid Apollo license has been detected.");
                     limits
@@ -593,9 +672,9 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                         "License violation, the router is using features not available for your license:\n\n{}\n\nThe license warning period has started. The Router will stop serving requests after the license expires. See {LICENSE_EXPIRED_URL} for more information.",
                         report
                     );
-                    return Err(ApolloRouterError::LicenseViolation(
+                    return Err(ReloadError::Permanent(ApolloRouterError::LicenseViolation(
                         report.restricted_features_in_use(),
-                    ));
+                    )));
                 } else {
                     tracing::warn!(
                         "License warning period has started. The Router will stop serving requests after the license expires. In order to continue using these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
@@ -640,9 +719,9 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                         report
                     );
                 }
-                return Err(ApolloRouterError::LicenseViolation(
+                return Err(ReloadError::Permanent(ApolloRouterError::LicenseViolation(
                     report.restricted_features_in_use(),
-                ));
+                )));
             }
             _ => {
                 tracing::debug!(
@@ -669,7 +748,9 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                 "The schema contains preview features not enabled in configuration.\n\n{}",
                 feature_gate_violations.iter().join("\n")
             );
-            return Err(ApolloRouterError::FeatureGateViolation);
+            return Err(ReloadError::Permanent(
+                ApolloRouterError::FeatureGateViolation,
+            ));
         }
 
         let router_service_factory = state_machine
@@ -683,40 +764,47 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                 effective_license.clone(),
             )
             .await
-            .map_err(ServiceCreationError)?;
+            // Building the pipelines can fail for reasons that have nothing to do with
+            // the inputs — a plugin failing to reach a dependency while it initializes,
+            // for example — so this is treated as transient and retried. A genuinely
+            // bad configuration will simply fail the same way on each attempt until the
+            // retry budget runs out.
+            .map_err(|e| ReloadError::Transient(ServiceCreationError(e)))?;
         // used to track if there are still in flight connections when shutting down
         let (all_connections_stopped_sender, all_connections_stopped_signal) =
             mpsc::channel::<()>(1);
         all_connections_stopped_signals.push(all_connections_stopped_signal);
         let web_endpoints = router_service_factory.web_endpoints();
 
-        // The point of no return. We take the previous server handle.
+        // The point of no return. We take the previous server handle, so a failure from
+        // here on is fatal — `attempt_reload` has no server left to fall back to, and it
+        // detects that from the handle rather than from the error. The classification
+        // below is therefore never acted on; transient is the honest label for these
+        // (a listen address in use does free up).
         let server_handle = match server_handle.take() {
-            None => {
-                state_machine
-                    .http_server_factory
-                    .create(
-                        router_service_factory.clone(),
-                        configuration.clone(),
-                        Default::default(),
-                        Default::default(),
-                        web_endpoints,
-                        effective_license,
-                        all_connections_stopped_sender,
-                    )
-                    .await?
-            }
-            Some(server_handle) => {
-                server_handle
-                    .restart(
-                        &state_machine.http_server_factory,
-                        router_service_factory.clone(),
-                        configuration.clone(),
-                        web_endpoints,
-                        effective_license,
-                    )
-                    .await?
-            }
+            None => state_machine
+                .http_server_factory
+                .create(
+                    router_service_factory.clone(),
+                    configuration.clone(),
+                    Default::default(),
+                    Default::default(),
+                    web_endpoints,
+                    effective_license,
+                    all_connections_stopped_sender,
+                )
+                .await
+                .map_err(ReloadError::Transient)?,
+            Some(server_handle) => server_handle
+                .restart(
+                    &state_machine.http_server_factory,
+                    router_service_factory.clone(),
+                    configuration.clone(),
+                    web_endpoints,
+                    effective_license,
+                )
+                .await
+                .map_err(ReloadError::Transient)?,
         };
 
         listen_addresses_guard.extra_listen_addresses = server_handle.listen_addresses().to_vec();
@@ -910,6 +998,38 @@ where
                 panic!("must finish on stopped or errored state")
             }
         }
+    }
+}
+
+/// Records the outcome of a single reload attempt, following the shape of
+/// `apollo.router.lifecycle.query_planner.init`: one counter per attempt carrying a
+/// success flag, plus the kind of failure when there is one. Emitting successes too
+/// is what makes a reload failure rate computable from this metric alone.
+///
+/// `error_kind` is `None` on success, and otherwise one of:
+/// - `"transient"` — the attempt may succeed if retried with the same inputs.
+/// - `"permanent"` — it cannot; the router waits for new inputs (see `ReloadError`).
+/// - `"fatal"` — the failure came after the point of no return, so the router stops.
+///
+/// Startup is not a reload and is deliberately not counted here.
+fn record_reload_attempt(error_kind: Option<&'static str>) {
+    if let Some(error_kind) = error_kind {
+        u64_counter_with_unit!(
+            "apollo.router.state.reload.attempt",
+            "Router reload attempts",
+            "{attempt}",
+            1,
+            "error_kind" = error_kind,
+            "is_success" = false
+        );
+    } else {
+        u64_counter_with_unit!(
+            "apollo.router.state.reload.attempt",
+            "Router reload attempts",
+            "{attempt}",
+            1,
+            "is_success" = true
+        );
     }
 }
 
@@ -2521,7 +2641,15 @@ mod tests {
                     StateMachine::for_tests(server_factory, router_factory, notify.clone());
                 let (tx, rx) = tokio::sync::mpsc::channel::<Event>(16);
                 let stream = ReceiverStream::new(rx);
-                let handle = tokio::spawn(state_machine.process_events(stream));
+                // The state machine runs in its own task, so it needs the calling test's
+                // meter provider explicitly — task locals do not cross `spawn`. Without
+                // this, metrics emitted by a reload would land in a different registry
+                // and `assert_counter!` would see nothing.
+                let handle = tokio::spawn(
+                    state_machine
+                        .process_events(stream)
+                        .with_current_meter_provider(),
+                );
                 Self { tx, notify, handle }
             }
 
@@ -2717,6 +2845,129 @@ mod tests {
             }
             harness.advance_and_wait(Duration::from_secs(11)).await; // 7th attempt succeeds
             harness.finish().await;
+        }
+
+        /// A schema that does not parse — the cheapest permanent failure to trigger,
+        /// and one that fails before `create()` is ever reached.
+        fn unparseable_schema() -> SchemaState {
+            SchemaState {
+                sdl: "this is not valid graphql".to_owned(),
+                launch_id: None,
+            }
+        }
+
+        // A permanent failure must disarm the retry timer rather than churn on it: the
+        // same inputs will fail in the same place every time.
+        //
+        // These failures happen early in try_start, before `create()` is reached, so the
+        // mock router factory's call count cannot observe the retries at all — it would
+        // pass whether or not the timer fired. Assert on the state machine's own
+        // transition signal instead: every loop iteration notifies exactly once, so a
+        // retry that fires leaves a permit behind.
+        #[test(tokio::test(start_paused = true))]
+        async fn permanent_failure_stops_retrying() {
+            // Only the startup build: the unparseable schema never reaches create().
+            let harness = Harness::new(factory(&[Ok(())]), 1);
+            harness.startup().await;
+            harness
+                .send_and_wait(UpdateSchema(unparseable_schema()))
+                .await;
+
+            let retried = harness.notify.notified();
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            assert!(
+                retried.now_or_never().is_none(),
+                "a permanent failure must not schedule a retry"
+            );
+
+            // Still serving the previous schema, and still able to shut down cleanly.
+            harness.finish().await;
+        }
+
+        // The same as `permanent_failure_stops_retrying`, but for a permanent failure that
+        // comes from license enforcement rather than the schema. Enforcement is derived
+        // from the configuration, schema and license together, so retrying an unlicensed
+        // router with a configuration that uses restricted features re-derives the
+        // identical violation.
+        #[test(tokio::test(start_paused = true))]
+        async fn permanent_license_failure_stops_retrying() {
+            // Startup is unlicensed with no restricted features in use, which is allowed.
+            let harness = Harness::new(factory(&[Ok(())]), 1);
+            harness.startup().await;
+            // Publishing a configuration that uses restricted features is a violation,
+            // and fails before create().
+            harness
+                .send_and_wait(UpdateConfiguration(test_config_restricted()))
+                .await;
+
+            let retried = harness.notify.notified();
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            assert!(
+                retried.now_or_never().is_none(),
+                "a permanent license violation must not schedule a retry"
+            );
+
+            harness.finish().await;
+        }
+
+        // Disarming the timer must not wedge the state machine. A permanent failure is
+        // permanent for *those inputs* only — the next publish resets the retry budget
+        // and gets an immediate attempt via the event arm.
+        #[test(tokio::test(start_paused = true))]
+        async fn permanent_failure_recovers_on_new_input() {
+            // Startup, then one more build for the good schema published after the
+            // unparseable one; the unparseable schema itself never reaches create().
+            let harness = Harness::new(factory(&[Ok(()), Ok(())]), 2);
+            harness.startup().await;
+            harness
+                .send_and_wait(UpdateSchema(unparseable_schema()))
+                .await;
+            harness.send_and_wait(UpdateSchema(minimal_schema())).await;
+            harness.finish().await;
+        }
+
+        // Every reload attempt is counted with its outcome, so that a reload failure rate
+        // is computable from this metric alone and a router stuck on a stale schema is
+        // distinguishable from one still retrying.
+        #[test(tokio::test(start_paused = true))]
+        async fn reload_attempt_metric_records_outcome() {
+            async {
+                let zero_retries = Arc::new(
+                    Configuration::from_str("reload:\n  max_retries: 0")
+                        .expect("config with max_retries: 0 must be valid"),
+                );
+                let harness = Harness::new(factory(&[Ok(()), Err(()), Ok(())]), 2);
+                harness.startup_with_config(zero_retries).await;
+
+                // A failing create() is transient: the same inputs may well build next time.
+                harness.send_and_wait(UpdateSchema(minimal_schema())).await;
+                assert_counter!(
+                    "apollo.router.state.reload.attempt",
+                    1,
+                    "error_kind" = "transient",
+                    "is_success" = false
+                );
+
+                // A schema that does not parse is permanent.
+                harness
+                    .send_and_wait(UpdateSchema(unparseable_schema()))
+                    .await;
+                assert_counter!(
+                    "apollo.router.state.reload.attempt",
+                    1,
+                    "error_kind" = "permanent",
+                    "is_success" = false
+                );
+
+                // A reload that builds is counted too — startup, which is not a reload,
+                // is not, so this is the first success recorded.
+                harness.send_and_wait(UpdateSchema(minimal_schema())).await;
+                assert_counter!("apollo.router.state.reload.attempt", 1, "is_success" = true);
+
+                harness.finish().await;
+            }
+            .with_metrics()
+            .await;
         }
 
         // Verify that the router can perform more than two consecutive successful reloads

--- a/docs/source/routing/configuration/hot-reload-schema.mdx
+++ b/docs/source/routing/configuration/hot-reload-schema.mdx
@@ -47,6 +47,10 @@ reload:
 
 The retry budget is reset whenever the router receives a new reload trigger — a new schema or license from Uplink, a configuration or rhai script file change, or an explicit reload signal — so any new change will always get a fresh set of attempts even if previous retries were exhausted.
 
+The router only retries failures that a later attempt might resolve. Some reloads fail for a reason that can't change on its own: a schema that doesn't parse, a configuration that isn't valid for your license, or a schema that uses preview features your configuration doesn't enable. The router doesn't spend retries on these. It keeps serving the previous schema, configuration, and license, and waits for your next update, which gets a fresh set of attempts.
+
+The `apollo.router.state.reload.attempt` metric counts reload attempts. Its `is_success` attribute tells you whether the reload built, and `error_kind` tells you why it didn't, so you can distinguish a router that's still retrying (`transient`) from one that's waiting for you to publish a fix (`permanent`).
+
 ## Production recommendations
 
 For production deployments with high traffic:


### PR DESCRIPTION
Bottom of a 3-PR stack (#10000 → #10001 → #10002). Review this one first.

## What

When the router hot reloads — a new schema or license from GraphOS, or a changed configuration file — it now distinguishes failures a retry might fix from ones it cannot.

`try_start` failures are classified `ReloadError::Transient` or `ReloadError::Permanent`. Permanent covers a schema that fails to parse, a configuration that violates license enforcement, and a schema using preview features the configuration hasn't enabled. Those are pure functions of the three inputs, so they fail identically on every attempt; the retry budget is pinned to `Some(0)` to disarm the timer rather than churn. Everything from `create()` stays transient and is retried as before.

Classification is applied at each failure site rather than derived from the `ApolloRouterError` variant, because a schema parse failure and a `create()` failure both surface as `ServiceCreationError` — the variant can't tell them apart.

## Scope

This only changes what happens on the retry timer. Whatever the failure, the router keeps serving the previously committed schema, configuration and license, and the next publish still gets an immediate attempt with a fresh budget.

## Observability

New counter `apollo.router.state.reload.attempt`, shaped like `apollo.router.lifecycle.query_planner.init`: one record per attempt with `is_success`, plus `error_kind` of `transient` / `permanent` / `fatal` on failure. Successes are recorded too, so a reload failure rate is computable from this metric alone. Startup is deliberately not counted — it is a start, not a reload.

`fatal` is not a `ReloadError` variant. Fatality is positional, decided by whether `try_start` had already consumed the server handle, so `attempt_reload` supplies that label from the arm that knows.

## Tests

Four new tests: no retry is scheduled after a permanent failure (schema parse, and separately license enforcement), a later good publish still recovers, and the metric attributes.

The two negative-assertion tests use `sleep` rather than `advance` under a paused clock. `advance` doesn't park the runtime, so an armed retry never actually runs and the assertion passes vacuously — verified by removing the classification, where the `sleep` form fails and the `advance` form does not.

Also threaded `with_current_meter_provider()` through the test harness's `tokio::spawn`, since task locals don't cross `spawn` and `assert_counter!` would otherwise see nothing.

## Known gap

The `"fatal"` label ships untested: `create_mock_server_factory` cannot fail, so no test reaches the point-of-no-return arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)