### PR TITLE
fix(rhai): redact the Rhai wrapper from client-facing error responses

### DIFF
--- a/.changesets/fix_rohan_b99_redact_rhai_internals_from_client_errors.md
+++ b/.changesets/fix_rohan_b99_redact_rhai_internals_from_client_errors.md
@@ -1,0 +1,32 @@
+### Stop disclosing Rhai internals in client-facing error responses ([PR #10004](https://github.com/apollographql/router/pull/10004))
+
+When a Rhai script failed, the router wrapped the failure in its own error text before returning it to the client, which exposed the fact that the router runs Rhai, the names of the script's callbacks, and the line and position where the failure happened:
+
+```json
+{
+  "errors": [
+    {
+      "message": "rhai execution error: 'Runtime error: Invalid request (line 25, position 39)\nin call to function 'process_router_request' @ 'process_router_request' (line 6, position 29)'"
+    }
+  ]
+}
+```
+
+Clients now receive only the message the script author chose. A thrown string is returned as written, with the Rhai wrapper stripped:
+
+```rhai
+throw "Invalid request";                          // client sees: Invalid request
+throw #{ status: 403, message: "Forbidden" };     // client sees: Forbidden
+throw #{ status: 403, body: #{ errors: [...] } }; // client sees the custom body
+```
+
+Anything the script did *not* choose is replaced with the status code's reason phrase, and the underlying error is logged at `ERROR` level instead. This covers failures raised by the Rhai engine itself (such as calling an undefined function or a type mismatch), a `throw` carrying only a status - `throw #{ status: 400 }` now reads `Bad Request` rather than dumping the thrown object - failures in the router's own Rhai functions that carry no message, such as reading a header that isn't present, and a `throw` the router cannot read as a message - a value that is not a string or an object map, such as `throw 42`, or a map with an unreadable field, such as `throw #{ status: "four hundred", message: "Invalid request" }`, which is discarded whole so the `message` beside the bad status goes with it.
+
+Failures in the router's own Rhai functions that *do* carry a message are only partly covered: the wrapper, the script line and position and the chain of callbacks are gone, but the function's own message still reaches the client. `env::get()` on a variable that isn't set still reports `could not expand variable: MY_VAR, environment variable not found`, and `json::decode()` on malformed input still reports the parse error. A router function's error is indistinguishable from a script's own `throw`, so telling them apart would take recording which side raised it - the Rhai customization docs carry this as a documented limitation. If a script of yours calls those functions on a client-facing path, catch the error and throw your own.
+
+Two things to be aware of when upgrading:
+
+- Client-facing messages for a thrown string no longer include the `rhai execution error: 'Runtime error: ... (line N, position M)'` wrapper. Only the string you threw is returned. The full error is still in the logs.
+- Nothing changes for scripts themselves: a `catch` block receives exactly what it received before, and status codes are unchanged.
+
+By [@rohan-b99](https://github.com/rohan-b99) in https://github.com/apollographql/router/pull/10004

--- a/apollo-router/src/plugins/rhai/engine/mod.rs
+++ b/apollo-router/src/plugins/rhai/engine/mod.rs
@@ -76,6 +76,25 @@ const CANNOT_ACCESS_STATUS_CODE_ON_A_DEFERRED_RESPONSE: &str =
 
 const CANNOT_GET_ENVIRONMENT_VARIABLE: &str = "environment variable not found";
 
+/// Raised by a router Rhai function that has nothing to tell a client - a lookup that found
+/// nothing, for instance.
+///
+/// A router function's error is indistinguishable from a script's own `throw "..."`: both arrive as
+/// `EvalAltResult::ErrorRuntime` carrying a string, with nothing recording which side raised it.
+/// `super::process_error` therefore discriminates on the value, not the origin - it redacts an
+/// empty message and returns any other verbatim - and this constant is that value. Two consequences
+/// worth knowing:
+///
+/// - Giving this text would disclose it, and the Rhai function it came from, in client-facing error
+///   responses. That is why the router functions above raise nothing rather than something helpful.
+/// - A script's own `throw ""` is redacted by the same branch, because nothing can tell it apart.
+///
+/// Router functions that *do* raise text (`env::get`, `json::decode`) therefore reach clients with
+/// that text. Redacting them as well would take provenance rather than a value check: a distinct
+/// thrown type, or a variant other than `ErrorRuntime`, so the two can be told apart without
+/// inspecting the message. The Rhai customization docs carry this as a documented limitation.
+pub(super) const NO_CLIENT_MESSAGE: &str = "";
+
 pub(crate) use types::OptionDance;
 pub(crate) use types::SharedMut;
 
@@ -278,7 +297,7 @@ mod router_header_map {
         x: &mut HeaderMap,
         key: &str,
     ) -> Result<String, Box<EvalAltResult>> {
-        Ok(String::from_utf8_lossy(x.remove(key).ok_or("")?.as_bytes()).to_string())
+        Ok(String::from_utf8_lossy(x.remove(key).ok_or(NO_CLIENT_MESSAGE)?.as_bytes()).to_string())
     }
 
     // Register a HeaderMap indexer so we can get/set headers
@@ -296,7 +315,10 @@ mod router_header_map {
     ) -> Result<String, Box<EvalAltResult>> {
         let search_name =
             HeaderName::from_str(key).map_err(|e: InvalidHeaderName| e.to_string())?;
-        Ok(String::from_utf8_lossy(x.get(search_name).ok_or("")?.as_bytes()).to_string())
+        Ok(
+            String::from_utf8_lossy(x.get(search_name).ok_or(NO_CLIENT_MESSAGE)?.as_bytes())
+                .to_string(),
+        )
     }
 
     #[rhai_fn(index_set, return_raw)]

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -389,7 +389,10 @@ macro_rules! gen_map_response {
                     if let Err(error) = result {
                         let error_details = process_error(error);
                         if error_details.body.is_none() {
-                            tracing::error!("map_request callback failed: {error_details:#?}");
+                            // The response macros run outside the span the request macros install,
+                            // so the stage has to be named on the event itself - it is all an
+                            // operator has to go on once the client message is redacted.
+                            tracing::error!(rhai.stage = %$stage, "map_response callback failed: {error_details:#?}");
                         }
                         let mut guard = shared_response.lock();
                         let response_opt = guard.take();
@@ -442,7 +445,7 @@ macro_rules! gen_map_router_deferred_response {
                     if let Err(error) = result {
                         let error_details = process_error(error);
                         if error_details.body.is_none() {
-                            tracing::error!("map_request callback failed: {error_details:#?}");
+                            tracing::error!(rhai.stage = %$stage, "map_response callback failed: {error_details:#?}");
                         }
                         let response_opt = shared_response.lock().take();
                         return Ok($base::response_failure(
@@ -537,10 +540,20 @@ macro_rules! gen_map_deferred_response {
                     if first.is_none() {
                         let error_details = ErrorDetails {
                             status: StatusCode::INTERNAL_SERVER_ERROR,
-                            message: Some("rhai execution error: empty response".to_string()),
+                            message: Some(redacted_message(StatusCode::INTERNAL_SERVER_ERROR)),
                             position: None,
-                            body: None
+                            body: None,
+                            // No Rhai error to redact, since no callback ran. The
+                            // `rhai execution error` prefix is still the marker every cause behind
+                            // a redacted client response is logged under, so keep it here too -
+                            // one log query has to find the whole class.
+                            internal_detail: Some(
+                                "rhai execution error: the response stream ended before a primary response was available".to_string()
+                            ),
                         };
+                        // Not a callback failure: the response stream ended before there was a
+                        // primary response to hand the map_response callback, so it never ran.
+                        tracing::error!(rhai.stage = %$stage, "map_response was not called: {error_details:#?}");
                         return Ok($base::response_failure(
                             context,
                             error_details
@@ -567,7 +580,7 @@ macro_rules! gen_map_deferred_response {
                     if let Err(error) = result {
                         let error_details = process_error(error);
                         if error_details.body.is_none() {
-                            tracing::error!("map_request callback failed: {error_details:#?}");
+                            tracing::error!(rhai.stage = %$stage, "map_response callback failed: {error_details:#?}");
                         }
                         let mut guard = shared_response.lock();
                         let response_opt = guard.take();
@@ -605,7 +618,7 @@ macro_rules! gen_map_deferred_response {
                             if let Err(error) = result {
                                 let error_details = process_error(error);
                                 if error_details.body.is_none() {
-                                    tracing::error!("map_request callback failed: {error_details:#?}");
+                                    tracing::error!(rhai.stage = %$stage, "map_response callback failed: {error_details:#?}");
                                 }
                                 let mut guard = shared_response.lock();
                                 let response_opt = guard.take();
@@ -759,31 +772,91 @@ struct ErrorDetails {
     message: Option<String>,
     position: Option<Position>,
     body: Option<crate::graphql::Response>,
+    /// The unredacted Rhai error, kept for server-side logging only.
+    ///
+    /// This holds Rhai implementation details - the engine's error text, script line numbers and
+    /// the names of the callbacks involved - so it must never be copied into `message` or into a
+    /// client-facing response. It is skipped by serde so that a value deserialized from a script's
+    /// `throw` can never set it either.
+    ///
+    /// Outside of tests this is read only through the `Debug` impl, which is how every call site
+    /// logs the whole struct - dead code analysis does not count that, hence the `allow`.
+    #[serde(skip)]
+    #[allow(dead_code)]
+    internal_detail: Option<String>,
 }
 
 fn default_thrown_status_code() -> StatusCode {
     StatusCode::INTERNAL_SERVER_ERROR
 }
 
+/// The client-facing message for a failure the script author did not choose, i.e. anything the
+/// script did not explicitly `throw`.
+///
+/// Returning the Rhai error itself discloses that the router runs Rhai, which script functions are
+/// registered, and where in the script the failure happened, so clients get the status code's
+/// reason phrase instead and the real error is logged.
+fn redacted_message(status: StatusCode) -> String {
+    // A script is free to throw a status code that has no reason phrase - `throw #{ status: 599 }`
+    // - so there has to be a fallback. It is deliberately as vague as the status is: saying
+    // "Internal Server Error" alongside a 599 would be a lie. Kept local to the redaction rather
+    // than shared with the other reason-phrase call sites: this wording is chosen for what a client
+    // sees instead of a Rhai error, and should be free to change without moving anything else.
+    status
+        .canonical_reason()
+        .unwrap_or("Unknown Error")
+        .to_string()
+}
+
 fn process_error(error: Box<EvalAltResult>) -> ErrorDetails {
     let mut error_details = ErrorDetails {
         status: StatusCode::INTERNAL_SERVER_ERROR,
-        message: Some(format!("rhai execution error: '{error}'")),
+        message: None,
         position: None,
         body: None,
+        // Rendered before `error` is taken apart below: this is the only place the whole Rhai
+        // error is available, including the chain of script callbacks it came up through.
+        internal_detail: Some(format!("rhai execution error: '{error}'")),
     };
 
     let inner_error = error.unwrap_inner();
-    // We only want to process runtime errors
-    if let EvalAltResult::ErrorRuntime(obj, pos) = inner_error {
-        if let Ok(temp_error_details) = rhai::serde::from_dynamic::<ErrorDetails>(obj) {
-            if temp_error_details.message.is_some() || temp_error_details.body.is_some() {
-                error_details = temp_error_details;
-            } else {
-                error_details.status = temp_error_details.status;
-            }
-        }
+    // A script's `throw` is the only source of a message the author chose to show a client, and it
+    // always arrives as `ErrorRuntime`. Every other variant is an engine failure - unknown
+    // function, type mismatch, script recursion limit - whose text describes the script's
+    // internals, so those keep the redacted message set below.
+    if let EvalAltResult::ErrorRuntime(thrown, pos) = inner_error {
         error_details.position = Some(pos.into());
+
+        if let Ok(thrown_message) = thrown.as_immutable_string_ref() {
+            // `throw "some message"`. The author wrote this string, so it is theirs to return -
+            // but only the string itself, not the Rhai wrapper around it.
+            //
+            // The router's own Rhai functions raise their errors in this same shape, with nothing
+            // recording which side raised them, so this discriminates on the value rather than the
+            // origin: an empty message - `engine::NO_CLIENT_MESSAGE`, all the router functions
+            // raise - falls through to the redacted message below. A script's own `throw ""` is
+            // caught by the same branch, and router functions that raise text of their own are
+            // returned verbatim; see `NO_CLIENT_MESSAGE` for why and for what a real fix needs.
+            if thrown_message.as_str() != engine::NO_CLIENT_MESSAGE {
+                error_details.message = Some(thrown_message.to_string());
+            }
+        } else if let Ok(thrown_details) = rhai::serde::from_dynamic::<ErrorDetails>(thrown) {
+            // `throw #{ status: ..., message: ..., body: ... }`.
+            //
+            // A throw carrying only a status - `throw #{ status: 400 }` - gets the status it asked
+            // for and, because there is no author-provided message, the redacted message below. An
+            // empty `message` is treated the same way as an empty thrown string.
+            error_details.status = thrown_details.status;
+            error_details.message = thrown_details.message.filter(|message| !message.is_empty());
+            error_details.body = thrown_details.body;
+        }
+        // Anything else a script can `throw` - an integer, an array, a map that does not
+        // deserialize - carries no message this code can return without also dumping the thrown
+        // value, so it keeps the redacted message below.
+    }
+
+    if error_details.message.is_none() {
+        error_details.message = Some(redacted_message(error_details.status));
     }
     error_details
 }

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__execution_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__execution_error_logging_without_body@logs.snap
@@ -4,7 +4,7 @@ expression: yaml
 ---
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n}"
   span:
     name: rhai_plugin
     otel.kind: INTERNAL
@@ -13,6 +13,7 @@ expression: yaml
     - name: rhai_plugin
       otel.kind: INTERNAL
       rhai service: "execution :: Request"
-- fields: {}
+- fields:
+    rhai.stage: ExecutionResponse
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_response callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n}"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_redacts_a_binding_error_that_carries_no_message@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_redacts_a_binding_error_that_carries_no_message@logs.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"Internal Server Error\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                15,\n            ),\n            pos: Some(\n                32,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error (line 15, position 32)'\",\n    ),\n}"
+  span:
+    name: rhai_plugin
+    otel.kind: INTERNAL
+    rhai service: "supergraph :: Request"
+  spans:
+    - name: rhai_plugin
+      otel.kind: INTERNAL
+      rhai service: "supergraph :: Request"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_redacts_an_empty_response_stream@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_redacts_an_empty_response_stream@logs.snap
@@ -1,0 +1,8 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields:
+    rhai.stage: SupergraphResponse
+  level: ERROR
+  message: "map_response was not called: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"Internal Server Error\",\n    ),\n    position: None,\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: the response stream ended before a primary response was available\",\n    ),\n}"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_redacts_engine_errors_from_client_responses@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__it_redacts_engine_errors_from_client_responses@logs.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/plugins/rhai/tests.rs
+expression: yaml
+---
+- fields: {}
+  level: ERROR
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"Internal Server Error\",\n    ),\n    position: None,\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Function not found: this_function_does_not_exist () (line 14, position 5)'\",\n    ),\n}"
+  span:
+    name: rhai_plugin
+    otel.kind: INTERNAL
+    rhai service: "execution :: Request"
+  spans:
+    - name: rhai_plugin
+      otel.kind: INTERNAL
+      rhai service: "execution :: Request"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__router_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__router_error_logging_without_body@logs.snap
@@ -4,7 +4,7 @@ expression: yaml
 ---
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n}"
   span:
     name: rhai_plugin
     otel.kind: INTERNAL
@@ -13,6 +13,7 @@ expression: yaml
     - name: rhai_plugin
       otel.kind: INTERNAL
       rhai service: "router :: Request"
-- fields: {}
+- fields:
+    rhai.stage: RouterResponse
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_response callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n}"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__subgraph_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__subgraph_error_logging_without_body@logs.snap
@@ -4,7 +4,7 @@ expression: yaml
 ---
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n}"
   span:
     name: rhai_plugin
     otel.kind: INTERNAL
@@ -13,6 +13,7 @@ expression: yaml
     - name: rhai_plugin
       otel.kind: INTERNAL
       rhai service: "subgraph :: Request"
-- fields: {}
+- fields:
+    rhai.stage: SubgraphResponse
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_response callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n}"

--- a/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__supergraph_error_logging_without_body@logs.snap
+++ b/apollo-router/src/plugins/rhai/snapshots/apollo_router__plugins__rhai__tests__supergraph_error_logging_without_body@logs.snap
@@ -4,7 +4,7 @@ expression: yaml
 ---
 - fields: {}
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                22,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 22, position 5)'\",\n    ),\n}"
   span:
     name: rhai_plugin
     otel.kind: INTERNAL
@@ -13,6 +13,7 @@ expression: yaml
     - name: rhai_plugin
       otel.kind: INTERNAL
       rhai service: "supergraph :: Request"
-- fields: {}
+- fields:
+    rhai.stage: SupergraphResponse
   level: ERROR
-  message: "map_request callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n}"
+  message: "map_response callback failed: ErrorDetails {\n    status: 500,\n    message: Some(\n        \"An error occurred without a body\",\n    ),\n    position: Some(\n        Position {\n            line: Some(\n                26,\n            ),\n            pos: Some(\n                5,\n            ),\n        },\n    ),\n    body: None,\n    internal_detail: Some(\n        \"rhai execution error: 'Runtime error: An error occurred without a body (line 26, position 5)'\",\n    ),\n}"

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -228,9 +228,11 @@ async fn rhai_plugin_execution_service_error() -> Result<(), BoxError> {
             );
         }
 
+        // The script threw this string, so the client gets it as written - without the Rhai
+        // wrapper that used to disclose the callback name and the line it failed on.
         assert_eq!(
             body.errors.first().unwrap().message.as_str(),
-            "rhai execution error: 'Runtime error: An error occured (line 30, position 5)'"
+            "An error occured"
         );
         crate::plugin::test::assert_no_mock_calls(handle).await;
         Ok(())
@@ -697,7 +699,10 @@ async fn it_can_process_string_subgraph_forbidden() {
     if let Err(error) = call_rhai_function("process_subgraph_response_string").await {
         let processed_error = process_error(error);
         assert_eq!(processed_error.status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(processed_error.message, Some("rhai execution error: 'Runtime error: I have raised an error (line 257, position 5)'".to_string()));
+        assert_eq!(
+            processed_error.message,
+            Some("I have raised an error".to_string())
+        );
     } else {
         // Test failed
         panic!("error processed incorrectly");
@@ -722,17 +727,242 @@ async fn it_cannot_process_om_subgraph_missing_message_and_body() {
     if let Err(error) = call_rhai_function("process_subgraph_response_om_missing_message").await {
         let processed_error = process_error(error);
         assert_eq!(processed_error.status, StatusCode::BAD_REQUEST);
-        assert_eq!(
-            processed_error.message,
-            Some(
-                "rhai execution error: 'Runtime error: #{\"status\": 400} (line 268, position 5)'"
-                    .to_string()
-            )
-        );
+        // The throw carries no message of its own, so the client gets the status code's reason
+        // phrase rather than a dump of the thrown object.
+        assert_eq!(processed_error.message, Some("Bad Request".to_string()));
     } else {
         // Test failed
         panic!("error processed incorrectly");
     }
+}
+
+// What a client must see is the same however the failure was reached, so the redaction tests below
+// assert it in one place. A macro rather than a function because each stage has its own response
+// type, and all they have in common is the shape asserted here.
+macro_rules! assert_client_sees_only_the_redacted_message {
+    ($response:expr) => {{
+        let mut response = $response;
+        assert_eq!(
+            response.response.status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        let body = response.next_response().await.expect("there is a response");
+        let message = &body.errors.first().expect("the request failed").message;
+        assert_eq!(message, "Internal Server Error");
+    }};
+}
+
+// A failure the script author did not choose - the Rhai engine's own, or one raised by a router
+// Rhai function - describes the script's internals, so the client gets the status code's reason
+// phrase and the real error goes to the logs.
+#[tokio::test]
+async fn it_redacts_engine_errors_from_client_responses() -> Result<(), BoxError> {
+    async {
+        let (mock_service, handle) =
+            tower_test::mock::pair::<execution::Request, execution::Response>();
+        let dyn_plugin = create_plugin("rhai_engine_error.rhai").await?;
+
+        // execution_service calls a function that does not exist, so the engine fails before any
+        // router function is reached.
+        let mut service = dyn_plugin.execution_service(mock_service.boxed());
+        let fake_req = http_ext::Request::fake_builder()
+            .body(Request::builder().query(String::new()).build())
+            .build()?;
+        let req = ExecutionRequest::fake_builder()
+            .context(Context::new())
+            .supergraph_request(fake_req)
+            .build();
+
+        assert_client_sees_only_the_redacted_message!(service.ready().await?.call(req).await?);
+
+        crate::plugin::test::assert_no_mock_calls(handle).await;
+        Ok(())
+    }
+    // The snapshot of the logs is what holds the router to still recording the real error.
+    .with_subscriber(assert_snapshot_subscriber!())
+    .await
+}
+
+// Only the router Rhai functions that raise no message of their own are redacted here - the ones
+// that raise text still return it to the client, which is why this test is named for the case it
+// covers rather than for binding failures in general.
+#[tokio::test]
+async fn it_redacts_a_binding_error_that_carries_no_message() -> Result<(), BoxError> {
+    async {
+        let (mock_service, handle) =
+            tower_test::mock::pair::<SupergraphRequest, SupergraphResponse>();
+        let dyn_plugin = create_plugin("rhai_redacted_error.rhai").await?;
+
+        // supergraph_service reads a header that is not there, which raises an exception carrying
+        // no message at all - the client must not see that as a blank error.
+        let mut service = dyn_plugin.supergraph_service(mock_service.boxed());
+        let req = SupergraphRequest::fake_builder()
+            .context(Context::new())
+            .build()?;
+
+        assert_client_sees_only_the_redacted_message!(service.ready().await?.call(req).await?);
+
+        crate::plugin::test::assert_no_mock_calls(handle).await;
+        Ok(())
+    }
+    .with_subscriber(assert_snapshot_subscriber!())
+    .await
+}
+
+// The response stream ending before there is a primary response is not a callback failure, but the
+// client still gets a redacted message, so the log is the only record of what actually happened.
+#[tokio::test]
+async fn it_redacts_an_empty_response_stream() -> Result<(), BoxError> {
+    async {
+        let (mock_service, mut handle) =
+            tower_test::mock::pair::<SupergraphRequest, SupergraphResponse>();
+        let driver = tokio::spawn(async move {
+            let (req, responder) = handle.next_request().await.unwrap();
+            let response = SupergraphResponse::fake_builder()
+                .context(req.context)
+                .build()
+                .unwrap();
+            // Throw away the primary response, leaving map_response nothing to be handed.
+            responder.send_response(response.map(|_| futures::stream::empty().boxed()));
+        });
+
+        let dyn_plugin = create_plugin("rhai_empty_response.rhai").await?;
+        let mut service = dyn_plugin.supergraph_service(mock_service.boxed());
+        let req = SupergraphRequest::fake_builder()
+            .context(Context::new())
+            .build()?;
+
+        assert_client_sees_only_the_redacted_message!(service.ready().await?.call(req).await?);
+
+        crate::plugin::test::await_mock_driver(driver).await;
+        Ok(())
+    }
+    // The snapshot is what holds the router to recording a cause the client no longer sees.
+    .with_subscriber(assert_snapshot_subscriber!())
+    .await
+}
+
+#[test]
+fn it_returns_a_thrown_string_without_the_rhai_wrapper() {
+    let engine = new_rhai_test_engine();
+    let error = engine
+        .eval::<()>(r#"throw "failed to convert header to a str";"#)
+        .expect_err("the script throws");
+
+    let processed_error = process_error(error);
+    assert_eq!(processed_error.status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        processed_error.message,
+        Some("failed to convert header to a str".to_string()),
+        "the author's string is theirs to return, but nothing around it is"
+    );
+}
+
+#[test]
+fn it_redacts_a_throw_whose_message_is_empty() {
+    let engine = new_rhai_test_engine();
+    // The expected status is spelled out rather than read back off the result, so that a throw
+    // losing the status it asked for fails here too - the reason phrase alone would move with it.
+    for (script, status, message) in [
+        (
+            r#"throw "";"#,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Internal Server Error",
+        ),
+        (
+            r#"throw #{ status: 400, message: "" };"#,
+            StatusCode::BAD_REQUEST,
+            "Bad Request",
+        ),
+    ] {
+        let error = engine.eval::<()>(script).expect_err("the script throws");
+
+        let processed_error = process_error(error);
+        assert_eq!(processed_error.status, status, "{script}");
+        assert_eq!(
+            processed_error.message.as_deref(),
+            Some(message),
+            "an empty message is not one a client can act on: {script}"
+        );
+    }
+}
+
+// A thrown scalar carries no message that can be returned without dumping the thrown value, which
+// is the disclosure this redaction exists to stop, so the author's value is dropped. Documented in
+// the Rhai customization docs alongside the other redacted cases.
+#[test]
+fn it_redacts_a_throw_that_is_not_a_string_or_a_map() {
+    let engine = new_rhai_test_engine();
+    for script in ["throw 42;", r#"throw ["a", "b"];"#, "throw true;"] {
+        let error = engine.eval::<()>(script).expect_err("the script throws");
+
+        let processed_error = process_error(error);
+        assert_eq!(
+            processed_error.status,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "{script}"
+        );
+        assert_eq!(
+            processed_error.message.as_deref(),
+            Some("Internal Server Error"),
+            "the thrown value must not reach the client: {script}"
+        );
+    }
+}
+
+// A map the router cannot read loses everything in it, including parts it could have read. Split out
+// from the scalar cases because this is the one a script author is liable to hit by accident, and
+// the only one where a message they did write is dropped.
+#[test]
+fn it_redacts_a_throw_whose_map_cannot_be_read() {
+    let engine = new_rhai_test_engine();
+    // `status` is not a status code, so deserializing the map fails as a whole - the `message`
+    // beside it is never read, and the status the author asked for is lost with it.
+    let error = engine
+        .eval::<()>(r#"throw #{ status: "four hundred", message: "nope" };"#)
+        .expect_err("the script throws");
+
+    let processed_error = process_error(error);
+    assert_eq!(processed_error.status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        processed_error.message.as_deref(),
+        Some("Internal Server Error"),
+        "a map that cannot be read must not be dumped to the client either"
+    );
+}
+
+#[test]
+fn it_redacts_a_throw_with_an_unrecognised_status() {
+    let engine = new_rhai_test_engine();
+    let error = engine
+        .eval::<()>("throw #{ status: 599 };")
+        .expect_err("the script throws");
+
+    let processed_error = process_error(error);
+    assert_eq!(processed_error.status.as_u16(), 599);
+    assert_eq!(processed_error.message, Some("Unknown Error".to_string()));
+}
+
+#[test]
+fn it_keeps_the_internal_detail_out_of_the_client_message() {
+    let engine = new_rhai_test_engine();
+    let error = engine
+        .eval::<()>("this_function_does_not_exist();")
+        .expect_err("the function does not exist");
+
+    let processed_error = process_error(error);
+    assert_eq!(
+        processed_error.message,
+        Some("Internal Server Error".to_string())
+    );
+    let internal_detail = processed_error
+        .internal_detail
+        .expect("the real error is kept for the logs");
+    assert!(
+        internal_detail.contains("this_function_does_not_exist"),
+        "the logs have to keep the reason the client no longer sees: {internal_detail}"
+    );
 }
 
 #[tokio::test]
@@ -955,16 +1185,11 @@ async fn test_rhai_header_removal_with_non_utf8_header() -> Result<(), BoxError>
 
     // Removing a non-UTF-8 header should be OK
     let body = service_response.next_response().await.unwrap();
-    if body.errors.is_empty() {
-        // yay, no errors
-    } else {
-        let rhai_error = body
-            .errors
-            .iter()
-            .find(|e| e.message.contains("rhai execution error"))
-            .expect("unexpected non-rhai error");
-        panic!("Got an unexpected rhai error: {rhai_error:?}");
-    }
+    assert!(
+        body.errors.is_empty(),
+        "removing a non-UTF-8 header should not fail: {:?}",
+        body.errors
+    );
 
     // Check that the header was actually removed
     let headers = service_response.response.headers().clone();

--- a/apollo-router/tests/fixtures/rhai_empty_response.rhai
+++ b/apollo-router/tests/fixtures/rhai_empty_response.rhai
@@ -1,0 +1,10 @@
+// Hooks map_response only, so the plugin reaches the point where it needs a primary response to
+// hand the callback. When the response stream is empty there is nothing to hand it and the callback
+// below never runs.
+
+fn supergraph_service(service) {
+    service.map_response(Fn("process_response"));
+}
+
+fn process_response(response) {
+}

--- a/apollo-router/tests/fixtures/rhai_engine_error.rhai
+++ b/apollo-router/tests/fixtures/rhai_engine_error.rhai
@@ -1,0 +1,15 @@
+// Fails inside the Rhai engine itself, before any router function is reached. Kept apart from
+// rhai_redacted_error.rhai, whose router_service breaks the pipeline before an execution callback
+// could ever run, so reaching the execution stage needs a script of its own.
+//
+// Used by both it_redacts_engine_errors_from_client_responses (whose log snapshot pins the line and
+// position below) and client_errors_omit_rhai_engine_internals. Moving a line here means updating
+// that snapshot.
+
+fn execution_service(service) {
+    service.map_request(Fn("call_undefined_function"));
+}
+
+fn call_undefined_function(request) {
+    this_function_does_not_exist();
+}

--- a/apollo-router/tests/fixtures/rhai_redacted_error.rhai
+++ b/apollo-router/tests/fixtures/rhai_redacted_error.rhai
@@ -1,0 +1,16 @@
+// A script that fails without throwing a message of its own. The failure below is not a message the
+// script author chose to show a client, so it must not appear in a client-facing response.
+
+fn router_service(service) {
+    service.map_request(Fn("read_missing_header"));
+}
+
+fn supergraph_service(service) {
+    service.map_request(Fn("read_missing_header"));
+}
+
+// Fails inside one of the router's own Rhai functions: reading an absent header raises an
+// exception carrying no message.
+fn read_missing_header(request) {
+    let value = request.headers["x-header-that-is-not-there"];
+}

--- a/apollo-router/tests/integration/batching.rs
+++ b/apollo-router/tests/integration/batching.rs
@@ -391,12 +391,12 @@ async fn it_handles_cancelled_by_rhai() -> Result<(), BoxError> {
         entryA:
           index: 0
     - errors:
-        - message: "rhai execution error: 'Runtime error: cancelled expected failure (line 5, position 13)'"
+        - message: cancelled expected failure
     - data:
         entryA:
           index: 1
     - errors:
-        - message: "rhai execution error: 'Runtime error: cancelled expected failure (line 5, position 13)'"
+        - message: cancelled expected failure
     "###);
     }
 
@@ -485,7 +485,7 @@ async fn it_handles_single_request_cancelled_by_rhai() -> Result<(), BoxError> {
         entryA:
           index: 1
     - errors:
-        - message: "rhai execution error: 'Runtime error: cancelled expected failure (line 5, position 13)'"
+        - message: cancelled expected failure
     "###);
     }
 

--- a/apollo-router/tests/integration/rhai.rs
+++ b/apollo-router/tests/integration/rhai.rs
@@ -58,6 +58,87 @@ rhai:
     router.graceful_shutdown().await;
 }
 
+// A script that fails used to report the Rhai error verbatim to the client, disclosing that the
+// router runs Rhai, the name of the failing callback, and where in the script it failed.
+//
+// `script_disclosures` are the details out of that particular script that the old message carried,
+// on top of the Rhai internals every failure used to carry. Only pass a string the pre-fix message
+// actually contained - anything else asserts nothing, since it was never there to leak.
+async fn assert_client_error_omits_rhai_internals(script: &str, script_disclosures: &[&str]) {
+    let config = format!(
+        r#"
+rhai:
+  scripts: tests/fixtures
+  main: {script}
+"#
+    );
+
+    let mut router = IntegrationTest::builder()
+        .config(config.as_str())
+        .supergraph(PathBuf::from("tests/fixtures/supergraph.graphql"))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let (_trace_id, response) = router
+        .execute_query(
+            Query::builder()
+                .body(json!({"query": "{ topProducts { name } }", "variables": {}}))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR
+    );
+    let body = response.text().await.expect("a response body");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&body).expect("a GraphQL response")["errors"][0]
+            ["message"],
+        json!("Internal Server Error")
+    );
+    for disclosure in ["rhai", "Rhai", "Runtime error", "line ", "position "]
+        .iter()
+        .chain(script_disclosures)
+    {
+        assert!(
+            !body.contains(*disclosure),
+            "client response leaks {disclosure:?}: {body}"
+        );
+    }
+
+    // The reason the client no longer sees has to be in the router's logs instead, otherwise this
+    // is just a silent failure.
+    router.wait_for_log_message("rhai execution error").await;
+
+    router.graceful_shutdown().await;
+}
+
+// A router Rhai function that fails without a message of its own.
+#[tokio::test(flavor = "multi_thread")]
+async fn client_errors_omit_rhai_internals() {
+    // No script-specific disclosure to check: the binding raises an empty message, so the pre-fix
+    // client message was `rhai execution error: 'Runtime error (line N, position M)'` and named
+    // neither the header nor the callback. The Rhai internals above are all this script leaked.
+    assert_client_error_omits_rhai_internals("rhai_redacted_error.rhai", &[]).await;
+}
+
+// The Rhai engine's own failure, which never reaches a router function. This needs a script of its
+// own: the router_service in rhai_redacted_error.rhai breaks the pipeline before an execution
+// callback could run.
+#[tokio::test(flavor = "multi_thread")]
+async fn client_errors_omit_rhai_engine_internals() {
+    // The engine names the function it could not find, so the pre-fix message carried it.
+    assert_client_error_omits_rhai_internals(
+        "rhai_engine_error.rhai",
+        &["this_function_does_not_exist"],
+    )
+    .await;
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_rhai_hot_reload_works() {
     let (sender, receiver) = tokio::sync::oneshot::channel();

--- a/docs/source/routing/customization/rhai/index.mdx
+++ b/docs/source/routing/customization/rhai/index.mdx
@@ -624,6 +624,7 @@ The log output includes:
 - HTTP status code (defaults to <code>500</code>)
 - Error message
 - Line number and position where the error occurred
+- The underlying Rhai error, including the callback that failed
 
 #### Errors with custom body
 
@@ -645,6 +646,59 @@ fn supergraph_service(service) {
             }
         };
     });
+}
+```
+
+### What clients see when a script fails
+
+Only a message your script chose is returned to clients. A script that throws is in control of its own error:
+
+```rhai
+fn supergraph_service(service) {
+    service.map_request(|request| {
+        // The client receives exactly: {"errors": [{"message": "Invalid request"}]}
+        throw "Invalid request";
+    });
+}
+```
+
+Throwing an object map works the same way, and additionally lets you pick the status code and the
+full GraphQL response body, as shown in the sections above.
+
+Every _other_ kind of failure is replaced with the status code's reason phrase - such as
+`Internal Server Error` - and the real error is written to the router's logs instead. This covers:
+
+- Failures raised by the Rhai engine itself, such as calling an undefined function or a type mismatch.
+- A `throw` that carries only a status, like `throw #{ status: 400 }`, which the client sees as `Bad Request`.
+- Failures in the router's own Rhai functions that carry no message of their own, such as reading a header that isn't present.
+- A `throw` of a value that is not a string or an object map, such as `throw 42`. Returning it would mean dumping the thrown value, so throw a string or an object map when you want the client to see a message.
+- A `throw` of an object map the router cannot read, such as `throw #{ status: "four hundred", message: "Invalid request" }` where the status is not a number. The map is discarded as a whole, so the `message` beside the unreadable field is dropped with it and the status falls back to `500`. If a message you threw does not arrive, check the router's logs for the map it could not read.
+
+This keeps script line numbers, callback names and the fact that the router runs Rhai out of
+client-facing responses.
+
+<Caution>
+
+A router function that fails with a message of its own still returns that message to the client.
+`env::get("MY_VAR")` on a variable that isn't set reports `could not expand variable: MY_VAR,
+environment variable not found`, and `json::decode(...)` on malformed input reports the parse
+error, which gives away the position it failed at. If your script calls these on a client-facing
+path, catch the error and throw your own rather than letting it propagate.
+
+</Caution>
+
+If you want a client to see a specific message for any of these cases, catch the error and throw
+your own:
+
+```rhai
+fn process_request(request) {
+    try {
+        let value = request.headers["x-custom-header"];
+    } catch(err) {
+        // Log the router's error, return your own.
+        log_error(`missing header: ${err}`);
+        throw #{ status: 400, message: "Invalid request" };
+    }
 }
 ```
 


### PR DESCRIPTION
A failing Rhai script used to have its error reported verbatim to the client, wrapped in the router's own text. That disclosed that the router runs Rhai, the names of the script's callbacks, and the line and position of the failure:

    "rhai execution error: 'Runtime error: Invalid request (line 25, position 39)
    in call to function 'process_router_request' @ 'process_router_request'
    (line 6, position 29)'"

Clients now receive only a message the script author chose. A thrown string is returned as written, and a thrown object map still picks the status code and the full GraphQL response body. Everything else is replaced with the status code's reason phrase and the real error is logged at ERROR level instead, which covers:

- Failures raised by the Rhai engine itself, such as an undefined function or a type mismatch.
- A throw carrying only a status: `throw #{ status: 400 }` now reads `Bad Request` rather than dumping the thrown map.
- Failures in the router's own Rhai functions that raise no message, such as reading a header that isn't there.
- A throw the router cannot read as a message - a value that is not a string or an object map, or a map with an unreadable field, which is discarded whole so any message beside the bad field goes with it.

`ErrorDetails` grows an `internal_detail` field holding the unredacted Rhai error for the logs. It is skipped by serde so a value deserialized from a script's `throw` can never populate it, and it is never copied into a client-facing response.

Response-stage failures are logged outside the span the request macros install, so they never recorded which stage failed. Now that the client message is redacted, that was the missing half of the only record: they carry `rhai.stage`, and they say `map_response` rather than `map_request`. The empty-response-stream failure is redacted and logged the same way.

Known limitation, documented in the Rhai customization docs: a router function that raises a message of its own still returns that message. A router function's error is indistinguishable from a script's `throw` - both arrive as `ErrorRuntime` carrying a string - so the discrimination is on the value, not the origin: `engine::NO_CLIENT_MESSAGE` is redacted, anything else is returned. `env::get()` on an unset variable and `json::decode()` on malformed input therefore still reach the client; catch them and throw your own error on a client-facing path.

Upgrade note: client-facing messages for a thrown string no longer include the `rhai execution error: 'Runtime error: ... (line N, position M)'` wrapper - only the string thrown. Nothing changes for scripts themselves: a `catch` block receives exactly what it did before, and status codes are unchanged.

<!-- start metadata -->

<!-- [ROUTER-2050] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-2050]: https://apollographql.atlassian.net/browse/ROUTER-2050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