### PR TITLE
refactor(license_enforcement): move license validation into LicenseEnforcementReport

### DIFF
--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -41,9 +41,7 @@ use crate::router_factory::RouterFactory;
 use crate::router_factory::RouterSuperServiceFactory;
 use crate::spec::Schema;
 use crate::uplink::feature_gate_enforcement::FeatureGateEnforcementReport;
-use crate::uplink::license_enforcement::LICENSE_EXPIRED_URL;
 use crate::uplink::license_enforcement::LicenseEnforcementReport;
-use crate::uplink::license_enforcement::LicenseLimits;
 use crate::uplink::license_enforcement::LicenseState;
 use crate::uplink::schema::SchemaState;
 
@@ -645,9 +643,15 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
             })?,
         );
 
-        // Check the license
-        let report = LicenseEnforcementReport::build(&configuration, &schema, &license);
-        let effective_license = report.check(license.clone()).map_err(ReloadError::Permanent)?;
+        // Check the license. A violation is permanent: enforcement is a pure function of
+        // the configuration, schema and license, so retrying these same three inputs
+        // re-derives the same violation. A newly published license is a separate event
+        // and gets its own attempt. `LicenseEnforcementViolation` is the only error `enforce` can
+        // return, which is what makes this blanket mapping safe.
+        let report = LicenseEnforcementReport::build(&configuration, &schema, license.clone());
+        let effective_license = report
+            .enforce()
+            .map_err(|violation| ReloadError::Permanent(violation.into()))?;
 
         if let Err(feature_gate_violations) =
             FeatureGateEnforcementReport::build(&configuration, &schema).check()
@@ -988,6 +992,7 @@ mod tests {
     use crate::services::new_service::ServiceFactory;
     use crate::services::router;
     use crate::services::router::pipeline_handle::PipelineRef;
+    use crate::uplink::license_enforcement::LicenseLimits;
     use crate::uplink::schema::SchemaState;
 
     type SharedOneShotReceiver = Arc<Mutex<Vec<oneshot::Receiver<()>>>>;

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -644,102 +644,10 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                 ReloadError::Permanent(ServiceCreationError(e.to_string().into()))
             })?,
         );
+
         // Check the license
         let report = LicenseEnforcementReport::build(&configuration, &schema, &license);
