### PR TITLE
test: mint license JWTs at runtime instead of pinning expired tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,7 +2312,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2556,7 +2556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3202,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4618,7 +4618,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6392,7 +6392,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6953,7 +6953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -7207,7 +7207,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -125,6 +125,30 @@ const TEST_LICENSE_JWKS_SECRET_BASE64URL: &str =
 /// stays valid through any reasonable test session and well within
 /// tokio's `DelayQueue` scheduler cap.
 fn mint_test_license_jwt() -> String {
+    mint_license_jwt(None, LICENSE_SIX_MONTHS_SECS, LICENSE_SIX_MONTHS_SECS)
+}
+
+/// ~6 months in seconds: far enough out that a minted JWT stays valid through
+/// any reasonable test session, and well within tokio's `DelayQueue`
+/// scheduler cap (about a year — see `mint_license_jwt`).
+#[allow(dead_code)]
+pub const LICENSE_SIX_MONTHS_SECS: i64 = 60 * 60 * 24 * 180;
+
+/// Mint a test license JWT signed with the bundled HS256 test secret.
+///
+/// `allowed_features` is the `allowedFeatures` claim: `None` omits the claim
+/// entirely (which `LicenseLimits` interprets as "all features allowed"),
+/// `Some(&[])` is an empty allow-list. `warn_at_offset_secs` and
+/// `halt_at_offset_secs` are relative to now — negative values put the claim
+/// in the past. Keep future offsets under about a year: the license stream
+/// schedules `haltAt`/`warnAt` on a tokio `DelayQueue`, which cannot schedule
+/// `Instant`s derived from far-future `SystemTime`s.
+#[allow(dead_code)]
+pub fn mint_license_jwt(
+    allowed_features: Option<&[&str]>,
+    warn_at_offset_secs: i64,
+    halt_at_offset_secs: i64,
+) -> String {
     use std::time::SystemTime;
     use std::time::UNIX_EPOCH;
 
@@ -134,23 +158,24 @@ fn mint_test_license_jwt() -> String {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system clock before unix epoch")
-        .as_secs();
-    let six_months_secs: u64 = 60 * 60 * 24 * 180;
-    let halt_at = now + six_months_secs;
+        .as_secs() as i64;
 
     let secret_bytes = URL_SAFE_NO_PAD
         .decode(TEST_LICENSE_JWKS_SECRET_BASE64URL)
         .expect("test JWKS secret is valid base64url");
     let key = jsonwebtoken::EncodingKey::from_secret(&secret_bytes);
     let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256);
-    let claims = serde_json::json!({
+    let mut claims = serde_json::json!({
         "exp": 10000000000_u64,
         "iss": "https://www.apollographql.com/",
         "sub": "apollo",
         "aud": "SELF_HOSTED",
-        "warnAt": halt_at,
-        "haltAt": halt_at,
+        "warnAt": now + warn_at_offset_secs,
+        "haltAt": now + halt_at_offset_secs,
     });
+    if let Some(features) = allowed_features {
+        claims["allowedFeatures"] = serde_json::json!(features);
+    }
     jsonwebtoken::encode(&header, &claims, &key).expect("sign test license JWT")
 }
 

--- a/apollo-router/tests/integration/allowed_features.rs
+++ b/apollo-router/tests/integration/allowed_features.rs
@@ -1,45 +1,117 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 use http::StatusCode;
 
 use crate::integration::IntegrationTest;
+use crate::integration::common::LICENSE_SIX_MONTHS_SECS;
 use crate::integration::common::TEST_JWKS_ENDPOINT;
-
-// NOTE: if these tests fail for haltAt/warnAt related reasons (that they're in the past), go to
-// jwt.io and doublecheck that those claims are still sensible. There's an issue when using
-// Instants to schedule things (like we do for license streams) if those Instants are derived from
-// some far-future SystemTime: tokio has an upper bound for how far out it schedules, putting a
-// pretty hard limit (about a year) for what we can set the haltAt/warnAt values in JWTs to
+use crate::integration::common::mint_license_jwt;
 
 const LICENSE_ALLOWED_FEATURES_DOES_NOT_INCLUDE_FEATURE_MSG: &str =
     "license violation, the router is using features not available for your license";
 const LICENSE_EXPIRED_MESSAGE: &str =
     "License has expired. The Router will no longer serve requests.";
 
-const JWT_WITH_EMPTY_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiYWxsb3dlZEZlYXR1cmVzIjogW10sCiAgImlzcyI6ICJodHRwczovL3d3dy5hcG9sbG9ncmFwaHFsLmNvbS8iLAogICJzdWIiOiAiYXBvbGxvIiwKICAiYXVkIjogIlNFTEZfSE9TVEVEIiwgCiAgIndhcm5BdCI6IDE3ODcwMDAwMDAsCiAgImhhbHRBdCI6IDE3ODcwMDAwMDAKfQ.nERzNxBzt7KLgBD4ouHydbht6_1jgyCYF8aKzFKGjhI"; // gitleaks:allow
+// The license JWTs below are minted at runtime with `warnAt`/`haltAt` relative
+// to now, so they can never silently expire the way pinned tokens used to.
+// `LICENSE_SIX_MONTHS_SECS` keeps future claims within tokio's DelayQueue
+// scheduler cap (about a year) — see `mint_license_jwt` in common.rs.
 
-const JWT_WITH_COPROCESSORS_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiYWxsb3dlZEZlYXR1cmVzIjogWyJjb3Byb2Nlc3NvcnMiXSwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhdWQiOiAiU0VMRl9IT1NURUQiLCAKICAid2FybkF0IjogMTc4NzAwMDAwMCwKICAiaGFsdEF0IjogMTc4NzAwMDAwMAp9.UD2JZtyvCSY6oXeDOsmWZehNGQjDqdhOiw-1f2TW4Og"; // gitleaks:allow
+static JWT_WITH_EMPTY_ALLOWED_FEATURES: LazyLock<String> =
+    LazyLock::new(|| mint_license_jwt(Some(&[]), LICENSE_SIX_MONTHS_SECS, LICENSE_SIX_MONTHS_SECS));
+
+static JWT_WITH_COPROCESSORS_IN_ALLOWED_FEATURES: LazyLock<String> = LazyLock::new(|| {
+    mint_license_jwt(
+        Some(&["coprocessors"]),
+        LICENSE_SIX_MONTHS_SECS,
+        LICENSE_SIX_MONTHS_SECS,
+    )
+});
 
 // In the CI environment we only install Redis on x86_64 Linux; this jwt is part of testing that
 // flow
 #[cfg(any(not(feature = "ci"), all(target_arch = "x86_64", target_os = "linux")))]
-const JWT_WITH_ENTITY_CACHING_COPROCESSORS_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbImVudGl0eV9jYWNoaW5nIiwgImNvcHJvY2Vzc29ycyJdLAogICJhdWQiOiAiU0VMRl9IT1NURUQiLCAKICAid2FybkF0IjogMTc4NzAwMDAwMCwgCiAgImhhbHRBdCI6IDE3ODcwMDAwMDAKfQ.HD_xzVtrXzXp8PdosAircXWPtnVaPRE-N2ZDlv6Llfo"; // gitleaks:allow
+static JWT_WITH_ENTITY_CACHING_COPROCESSORS_IN_ALLOWED_FEATURES: LazyLock<String> =
+    LazyLock::new(|| {
+        mint_license_jwt(
+            Some(&["entity_caching", "coprocessors"]),
+            LICENSE_SIX_MONTHS_SECS,
+            LICENSE_SIX_MONTHS_SECS,
+        )
+    });
 
-const JWT_WITH_COPROCESSORS_SUBSCRIPTION_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiYWxsb3dlZEZlYXR1cmVzIjogWwogICAgImNvcHJvY2Vzc29ycyIsCiAgICAic3Vic2NyaXB0aW9ucyIKICBdLAogICJpc3MiOiAiaHR0cHM6Ly93d3cuYXBvbGxvZ3JhcGhxbC5jb20vIiwKICAic3ViIjogImFwb2xsbyIsCiAgImF1ZCI6ICJTRUxGX0hPU1RFRCIsIAogICJ3YXJuQXQiOiAxNzg3MDAwMDAwLAogICJoYWx0QXQiOiAxNzg3MDAwMDAwCn0.MxjeQOea7wBjvs1J0-44oEfdoaVwKuEexy-JdgZ-3R8"; // gitleaks:allow
+static JWT_WITH_COPROCESSORS_SUBSCRIPTION_IN_ALLOWED_FEATURES: LazyLock<String> =
+    LazyLock::new(|| {
+        mint_license_jwt(
+            Some(&["coprocessors", "subscriptions"]),
+            LICENSE_SIX_MONTHS_SECS,
+            LICENSE_SIX_MONTHS_SECS,
+        )
+    });
 
-const JWT_WITH_ALLOWED_FEATURES_NONE: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhdWQiOiAiU0VMRl9IT1NURUQiLCAKICAid2FybkF0IjogMTc4NzAwMDAwMCwKICAiaGFsdEF0IjogMTc4NzAwMDAwMAp9.LPNJgPY20DH054mXgrzaxEFiME656ZJ-ge5y9Zh3kkc"; // gitleaks:allow
+static JWT_WITH_ALLOWED_FEATURES_NONE: LazyLock<String> =
+    LazyLock::new(|| mint_license_jwt(None, LICENSE_SIX_MONTHS_SECS, LICENSE_SIX_MONTHS_SECS));
 
-const JWT_WITH_ALLOWED_FEATURES_COPROCESSOR_WITH_FEATURE_UNDEFINED_IN_ROUTER: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiYWxsb3dlZEZlYXR1cmVzIjogWwogICAgImNvcHJvY2Vzc29ycyIsCiAgICAicmFuZG9tIiwKICAgICJzdWJzY3JpcHRpb25zIgogIF0sCiAgImlzcyI6ICJodHRwczovL3d3dy5hcG9sbG9ncmFwaHFsLmNvbS8iLAogICJzdWIiOiAiYXBvbGxvIiwKICAiYXVkIjogIlNFTEZfSE9TVEVEIiwgCiAgIndhcm5BdCI6IDE3ODcwMDAwMDAsCiAgImhhbHRBdCI6IDE3ODcwMDAwMDAKfQ.l4O-YLwIu2hjoSq1HseJQMS_9qFNL9v304I7gfLqV3w"; // gitleaks:allow
+static JWT_WITH_ALLOWED_FEATURES_COPROCESSOR_WITH_FEATURE_UNDEFINED_IN_ROUTER: LazyLock<String> =
+    LazyLock::new(|| {
+        mint_license_jwt(
+            Some(&["coprocessors", "random", "subscriptions"]),
+            LICENSE_SIX_MONTHS_SECS,
+            LICENSE_SIX_MONTHS_SECS,
+        )
+    });
 
-const JWT_WITH_ENTITY_CACHING_COPROCESSORS_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbImVudGl0eV9jYWNoaW5nIiwgImNvcHJvY2Vzc29ycyIsICJ0cmFmZmljX3NoYXBpbmciXSwKICAiYXVkIjogIlNFTEZfSE9TVEVEIiwgCiAgIndhcm5BdCI6IDE3ODcwMDAwMDAsIAogICJoYWx0QXQiOiAxNzg3MDAwMDAwCn0.HHfLHmDAjTdQwouAJguvWnpxnHsLzTWswQl70gmkMEM"; // gitleaks:allow
+static JWT_WITH_ENTITY_CACHING_COPROCESSORS_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES: LazyLock<String> =
+    LazyLock::new(|| {
+        mint_license_jwt(
+            Some(&["entity_caching", "coprocessors", "traffic_shaping"]),
+            LICENSE_SIX_MONTHS_SECS,
+            LICENSE_SIX_MONTHS_SECS,
+        )
+    });
 
-const JWT_PAST_EXPIRY_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_SUBSCRIPTIONS_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbImNvcHJvY2Vzc29ycyIsICJlbnRpdHlfY2FjaGluZyIsICJ0cmFmZmljX3NoYXBpbmciLCAic3Vic2NyaXB0aW9ucyJdLAogICJhdWQiOiAiU0VMRl9IT1NURUQiLCAKICAid2FybkF0IjogMTc1NTMwMjQwMCwgCiAgImhhbHRBdCI6IDE3NTUzMDI0MDAKfQ.2TPyUd9BUn3NCc2Kq8WsJS_6V16s2lgitElhf0lNcwg"; // gitleaks:allow
+static JWT_PAST_EXPIRY_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_SUBSCRIPTIONS_IN_ALLOWED_FEATURES:
+    LazyLock<String> = LazyLock::new(|| {
+    mint_license_jwt(
+        Some(&[
+            "coprocessors",
+            "entity_caching",
+            "traffic_shaping",
+            "subscriptions",
+        ]),
+        -LICENSE_SIX_MONTHS_SECS,
+        -LICENSE_SIX_MONTHS_SECS,
+    )
+});
 
-const JWT_PAST_EXPIRY_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbImNvcHJvY2Vzc29ycyIsICJlbnRpdHlfY2FjaGluZyIsICJ0cmFmZmljX3NoYXBpbmciXSwKICAiYXVkIjogIlNFTEZfSE9TVEVEIiwgCiAgIndhcm5BdCI6IDE3NTUzMDI0MDAsIAogICJoYWx0QXQiOiAxNzU1MzAyNDAwCn0.CERblSGfOVmKt6PtfB2LjnY-ahzMsNB4EGajXZfKWU4"; // gitleaks:allow
+static JWT_PAST_EXPIRY_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES:
+    LazyLock<String> = LazyLock::new(|| {
+    mint_license_jwt(
+        Some(&["coprocessors", "entity_caching", "traffic_shaping"]),
+        -LICENSE_SIX_MONTHS_SECS,
+        -LICENSE_SIX_MONTHS_SECS,
+    )
+});
 
-const JWT_PAST_WARN_AT_BUT_NOT_EXPIRED_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbImVudGl0eV9jYWNoaW5nIiwgImNvcHJvY2Vzc29ycyIsICJ0cmFmZmljX3NoYXBpbmciXSwKICAiYXVkIjogIlNFTEZfSE9TVEVEIiwgCiAgIndhcm5BdCI6IDE3NjU5MTA0MDAsIAogICJoYWx0QXQiOiAxNzg3MDAwMDAwCn0.33EWawSaU8dv5KqI8QbAzYFa0KKTcvqTXGaJfRkg-DU"; // gitleaks:allow
-const JWT_PAST_WARN_AT_BUT_NOT_EXPIRED_WITH_COPROCESSORS_SUBSCRIPTIONS_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbInN1YnNjcmlwdGlvbnMiLCAiY29wcm9jZXNzb3JzIl0sCiAgImF1ZCI6ICJTRUxGX0hPU1RFRCIsIAogICJ3YXJuQXQiOiAxNzU1MzAyNDAwLCAKICAiaGFsdEF0IjogMTc4NzAwMDAwMAp9.nxyKlFquWBijtIOtL8FnknNfAwvBaZh9TFIDcG7NtiE"; // gitleaks:allow
+static JWT_PAST_WARN_AT_BUT_NOT_EXPIRED_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES:
+    LazyLock<String> = LazyLock::new(|| {
+    mint_license_jwt(
+        Some(&["entity_caching", "coprocessors", "traffic_shaping"]),
+        -LICENSE_SIX_MONTHS_SECS,
+        LICENSE_SIX_MONTHS_SECS,
+    )
+});
+
+static JWT_PAST_WARN_AT_BUT_NOT_EXPIRED_WITH_COPROCESSORS_SUBSCRIPTIONS_IN_ALLOWED_FEATURES:
+    LazyLock<String> = LazyLock::new(|| {
+    mint_license_jwt(
+        Some(&["subscriptions", "coprocessors"]),
+        -LICENSE_SIX_MONTHS_SECS,
+        LICENSE_SIX_MONTHS_SECS,
+    )
+});
 
 const SUBSCRIPTION_CONFIG: &str = include_str!("subscriptions/fixtures/subscription.router.yaml");
 const SUBSCRIPTION_COPROCESSOR_CONFIG: &str =


### PR DESCRIPTION
The license JWTs in `tests/integration/allowed_features.rs` were hard-coded strings with `warnAt`/`haltAt` pinned to epoch `1787000000` — **2026-08-17**, which has now passed. Every license those tests treated as valid is now halted, so the router logs `License has expired` instead of the allowed-features violation the tests assert on, and the suite fails on every branch (first seen on the forward-port PR, but reproducible on plain `dev`/`dev-v3.x`).

The tokens couldn't be pinned further out: the license stream schedules `haltAt`/`warnAt` on a tokio `DelayQueue`, which caps far-future `SystemTime`-derived instants at roughly a year — the old comment in the file told whoever hit this to go re-mint on jwt.io.

This PR removes the rot instead of re-pinning:

- Generalises the existing `mint_test_license_jwt()` in `tests/common.rs` into `mint_license_jwt(allowed_features, warn_at_offset, halt_at_offset)`, signing with the HS256 test secret already bundled in `src/uplink/testdata/license.jwks.json` (offsets are relative to now; negative = past).
- Replaces all 11 pinned JWT constants with `LazyLock<String>` statics minted at runtime with the same `allowedFeatures` claims: +6 months for valid licenses, −6 months for the deliberately expired `PAST_EXPIRY` ones, −6/+6 for `PAST_WARN_AT_BUT_NOT_EXPIRED`.

Test-only change — nothing under `src/` is touched, and production license validation still uses the compiled-in EdDSA JWKS that the test secret cannot satisfy.

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] Changeset is included for user-facing changes — N/A, test-only
- [x] Tests added and passing