### PR TITLE
helm: only render the Service health port when it differs from the main port

### DIFF
--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -18,10 +18,19 @@ spec:
       targetPort: {{ .Values.service.targetport }}
       protocol: TCP
       name: http
-    - port: {{ (splitList ":" (index .Values.router.configuration "health_check").listen | last ) | default "8088" }}
+    {{- /* When the health listener is co-located with the main listener,
+           rendering a second entry with the same port and protocol produces
+           an invalid Service (spec.ports duplicate value), so the health
+           port is only rendered when it differs from the main port. The
+           health endpoint remains reachable through the main port in the
+           co-located case. */}}
+    {{- $healthPort := (splitList ":" (index .Values.router.configuration "health_check").listen | last ) | default "8088" }}
+    {{- if ne (toString $healthPort) (toString .Values.service.port) }}
+    - port: {{ $healthPort }}
       targetPort: health
       protocol: TCP
       name: health
+    {{- end }}
     {{- /* Should we expose an entity cache invalidation port? */}}
     {{- if and (.Values.router.configuration.preview_entity_cache).enabled (.Values.router.configuration.preview_entity_cache).invalidation }}
     - port: {{ (splitList ":" .Values.router.configuration.preview_entity_cache.invalidation.listen | last) }}


### PR DESCRIPTION
## Problem

When `router.configuration.health_check.listen` is co-located on the same port as the main supergraph listener (a supported and documented setup - it keeps the health endpoint reachable through the main port, which some load-balancer health monitors rely on), the chart renders two Service port entries with the same `(port, protocol)` pair. The Kubernetes API rejects that on a fresh apply:

```
Service "apollo-router" is invalid: spec.ports[1]: Duplicate value:
{"Name":"","Protocol":"TCP","AppProtocol":null,"Port":22216,"TargetPort":0,"NodePort":0}
```

Existing Services created before strict duplicate validation can linger, so this typically only surfaces when deploying the chart into a fresh cluster/namespace - which is how we hit it (GitOps sync of a new environment failed on all Service objects while everything else applied).

## Change

The health port entry is rendered only when it differs from `service.port`:

- co-located case: single valid `http` port; the health endpoint stays reachable through it
- default/split case (`health_check.listen` on 8088): rendering is byte-identical to before

Verified with `helm template` for both cases. No values schema change; chart version left untouched for the maintainers' release process.

## Context

Hit in production GitOps rollout at an Apollo Professional Services engagement; happy to adjust the approach (e.g. an explicit `service.healthPort.enabled` toggle instead of the implicit comparison) if maintainers prefer.