### PR TITLE
chore: change router-test-builds to use 7 character hashes to match with github's UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1040,7 +1040,7 @@ jobs:
             # Tag by branch + short commit sha -- NOT a release/nightly version.
             # This pipeline has nothing to do with release or nightly versioning.
             SANITIZED_BRANCH=$(printf '%s' "${CIRCLE_BRANCH}" | tr -c 'a-zA-Z0-9' '-')
-            SHORT_SHA=$(git rev-parse --short=8 HEAD)
+            SHORT_SHA=$(git rev-parse --short=7 HEAD)
             TAG="${SANITIZED_BRANCH}-${SHORT_SHA}"
 
             # Validate local artifact exists and calculate its checksum as a safety net


### PR DESCRIPTION
This makes it easier to verify/copy a hash from GH/CircleCI etc