-
-        let license_limits = match &*license {
-            LicenseState::Licensed { limits } => {
-                if report.uses_restricted_features() {
-                    tracing::error!(
-                        "The router is using features not available for your license:\n\n{}",
-                        report
-                    );
-                    // Enforcement is a pure function of the configuration, schema and
-                    // license, so a retry of these three re-derives the same violation.
-                    // A newly published license arrives as its own event and gets its
-                    // own attempt.
-                    return Err(ReloadError::Permanent(ApolloRouterError::LicenseViolation(
-                        report.restricted_features_in_use(),
-                    )));
-                } else {
-                    tracing::debug!("A valid Apollo license has been detected.");
-                    limits
-                }
-            }
-            LicenseState::LicensedWarn { limits } => {
-                if report.uses_restricted_features() {
-                    tracing::error!(
-                        "License violation, the router is using features not available for your license:\n\n{}\n\nThe license warning period has started. The Router will stop serving requests after the license expires. See {LICENSE_EXPIRED_URL} for more information.",
-                        report
-                    );
-                    return Err(ReloadError::Permanent(ApolloRouterError::LicenseViolation(
-                        report.restricted_features_in_use(),
-                    )));
-                } else {
-                    tracing::warn!(
-                        "License warning period has started. The Router will stop serving requests after the license expires. In order to continue using these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
-                        // The report does not contain any features because they are contained within the allowedFeatures claim,
-                        // therefore we output all of the allowed features that the user's license enables them to use.
-                        license.get_allowed_features()
-                    );
-                    limits
-                }
-            }
-            // LicensedHalt doesn't return an error, which might be surprising; rather, the middleware in the axum
-            // server (`license_handler`) will check for halted licenses and send back a canned response
-            LicenseState::LicensedHalt { limits } => {
-                if report.uses_restricted_features() {
-                    tracing::error!(
-                        "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
-                        report
-                    );
-                    limits
-                } else {
-                    tracing::error!(
-                        "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
-                        // The report does not contain any features because they are contained within the allowedFeatures claim,
-                        // therefore we output all of the allowed features that the user's license enables them to use.
-                        license.get_allowed_features()
-                    );
-                    limits
-                }
-            }
-            LicenseState::Unlicensed if report.uses_restricted_features() => {
-                // This is OSS, so fail to reload or start.
-                if crate::services::APOLLO_KEY.lock().is_some()
-                    && crate::services::APOLLO_GRAPH_REF.lock().is_some()
-                {
-                    tracing::error!(
-                        "License not found. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides a license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
-                        report
-                    );
-                } else {
-                    tracing::error!(
-                        "Not connected to GraphOS. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS (using APOLLO_KEY and APOLLO_GRAPH_REF) that provides a license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
-                        report
-                    );
-                }
-                return Err(ReloadError::Permanent(ApolloRouterError::LicenseViolation(
-                    report.restricted_features_in_use(),
-                )));
-            }
-            _ => {
-                tracing::debug!(
-                    "A valid Apollo license was not detected. However, no restricted features are in use."
-                );
-                // Without restricted features, there's no need to limit the router
-                &Option::<LicenseLimits>::None
-            }
-        };
-
-        // If there are no restricted features in use then the effective license is Licensed as we don't need warn or halt behavior.
-        let effective_license = if !report.uses_restricted_features() {
-            Arc::new(LicenseState::Licensed {
-                limits: license_limits.clone(),
-            })
-        } else {
-            license.clone()
-        };
+        let effective_license = report.check(license.clone()).map_err(ReloadError::Permanent)?;
 
         if let Err(feature_gate_violations) =
             FeatureGateEnforcementReport::build(&configuration, &schema).check()

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -468,57 +468,41 @@ impl LicenseEnforcementReport {
     }
 
     pub(crate) fn check(&self, license: Arc<LicenseState>) -> Result<Arc<LicenseState>, ApolloRouterError> {
+        if self.uses_restricted_features() {
+            self.check_restricted_features(license)
+        } else {
+            Ok(self.check_no_restricted_features(license))
+        }
+    }
+
+    fn check_restricted_features(&self, license: Arc<LicenseState>) -> Result<Arc<LicenseState>, ApolloRouterError> {
         let license_violation_error = || ApolloRouterError::LicenseViolation(self.restricted_features_in_use());
 
-        let license_limits = match &*license {
-            LicenseState::Licensed { limits } => {
-                if self.uses_restricted_features() {
-                    tracing::error!(
-                        "The router is using features not available for your license:\n\n{}",
-                        self
-                    );
-                    return Err(license_violation_error());
-                } else {
-                    tracing::debug!("A valid Apollo license has been detected.");
-                    limits
-                }
+         match &*license {
+            LicenseState::Licensed { .. } => {
+                tracing::error!(
+                    "The router is using features not available for your license:\n\n{}",
+                    self
+                );
+                Err(license_violation_error())
             }
-            LicenseState::LicensedWarn { limits } => {
-                if self.uses_restricted_features() {
-                    tracing::error!(
-                        "License violation, the router is using features not available for your license:\n\n{}\n\nThe license warning period has started. The Router will stop serving requests after the license expires. See {LICENSE_EXPIRED_URL} for more information.",
-                        self
-                    );
-                    return Err(license_violation_error());
-                } else {
-                    tracing::warn!(
-                        "License warning period has started. The Router will stop serving requests after the license expires. In order to continue using these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
-                        // The report does not contain any features because they are contained within the allowedFeatures claim,
-                        // therefore we output all of the allowed features that the user's license enables them to use.
-                        license.get_allowed_features()
-                    );
-                    limits
-                }
+            LicenseState::LicensedWarn { .. } => {
+                tracing::error!(
+                    "License violation, the router is using features not available for your license:\n\n{}\n\nThe license warning period has started. The Router will stop serving requests after the license expires. See {LICENSE_EXPIRED_URL} for more information.",
+                    self
+                );
+                Err(license_violation_error())
             }
             // LicensedHalt doesn't return an error, which might be surprising; rather, the middleware in the axum
             // server (`license_handler`) will check for halted licenses and send back a canned response
-            LicenseState::LicensedHalt { limits } => {
-                if self.uses_restricted_features() {
-                    tracing::error!(
-                        "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
-                        self
-                    );
-                } else {
-                    tracing::error!(
-                        "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
-                        // The report does not contain any features because they are contained within the allowedFeatures claim,
-                        // therefore we output all of the allowed features that the user's license enables them to use.
-                        license.get_allowed_features()
-                    );
-                }
-                limits
+            LicenseState::LicensedHalt { .. } => {
+                tracing::error!(
+                    "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
+                    self
+                );
+                Ok(license.clone())
             }
-            LicenseState::Unlicensed if self.uses_restricted_features() => {
+            LicenseState::Unlicensed => {
                 // This is OSS, so fail to reload or start.
                 if crate::services::APOLLO_KEY.lock().is_some()
                     && crate::services::APOLLO_GRAPH_REF.lock().is_some()
@@ -533,27 +517,50 @@ impl LicenseEnforcementReport {
                         self
                     );
                 }
-                return Err(license_violation_error());
+                Err(license_violation_error())
             }
-            _ => {
+        }
+    }
+
+    fn check_no_restricted_features(&self, license: Arc<LicenseState>) -> Arc<LicenseState> {
+        let license_limits = match &*license {
+            LicenseState::Licensed { limits } => {
+                tracing::debug!("A valid Apollo license has been detected.");
+                limits
+            }
+            LicenseState::LicensedWarn { limits } => {
+                tracing::warn!(
+                    "License warning period has started. The Router will stop serving requests after the license expires. In order to continue using these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
+                    // The report does not contain any features because they are contained within the allowedFeatures claim,
+                    // therefore we output all of the allowed features that the user's license enables them to use.
+                    license.get_allowed_features()
+                );
+                limits
+            }
+            // LicensedHalt doesn't return an error, which might be surprising; rather, the middleware in the axum
+            // server (`license_handler`) will check for halted licenses and send back a canned response
+            LicenseState::LicensedHalt { limits } => {
+                tracing::error!(
+                    "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
+                    // The report does not contain any features because they are contained within the allowedFeatures claim,
+                    // therefore we output all of the allowed features that the user's license enables them to use.
+                    license.get_allowed_features()
+                );
+                limits
+            }
+            LicenseState::Unlicensed => {
                 tracing::debug!(
                     "A valid Apollo license was not detected. However, no restricted features are in use."
                 );
                 // Without restricted features, there's no need to limit the router
-                &Option::<LicenseLimits>::None
+                &None
             }
         };
 
         // If there are no restricted features in use then the effective license is Licensed as we don't need warn or halt behavior.
-        let effective_license = if !self.uses_restricted_features() {
-            Arc::new(LicenseState::Licensed {
-                limits: license_limits.clone(),
-            })
-        } else {
-            license.clone()
-        };
-
-        Ok(effective_license)
+        Arc::new(LicenseState::Licensed {
+            limits: license_limits.clone(),
+        })
     }
 }
 

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -495,12 +495,11 @@ impl LicenseEnforcementReport {
     fn enforce_restricted_features(
         &self,
     ) -> Result<Arc<LicenseState>, LicenseEnforcementViolation> {
-        let license = self.license.clone();
         let license_violation_error = || LicenseEnforcementViolation {
             restricted_features: self.restricted_features_in_use(),
         };
 
-        match &*license {
+        match &*self.license {
             LicenseState::Licensed { .. } => {
                 tracing::error!(
                     "The router is using features not available for your license:\n\n{self}"
@@ -520,7 +519,7 @@ impl LicenseEnforcementReport {
                 tracing::error!(
                     "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{self}\n\nSee {LICENSE_EXPIRED_URL} for more information."
                 );
-                Ok(license.clone())
+                Ok(self.license.clone())
             }
             LicenseState::Unlicensed => {
                 // This is OSS, so fail to reload or start.
@@ -544,8 +543,7 @@ impl LicenseEnforcementReport {
     /// construction: with nothing to enforce, every license state is acceptable and
     /// only the logging differs.
     fn effective_license_unrestricted(&self) -> Arc<LicenseState> {
-        let license = self.license.clone();
-        let license_limits = match &*license {
+        let license_limits = match &*self.license {
             LicenseState::Licensed { limits } => {
                 tracing::debug!("A valid Apollo license has been detected.");
                 limits
@@ -555,7 +553,7 @@ impl LicenseEnforcementReport {
                     "License warning period has started. The Router will stop serving requests after the license expires. In order to continue using these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
                     // The report does not contain any features because they are contained within the allowedFeatures claim,
                     // therefore we output all of the allowed features that the user's license enables them to use.
-                    license.get_allowed_features()
+                    self.license.get_allowed_features()
                 );
                 limits
             }
@@ -566,7 +564,7 @@ impl LicenseEnforcementReport {
                     "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
                     // The report does not contain any features because they are contained within the allowedFeatures claim,
                     // therefore we output all of the allowed features that the user's license enables them to use.
-                    license.get_allowed_features()
+                    self.license.get_allowed_features()
                 );
                 limits
             }

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -34,7 +34,8 @@ use strum::IntoEnumIterator;
 use thiserror::Error;
 
 use super::parsed_link_spec::ParsedLinkSpec;
-use crate::{ApolloRouterError, Configuration};
+use crate::ApolloRouterError;
+use crate::Configuration;
 use crate::plugins::authentication::jwks::convert_key_algorithm;
 use crate::spec::LINK_DIRECTIVE_NAME;
 use crate::spec::Schema;
@@ -467,7 +468,10 @@ impl LicenseEnforcementReport {
         schema_restrictions
     }
 
-    pub(crate) fn check(&self, license: Arc<LicenseState>) -> Result<Arc<LicenseState>, ApolloRouterError> {
+    pub(crate) fn check(
+        &self,
+        license: Arc<LicenseState>,
+    ) -> Result<Arc<LicenseState>, ApolloRouterError> {
         if self.uses_restricted_features() {
             self.check_restricted_features(license)
         } else {
@@ -475,30 +479,32 @@ impl LicenseEnforcementReport {
         }
     }
 
-    fn check_restricted_features(&self, license: Arc<LicenseState>) -> Result<Arc<LicenseState>, ApolloRouterError> {
-        let license_violation_error = || ApolloRouterError::LicenseViolation(self.restricted_features_in_use());
+    fn check_restricted_features(
+        &self,
+        license: Arc<LicenseState>,
+    ) -> Result<Arc<LicenseState>, ApolloRouterError> {
+        let license_violation_error =
+            || ApolloRouterError::LicenseViolation(self.restricted_features_in_use());
 
-         match &*license {
+        match &*license {
             LicenseState::Licensed { .. } => {
                 tracing::error!(
-                    "The router is using features not available for your license:\n\n{}",
-                    self
+                    "The router is using features not available for your license:\n\n{self}"
                 );
                 Err(license_violation_error())
             }
             LicenseState::LicensedWarn { .. } => {
                 tracing::error!(
-                    "License violation, the router is using features not available for your license:\n\n{}\n\nThe license warning period has started. The Router will stop serving requests after the license expires. See {LICENSE_EXPIRED_URL} for more information.",
-                    self
+                    "License violation, the router is using features not available for your license:\n\n{self}\n\nThe license warning period has started. The Router will stop serving requests after the license expires. See {LICENSE_EXPIRED_URL} for more information."
                 );
                 Err(license_violation_error())
             }
+
             // LicensedHalt doesn't return an error, which might be surprising; rather, the middleware in the axum
             // server (`license_handler`) will check for halted licenses and send back a canned response
             LicenseState::LicensedHalt { .. } => {
                 tracing::error!(
-                    "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
-                    self
+                    "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{self}\n\nSee {LICENSE_EXPIRED_URL} for more information."
                 );
                 Ok(license.clone())
             }
@@ -508,13 +514,11 @@ impl LicenseEnforcementReport {
                     && crate::services::APOLLO_GRAPH_REF.lock().is_some()
                 {
                     tracing::error!(
-                        "License not found. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides a license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
-                        self
+                        "License not found. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides a license for the following features:\n\n{self}\n\nSee {LICENSE_EXPIRED_URL} for more information."
                     );
                 } else {
                     tracing::error!(
-                        "Not connected to GraphOS. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS (using APOLLO_KEY and APOLLO_GRAPH_REF) that provides a license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
-                        self
+                        "Not connected to GraphOS. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS (using APOLLO_KEY and APOLLO_GRAPH_REF) that provides a license for the following features:\n\n{self}\n\nSee {LICENSE_EXPIRED_URL} for more information."
                     );
                 }
                 Err(license_violation_error())

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -468,6 +468,8 @@ impl LicenseEnforcementReport {
     }
 
     pub(crate) fn check(&self, license: Arc<LicenseState>) -> Result<Arc<LicenseState>, ApolloRouterError> {
+        let license_violation_error = || ApolloRouterError::LicenseViolation(self.restricted_features_in_use());
+
         let license_limits = match &*license {
             LicenseState::Licensed { limits } => {
                 if self.uses_restricted_features() {
@@ -475,13 +477,7 @@ impl LicenseEnforcementReport {
                         "The router is using features not available for your license:\n\n{}",
                         self
                     );
-                    // Enforcement is a pure function of the configuration, schema and
-                    // license, so a retry of these three re-derives the same violation.
-                    // A newly published license arrives as its own event and gets its
-                    // own attempt.
-                    return Err(ApolloRouterError::LicenseViolation(
-                        self.restricted_features_in_use(),
-                    ));
+                    return Err(license_violation_error());
                 } else {
                     tracing::debug!("A valid Apollo license has been detected.");
                     limits
@@ -493,9 +489,7 @@ impl LicenseEnforcementReport {
                         "License violation, the router is using features not available for your license:\n\n{}\n\nThe license warning period has started. The Router will stop serving requests after the license expires. See {LICENSE_EXPIRED_URL} for more information.",
                         self
                     );
-                    return Err((ApolloRouterError::LicenseViolation(
-                        self.restricted_features_in_use(),
-                    )));
+                    return Err(license_violation_error());
                 } else {
                     tracing::warn!(
                         "License warning period has started. The Router will stop serving requests after the license expires. In order to continue using these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
@@ -539,9 +533,7 @@ impl LicenseEnforcementReport {
                         self
                     );
                 }
-                return Err((ApolloRouterError::LicenseViolation(
-                    self.restricted_features_in_use(),
-                )));
+                return Err(license_violation_error());
             }
             _ => {
                 tracing::debug!(

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -7,7 +7,9 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::ops::Deref;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
@@ -32,7 +34,7 @@ use strum::IntoEnumIterator;
 use thiserror::Error;
 
 use super::parsed_link_spec::ParsedLinkSpec;
-use crate::Configuration;
+use crate::{ApolloRouterError, Configuration};
 use crate::plugins::authentication::jwks::convert_key_algorithm;
 use crate::spec::LINK_DIRECTIVE_NAME;
 use crate::spec::Schema;
@@ -463,6 +465,103 @@ impl LicenseEnforcementReport {
         }
 
         schema_restrictions
+    }
+
+    pub(crate) fn check(&self, license: Arc<LicenseState>) -> Result<Arc<LicenseState>, ApolloRouterError> {
+        let license_limits = match &*license {
+            LicenseState::Licensed { limits } => {
+                if self.uses_restricted_features() {
+                    tracing::error!(
+                        "The router is using features not available for your license:\n\n{}",
+                        self
+                    );
+                    // Enforcement is a pure function of the configuration, schema and
+                    // license, so a retry of these three re-derives the same violation.
+                    // A newly published license arrives as its own event and gets its
+                    // own attempt.
+                    return Err(ApolloRouterError::LicenseViolation(
+                        self.restricted_features_in_use(),
+                    ));
+                } else {
+                    tracing::debug!("A valid Apollo license has been detected.");
+                    limits
+                }
+            }
+            LicenseState::LicensedWarn { limits } => {
+                if self.uses_restricted_features() {
+                    tracing::error!(
+                        "License violation, the router is using features not available for your license:\n\n{}\n\nThe license warning period has started. The Router will stop serving requests after the license expires. See {LICENSE_EXPIRED_URL} for more information.",
+                        self
+                    );
+                    return Err((ApolloRouterError::LicenseViolation(
+                        self.restricted_features_in_use(),
+                    )));
+                } else {
+                    tracing::warn!(
+                        "License warning period has started. The Router will stop serving requests after the license expires. In order to continue using these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
+                        // The report does not contain any features because they are contained within the allowedFeatures claim,
+                        // therefore we output all of the allowed features that the user's license enables them to use.
+                        license.get_allowed_features()
+                    );
+                    limits
+                }
+            }
+            // LicensedHalt doesn't return an error, which might be surprising; rather, the middleware in the axum
+            // server (`license_handler`) will check for halted licenses and send back a canned response
+            LicenseState::LicensedHalt { limits } => {
+                if self.uses_restricted_features() {
+                    tracing::error!(
+                        "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
+                        self
+                    );
+                } else {
+                    tracing::error!(
+                        "License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{:?}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
+                        // The report does not contain any features because they are contained within the allowedFeatures claim,
+                        // therefore we output all of the allowed features that the user's license enables them to use.
+                        license.get_allowed_features()
+                    );
+                }
+                limits
+            }
+            LicenseState::Unlicensed if self.uses_restricted_features() => {
+                // This is OSS, so fail to reload or start.
+                if crate::services::APOLLO_KEY.lock().is_some()
+                    && crate::services::APOLLO_GRAPH_REF.lock().is_some()
+                {
+                    tracing::error!(
+                        "License not found. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides a license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
+                        self
+                    );
+                } else {
+                    tracing::error!(
+                        "Not connected to GraphOS. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS (using APOLLO_KEY and APOLLO_GRAPH_REF) that provides a license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.",
+                        self
+                    );
+                }
+                return Err((ApolloRouterError::LicenseViolation(
+                    self.restricted_features_in_use(),
+                )));
+            }
+            _ => {
+                tracing::debug!(
+                    "A valid Apollo license was not detected. However, no restricted features are in use."
+                );
+                // Without restricted features, there's no need to limit the router
+                &Option::<LicenseLimits>::None
+            }
+        };
+
+        // If there are no restricted features in use then the effective license is Licensed as we don't need warn or halt behavior.
+        let effective_license = if !self.uses_restricted_features() {
+            Arc::new(LicenseState::Licensed {
+                limits: license_limits.clone(),
+            })
+        } else {
+            license.clone()
+        };
+
+        Ok(effective_license)
     }
 }
 

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt::Display;
 use std::fmt::Formatter;
-use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -110,6 +109,10 @@ where
 pub(crate) struct LicenseEnforcementReport {
     restricted_config_in_use: Vec<ConfigurationRestriction>,
     restricted_schema_in_use: Vec<SchemaViolation>,
+    /// The license the restrictions above were derived from. Held so that `enforce`
+    /// cannot be handed a *different* license than the one the report was built
+    /// against, which would silently produce a verdict about neither.
+    license: Arc<LicenseState>,
 }
 
 impl LicenseEnforcementReport {
@@ -120,17 +123,18 @@ impl LicenseEnforcementReport {
     pub(crate) fn build(
         configuration: &Configuration,
         schema: &Schema,
-        license: &LicenseState,
+        license: Arc<LicenseState>,
     ) -> LicenseEnforcementReport {
         LicenseEnforcementReport {
             restricted_config_in_use: Self::validate_configuration(
                 configuration,
-                &Self::configuration_restrictions(license),
+                &Self::configuration_restrictions(&license),
             ),
             restricted_schema_in_use: Self::validate_schema(
                 schema,
-                &Self::schema_restrictions(license),
+                &Self::schema_restrictions(&license),
             ),
+            license,
         }
     }
 
@@ -468,23 +472,33 @@ impl LicenseEnforcementReport {
         schema_restrictions
     }
 
-    pub(crate) fn check(
-        &self,
-        license: Arc<LicenseState>,
-    ) -> Result<Arc<LicenseState>, ApolloRouterError> {
+    /// Applies license enforcement, returning the *effective* license the router
+    /// should run under.
+    ///
+    /// The effective license is not always the published one: when no restricted
+    /// features are in use there is nothing to warn or halt about, so any license
+    /// collapses to `Licensed` and the router runs unrestricted.
+    ///
+    /// `LicenseEnforcementViolation` is the only failure this can produce, and it is a pure
+    /// function of the configuration, schema and license the report was built from —
+    /// see the type's documentation.
+    pub(crate) fn enforce(&self) -> Result<Arc<LicenseState>, LicenseEnforcementViolation> {
         if self.uses_restricted_features() {
-            self.check_restricted_features(license)
+            self.enforce_restricted_features()
         } else {
-            Ok(self.check_no_restricted_features(license))
+            Ok(self.effective_license_unrestricted())
         }
     }
 
-    fn check_restricted_features(
+    /// Enforcement when restricted features *are* in use, so the license has to
+    /// actually permit them.
+    fn enforce_restricted_features(
         &self,
-        license: Arc<LicenseState>,
-    ) -> Result<Arc<LicenseState>, ApolloRouterError> {
-        let license_violation_error =
-            || ApolloRouterError::LicenseViolation(self.restricted_features_in_use());
+    ) -> Result<Arc<LicenseState>, LicenseEnforcementViolation> {
+        let license = self.license.clone();
+        let license_violation_error = || LicenseEnforcementViolation {
+            restricted_features: self.restricted_features_in_use(),
+        };
 
         match &*license {
             LicenseState::Licensed { .. } => {
@@ -526,7 +540,11 @@ impl LicenseEnforcementReport {
         }
     }
 
-    fn check_no_restricted_features(&self, license: Arc<LicenseState>) -> Arc<LicenseState> {
+    /// The effective license when no restricted features are in use. Infallible by
+    /// construction: with nothing to enforce, every license state is acceptable and
+    /// only the logging differs.
+    fn effective_license_unrestricted(&self) -> Arc<LicenseState> {
+        let license = self.license.clone();
         let license_limits = match &*license {
             LicenseState::Licensed { limits } => {
                 tracing::debug!("A valid Apollo license has been detected.");
@@ -594,6 +612,26 @@ impl Display for LicenseEnforcementReport {
         }
 
         Ok(())
+    }
+}
+
+/// The router is using features its license does not permit.
+///
+/// This is deliberately the *only* failure `LicenseEnforcementReport::enforce` can
+/// return, rather than the broader `ApolloRouterError`. Enforcement is a pure
+/// function of the configuration, schema and license, so callers are entitled to
+/// treat this as permanent — re-running enforcement on the same three inputs derives
+/// the same violation. Keeping the type this narrow means that entitlement is checked
+/// by the compiler: a new failure mode inside `enforce` cannot quietly inherit
+/// "permanent" without changing this signature.
+#[derive(Debug)]
+pub(crate) struct LicenseEnforcementViolation {
+    restricted_features: Vec<String>,
+}
+
+impl From<LicenseEnforcementViolation> for ApolloRouterError {
+    fn from(violation: LicenseEnforcementViolation) -> Self {
+        ApolloRouterError::LicenseViolation(violation.restricted_features)
     }
 }
 
@@ -971,6 +1009,7 @@ impl License {
 mod test {
     use std::collections::HashSet;
     use std::str::FromStr;
+    use std::sync::Arc;
     use std::time::Duration;
     use std::time::UNIX_EPOCH;
 
@@ -982,6 +1021,7 @@ mod test {
     use crate::spec::Schema;
     use crate::uplink::license_enforcement::Audience;
     use crate::uplink::license_enforcement::Claims;
+    use crate::uplink::license_enforcement::ConfigurationRestriction;
     use crate::uplink::license_enforcement::License;
     use crate::uplink::license_enforcement::LicenseEnforcementReport;
     use crate::uplink::license_enforcement::LicenseLimits;
@@ -998,7 +1038,115 @@ mod test {
         let schema =
             Schema::parse(supergraph_schema, &config).expect("supergraph schema must be valid");
 
-        LicenseEnforcementReport::build(&config, &schema, &license)
+        LicenseEnforcementReport::build(&config, &schema, Arc::new(license))
+    }
+
+    /// A report for `license`, carrying one fake restricted-feature entry when
+    /// `uses_restricted_features` is set. Constructed directly rather than through
+    /// `build` so that each case states exactly the two things enforcement depends
+    /// on, without a configuration and schema in between.
+    fn report_for(
+        license: LicenseState,
+        uses_restricted_features: bool,
+    ) -> LicenseEnforcementReport {
+        let mut config_restrictions = Vec::new();
+        if uses_restricted_features {
+            config_restrictions.push(
+                ConfigurationRestriction::builder()
+                    .name("Test feature")
+                    .path("$.test")
+                    .build(),
+            );
+        }
+
+        LicenseEnforcementReport {
+            restricted_config_in_use: config_restrictions,
+            restricted_schema_in_use: vec![],
+            license: Arc::new(license),
+        }
+    }
+
+    // With nothing restricted in use there is nothing to enforce, so every license
+    // state is acceptable and collapses to `Licensed`: warn and halt behavior only
+    // exists to police restricted features, and there are none.
+    #[rstest::rstest]
+    #[case(LicenseState::Licensed { limits: None })]
+    #[case(LicenseState::LicensedWarn { limits: None })]
+    #[case(LicenseState::LicensedHalt { limits: None })]
+    #[case(LicenseState::Unlicensed)]
+    fn test_enforce_without_restricted_features_collapses_to_licensed(
+        #[case] license: LicenseState,
+    ) {
+        let effective = report_for(license.clone(), false)
+            .enforce()
+            .expect("no restricted features in use, so any license is acceptable");
+
+        assert_eq!(
+            *effective,
+            LicenseState::Licensed { limits: None },
+            "{license} should collapse to Licensed when nothing is restricted"
+        );
+    }
+
+    // Collapsing to `Licensed` must carry the limits over rather than discarding them —
+    // dropping them would silently un-limit a router whose license caps it.
+    #[rstest::rstest]
+    #[case(LicenseState::Licensed { limits: Some(LicenseLimits::default()) })]
+    #[case(LicenseState::LicensedWarn { limits: Some(LicenseLimits::default()) })]
+    #[case(LicenseState::LicensedHalt { limits: Some(LicenseLimits::default()) })]
+    fn test_enforce_without_restricted_features_preserves_limits(#[case] license: LicenseState) {
+        let effective = report_for(license.clone(), false)
+            .enforce()
+            .expect("no restricted features in use, so any license is acceptable");
+
+        assert_eq!(
+            *effective,
+            LicenseState::Licensed {
+                limits: Some(LicenseLimits::default())
+            },
+            "{license} should keep its limits when collapsing to Licensed"
+        );
+    }
+
+    // Once restricted features are in use the license has to actually permit them.
+    // Licensed and LicensedWarn mean the features are not paid for, and Unlicensed
+    // means there is no license at all; all three are violations naming the feature.
+    #[rstest::rstest]
+    #[case(LicenseState::Licensed { limits: None })]
+    #[case(LicenseState::LicensedWarn { limits: None })]
+    #[case(LicenseState::Unlicensed)]
+    fn test_enforce_with_restricted_features_rejects_licenses_that_do_not_permit_them(
+        #[case] license: LicenseState,
+    ) {
+        let violation = report_for(license.clone(), true)
+            .enforce()
+            .expect_err("restricted features in use must be a violation");
+
+        assert_eq!(
+            violation.restricted_features,
+            vec!["Test feature".to_string()],
+            "{license} should report the restricted feature in use"
+        );
+    }
+
+    // LicensedHalt is the one state that passes enforcement *with* restricted features
+    // in use, and the one case where the effective license is not `Licensed`. Halting is
+    // enforced by the axum middleware (`license_handler`) returning a canned response,
+    // not by refusing to build the router — so the halt state has to survive to the
+    // server, and collapsing it here would quietly resume serving an expired license.
+    #[rstest::rstest]
+    #[case(None)]
+    #[case(Some(LicenseLimits::default()))]
+    fn test_enforce_with_restricted_features_preserves_halt(#[case] limits: Option<LicenseLimits>) {
+        let license = LicenseState::LicensedHalt {
+            limits: limits.clone(),
+        };
+
+        let effective = report_for(license.clone(), true)
+            .enforce()
+            .expect("a halted license does not fail enforcement");
+
+        assert_eq!(*effective, LicenseState::LicensedHalt { limits });
     }
 
     #[test]


### PR DESCRIPTION
Second of a 3-PR stack (#10000 → #10001 → #10002). Stacked on #10000.

Pure refactor — no behavior change.

## What

License validation lived in `state_machine.rs` as a single `match` on `LicenseState` with an `if report.uses_restricted_features()` inside each arm. This moves it onto `LicenseEnforcementReport`, where the data already is, and inverts the nesting: restricted-vs-not on the outside, license state inside.

## Why the inversion is worth it

Both resulting matches are exhaustive over `LicenseState` with no `_` arm. Previously `_` silently absorbed `Unlicensed && !restricted`, so adding a `LicenseState` variant would have compiled and fallen into it with `None` limits. Now it's a compile error in both places.

## The API is narrower too

- **The report holds the license it was built from**, so `enforce()` takes no arguments. Previously the license was passed to both `build()` and the check, with nothing stopping the two from being different licenses — which would have produced a verdict about neither.
- **`enforce()` returns `LicenseEnforcementViolation`**, not `ApolloRouterError`. That is the only failure it can produce, so #10000's blanket mapping to a permanent reload error is now total by construction: a new failure mode inside `enforce` cannot inherit "permanent" without changing this signature and forcing the call site to be revisited.
- `check` → `enforce`, and its two halves to `enforce_restricted_features` / `effective_license_unrestricted`, so the infallible one no longer reads as a check.

## Verification

I enumerated all 8 combinations of license state × `uses_restricted_features()` against the original nested form. Every outcome and every log message matches, including the two easy-to-break ones:

- **LicensedHalt + restricted** → still `Ok`, and still returns the *halt* license rather than collapsing it to `Licensed`. Halting is enforced by the axum `license_handler` middleware, so the halt state has to survive to the server; collapsing it would quietly resume serving an expired license.
- **Unlicensed + not restricted** → previously reached only via `_`; now handled explicitly with the same `debug!` and `None` limits.

Adds unit tests over that matrix (4 `rstest` functions, 12 cases) covering the collapse to `Licensed`, that limits survive the collapse, which states violate, and that `LicensedHalt` keeps its halt state. Previously this logic was only reachable indirectly through `try_start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)