### PR TITLE
feat(composition): run connectors validation inside `compose`

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -14,8 +14,8 @@ use apollo_federation::bail;
 use apollo_federation::composition;
 use apollo_federation::composition::CompositionFailure;
 use apollo_federation::composition::CompositionOptions;
-use apollo_federation::composition::compose_with_connectors;
-use apollo_federation::composition::validate_satisfiability_with_connectors;
+use apollo_federation::composition::compose;
+use apollo_federation::composition::validate_satisfiability;
 use apollo_federation::connectors::expand::ExpansionResult;
 use apollo_federation::connectors::expand::expand_connectors;
 use apollo_federation::error::CompositionError;
@@ -277,7 +277,7 @@ fn compose_files_inner(
         let doc_str = std::fs::read_to_string(path).unwrap();
         let url = format!("file://{}", path.to_str().unwrap());
         let basename = path.file_stem().unwrap().to_str().unwrap();
-        let result = typestate::Subgraph::parse(basename, &url, &doc_str);
+        let result = typestate::Subgraph::from_sdl(basename, &url, &doc_str);
         match result {
             Ok(subgraph) => {
                 subgraphs.push(subgraph);
@@ -295,7 +295,7 @@ fn compose_files_inner(
         return Err(CompositionFailure::from_errors(composition_errors));
     }
 
-    compose_with_connectors(subgraphs, CompositionOptions::default())
+    compose(subgraphs, CompositionOptions::default())
 }
 
 /// Compose a supergraph from a Rover config YAML file.
@@ -343,7 +343,7 @@ fn compose_from_config_inner(
             ]));
         };
 
-        let result = typestate::Subgraph::parse(&name, &subgraph_config.routing_url, &doc_str);
+        let result = typestate::Subgraph::from_sdl(&name, &subgraph_config.routing_url, &doc_str);
         match result {
             Ok(subgraph) => {
                 subgraphs.push(subgraph);
@@ -362,7 +362,7 @@ fn compose_from_config_inner(
         return Err(CompositionFailure::from_errors(composition_errors));
     }
 
-    compose_with_connectors(subgraphs, CompositionOptions::default())
+    compose(subgraphs, CompositionOptions::default())
 }
 
 /// Compose a supergraph from multiple subgraph files.
@@ -545,7 +545,7 @@ fn cmd_subgraph(file_path: &Path) -> Result<(), AnyError> {
 fn cmd_satisfiability(file_path: &Path) -> Result<(), AnyError> {
     let doc_str = read_input(file_path);
     let supergraph = new_supergraph::Supergraph::parse(&doc_str).unwrap();
-    match validate_satisfiability_with_connectors(supergraph, &CompositionOptions::default()) {
+    match validate_satisfiability(supergraph, &CompositionOptions::default()) {
         Ok(_) => {
             println!("[SUCCESS]");
             Ok(())

--- a/apollo-federation/src/composition/mod.rs
+++ b/apollo-federation/src/composition/mod.rs
@@ -1,21 +1,18 @@
 mod satisfiability;
 
-use std::sync::Arc;
 use std::vec;
 
 use tracing::instrument;
 
 pub use crate::composition::satisfiability::validate_satisfiability;
-use crate::connectors::Connector;
-use crate::connectors::expand::Connectors;
-use crate::connectors::expand::ExpansionResult;
-use crate::connectors::expand::expand_connectors;
 use crate::error::CompositionError;
 use crate::merger::merge::Merger;
 pub use crate::schema::schema_upgrader::upgrade_subgraphs_if_necessary;
+use crate::schema::validators::connectors::validate_override_on_connector;
 use crate::schema::validators::root_fields::validate_consistent_root_fields;
 use crate::subgraph::typestate::Expanded;
 use crate::subgraph::typestate::Initial;
+use crate::subgraph::typestate::Source;
 use crate::subgraph::typestate::Subgraph;
 use crate::subgraph::typestate::Validated;
 pub use crate::supergraph::CompositionHint;
@@ -56,7 +53,7 @@ pub struct CompositionOptions {
 /// Mirrors the JS `compose` function.
 #[instrument(skip(subgraphs, options))]
 pub fn compose(
-    subgraphs: Vec<Subgraph<Initial>>,
+    subgraphs: Vec<Subgraph<Source>>,
     options: CompositionOptions,
 ) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
     // explicitly sort subgraphs by their names
@@ -64,6 +61,35 @@ pub fn compose(
     let mut subgraphs = subgraphs;
     subgraphs.sort_by(|s1, s2| s1.name.cmp(&s2.name));
 
+    // Connectors issues are found before anything else, so they are reported first.
+    let mut hints: Vec<CompositionHint> = vec![];
+
+    tracing::debug!("Validating connectors...");
+    let subgraphs = match validate_connectors(subgraphs, &mut hints) {
+        Ok(subgraphs) => subgraphs,
+        Err(errors) => return Err(CompositionFailure { errors, hints }),
+    };
+
+    let mut result = compose_subgraphs(subgraphs, options);
+    match &mut result {
+        Ok(supergraph) => prepend_hints(supergraph.hints_mut(), hints),
+        Err(failure) => prepend_hints(&mut failure.hints, hints),
+    }
+    result
+}
+
+fn prepend_hints(target: &mut Vec<CompositionHint>, mut hints: Vec<CompositionHint>) {
+    if hints.is_empty() {
+        return;
+    }
+    hints.append(target);
+    *target = hints;
+}
+
+fn compose_subgraphs(
+    subgraphs: Vec<Subgraph<Initial>>,
+    options: CompositionOptions,
+) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
     tracing::debug!("Expanding subgraphs...");
     let expanded_subgraphs = expand_subgraphs(subgraphs)?;
     tracing::debug!("Upgrading subgraphs...");
@@ -72,45 +98,46 @@ pub fn compose(
 
     tracing::debug!("Pre-merge validations...");
     pre_merge_validations(&validated_subgraphs)?;
+
+    // Reads the subgraphs, but is only reported if merging succeeds — see
+    // `validate_override_on_connector`. Merging consumes the subgraphs, hence running it here and
+    // holding on to the result rather than doing both after the merge.
+    let override_on_connector = validate_override_on_connector(&validated_subgraphs);
+
     tracing::debug!("Merging subgraphs...");
     let supergraph = merge_subgraphs(validated_subgraphs, &options)?;
     tracing::debug!("Post-merge validations...");
     post_merge_validations(&supergraph)?;
+    override_on_connector.map_err(CompositionFailure::from_errors)?;
+
     tracing::debug!("Validating satisfiability...");
     validate_satisfiability(supergraph, &options)
 }
 
-/// Mirrors the `HybridComposition::compose` from the apollo-composition crate.
-pub fn compose_with_connectors(
-    subgraphs: Vec<Subgraph<Initial>>,
-    options: CompositionOptions,
-) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
-    // Pre-expand validation
-    // - These were supposed to be pre-merge validations, but historically FBP performed these
-    //   Rust-based validation, before JS composition.
-    // - Once JS-to-Rust migration is done, we can move these to pre-merge validations.
-    // TODO: (FED-855) Call `connectors::validation`, which may change the subgraphs before upgrading.
+/// Runs the connectors (`@source`/`@connect`) validations over every subgraph document, producing
+/// the parsed subgraphs.
+///
+/// Connectors errors are fatal: the later composition phases assume connectors are well-formed.
+#[instrument(skip(subgraphs, hints))]
+fn validate_connectors(
+    subgraphs: Vec<Subgraph<Source>>,
+    hints: &mut Vec<CompositionHint>,
+) -> Result<Vec<Subgraph<Initial>>, Vec<CompositionError>> {
+    let mut errors: Vec<CompositionError> = vec![];
+    let parsed = subgraphs
+        .into_iter()
+        .filter_map(|s| {
+            s.validate_connectors(hints)
+                .map_err(|e| errors.extend(e))
+                .ok()
+        })
+        .collect();
 
-    tracing::debug!("Expanding subgraphs...");
-    let expanded_subgraphs = expand_subgraphs(subgraphs)?;
-
-    tracing::debug!("Upgrading subgraphs...");
-    let validated_subgraphs = upgrade_subgraphs_if_necessary(expanded_subgraphs)
-        .map_err(CompositionFailure::from_errors)?;
-
-    tracing::debug!("Pre-merge validations...");
-    pre_merge_validations(&validated_subgraphs)?;
-
-    tracing::debug!("Merging subgraphs...");
-    let supergraph = merge_subgraphs(validated_subgraphs, &options)?;
-
-    tracing::debug!("Post-merge validations...");
-    post_merge_validations(&supergraph)?;
-    // TODO: (FED-855) Call `validate_overrides`, which validates the original subgraphs for connectors after merging.
-    // - Once JS-to-Rust migration is done, we may consider to move that to the pre-merge validation step.
-
-    tracing::debug!("Validating satisfiability...");
-    validate_satisfiability_with_connectors(supergraph, &options)
+    if errors.is_empty() {
+        Ok(parsed)
+    } else {
+        Err(errors)
+    }
 }
 
 /// Apollo Federation allow subgraphs to specify partial schemas (i.e. "import" directives through
@@ -183,92 +210,4 @@ pub fn post_merge_validations(_supergraph: &Supergraph<Merged>) -> Result<(), Co
     // TODO: (FED-714) Implement any post-merge validations other than satisfiability, which is
     // checked separately.
     Ok(())
-}
-
-/// Mirroring HybridComposition in the apollo-composition crate.
-/// - Expand connectors as needed.
-pub fn validate_satisfiability_with_connectors(
-    supergraph: Supergraph<Merged>,
-    options: &CompositionOptions,
-) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
-    let merge_hints = supergraph.hints().to_vec();
-    let supergraph_str = supergraph.schema().schema().to_string();
-    let expansion_result = match expand_connectors(&supergraph_str, &Default::default()) {
-        Ok(result) => result,
-        Err(e) => {
-            return Err(CompositionFailure {
-                errors: vec![CompositionError::InternalError {
-                    message: format!(
-                        "Composition failed due to an internal error when expanding connectors, please report this: {e}"
-                    ),
-                }],
-                hints: merge_hints,
-            });
-        }
-    };
-
-    match expansion_result {
-        ExpansionResult::Expanded {
-            raw_sdl,
-            connectors: Connectors {
-                by_service_name, ..
-            },
-            ..
-        } => {
-            let expanded_supergraph = match Supergraph::parse(&raw_sdl) {
-                Ok(s) => s,
-                Err(e) => {
-                    return Err(CompositionFailure {
-                        errors: vec![CompositionError::InternalError {
-                            message: e.to_string(),
-                        }],
-                        hints: merge_hints,
-                    });
-                }
-            };
-            match validate_satisfiability(expanded_supergraph, options) {
-                Ok(mut supergraph) => {
-                    for hint in supergraph.hints_mut() {
-                        sanitize_connectors_message(&mut hint.message, by_service_name.iter());
-                    }
-                    Ok(supergraph)
-                }
-                Err(mut failure) => {
-                    failure.hints.extend(merge_hints);
-                    for error in failure.errors.iter_mut() {
-                        sanitize_connectors_error(error, by_service_name.iter());
-                    }
-                    for hint in failure.hints.iter_mut() {
-                        sanitize_connectors_message(&mut hint.message, by_service_name.iter());
-                    }
-                    Err(failure)
-                }
-            }
-        }
-        ExpansionResult::Unchanged => validate_satisfiability(supergraph, options),
-    }
-}
-
-fn sanitize_connectors_error<'a>(
-    issue: &mut CompositionError,
-    connector_subgraphs: impl Iterator<Item = (&'a Arc<str>, &'a Connector)>,
-) {
-    match issue {
-        CompositionError::SatisfiabilityError { message } => {
-            sanitize_connectors_message(message, connector_subgraphs);
-        }
-        CompositionError::ShareableHasMismatchedRuntimeTypes { message } => {
-            sanitize_connectors_message(message, connector_subgraphs);
-        }
-        _ => {}
-    }
-}
-
-fn sanitize_connectors_message<'a>(
-    message: &mut String,
-    connector_subgraphs: impl Iterator<Item = (&'a Arc<str>, &'a Connector)>,
-) {
-    for (service_name, connector) in connector_subgraphs {
-        *message = message.replace(&**service_name, connector.id.subgraph_name.as_str());
-    }
 }

--- a/apollo-federation/src/composition/satisfiability.rs
+++ b/apollo-federation/src/composition/satisfiability.rs
@@ -13,6 +13,10 @@ use crate::api_schema;
 use crate::composition::CompositionFailure;
 use crate::composition::CompositionOptions;
 use crate::composition::satisfiability::validation_traversal::ValidationTraversal;
+use crate::connectors::Connector;
+use crate::connectors::expand::Connectors;
+use crate::connectors::expand::ExpansionResult;
+use crate::connectors::expand::expand_connectors;
 use crate::error::CompositionError;
 use crate::error::FederationError;
 use crate::query_graph::QueryGraph;
@@ -24,15 +28,76 @@ use crate::supergraph::Merged;
 use crate::supergraph::Satisfiable;
 use crate::supergraph::Supergraph;
 
+/// Validates that all the queries expressible on the supergraph's API schema can be executed
+/// against the subgraphs it was composed from.
+///
+/// Connectors, if the supergraph uses any, are first expanded into their own synthetic subgraphs,
+/// which is the only shape satisfiability can reason about them in. That expansion is an
+/// implementation detail of the check: the supergraph returned here is always the merged one that
+/// was passed in, and messages naming a synthetic subgraph are rewritten to name the real one.
+// PORT_NOTE: The connectors handling mirrors the tail of
+// `HybridComposition::experimental_compose` in the apollo-composition crate.
 #[instrument(skip(supergraph, options))]
 pub fn validate_satisfiability(
-    mut supergraph: Supergraph<Merged>,
+    supergraph: Supergraph<Merged>,
     options: &CompositionOptions,
 ) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
-    let supergraph_schema = supergraph.schema().clone();
+    let merged_schema = supergraph.schema().clone();
+    // Hints carried over from merging. Taken from the merged supergraph rather than from whatever
+    // we end up checking, because the expanded copy is parsed from SDL and so has none of them.
+    let mut hints = supergraph.hints().to_vec();
+
+    let expansion = match expand_connectors(
+        &merged_schema.schema().to_string(),
+        &Default::default(),
+    ) {
+        Ok(expansion) => expansion,
+        Err(e) => {
+            return Err(CompositionFailure {
+                errors: vec![CompositionError::InternalError {
+                    message: format!(
+                        "Composition failed due to an internal error when expanding connectors, please report this: {e}"
+                    ),
+                }],
+                hints,
+            });
+        }
+    };
+    let (to_check, connectors) = match expansion {
+        ExpansionResult::Expanded {
+            raw_sdl,
+            connectors,
+            ..
+        } => match Supergraph::parse(&raw_sdl) {
+            Ok(expanded) => (expanded, Some(connectors)),
+            Err(e) => {
+                return Err(CompositionFailure {
+                    errors: vec![CompositionError::InternalError {
+                        message: e.to_string(),
+                    }],
+                    hints,
+                });
+            }
+        },
+        ExpansionResult::Unchanged => (supergraph, None),
+    };
+
     let mut errors = vec![];
-    let mut hints = supergraph.hints_mut().drain(..).collect();
-    if let Err(e) = validate_satisfiability_inner(supergraph, options, &mut errors, &mut hints) {
+    let result = validate_satisfiability_inner(to_check, options, &mut errors, &mut hints);
+
+    if let Some(Connectors {
+        by_service_name, ..
+    }) = &connectors
+    {
+        for error in errors.iter_mut() {
+            sanitize_connectors_error(error, by_service_name.iter());
+        }
+        for hint in hints.iter_mut() {
+            sanitize_connectors_message(&mut hint.message, by_service_name.iter());
+        }
+    }
+
+    if let Err(e) = result {
         return Err(CompositionFailure {
             errors: vec![CompositionError::InternalError {
                 message: e.to_string(),
@@ -43,7 +108,7 @@ pub fn validate_satisfiability(
     if !errors.is_empty() {
         return Err(CompositionFailure { errors, hints });
     }
-    Ok(Supergraph::<Satisfiable>::new(supergraph_schema, hints))
+    Ok(Supergraph::<Satisfiable>::new(merged_schema, hints))
 }
 
 fn validate_satisfiability_inner(
@@ -97,6 +162,30 @@ fn validate_graph_composition(
         composition_options,
     )?
     .validate(errors, hints)
+}
+
+fn sanitize_connectors_error<'a>(
+    issue: &mut CompositionError,
+    connector_subgraphs: impl Iterator<Item = (&'a Arc<str>, &'a Connector)>,
+) {
+    match issue {
+        CompositionError::SatisfiabilityError { message } => {
+            sanitize_connectors_message(message, connector_subgraphs);
+        }
+        CompositionError::ShareableHasMismatchedRuntimeTypes { message } => {
+            sanitize_connectors_message(message, connector_subgraphs);
+        }
+        _ => {}
+    }
+}
+
+fn sanitize_connectors_message<'a>(
+    message: &mut String,
+    connector_subgraphs: impl Iterator<Item = (&'a Arc<str>, &'a Connector)>,
+) {
+    for (service_name, connector) in connector_subgraphs {
+        *message = message.replace(&**service_name, connector.id.subgraph_name.as_str());
+    }
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/connectors/validation/mod.rs
+++ b/apollo-federation/src/connectors/validation/mod.rs
@@ -300,7 +300,7 @@ pub enum Code {
     ///
     /// Unlike every other code here, this one is not raised by the subgraph validations in this
     /// module — it comes from a post-merge composition check, which needs all subgraphs at once.
-    /// See [`validate_override_on_connector`](crate::schema::validators::connectors::validate_override_on_connector).
+    /// See `schema::validators::connectors::validate_override_on_connector`.
     OverrideOnConnector,
 }
 

--- a/apollo-federation/src/connectors/validation/mod.rs
+++ b/apollo-federation/src/connectors/validation/mod.rs
@@ -18,6 +18,7 @@ use apollo_compiler::schema::SchemaBuilder;
 use itertools::Itertools;
 pub(crate) use schema::field_set_is_subset;
 use strum_macros::Display;
+use strum_macros::EnumIter;
 use strum_macros::IntoStaticStr;
 
 use crate::connectors::ConnectSpec;
@@ -183,7 +184,7 @@ pub struct Message {
 ///
 /// Note that these codes are global, not scoped to connectors, so they should attempt to be
 /// unique across all pieces of composition, including JavaScript components.
-#[derive(Clone, Copy, Debug, Display, Eq, IntoStaticStr, PartialEq)]
+#[derive(Clone, Copy, Debug, Display, EnumIter, Eq, Hash, IntoStaticStr, PartialEq)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum Code {
     /// A problem with GraphQL syntax or semantics was found. These will usually be caught before
@@ -295,6 +296,12 @@ pub enum Code {
     /// is transport-agnostic so that if/when a `sql:` (or other) transport
     /// joins `http:`, this same code keeps describing the same condition.
     RequestlessSelectionUsesRequestData,
+    /// A field uses `@override(from:)` to override a connector-enabled subgraph.
+    ///
+    /// Unlike every other code here, this one is not raised by the subgraph validations in this
+    /// module — it comes from a post-merge composition check, which needs all subgraphs at once.
+    /// See [`validate_override_on_connector`](crate::schema::validators::connectors::validate_override_on_connector).
+    OverrideOnConnector,
 }
 
 impl Code {

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -292,9 +292,10 @@ pub enum CompositionError {
         message: String,
         locations: Locations,
     },
-    /// An error reported by the `@source`/`@connect` (connectors) subgraph validations.
+    /// An error reported by one of the connectors (`@source`/`@connect`) validations, whether it
+    /// ran against a subgraph or against the whole composition.
     #[error("{message}")]
-    ConnectorsError {
+    ConnectorsValidationError {
         code: ConnectorsCode,
         message: String,
         locations: Locations,
@@ -304,7 +305,7 @@ pub enum CompositionError {
 impl CompositionError {
     pub fn code(&self) -> ErrorCode {
         match self {
-            Self::ConnectorsError { code, .. } => ErrorCode::Connectors(*code),
+            Self::ConnectorsValidationError { code, .. } => ErrorCode::Connectors(*code),
             Self::SubgraphError { error, .. } => error.code(),
             Self::MergeError { error, .. } => error.code(),
             Self::MergeValidationError { error, .. } => error.code(),
@@ -511,7 +512,7 @@ impl CompositionError {
             | Self::OverrideOnInterface { .. }
             | Self::OverrideSourceHasOverride { .. }
             | Self::QueryRootMissing { .. }
-            | Self::ConnectorsError { .. } => self,
+            | Self::ConnectorsValidationError { .. } => self,
         }
     }
 
@@ -551,7 +552,7 @@ impl CompositionError {
             | Self::ArgumentDefaultMismatch { locations, .. }
             | Self::InputFieldDefaultMismatch { locations, .. }
             | Self::InterfaceFieldNoImplem { locations, .. }
-            | Self::ConnectorsError { locations, .. } => locations,
+            | Self::ConnectorsValidationError { locations, .. } => locations,
             _ => &[],
         }
     }

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod suggestion;
 
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Write;
@@ -13,7 +14,9 @@ use apollo_compiler::ast::OperationType;
 use apollo_compiler::parser::LineColumn;
 use apollo_compiler::validation::DiagnosticList;
 use apollo_compiler::validation::WithErrors;
+use strum::IntoEnumIterator;
 
+pub use crate::connectors::validation::Code as ConnectorsCode;
 use crate::subgraph::SubgraphError;
 use crate::subgraph::spec::FederationSpecError;
 use crate::subgraph::typestate::HasMetadata;
@@ -289,11 +292,19 @@ pub enum CompositionError {
         message: String,
         locations: Locations,
     },
+    /// An error reported by the `@source`/`@connect` (connectors) subgraph validations.
+    #[error("{message}")]
+    ConnectorsError {
+        code: ConnectorsCode,
+        message: String,
+        locations: Locations,
+    },
 }
 
 impl CompositionError {
     pub fn code(&self) -> ErrorCode {
         match self {
+            Self::ConnectorsError { code, .. } => ErrorCode::Connectors(*code),
             Self::SubgraphError { error, .. } => error.code(),
             Self::MergeError { error, .. } => error.code(),
             Self::MergeValidationError { error, .. } => error.code(),
@@ -499,7 +510,8 @@ impl CompositionError {
             | Self::OverrideLabelInvalid { .. }
             | Self::OverrideOnInterface { .. }
             | Self::OverrideSourceHasOverride { .. }
-            | Self::QueryRootMissing { .. } => self,
+            | Self::QueryRootMissing { .. }
+            | Self::ConnectorsError { .. } => self,
         }
     }
 
@@ -538,7 +550,8 @@ impl CompositionError {
             | Self::MergeError { locations, .. }
             | Self::ArgumentDefaultMismatch { locations, .. }
             | Self::InputFieldDefaultMismatch { locations, .. }
-            | Self::InterfaceFieldNoImplem { locations, .. } => locations,
+            | Self::InterfaceFieldNoImplem { locations, .. }
+            | Self::ConnectorsError { locations, .. } => locations,
             _ => &[],
         }
     }
@@ -2274,6 +2287,29 @@ static INTERFACE_KEY_MISSING_IMPLEMENTATION_TYPE: LazyLock<ErrorCodeDefinition> 
     },
 );
 
+/// Connectors validation errors carry their own code enum, so instead of duplicating every one of
+/// them as an [`ErrorCode`] variant we derive the definitions from that enum. The code string is
+/// the only part consumers rely on today, hence the generic description.
+static CONNECTORS_ERROR_CODE_DEFINITIONS: LazyLock<HashMap<ConnectorsCode, ErrorCodeDefinition>> =
+    LazyLock::new(|| {
+        ConnectorsCode::iter()
+            .map(|code| {
+                let definition = ErrorCodeDefinition::new(
+                    <&'static str>::from(code).to_owned(),
+                    "A connectors (`@source`/`@connect`) validation error.".to_owned(),
+                    None,
+                );
+                (code, definition)
+            })
+            .collect()
+    });
+
+fn connectors_error_code_definition(code: ConnectorsCode) -> &'static ErrorCodeDefinition {
+    CONNECTORS_ERROR_CODE_DEFINITIONS
+        .get(&code)
+        .unwrap_or(&ERROR_CODE_MISSING)
+}
+
 static INTERNAL: LazyLock<ErrorCodeDefinition> = LazyLock::new(|| {
     ErrorCodeDefinition::new(
         "INTERNAL".to_owned(),
@@ -2576,8 +2612,12 @@ static MISSING_TRANSITIVE_AUTH_REQUIREMENTS: LazyLock<ErrorCodeDefinition> = Laz
         )
 });
 
-#[derive(Debug, PartialEq, strum_macros::EnumIter)]
+#[derive(Debug, PartialEq)]
 pub enum ErrorCode {
+    /// An error raised by the connectors (`@source`/`@connect`) subgraph validations. Those codes
+    /// live in their own enum but are part of the same global code namespace as the rest of the
+    /// composition error codes.
+    Connectors(ConnectorsCode),
     ErrorCodeMissing,
     Internal,
     ExtensionWithNoBase,
@@ -2690,6 +2730,7 @@ pub enum ErrorCode {
 impl ErrorCode {
     pub fn definition(&self) -> &'static ErrorCodeDefinition {
         match self {
+            ErrorCode::Connectors(code) => connectors_error_code_definition(*code),
             ErrorCode::Internal => &INTERNAL,
             ErrorCode::ExtensionWithNoBase => &EXTENSION_WITH_NO_BASE,
             ErrorCode::InvalidGraphQL => &INVALID_GRAPHQL,

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -305,7 +305,7 @@ pub enum CompositionError {
 impl CompositionError {
     pub fn code(&self) -> ErrorCode {
         match self {
-            Self::ConnectorsValidationError { code, .. } => ErrorCode::Connectors(*code),
+            Self::ConnectorsValidationError { code, .. } => ErrorCode::ConnectorsValidation(*code),
             Self::SubgraphError { error, .. } => error.code(),
             Self::MergeError { error, .. } => error.code(),
             Self::MergeValidationError { error, .. } => error.code(),
@@ -2615,10 +2615,10 @@ static MISSING_TRANSITIVE_AUTH_REQUIREMENTS: LazyLock<ErrorCodeDefinition> = Laz
 
 #[derive(Debug, PartialEq)]
 pub enum ErrorCode {
-    /// An error raised by the connectors (`@source`/`@connect`) subgraph validations. Those codes
+    /// An error raised by one of the connectors (`@source`/`@connect`) validations. Those codes
     /// live in their own enum but are part of the same global code namespace as the rest of the
     /// composition error codes.
-    Connectors(ConnectorsCode),
+    ConnectorsValidation(ConnectorsCode),
     ErrorCodeMissing,
     Internal,
     ExtensionWithNoBase,
@@ -2731,7 +2731,7 @@ pub enum ErrorCode {
 impl ErrorCode {
     pub fn definition(&self) -> &'static ErrorCodeDefinition {
         match self {
-            ErrorCode::Connectors(code) => connectors_error_code_definition(*code),
+            ErrorCode::ConnectorsValidation(code) => connectors_error_code_definition(*code),
             ErrorCode::Internal => &INTERNAL,
             ErrorCode::ExtensionWithNoBase => &EXTENSION_WITH_NO_BASE,
             ErrorCode::InvalidGraphQL => &INVALID_GRAPHQL,

--- a/apollo-federation/src/merger/hints.rs
+++ b/apollo-federation/src/merger/hints.rs
@@ -1,10 +1,16 @@
+use std::collections::HashMap;
 use std::sync::LazyLock;
 
+use strum::IntoEnumIterator;
+
+use crate::error::ConnectorsCode;
 use crate::supergraph::HintCodeDefinition;
 use crate::supergraph::HintLevel;
 
 #[derive(Clone, Debug)]
 pub enum HintCode {
+    /// A warning raised by the connectors (`@source`/`@connect`) subgraph validations.
+    Connectors(ConnectorsCode),
     InconsistentButCompatibleFieldType,
     InconsistentButCompatibleArgumentType,
     InconsistentDefaultValuePresence,
@@ -41,6 +47,7 @@ pub enum HintCode {
 impl HintCode {
     pub fn definition(&self) -> &'static HintCodeDefinition {
         match self {
+            HintCode::Connectors(code) => connectors_hint_definition(*code),
             HintCode::InconsistentButCompatibleFieldType => &INCONSISTENT_BUT_COMPATIBLE_FIELD_TYPE,
             HintCode::InconsistentButCompatibleArgumentType => {
                 &INCONSISTENT_BUT_COMPATIBLE_ARGUMENT_TYPE
@@ -108,6 +115,36 @@ impl HintCode {
     pub fn code(&self) -> &str {
         self.definition().code()
     }
+}
+
+/// Like the connectors error codes, connectors warnings reuse the connectors code enum rather than
+/// duplicating a [`HintCode`] variant per code.
+static CONNECTORS_HINT_DEFINITIONS: LazyLock<HashMap<ConnectorsCode, HintCodeDefinition>> =
+    LazyLock::new(|| {
+        ConnectorsCode::iter()
+            .map(|code| {
+                let definition = HintCodeDefinition::new(
+                    <&'static str>::from(code),
+                    HintLevel::Warn,
+                    "A connectors (`@source`/`@connect`) validation warning.",
+                );
+                (code, definition)
+            })
+            .collect()
+    });
+
+static UNKNOWN_CONNECTORS_HINT: LazyLock<HintCodeDefinition> = LazyLock::new(|| {
+    HintCodeDefinition::new(
+        "UNKNOWN_CONNECTORS_WARNING",
+        HintLevel::Warn,
+        "A connectors (`@source`/`@connect`) validation warning with an unknown code.",
+    )
+});
+
+fn connectors_hint_definition(code: ConnectorsCode) -> &'static HintCodeDefinition {
+    CONNECTORS_HINT_DEFINITIONS
+        .get(&code)
+        .unwrap_or(&UNKNOWN_CONNECTORS_HINT)
 }
 
 pub(crate) static INCONSISTENT_BUT_COMPATIBLE_FIELD_TYPE: LazyLock<HintCodeDefinition> =

--- a/apollo-federation/src/merger/hints.rs
+++ b/apollo-federation/src/merger/hints.rs
@@ -10,7 +10,7 @@ use crate::supergraph::HintLevel;
 #[derive(Clone, Debug)]
 pub enum HintCode {
     /// A warning raised by the connectors (`@source`/`@connect`) subgraph validations.
-    Connectors(ConnectorsCode),
+    ConnectorsHint(ConnectorsCode),
     InconsistentButCompatibleFieldType,
     InconsistentButCompatibleArgumentType,
     InconsistentDefaultValuePresence,
@@ -47,7 +47,7 @@ pub enum HintCode {
 impl HintCode {
     pub fn definition(&self) -> &'static HintCodeDefinition {
         match self {
-            HintCode::Connectors(code) => connectors_hint_definition(*code),
+            HintCode::ConnectorsHint(code) => connectors_hint_definition(*code),
             HintCode::InconsistentButCompatibleFieldType => &INCONSISTENT_BUT_COMPATIBLE_FIELD_TYPE,
             HintCode::InconsistentButCompatibleArgumentType => {
                 &INCONSISTENT_BUT_COMPATIBLE_ARGUMENT_TYPE

--- a/apollo-federation/src/schema/validators/connectors.rs
+++ b/apollo-federation/src/schema/validators/connectors.rs
@@ -1,0 +1,101 @@
+use apollo_compiler::ast::Value;
+
+use crate::connectors::ConnectSpec;
+use crate::error::CompositionError;
+use crate::error::ConnectorsCode;
+use crate::error::SubgraphLocation;
+use crate::link::Link;
+use crate::schema::position::HasAppliedDirectives;
+use crate::subgraph::typestate::HasMetadata;
+use crate::subgraph::typestate::Subgraph;
+
+/// Rejects `@override(from:)` pointing at a connector-enabled subgraph.
+///
+/// Overrides mess with the supergraph in ways that can be difficult to detect when expanding
+/// connectors; the supergraph may omit overridden fields and other shenanigans. To allow for a
+/// better developer experience, we check here if any connector-enabled subgraphs have fields
+/// overridden.
+///
+/// # Ordering
+///
+/// This runs after merging so that connectors-related override errors are only reported once
+/// merging succeeded, and before connector expansion, which these overrides would otherwise
+/// corrupt. It looks at the subgraphs rather than the supergraph precisely because merging may
+/// have dropped the overridden fields.
+// PORT_NOTE: Corresponds to `validate_overrides` in the apollo-composition crate. That version
+// worked on the unexpanded subgraph schemas and so had to match the `@override` directive by name
+// against a hardcoded list, missing any subgraph that imported it under an alias. Here the name is
+// resolved through the federation spec, so aliases are handled.
+pub(crate) fn validate_override_on_connector<T: HasMetadata>(
+    subgraphs: &[Subgraph<T>],
+) -> Result<(), Vec<CompositionError>> {
+    let connector_subgraphs: Vec<&str> = subgraphs
+        .iter()
+        .filter(|subgraph| has_connectors(subgraph))
+        .map(|subgraph| subgraph.name.as_str())
+        .collect();
+    if connector_subgraphs.is_empty() {
+        return Ok(());
+    }
+
+    let mut errors = vec![];
+    for subgraph in subgraphs {
+        let Some(override_directive_name) = subgraph.override_directive_name() else {
+            continue;
+        };
+        let schema = subgraph.schema();
+        // `@override` is only valid on object/interface fields, so those are the only referencers
+        // worth looking at.
+        let overridden_fields = schema
+            .referencers()
+            .get_directive(&override_directive_name)
+            .object_or_interface_fields();
+
+        for field in overridden_fields {
+            for directive in field.get_applied_directives(schema, &override_directive_name) {
+                // A missing or non-string `from` is not this validation's problem: the merger
+                // reports it, and there is nothing to check against here.
+                let Ok(Value::String(from)) = directive
+                    .argument_by_name("from", schema.schema())
+                    .map(|arg| arg.as_ref())
+                else {
+                    continue;
+                };
+                if !connector_subgraphs.contains(&from.as_str()) {
+                    continue;
+                }
+
+                errors.push(CompositionError::ConnectorsError {
+                    code: ConnectorsCode::OverrideOnConnector,
+                    message: format!(
+                        r#"Field "{type_name}.{field_name}" on subgraph "{subgraph_name}" is trying to override connector-enabled subgraph "{from}", which is not yet supported. See https://go.apollo.dev/connectors/limitations#override-is-partially-unsupported"#,
+                        type_name = field.type_name(),
+                        field_name = field.field_name(),
+                        subgraph_name = subgraph.name,
+                    ),
+                    locations: schema
+                        .node_locations(directive)
+                        .map(|range| SubgraphLocation {
+                            // The `@override` application lives in this subgraph, not in the one
+                            // it points at.
+                            subgraph: subgraph.name.clone(),
+                            range,
+                        })
+                        .collect(),
+                });
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+/// Whether the subgraph `@link`s the connect spec. Link expansion keeps the `@link` around, so this
+/// is answerable at any point after the subgraph has been expanded.
+fn has_connectors<T: HasMetadata>(subgraph: &Subgraph<T>) -> bool {
+    Link::for_identity(subgraph.schema().schema(), &ConnectSpec::identity()).is_some()
+}

--- a/apollo-federation/src/schema/validators/connectors.rs
+++ b/apollo-federation/src/schema/validators/connectors.rs
@@ -65,7 +65,7 @@ pub(crate) fn validate_override_on_connector<T: HasMetadata>(
                     continue;
                 }
 
-                errors.push(CompositionError::ConnectorsError {
+                errors.push(CompositionError::ConnectorsValidationError {
                     code: ConnectorsCode::OverrideOnConnector,
                     message: format!(
                         r#"Field "{type_name}.{field_name}" on subgraph "{subgraph_name}" is trying to override connector-enabled subgraph "{from}", which is not yet supported. See https://go.apollo.dev/connectors/limitations#override-is-partially-unsupported"#,

--- a/apollo-federation/src/schema/validators/mod.rs
+++ b/apollo-federation/src/schema/validators/mod.rs
@@ -22,6 +22,7 @@ use crate::schema::subgraph_metadata::SubgraphMetadata;
 
 pub(crate) mod access_control;
 pub(crate) mod cache_tag;
+pub(crate) mod connectors;
 pub(crate) mod context;
 pub(crate) mod cost;
 pub(crate) mod external;

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -258,7 +258,7 @@ impl Subgraph<Source> {
                     })
                 }
                 ConnectorsSeverity::Warning => hints.push(CompositionHint {
-                    definition: HintCode::Connectors(message.code).definition(),
+                    definition: HintCode::ConnectorsHint(message.code).definition(),
                     message: message.message,
                     locations,
                 }),

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -250,11 +250,13 @@ impl Subgraph<Source> {
                 })
                 .collect();
             match message.code.severity() {
-                ConnectorsSeverity::Error => errors.push(CompositionError::ConnectorsError {
-                    code: message.code,
-                    message: message.message,
-                    locations,
-                }),
+                ConnectorsSeverity::Error => {
+                    errors.push(CompositionError::ConnectorsValidationError {
+                        code: message.code,
+                        message: message.message,
+                        locations,
+                    })
+                }
                 ConnectorsSeverity::Warning => hints.push(CompositionHint {
                     definition: HintCode::Connectors(message.code).definition(),
                     message: message.message,

--- a/apollo-federation/src/subgraph/typestate.rs
+++ b/apollo-federation/src/subgraph/typestate.rs
@@ -20,7 +20,11 @@ use crate::LinkSpecDefinition;
 use crate::ValidFederationSchema;
 use crate::bail;
 use crate::compat::coerce_and_validate_schema_values;
+use crate::connectors::validation::Severity as ConnectorsSeverity;
+use crate::connectors::validation::ValidationResult;
+use crate::connectors::validation::validate as validate_connectors;
 use crate::ensure;
+use crate::error::CompositionError;
 use crate::error::FederationError;
 use crate::error::Locations;
 use crate::error::MultipleFederationErrors;
@@ -44,6 +48,7 @@ use crate::link::link_spec_definition::LINK_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::link_spec_definition::LINK_DIRECTIVE_URL_ARGUMENT_NAME;
 use crate::link::spec::Identity;
 use crate::link::spec_definition::SpecDefinition;
+use crate::merger::hints::HintCode;
 use crate::query_graph::build_query_graph::FEDERATED_GRAPH_ROOT_SOURCE;
 use crate::schema::FederationSchema;
 use crate::schema::blueprint::FederationBlueprint;
@@ -61,6 +66,7 @@ use crate::schema::type_and_directive_specification::TypeAndDirectiveSpecificati
 use crate::schema::type_and_directive_specification::UnionTypeSpecification;
 use crate::subgraph::SubgraphError;
 use crate::supergraph::ANY_TYPE_SPEC;
+use crate::supergraph::CompositionHint;
 use crate::supergraph::EMPTY_QUERY_TYPE_SPEC;
 use crate::supergraph::FEDERATION_ANY_TYPE_NAME;
 use crate::supergraph::FEDERATION_ENTITIES_FIELD_NAME;
@@ -71,6 +77,17 @@ use crate::supergraph::GRAPHQL_MUTATION_TYPE_NAME;
 use crate::supergraph::GRAPHQL_QUERY_TYPE_NAME;
 use crate::supergraph::GRAPHQL_SUBSCRIPTION_TYPE_NAME;
 use crate::supergraph::SERVICE_TYPE_SPEC;
+
+/// A subgraph as the user wrote it: the schema document, not yet parsed.
+///
+/// Validations that work on the document rather than on the parsed schema belong here, so that the
+/// locations they report point back at what the user actually wrote, and so that they can rewrite
+/// the document before it is parsed. Today that means the connectors (`@source`/`@connect`)
+/// validations, which is why [`Subgraph::validate_connectors`] is the only way out of this state.
+#[derive(Clone, Debug)]
+pub struct Source {
+    sdl: String,
+}
 
 #[derive(Clone, Debug)]
 pub struct Initial {
@@ -186,6 +203,125 @@ pub struct Subgraph<S> {
     pub state: S,
 }
 
+impl Subgraph<Source> {
+    /// Creates a subgraph from the schema document the user wrote.
+    pub fn from_sdl(
+        name: &str,
+        url: &str,
+        sdl: impl Into<String>,
+    ) -> Result<Subgraph<Source>, SubgraphError> {
+        check_subgraph_name(name)?;
+        Ok(Subgraph {
+            name: name.to_string(),
+            url: url.to_string(),
+            state: Source { sdl: sdl.into() },
+        })
+    }
+
+    pub fn sdl(&self) -> &str {
+        &self.state.sdl
+    }
+
+    /// Validates the connectors (`@source`/`@connect`) directives, then parses the document.
+    ///
+    /// Warnings are appended to `hints`; errors are returned and are fatal for this subgraph.
+    /// Parsing is part of this transition because the validations may rewrite the document — today
+    /// they auto-upgrade `connect/v0.1` to `v0.2` — and it is the rewritten document that the rest
+    /// of composition must work from.
+    // PORT_NOTE: Mirrors `validate_connector_subgraphs` from the apollo-composition crate.
+    pub fn validate_connectors(
+        self,
+        hints: &mut Vec<CompositionHint>,
+    ) -> Result<Subgraph<Initial>, Vec<CompositionError>> {
+        let ValidationResult {
+            errors: messages,
+            transformed,
+            ..
+        } = validate_connectors(self.state.sdl, &self.name);
+
+        let mut errors = vec![];
+        for message in messages {
+            let locations = message
+                .locations
+                .into_iter()
+                .map(|range| SubgraphLocation {
+                    subgraph: self.name.clone(),
+                    range,
+                })
+                .collect();
+            match message.code.severity() {
+                ConnectorsSeverity::Error => errors.push(CompositionError::ConnectorsError {
+                    code: message.code,
+                    message: message.message,
+                    locations,
+                }),
+                ConnectorsSeverity::Warning => hints.push(CompositionHint {
+                    definition: HintCode::Connectors(message.code).definition(),
+                    message: message.message,
+                    locations,
+                }),
+            }
+        }
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        Subgraph::parse(&self.name, &self.url, &transformed)
+            .map_err(|e| e.to_composition_errors().collect())
+    }
+
+    /// Given a document that is assumed to _not_ be a fed2 schema (it does not have a `@link` to
+    /// the federation spec), converts it to a fed2 schema by adding a `@link` to the last known
+    /// federation spec.
+    ///
+    /// - It is assumed to have no `@link` to the federation spec.
+    /// - Returns an equivalent subgraph with a `@link` added with latest federation spec.
+    /// - Based on the `include_all_imports` param, we either import ALL directive definitions OR just up to fed v2.4
+    /// - This is mainly for testing and not optimized.
+    // PORT_NOTE: Corresponds to `asFed2SubgraphDocument` function in JS, but simplified.
+    pub fn into_fed2_test_subgraph(self, include_all_imports: bool) -> Result<Self, SubgraphError> {
+        let federation_spec = FederationSpecDefinition::latest();
+        let spec_to_import = if include_all_imports {
+            federation_spec
+        } else {
+            FederationSpecDefinition::auto_expanded_federation_spec()
+        };
+        let imports = spec_to_import
+            .directive_specs()
+            .iter()
+            .map(|d| format!(r#""@{}""#, d.name()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let link = format!(
+            r#"extend schema @link(url: "{url}", import: [{imports}])"#,
+            url = federation_spec.url(),
+        );
+
+        // Test documents are written as raw strings that open with a newline, so the `@link` goes
+        // on that otherwise-empty first line rather than pushing every line of the document down by
+        // one. Locations reported against the document then still match what the test author wrote.
+        let sdl = match self.state.sdl.strip_prefix('\n') {
+            Some(rest) => format!("{link}\n{rest}"),
+            None => format!("{link}\n{}", self.state.sdl),
+        };
+        Self::from_sdl(&self.name, &self.url, sdl)
+    }
+}
+
+fn check_subgraph_name(name: &str) -> Result<(), SubgraphError> {
+    // We use this name as the "source" of root nodes in our federated query graph.
+    if name == FEDERATED_GRAPH_ROOT_SOURCE {
+        Err(SubgraphError::new_without_locations(
+            name.to_string(),
+            SingleFederationError::InvalidSubgraphName {
+                message: format!("Invalid name {name} for a subgraph: this name is reserved"),
+            },
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 impl Subgraph<Initial> {
     pub fn new(
         name: &str,
@@ -193,24 +329,15 @@ impl Subgraph<Initial> {
         schema: Schema,
         orphan_extension_types: HashSet<Name>,
     ) -> Result<Subgraph<Initial>, SubgraphError> {
-        // We use this name as the "source" of root nodes in our federated query graph.
-        if name == FEDERATED_GRAPH_ROOT_SOURCE {
-            Err(SubgraphError::new_without_locations(
-                name.to_string(),
-                SingleFederationError::InvalidSubgraphName {
-                    message: format!("Invalid name {name} for a subgraph: this name is reserved"),
-                },
-            ))
-        } else {
-            Ok(Subgraph {
-                name: name.to_string(),
-                url: url.to_string(),
-                state: Initial {
-                    schema,
-                    orphan_extension_types,
-                },
-            })
-        }
+        check_subgraph_name(name)?;
+        Ok(Subgraph {
+            name: name.to_string(),
+            url: url.to_string(),
+            state: Initial {
+                schema,
+                orphan_extension_types,
+            },
+        })
     }
 
     pub fn parse(

--- a/apollo-federation/tests/composition/compose_auth.rs
+++ b/apollo-federation/tests/composition/compose_auth.rs
@@ -500,8 +500,8 @@ fn specs_compose_in_consistent_order() {
           dob: String! @policy(policies: [["user"]])
         }
     "#;
-    let users =
-        Subgraph::parse("users", "http://users/graphql", users_sdl).expect("valid users subgraph");
+    let users = Subgraph::from_sdl("users", "http://users/graphql", users_sdl)
+        .expect("valid users subgraph");
 
     let address_sdl = r#"
         extend schema @link(url: "https://specs.apollo.dev/federation/v2.12", import: ["@key", "@requiresScopes"])
@@ -511,7 +511,7 @@ fn specs_compose_in_consistent_order() {
           address: String
         }
     "#;
-    let address = Subgraph::parse("address", "http://address/graphql", address_sdl)
+    let address = Subgraph::from_sdl("address", "http://address/graphql", address_sdl)
         .expect("valid address subgraph");
 
     let result = compose(vec![users.clone(), address.clone()]).expect("composes successfully");
@@ -1563,7 +1563,7 @@ fn verify_auth_works_with_older_federation_version() {
         }
     "#;
     let orders =
-        Subgraph::parse("orders", "http://orders/graphql", orders_sdl).expect("valid subgraph");
+        Subgraph::from_sdl("orders", "http://orders/graphql", orders_sdl).expect("valid subgraph");
 
     let users_sdl = r#"
         extend schema
@@ -1580,7 +1580,7 @@ fn verify_auth_works_with_older_federation_version() {
         }
     "#;
     let users =
-        Subgraph::parse("users", "http://users/graphql", users_sdl).expect("valid subgraph");
+        Subgraph::from_sdl("users", "http://users/graphql", users_sdl).expect("valid subgraph");
 
     let result = compose(vec![orders, users]).expect("composition should succeed");
     let schema = result.schema().schema();
@@ -2429,13 +2429,13 @@ mod propagate_auth {
         };
 
         let subgraphs = vec![
-            Subgraph::parse(
+            Subgraph::from_sdl(
                 subgraph1.name,
                 &format!("http://{}", subgraph1.name),
                 subgraph1.type_defs,
             )
             .expect("valid subgraph"),
-            Subgraph::parse(
+            Subgraph::from_sdl(
                 subgraph2.name,
                 &format!("http://{}", subgraph2.name),
                 subgraph2.type_defs,

--- a/apollo-federation/tests/composition/compose_basic.rs
+++ b/apollo-federation/tests/composition/compose_basic.rs
@@ -603,7 +603,7 @@ fn override_from_nonexistent_subgraph_hint_has_subgraph_location() {
 /// for the `query` root operation type" errors.
 #[test]
 fn supergraph_sdl_is_reparseable_when_subgraphs_use_extend_schema() {
-    let sub1 = Subgraph::parse(
+    let sub1 = Subgraph::from_sdl(
         "s1",
         "http://s1",
         r#"
@@ -634,7 +634,7 @@ fn supergraph_sdl_is_reparseable_when_subgraphs_use_extend_schema() {
     )
     .unwrap();
 
-    let sub2 = Subgraph::parse(
+    let sub2 = Subgraph::from_sdl(
         "s2",
         "http://s2",
         r#"

--- a/apollo-federation/tests/composition/compose_cache_tag.rs
+++ b/apollo-federation/tests/composition/compose_cache_tag.rs
@@ -70,7 +70,7 @@ fn cache_tag_can_be_renamed() {
         }
     "#;
     let products =
-        Subgraph::parse("products", "http://products/graphql", sdl).expect("parsed subgraph");
+        Subgraph::from_sdl("products", "http://products/graphql", sdl).expect("parsed subgraph");
     let result = compose(vec![products]).expect("composed successfully");
     assert_snapshot!(result.schema().schema());
 }

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -1,6 +1,6 @@
 use apollo_compiler::Name;
 use apollo_compiler::coord;
-use apollo_federation::subgraph::typestate::Initial;
+use apollo_federation::subgraph::typestate::Source;
 use apollo_federation::subgraph::typestate::Subgraph;
 use apollo_federation::supergraph::Satisfiable;
 use apollo_federation::supergraph::Supergraph;
@@ -80,7 +80,7 @@ mod simple_cases {
 
     #[test]
     fn simple_success_case_renamed_compose_directive() {
-        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+        let subgraph_a = Subgraph::from_sdl("subgraphA", "", r#"
       extend schema
         @link(url: "https://specs.apollo.dev/link/v1.0")
         @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", { name: "@composeDirective", as: "@apolloCompose" }])
@@ -159,7 +159,7 @@ mod federation_directives {
     #[case("@authenticated")]
     #[case("@requiresScopes")]
     fn hints_for_renamed_default_composed_federation_directives(#[case] directive: &str) {
-        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+        let subgraph_a = Subgraph::from_sdl("subgraphA", "", r#"
       extend schema
         @link(url: "https://specs.apollo.dev/link/v1.0")
         @link(url: "https://specs.apollo.dev/federation/v2.5", import: [{ name: "@key" }, { name: "@composeDirective" } , { name: "<DIRECTIVE>", as: "@apolloDirective" }])
@@ -238,7 +238,7 @@ mod federation_directives {
     fn errors_for_renamed_federation_directives_with_nontrivial_compositions(
         #[case] directive: &str,
     ) {
-        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+        let subgraph_a = Subgraph::from_sdl("subgraphA", "", r#"
       extend schema
         @link(url: "https://specs.apollo.dev/link/v1.0")
         @link(url: "https://specs.apollo.dev/federation/v2.1", import: [{ name: "@key" }, { name: "@composeDirective" } , { name: "<DIRECTIVE>", as: "@apolloDirective" }])
@@ -985,7 +985,7 @@ mod inconsistent_imports {
 
     #[test]
     fn errors_when_exported_directives_conflict_with_federation_directives() {
-        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+        let subgraph_a = Subgraph::from_sdl("subgraphA", "", r#"
             extend schema
                 @link(url: "https://specs.apollo.dev/link/v1.0")
                 @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective"])
@@ -1001,7 +1001,7 @@ mod inconsistent_imports {
                 a: String @inaccessible(name: "a")
             }
         "#).unwrap();
-        let subgraph_b = Subgraph::parse("subgraphB", "", r#"
+        let subgraph_b = Subgraph::from_sdl("subgraphB", "", r#"
             extend schema
                 @link(url: "https://specs.apollo.dev/link/v1.0")
                 @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@inaccessible"])
@@ -1156,7 +1156,7 @@ mod composition {
 
     #[test]
     fn composes_custom_tag_directive_when_renamed() {
-        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+        let subgraph_a = Subgraph::from_sdl("subgraphA", "", r#"
             extend schema
                 @link(url: "https://specs.apollo.dev/link/v1.0")
                 @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@tag"])
@@ -1218,7 +1218,7 @@ mod composition {
 
     #[test]
     fn composes_custom_tag_when_federation_tag_is_renamed() {
-        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+        let subgraph_a = Subgraph::from_sdl("subgraphA", "", r#"
             extend schema
                 @link(url: "https://specs.apollo.dev/link/v1.0")
                 @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", {name: "@tag", as: "@mytag"}])
@@ -1235,7 +1235,7 @@ mod composition {
                 b: String @mytag(name: "c")
             }
         "#).unwrap();
-        let subgraph_b = Subgraph::parse(
+        let subgraph_b = Subgraph::from_sdl(
             "subgraphB",
             "",
             r#"
@@ -1294,7 +1294,7 @@ mod composition {
 
     #[test]
     fn composes_repeatable_custom_directives() {
-        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+        let subgraph_a = Subgraph::from_sdl("subgraphA", "", r#"
             extend schema @composeDirective(name: "@auth")
               @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
               @link(url: "https://custom.dev/auth/v1.0", import: ["@auth"])
@@ -1304,7 +1304,7 @@ mod composition {
               shared: String @shareable @auth(scope: "VIEWER")
             }
         "#).unwrap();
-        let subgraph_b = Subgraph::parse("subgraphB", "", r#"
+        let subgraph_b = Subgraph::from_sdl("subgraphB", "", r#"
             extend schema @composeDirective(name: "@auth")
               @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
               @link(url: "https://custom.dev/auth/v1.0", import: ["@auth"])
@@ -1337,7 +1337,7 @@ mod composition {
 
     #[test]
     fn composes_custom_directive_with_nullable_array_arguments() {
-        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+        let subgraph_a = Subgraph::from_sdl("subgraphA", "", r#"
             extend schema @composeDirective(name: "@auth")
               @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
               @link(url: "https://custom.dev/auth/v1.0", import: ["@auth"])
@@ -1347,7 +1347,7 @@ mod composition {
               shared: String @shareable @auth(scope: ["VIEWER"])
             }
         "#).unwrap();
-        let subgraph_b = Subgraph::parse("subgraphB", "", r#"
+        let subgraph_b = Subgraph::from_sdl("subgraphB", "", r#"
             extend schema @composeDirective(name: "@auth")
               @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
               @link(url: "https://custom.dev/auth/v1.0", import: ["@auth"])
@@ -1387,7 +1387,7 @@ mod composition {
         // it without specifying the argument (relying on the default).
         // Subgraph B defines @foo without a default value for `debug` and
         // applies it explicitly with the value matching subgraph A's default.
-        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+        let subgraph_a = Subgraph::from_sdl("subgraphA", "", r#"
             extend schema @composeDirective(name: "@foo")
               @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
               @link(url: "https://custom.dev/foo/v1.0", import: ["@foo"])
@@ -1397,7 +1397,7 @@ mod composition {
               shared: String @shareable @foo(name: "test")
             }
         "#).expect("valid subgraph");
-        let subgraph_b = Subgraph::parse("subgraphB", "", r#"
+        let subgraph_b = Subgraph::from_sdl("subgraphB", "", r#"
             extend schema @composeDirective(name: "@foo")
               @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
               @link(url: "https://custom.dev/foo/v1.1", import: ["@foo"])
@@ -1519,7 +1519,7 @@ mod string_to_enum_coercion {
     /// unquoted enum value `INTERNAL` is a valid representation of string `"INTERNAL"`.
     #[test]
     fn composes_directive_with_enum_arg_when_other_subgraph_uses_string() {
-        let subgraph_a = Subgraph::parse("subgraphA", "", r#"
+        let subgraph_a = Subgraph::from_sdl("subgraphA", "", r#"
             extend schema @composeDirective(name: "@custom")
               @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
               @link(url: "https://custom.dev/custom/v1.0", import: ["@custom"])
@@ -1541,7 +1541,7 @@ mod string_to_enum_coercion {
             }
         "#).expect("valid first subgraph");
 
-        let subgraph_b = Subgraph::parse("subgraphB", "", r#"
+        let subgraph_b = Subgraph::from_sdl("subgraphB", "", r#"
             extend schema @composeDirective(name: "@custom")
               @link(url: "https://specs.apollo.dev/federation/v2.1", import: ["@key", "@composeDirective", "@shareable"])
               @link(url: "https://custom.dev/custom/v1.0", import: ["@custom"])
@@ -1572,7 +1572,7 @@ fn generate_subgraph(
     compose_text: &str,
     directive_text: &str,
     usage: &str,
-) -> Subgraph<Initial> {
+) -> Subgraph<Source> {
     let schema = r#"
         extend schema
             @link(url: "https://specs.apollo.dev/link/v1.0")
@@ -1595,7 +1595,7 @@ fn generate_subgraph(
     .replace("<NAME>", name)
     .replace("<USAGE>", usage);
 
-    Subgraph::parse(name, "", schema.as_str())
+    Subgraph::from_sdl(name, "", schema.as_str())
         .unwrap()
         .into_fed2_test_subgraph(true)
         .unwrap()

--- a/apollo-federation/tests/composition/compose_directive_sharing.rs
+++ b/apollo-federation/tests/composition/compose_directive_sharing.rs
@@ -544,7 +544,7 @@ fn interface_object_key_field_is_shareable() {
 
 #[test]
 fn federation_directive_handles_renamed_federation_directives() {
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraphA", 
         "http://subgraphA",
         r#"
@@ -566,7 +566,7 @@ fn federation_directive_handles_renamed_federation_directives() {
         "#,
     ).expect("subgraphA should parse successfully");
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "http://subgraphB",
         r#"
@@ -609,7 +609,7 @@ fn composition_with_shareable_on_interface_object_field() {
     // copying AST nodes from the subgraph. This sometimes wrongly copied subgraph-only directives
     // to the supergraph.
 
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraphA",
         "http://subgraphA",
         r#"
@@ -634,7 +634,7 @@ fn composition_with_shareable_on_interface_object_field() {
     )
     .expect("subgraphA should parse successfully");
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "http://subgraphB",
         r#"

--- a/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_fed1_subgraphs.rs
@@ -15,7 +15,7 @@ fn compose_services(
     let mut subgraphs = Vec::new();
     let mut errors = Vec::new();
     for service in service_list {
-        let result = Subgraph::parse(
+        let result = Subgraph::from_sdl(
             service.name,
             &format!("http://{}", service.name),
             service.type_defs,

--- a/apollo-federation/tests/composition/compose_inaccessible.rs
+++ b/apollo-federation/tests/composition/compose_inaccessible.rs
@@ -145,7 +145,7 @@ fn inaccessible_rejects_inaccessible_and_external_together() {
 
 #[test]
 fn inaccessible_errors_if_imported_under_mismatched_names() {
-    let subgraph_a = Subgraph::parse("subgraphA", "",
+    let subgraph_a = Subgraph::from_sdl("subgraphA", "",
         r#"
         extend schema
           @link(url: "https://specs.apollo.dev/federation/v2.0", import: [{name: "@inaccessible", as: "@private"}])
@@ -157,7 +157,7 @@ fn inaccessible_errors_if_imported_under_mismatched_names() {
         "#,
     ).unwrap();
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "",
         r#"
@@ -183,7 +183,7 @@ fn inaccessible_errors_if_imported_under_mismatched_names() {
 
 #[test]
 fn inaccessible_succeeds_if_imported_under_same_non_default_name() {
-    let subgraph_a = Subgraph::parse("subgraphA", "",
+    let subgraph_a = Subgraph::from_sdl("subgraphA", "",
         r#"
         extend schema
           @link(url: "https://specs.apollo.dev/federation/v2.0", import: [{name: "@inaccessible", as: "@private"}])
@@ -195,7 +195,7 @@ fn inaccessible_succeeds_if_imported_under_same_non_default_name() {
         "#,
     ).unwrap();
 
-    let subgraph_b = Subgraph::parse("subgraphB", "",
+    let subgraph_b = Subgraph::from_sdl("subgraphB", "",
         r#"
         extend schema
           @link(url: "https://specs.apollo.dev/federation/v2.0", import: [{name: "@inaccessible", as: "@private"}])
@@ -419,7 +419,7 @@ fn inaccessible_uses_security_core_purpose_in_supergraph() {
 fn namespaced_inaccessible_composes_correctly() {
     // This subgraph uses the namespaced form @federation__inaccessible because it does not
     // explicitly import @inaccessible in the @link directive
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraphA",
         "http://subgraphA",
         r#"
@@ -440,7 +440,7 @@ fn namespaced_inaccessible_composes_correctly() {
     )
     .unwrap();
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "http://subgraphB",
         r#"

--- a/apollo-federation/tests/composition/compose_interface_object.rs
+++ b/apollo-federation/tests/composition/compose_interface_object.rs
@@ -517,9 +517,9 @@ fn interface_object_with_inaccessible_field() {
         }
     "#;
 
-    let parsed_a = Subgraph::parse("subgraph-a", "http://example.com", subgraph_a).unwrap();
-    let parsed_b = Subgraph::parse("subgraph-b", "http://example.com", subgraph_b).unwrap();
-    let parsed_c = Subgraph::parse("subgraph-c", "http://example.com", subgraph_c).unwrap();
+    let parsed_a = Subgraph::from_sdl("subgraph-a", "http://example.com", subgraph_a).unwrap();
+    let parsed_b = Subgraph::from_sdl("subgraph-b", "http://example.com", subgraph_b).unwrap();
+    let parsed_c = Subgraph::from_sdl("subgraph-c", "http://example.com", subgraph_c).unwrap();
 
     let supergraph = compose(vec![parsed_a, parsed_b, parsed_c]).unwrap();
 
@@ -591,9 +591,9 @@ fn interface_object_field_tag_propagates_to_locally_external_field() {
     "#;
 
     let parsed_a =
-        Subgraph::parse("subgraph-a", "http://example.com", subgraph_a).expect("valid subgraph");
+        Subgraph::from_sdl("subgraph-a", "http://example.com", subgraph_a).expect("valid subgraph");
     let parsed_b =
-        Subgraph::parse("subgraph-b", "http://example.com", subgraph_b).expect("valid subgraph");
+        Subgraph::from_sdl("subgraph-b", "http://example.com", subgraph_b).expect("valid subgraph");
 
     let supergraph = compose(vec![parsed_a, parsed_b]).expect("Expected composition to succeed");
 

--- a/apollo-federation/tests/composition/compose_misc.rs
+++ b/apollo-federation/tests/composition/compose_misc.rs
@@ -291,7 +291,7 @@ fn misc_handles_fragments_in_requires_using_inaccessible_types() {
 
 #[test]
 fn misc_existing_authenticated_directive_with_fed1() {
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraphA",
         "http://subgraphA",
         r#"
@@ -305,7 +305,7 @@ fn misc_existing_authenticated_directive_with_fed1() {
     )
     .expect("valid subgraph");
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "http://subgraphB",
         r#"
@@ -459,9 +459,9 @@ fn test_satisfiability_handles_extra_implicit_downcast() {
         }
     "#;
 
-    let parsed_a = Subgraph::parse("subgraph-a", "http://subgraph-a", subgraph_a)
+    let parsed_a = Subgraph::from_sdl("subgraph-a", "http://subgraph-a", subgraph_a)
         .expect("Failed to parse subgraph-a");
-    let parsed_b = Subgraph::parse("subgraph-b", "http://subgraph-b", subgraph_b)
+    let parsed_b = Subgraph::from_sdl("subgraph-b", "http://subgraph-b", subgraph_b)
         .expect("Failed to parse subgraph-b");
 
     // Before the fix, this would fail with:
@@ -624,7 +624,7 @@ mod supergraph_spec_imports {
             }
         "#;
         let subgraph =
-            Subgraph::parse("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
+            Subgraph::from_sdl("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
 
         let supergraph = compose(vec![subgraph]).expect("composition should succeed");
         assert_snapshot!(supergraph.schema().schema());
@@ -647,7 +647,7 @@ mod supergraph_spec_imports {
                 internalCode: String @inaccessible
             }
         "#;
-        let subgraph = Subgraph::parse("products", "http://products/graphql", sdl)
+        let subgraph = Subgraph::from_sdl("products", "http://products/graphql", sdl)
             .expect("successfully parsed");
         let result = compose(vec![subgraph]);
         assert_composition_errors(
@@ -678,7 +678,7 @@ mod supergraph_spec_imports {
             }
         "#;
         let subgraph =
-            Subgraph::parse("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
+            Subgraph::from_sdl("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
         let result = compose(vec![subgraph]);
         assert_composition_errors(
             &result,
@@ -719,7 +719,7 @@ mod supergraph_spec_imports {
             }
         "#;
         let subgraph =
-            Subgraph::parse("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
+            Subgraph::from_sdl("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
 
         let supergraph = compose(vec![subgraph]).expect("composition should succeed");
         assert_snapshot!(supergraph.schema().schema());
@@ -746,7 +746,7 @@ mod supergraph_spec_imports {
             }
         "#;
         let subgraph =
-            Subgraph::parse("products", "http://products/graphql", sdl).expect("valid subgraph");
+            Subgraph::from_sdl("products", "http://products/graphql", sdl).expect("valid subgraph");
         let result = compose(vec![subgraph]);
         assert_composition_errors(
             &result,
@@ -783,7 +783,7 @@ mod supergraph_spec_imports {
             }
         "#;
         let subgraph =
-            Subgraph::parse("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
+            Subgraph::from_sdl("accounts", "http://accounts/graphql", sdl).expect("valid subgraph");
 
         let supergraph = compose(vec![subgraph]).expect("composition should succeed");
         let schema = supergraph.schema().schema();

--- a/apollo-federation/tests/composition/compose_set_context.rs
+++ b/apollo-federation/tests/composition/compose_set_context.rs
@@ -1424,7 +1424,7 @@ fn from_context_field_in_all_subgraphs_preserves_join_field() {
     use apollo_federation::subgraph::typestate::Subgraph;
 
     // s1: owns T with @context, U.f has @fromContext on its argument
-    let s1 = Subgraph::parse(
+    let s1 = Subgraph::from_sdl(
         "s1",
         "http://s1",
         r#"
@@ -1462,7 +1462,7 @@ fn from_context_field_in_all_subgraphs_preserves_join_field() {
     .unwrap();
 
     // s2: also has U.f with same type but no @fromContext
-    let s2 = Subgraph::parse(
+    let s2 = Subgraph::from_sdl(
         "s2",
         "http://s2",
         r#"

--- a/apollo-federation/tests/composition/compose_tag.rs
+++ b/apollo-federation/tests/composition/compose_tag.rs
@@ -140,7 +140,7 @@ fn tag_propagates_to_supergraph_fed2_subgraphs() {
 
 #[test]
 fn tag_propagates_to_supergraph_fed1_subgraphs() {
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraphA",
         "",
         r#"
@@ -156,7 +156,7 @@ fn tag_propagates_to_supergraph_fed1_subgraphs() {
     )
     .unwrap();
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "",
         r#"
@@ -176,7 +176,7 @@ fn tag_propagates_to_supergraph_fed1_subgraphs() {
 
 #[test]
 fn tag_propagates_to_supergraph_mixed_fed1_fed2_subgraphs() {
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraphA",
         "",
         r#"
@@ -192,7 +192,7 @@ fn tag_propagates_to_supergraph_mixed_fed1_fed2_subgraphs() {
     )
     .unwrap();
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "",
         r#"
@@ -261,7 +261,7 @@ fn tag_merges_multiple_tags_fed2_subgraphs() {
 
 #[test]
 fn tag_merges_multiple_tags_fed1_subgraphs() {
-    let subgraph_a = Subgraph::parse("subgraphA", "", 
+    let subgraph_a = Subgraph::from_sdl("subgraphA", "", 
         r#"
         type Query {
           user: [User]
@@ -279,7 +279,7 @@ fn tag_merges_multiple_tags_fed1_subgraphs() {
         "#,
     ).unwrap();
 
-    let subgraph_b = Subgraph::parse( "subgraphB", "",
+    let subgraph_b = Subgraph::from_sdl( "subgraphB", "",
         r#"
         type User @key(fields: "id") @tag(name: "aTagOnTypeFromSubgraphB") @tag(name: "aMergedTagOnType") {
           id: ID!
@@ -300,7 +300,7 @@ fn tag_merges_multiple_tags_fed1_subgraphs() {
 
 #[test]
 fn tag_merges_multiple_tags_mixed_fed1_fed2_subgraphs() {
-    let subgraph_a = Subgraph::parse("subgraphA", "", 
+    let subgraph_a = Subgraph::from_sdl("subgraphA", "", 
         r#"
         type Query {
           user: [User]
@@ -318,7 +318,7 @@ fn tag_merges_multiple_tags_mixed_fed1_fed2_subgraphs() {
         "#,
     ).unwrap();
 
-    let subgraph_b = Subgraph::parse( "subgraphB", "",
+    let subgraph_b = Subgraph::from_sdl( "subgraphB", "",
         r#"
         type User @key(fields: "id") @tag(name: "aTagOnTypeFromSubgraphB") @tag(name: "aMergedTagOnType") {
           id: ID!
@@ -381,7 +381,7 @@ fn tag_rejects_tag_and_external_together_fed2_subgraphs() {
 
 #[test]
 fn tag_rejects_tag_and_external_together_fed1_subgraphs() {
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraphA",
         "",
         r#"
@@ -399,7 +399,7 @@ fn tag_rejects_tag_and_external_together_fed1_subgraphs() {
     )
     .unwrap();
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "",
         r#"
@@ -423,7 +423,7 @@ fn tag_rejects_tag_and_external_together_fed1_subgraphs() {
 
 #[test]
 fn tag_rejects_tag_and_external_together_mixed_fed1_fed2_subgraphs() {
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraphA",
         "",
         r#"
@@ -441,7 +441,7 @@ fn tag_rejects_tag_and_external_together_mixed_fed1_fed2_subgraphs() {
     )
     .unwrap();
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "",
         r#"
@@ -471,7 +471,7 @@ fn tag_rejects_tag_and_external_together_mixed_fed1_fed2_subgraphs() {
 
 #[test]
 fn tag_errors_if_imported_under_mismatched_names() {
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraphA",
         "",
         r#"
@@ -485,7 +485,7 @@ fn tag_errors_if_imported_under_mismatched_names() {
     )
     .unwrap();
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "",
         r#"
@@ -511,7 +511,7 @@ fn tag_errors_if_imported_under_mismatched_names() {
 
 #[test]
 fn tag_succeeds_if_imported_under_same_non_default_name() {
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraphA",
         "",
         r#"
@@ -525,7 +525,7 @@ fn tag_succeeds_if_imported_under_same_non_default_name() {
     )
     .unwrap();
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "",
         r#"

--- a/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
+++ b/apollo-federation/tests/composition/compose_upgrade_subgraphs.rs
@@ -282,7 +282,7 @@ fn upgrade_does_not_add_shareable_to_key_fields_in_partial_schemas() {
 /// in the supergraph.
 #[test]
 fn fed1_requires_with_cross_subgraph_inline_fragment_type_condition() {
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraphA",
         "",
         r#"
@@ -307,7 +307,7 @@ fn fed1_requires_with_cross_subgraph_inline_fragment_type_condition() {
     )
     .expect("parses subgraphA");
 
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraphB",
         "",
         r#"

--- a/apollo-federation/tests/composition/connectors.rs
+++ b/apollo-federation/tests/composition/connectors.rs
@@ -1,7 +1,11 @@
+use apollo_federation::subgraph::typestate::Subgraph;
+use apollo_federation::supergraph::HintLevel;
 use insta::assert_snapshot;
 
 use super::ServiceDefinition;
-use super::compose_as_fed2_subgraphs;
+use super::assert_composition_errors;
+use super::compose;
+use super::compose_as_fed2_connectors_subgraphs;
 
 #[cfg(test)]
 mod tests {
@@ -21,7 +25,10 @@ mod tests {
 
                 type Query {
                     resources: [Resource!]!
-                    @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "id name")
+
+                    resource(id: ID!): Resource
+                    @connect(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id name", entity: true)
                 }
 
                 type Resource @key(fields: "id") {
@@ -31,7 +38,7 @@ mod tests {
             "#,
         };
 
-        let result = compose_as_fed2_subgraphs(&[with_connectors]);
+        let result = compose_as_fed2_connectors_subgraphs(&[with_connectors]);
         let supergraph = result.expect("Expected composition to succeed");
         let schema_string = supergraph.schema().schema().to_string();
 
@@ -42,16 +49,17 @@ mod tests {
             .expect("Expected API schema generation to succeed");
         let api_schema_string = api_schema.schema().to_string();
 
-        assert_snapshot!(api_schema_string, @r###"
+        assert_snapshot!(api_schema_string, @"
         type Query {
           resources: [Resource!]!
+          resource(id: ID!): Resource
         }
 
         type Resource {
           id: ID!
           name: String!
         }
-        "###);
+        ");
     }
 
     #[test]
@@ -68,7 +76,10 @@ mod tests {
 
                 type Query {
                     resources: [Resource!]!
-                    @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "id name")
+
+                    resource(id: ID!): Resource
+                    @connect(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id name", entity: true)
                 }
 
                 type Resource @key(fields: "id") {
@@ -78,7 +89,7 @@ mod tests {
             "#,
         };
 
-        let result = compose_as_fed2_subgraphs(&[with_connectors]);
+        let result = compose_as_fed2_connectors_subgraphs(&[with_connectors]);
         let supergraph = result.expect("Expected composition to succeed");
         let schema_string = supergraph.schema().schema().to_string();
 
@@ -89,16 +100,17 @@ mod tests {
             .expect("Expected API schema generation to succeed");
         let api_schema_string = api_schema.schema().to_string();
 
-        assert_snapshot!(api_schema_string, @r###"
+        assert_snapshot!(api_schema_string, @"
         type Query {
           resources: [Resource!]!
+          resource(id: ID!): Resource
         }
 
         type Resource {
           id: ID!
           name: String!
         }
-        "###);
+        ");
     }
 
     #[test]
@@ -116,7 +128,10 @@ mod tests {
 
                 type Query {
                     resources: [Resource!]!
-                    @http(source: "v1", http: { GET: "/resources" }, selection: "")
+                    @http(source: "v1", http: { GET: "/resources" }, selection: "id name")
+
+                    resource(id: ID!): Resource
+                    @http(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id name", entity: true)
                 }
 
                 type Resource @key(fields: "id") {
@@ -126,7 +141,7 @@ mod tests {
             "#,
         };
 
-        let result = compose_as_fed2_subgraphs(&[with_connectors]);
+        let result = compose_as_fed2_connectors_subgraphs(&[with_connectors]);
         let supergraph = result.expect("Expected composition to succeed");
         let schema_string = supergraph.schema().schema().to_string();
 
@@ -137,16 +152,17 @@ mod tests {
             .expect("Expected API schema generation to succeed");
         let api_schema_string = api_schema.schema().to_string();
 
-        assert_snapshot!(api_schema_string, @r###"
+        assert_snapshot!(api_schema_string, @"
         type Query {
           resources: [Resource!]!
+          resource(id: ID!): Resource
         }
 
         type Resource {
           id: ID!
           name: String!
         }
-        "###);
+        ");
     }
 
     #[test]
@@ -163,15 +179,18 @@ mod tests {
                   name: "v1"
                   http: {
                     baseURL: "http://v1"
-                    path: ""
-                    queryParams: ""
+                    path: "$(['v1'])"
+                    queryParams: "$({ locale: 'en' })"
                   }
-                  errors: { message: "" extensions: "" }
+                  errors: { message: "error.message" extensions: "code: error.code" }
                 )
 
                 type Query {
                     resources: [Resource!]!
-                    @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "id name")
+
+                    resource(id: ID!): Resource
+                    @connect(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id name", entity: true)
                 }
 
                 type Resource @key(fields: "id")
@@ -179,12 +198,12 @@ mod tests {
                     source: "v1"
                     http: {
                       GET: "/resources"
-                      path: ""
-                      queryParams: ""
+                      path: "$(['v1'])"
+                      queryParams: "$({ locale: 'en' })"
                     }
                     batch: { maxSize: 5 }
-                    errors: { message: "" extensions: "" }
-                    selection: ""
+                    errors: { message: "error.message" extensions: "code: error.code" }
+                    selection: "id name"
                   ) {
                     id: ID!
                     name: String!
@@ -204,7 +223,10 @@ mod tests {
 
                 type Query {
                     widgets: [Widget!]!
-                    @connect(source: "v1", http: { GET: "/widgets" }, selection: "")
+                    @connect(source: "v1", http: { GET: "/widgets" }, selection: "id name")
+
+                    widget(id: ID!): Widget
+                    @connect(source: "v1", http: { GET: "/widgets/{$args.id}" }, selection: "id name", entity: true)
                 }
 
                 type Widget @key(fields: "id") {
@@ -214,7 +236,8 @@ mod tests {
             "#,
         };
 
-        let result = compose_as_fed2_subgraphs(&[with_connectors_v0_2, with_connectors_v0_1]);
+        let result =
+            compose_as_fed2_connectors_subgraphs(&[with_connectors_v0_2, with_connectors_v0_1]);
         let supergraph = result.expect("Expected composition to succeed");
         let schema_string = supergraph.schema().schema().to_string();
 
@@ -228,7 +251,9 @@ mod tests {
         assert_snapshot!(api_schema_string, @"
         type Query {
           widgets: [Widget!]!
+          widget(id: ID!): Widget
           resources: [Resource!]!
+          resource(id: ID!): Resource
         }
 
         type Widget {
@@ -261,7 +286,10 @@ mod tests {
 
                 type Query {
                     resources: [Resource!]!
-                    @http(source: "v1", http: { GET: "/resources" }, selection: "")
+                    @http(source: "v1", http: { GET: "/resources" }, selection: "id name")
+
+                    resource(id: ID!): Resource
+                    @http(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id name", entity: true)
                 }
 
                 type Resource @key(fields: "id") {
@@ -271,7 +299,7 @@ mod tests {
             "#,
         };
 
-        let result = compose_as_fed2_subgraphs(&[with_connectors]);
+        let result = compose_as_fed2_connectors_subgraphs(&[with_connectors]);
         let supergraph = result.expect("Expected composition to succeed");
         let schema_string = supergraph.schema().schema().to_string();
 
@@ -282,16 +310,17 @@ mod tests {
             .expect("Expected API schema generation to succeed");
         let api_schema_string = api_schema.schema().to_string();
 
-        assert_snapshot!(api_schema_string, @r###"
+        assert_snapshot!(api_schema_string, @"
         type Query {
           resources: [Resource!]!
+          resource(id: ID!): Resource
         }
 
         type Resource {
           id: ID!
           name: String!
         }
-        "###);
+        ");
     }
     #[test]
     #[ignore]
@@ -308,7 +337,10 @@ mod tests {
 
                 type Query {
                     resources: [Resource!]!
-                    @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "id name")
+
+                    resource(id: ID!): Resource
+                    @connect(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id name", entity: true)
                 }
 
                 type Resource @key(fields: "id") {
@@ -318,7 +350,7 @@ mod tests {
             "#,
         };
 
-        let result = compose_as_fed2_subgraphs(&[subgraphs]);
+        let result = compose_as_fed2_connectors_subgraphs(&[subgraphs]);
 
         // This should fail with error: [with-connectors] Directive "@source" argument "http"
         // of type "connect__SourceHTTP!" is required, but it was not provided.
@@ -365,7 +397,7 @@ mod tests {
 
                 type Query {
                     resources: [Resource!]!
-                    @connect(source: "v1", selection: "")
+                    @connect(source: "v1", selection: "id name")
                 }
 
                 type Resource @key(fields: "id") {
@@ -375,7 +407,7 @@ mod tests {
             "#,
         };
 
-        let result = compose_as_fed2_subgraphs(&[subgraphs]);
+        let result = compose_as_fed2_connectors_subgraphs(&[subgraphs]);
 
         // This should fail with error: [with-connectors] Directive "@connect" argument "http"
         // of type "connect__ConnectHTTP!" is required, but it was not provided.
@@ -421,16 +453,19 @@ mod tests {
                   name: "v1"
                   http: {
                     baseURL: "http://v1"
-                    path: ""
-                    queryParams: ""
+                    path: "$(['v1'])"
+                    queryParams: "$({ locale: 'en' })"
                   }
-                  errors: { message: "" extensions: "" }
-                  isSuccess: ""
+                  errors: { message: "error.message" extensions: "code: error.code" }
+                  isSuccess: "$status->eq(200)"
                 )
 
                 type Query {
                     resources: [Resource!]!
-                    @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "id name")
+
+                    resource(id: ID!): Resource
+                    @connect(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id name", entity: true)
                 }
 
                 type Resource @key(fields: "id")
@@ -439,13 +474,13 @@ mod tests {
                     source: "v1"
                     http: {
                       GET: "/resources"
-                      path: ""
-                      queryParams: ""
+                      path: "$(['v1'])"
+                      queryParams: "$({ locale: 'en' })"
                     }
                     batch: { maxSize: 5 }
-                    errors: { message: "" extensions: "" }
-                    isSuccess: ""
-                    selection: ""
+                    errors: { message: "error.message" extensions: "code: error.code" }
+                    isSuccess: "$status->eq(200)"
+                    selection: "id name"
                   ) {
                     id: ID!
                     name: String!
@@ -465,7 +500,10 @@ mod tests {
 
                 type Query {
                     widgets: [Widget!]!
-                    @connect(source: "v1", http: { GET: "/widgets" }, selection: "")
+                    @connect(source: "v1", http: { GET: "/widgets" }, selection: "id name")
+
+                    widget(id: ID!): Widget
+                    @connect(source: "v1", http: { GET: "/widgets/{$args.id}" }, selection: "id name", entity: true)
                 }
 
                 type Widget @key(fields: "id") {
@@ -475,7 +513,8 @@ mod tests {
             "#,
         };
 
-        let result = compose_as_fed2_subgraphs(&[with_connectors_v0_3, with_connectors_v0_1]);
+        let result =
+            compose_as_fed2_connectors_subgraphs(&[with_connectors_v0_3, with_connectors_v0_1]);
         let supergraph = result.expect("Expected composition to succeed");
         let schema_string = supergraph.schema().schema().to_string();
 
@@ -503,16 +542,19 @@ mod tests {
                   name: "v1"
                   http: {
                     baseURL: "http://v1"
-                    path: ""
-                    queryParams: ""
+                    path: "$(['v1'])"
+                    queryParams: "$({ locale: 'en' })"
                   }
-                  errors: { message: "" extensions: "" }
-                  isSuccess: ""
+                  errors: { message: "error.message" extensions: "code: error.code" }
+                  isSuccess: "$status->eq(200)"
                 )
 
                 type Query {
                     resources: [Resource!]!
-                    @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "id name")
+
+                    resource(id: ID!): Resource
+                    @connect(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id name", entity: true)
                 }
 
                 type Resource @key(fields: "id")
@@ -521,13 +563,13 @@ mod tests {
                     source: "v1"
                     http: {
                       GET: "/resources"
-                      path: ""
-                      queryParams: ""
+                      path: "$(['v1'])"
+                      queryParams: "$({ locale: 'en' })"
                     }
                     batch: { maxSize: 5 }
-                    errors: { message: "" extensions: "" }
-                    isSuccess: ""
-                    selection: ""
+                    errors: { message: "error.message" extensions: "code: error.code" }
+                    isSuccess: "$status->eq(200)"
+                    selection: "id name"
                   ) {
                     id: ID!
                     name: String!
@@ -547,7 +589,10 @@ mod tests {
 
                 type Query {
                     widgets: [Widget!]!
-                    @connect(source: "v4", http: { GET: "/widgets" }, selection: "")
+                    @connect(source: "v4", http: { GET: "/widgets" }, selection: "id name")
+
+                    widget(id: ID!): Widget
+                    @connect(source: "v4", http: { GET: "/widgets/{$args.id}" }, selection: "id name", entity: true)
                 }
 
                 type Widget @key(fields: "id") {
@@ -557,7 +602,8 @@ mod tests {
             "#,
         };
 
-        let result = compose_as_fed2_subgraphs(&[with_connectors_v0_3, with_connectors_v0_4]);
+        let result =
+            compose_as_fed2_connectors_subgraphs(&[with_connectors_v0_3, with_connectors_v0_4]);
         let supergraph = result.expect("Expected composition to succeed");
         let schema_string = supergraph.schema().schema().to_string();
 
@@ -569,5 +615,401 @@ mod tests {
         let api_schema_string = api_schema.schema().to_string();
 
         assert_snapshot!(api_schema_string);
+    }
+
+    #[test]
+    fn connectors_validation_errors_fail_composition() {
+        let with_connectors = ServiceDefinition {
+            name: "with-connectors",
+            type_defs: r#"
+                extend schema
+                @link(
+                    url: "https://specs.apollo.dev/connect/v0.2"
+                    import: ["@connect", "@source"]
+                )
+                @source(name: "v1", http: { baseURL: "http://v1" })
+
+                type Query {
+                    resources: [Resource!]!
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+                }
+
+                type Resource {
+                    id: ID!
+                    name: String!
+                }
+            "#,
+        };
+
+        let result = compose_as_fed2_connectors_subgraphs(&[with_connectors]);
+
+        assert_composition_errors(
+            &result,
+            &[(
+                "INVALID_SELECTION",
+                "`@connect(selection:)` on `Query.resources` is empty",
+            )],
+        );
+    }
+
+    /// Connectors validations run against the schema document the user wrote, so the locations
+    /// they report have to point back into it.
+    #[test]
+    fn connectors_validation_errors_keep_subgraph_locations() {
+        let type_defs = r#"
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.11", import: ["@key"])
+  @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"])
+  @source(name: "v1", http: { baseURL: "http://v1" })
+
+type Query {
+  resources: [Resource!]! @connect(source: "v1", http: { GET: "/resources" }, selection: "")
+}
+
+type Resource {
+  id: ID!
+  name: String!
+}
+        "#;
+        let subgraph =
+            Subgraph::from_sdl("with-connectors", "http://with-connectors", type_defs).unwrap();
+
+        let failure = compose(vec![subgraph]).expect_err("Expected composition to fail");
+        let locations = failure.errors[0].locations();
+
+        assert_eq!(locations.len(), 1);
+        assert_eq!(locations[0].subgraph, "with-connectors");
+        // The empty `selection` argument is on line 8 of the subgraph document.
+        assert_eq!(locations[0].range.start.line, 8);
+    }
+
+    /// Connectors warnings are reported as composition hints rather than failing the composition.
+    #[test]
+    fn connectors_validation_warnings_are_reported_as_hints() {
+        let with_connectors = ServiceDefinition {
+            name: "with-connectors",
+            type_defs: r#"
+                extend schema
+                @link(
+                    url: "https://specs.apollo.dev/connect/v0.2"
+                    import: ["@connect"]
+                )
+
+                type Query {
+                    resources: [Resource!]!
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "id name")
+                }
+
+                type Resource {
+                    id: ID!
+                    name: String!
+                }
+            "#,
+        };
+
+        let failure = compose_as_fed2_connectors_subgraphs(&[with_connectors])
+            .expect_err("Expected composition to fail");
+
+        assert!(
+            failure.hints.iter().any(|hint| {
+                hint.code() == "NO_SOURCE_IMPORT" && matches!(hint.level(), HintLevel::Warn)
+            }),
+            "Expected a NO_SOURCE_IMPORT hint, got: {:?}",
+            failure
+                .hints
+                .iter()
+                .map(|hint| hint.code())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// `@override(from:)` pointing at a connector-enabled subgraph is rejected.
+    #[test]
+    fn override_on_connector_subgraph_is_rejected() {
+        let with_connectors = ServiceDefinition {
+            name: "with-connectors",
+            type_defs: r#"
+                extend schema
+                @link(
+                    url: "https://specs.apollo.dev/connect/v0.2"
+                    import: ["@connect", "@source"]
+                )
+                @source(name: "v1", http: { baseURL: "http://v1" })
+
+                type Query {
+                    resources: [Resource!]!
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "id name")
+
+                    resource(id: ID!): Resource
+                    @connect(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id name", entity: true)
+                }
+
+                type Resource @key(fields: "id") {
+                    id: ID!
+                    name: String!
+                }
+            "#,
+        };
+
+        let plain = ServiceDefinition {
+            name: "plain",
+            type_defs: r#"
+                type Query {
+                    other: String
+                }
+
+                type Resource @key(fields: "id") {
+                    id: ID!
+                    name: String! @override(from: "with-connectors")
+                }
+            "#,
+        };
+
+        let result = compose_as_fed2_connectors_subgraphs(&[with_connectors, plain]);
+
+        assert_composition_errors(
+            &result,
+            &[(
+                "OVERRIDE_ON_CONNECTOR",
+                r#"Field "Resource.name" on subgraph "plain" is trying to override connector-enabled subgraph "with-connectors", which is not yet supported. See https://go.apollo.dev/connectors/limitations#override-is-partially-unsupported"#,
+            )],
+        );
+    }
+
+    /// The check resolves `@override` through the federation spec, so a subgraph that imports it
+    /// under an alias is still caught. The pre-Rust implementation matched the directive name
+    /// against a hardcoded list and missed this case entirely.
+    ///
+    /// Built with `compose` directly rather than the fed2 helper, since both subgraphs need to
+    /// bring their own federation `@link`.
+    #[test]
+    fn override_on_connector_subgraph_is_rejected_when_aliased() {
+        let with_connectors = Subgraph::from_sdl(
+            "with-connectors",
+            "http://with-connectors",
+            r#"
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.11", import: ["@key"])
+  @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"])
+  @source(name: "v1", http: { baseURL: "http://v1" })
+
+type Query {
+  resources: [Resource!]! @connect(source: "v1", http: { GET: "/resources" }, selection: "id name")
+  resource(id: ID!): Resource
+    @connect(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id name", entity: true)
+}
+
+type Resource @key(fields: "id") {
+  id: ID!
+  name: String!
+}
+            "#,
+        )
+        .unwrap();
+
+        // `@override` is imported under an alias here.
+        let plain = Subgraph::from_sdl(
+            "plain",
+            "http://plain",
+            r#"
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.11"
+    import: ["@key", { name: "@override", as: "@replaces" }]
+  )
+
+type Query {
+  other: String
+}
+
+type Resource @key(fields: "id") {
+  id: ID!
+  name: String! @replaces(from: "with-connectors")
+}
+            "#,
+        )
+        .unwrap();
+
+        let failure =
+            compose(vec![with_connectors, plain]).expect_err("Expected composition to fail");
+
+        let codes: Vec<_> = failure
+            .errors
+            .iter()
+            .map(|e| e.code().definition().code())
+            .collect();
+        assert!(
+            codes.contains(&"OVERRIDE_ON_CONNECTOR"),
+            "Expected an OVERRIDE_ON_CONNECTOR error, got: {codes:?}"
+        );
+    }
+
+    /// `@override` against a subgraph without connectors is unaffected.
+    #[test]
+    fn override_on_non_connector_subgraph_is_allowed() {
+        let with_connectors = ServiceDefinition {
+            name: "with-connectors",
+            type_defs: r#"
+                extend schema
+                @link(
+                    url: "https://specs.apollo.dev/connect/v0.2"
+                    import: ["@connect", "@source"]
+                )
+                @source(name: "v1", http: { baseURL: "http://v1" })
+
+                type Query {
+                    resources: [Resource!]!
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "id")
+
+                    resource(id: ID!): Resource
+                    @connect(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id", entity: true)
+                }
+
+                type Resource @key(fields: "id") {
+                    id: ID!
+                }
+            "#,
+        };
+
+        let owner = ServiceDefinition {
+            name: "owner",
+            type_defs: r#"
+                type Query {
+                    widgets: [Widget!]!
+                }
+
+                type Widget @key(fields: "id") {
+                    id: ID!
+                    name: String!
+                }
+            "#,
+        };
+
+        let overrider = ServiceDefinition {
+            name: "overrider",
+            type_defs: r#"
+                type Query {
+                    other: String
+                }
+
+                type Widget @key(fields: "id") {
+                    id: ID!
+                    name: String! @override(from: "owner")
+                }
+            "#,
+        };
+
+        compose_as_fed2_connectors_subgraphs(&[with_connectors, owner, overrider])
+            .expect("Expected composition to succeed");
+    }
+
+    /// Override errors are only reported once merging has succeeded, so that a merge failure isn't
+    /// buried under connectors noise.
+    #[test]
+    fn override_on_connector_is_not_reported_when_merge_fails() {
+        let with_connectors = ServiceDefinition {
+            name: "with-connectors",
+            type_defs: r#"
+                extend schema
+                @link(
+                    url: "https://specs.apollo.dev/connect/v0.2"
+                    import: ["@connect", "@source"]
+                )
+                @source(name: "v1", http: { baseURL: "http://v1" })
+
+                type Query {
+                    resources: [Resource!]!
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "id name")
+                }
+
+                type Resource @key(fields: "id") {
+                    id: ID!
+                    name: String!
+                }
+            "#,
+        };
+
+        // `Resource.name` is an Int here but a String above, which fails the merge.
+        let plain = ServiceDefinition {
+            name: "plain",
+            type_defs: r#"
+                type Query {
+                    other: String
+                }
+
+                type Resource @key(fields: "id") {
+                    id: ID!
+                    name: Int! @override(from: "with-connectors")
+                }
+            "#,
+        };
+
+        let failure = compose_as_fed2_connectors_subgraphs(&[with_connectors, plain])
+            .expect_err("Expected composition to fail");
+
+        let codes: Vec<_> = failure
+            .errors
+            .iter()
+            .map(|e| e.code().definition().code())
+            .collect();
+        assert!(
+            !codes.contains(&"OVERRIDE_ON_CONNECTOR"),
+            "Merge errors should be reported alone, got: {codes:?}"
+        );
+        assert!(!codes.is_empty(), "Expected merge errors");
+    }
+
+    /// Merge hints have to survive the connector-expansion detour: satisfiability runs against a
+    /// supergraph parsed from expanded SDL, which carries none of them.
+    #[test]
+    fn merge_hints_survive_connector_expansion() {
+        let with_connectors = ServiceDefinition {
+            name: "with-connectors",
+            type_defs: r#"
+                extend schema
+                @link(
+                    url: "https://specs.apollo.dev/connect/v0.2"
+                    import: ["@connect", "@source"]
+                )
+                @source(name: "v1", http: { baseURL: "http://v1" })
+
+                type Query {
+                    resources: [Resource!]!
+                    @connect(source: "v1", http: { GET: "/resources" }, selection: "id name")
+
+                    resource(id: ID!): Resource
+                    @connect(source: "v1", http: { GET: "/resources/{$args.id}" }, selection: "id name", entity: true)
+                }
+
+                "A description only this subgraph has"
+                type Resource @key(fields: "id") {
+                    id: ID!
+                    name: String!
+                }
+            "#,
+        };
+
+        let plain = ServiceDefinition {
+            name: "plain",
+            type_defs: r#"
+                type Query {
+                    other: String
+                }
+
+                "A different description"
+                type Resource @key(fields: "id") {
+                    id: ID!
+                }
+            "#,
+        };
+
+        let supergraph = compose_as_fed2_connectors_subgraphs(&[with_connectors, plain])
+            .expect("Expected composition to succeed");
+
+        let codes: Vec<_> = supergraph.hints().iter().map(|h| h.code()).collect();
+        assert!(
+            codes.contains(&"INCONSISTENT_DESCRIPTION"),
+            "Expected the merge hint to survive expansion, got: {codes:?}"
+        );
     }
 }

--- a/apollo-federation/tests/composition/demand_control.rs
+++ b/apollo-federation/tests/composition/demand_control.rs
@@ -3,7 +3,7 @@ use apollo_compiler::coord;
 use apollo_compiler::schema::ExtendedType;
 use apollo_federation::composition::Supergraph;
 use apollo_federation::error::ErrorCode;
-use apollo_federation::subgraph::typestate::Initial;
+use apollo_federation::subgraph::typestate::Source;
 use apollo_federation::subgraph::typestate::Subgraph;
 use apollo_federation::supergraph::Satisfiable;
 use test_log::test;
@@ -173,8 +173,8 @@ fn check_cost_and_listsize_directives(
     );
 }
 
-fn subgraph_with_cost() -> Subgraph<Initial> {
-    Subgraph::parse(
+fn subgraph_with_cost() -> Subgraph<Source> {
+    Subgraph::from_sdl(
         "subgraphWithCost",
         "",
         r#"
@@ -211,8 +211,8 @@ fn subgraph_with_cost() -> Subgraph<Initial> {
     .unwrap()
 }
 
-fn subgraph_with_listsize() -> Subgraph<Initial> {
-    Subgraph::parse("subgraphWithListSize", "", r#"
+fn subgraph_with_listsize() -> Subgraph<Source> {
+    Subgraph::from_sdl("subgraphWithListSize", "", r#"
     extend schema
         @link(url: "https://specs.apollo.dev/link/v1.0")
         @link(url: "https://specs.apollo.dev/federation/v2.9")
@@ -229,8 +229,8 @@ fn subgraph_with_listsize() -> Subgraph<Initial> {
     "#).unwrap()
 }
 
-fn subgraph_with_renamed_cost() -> Subgraph<Initial> {
-    Subgraph::parse("subgraphWithCost", "", r#"
+fn subgraph_with_renamed_cost() -> Subgraph<Source> {
+    Subgraph::from_sdl("subgraphWithCost", "", r#"
     extend schema
         @link(url: "https://specs.apollo.dev/link/v1.0")
         @link(url: "https://specs.apollo.dev/cost/v0.1", import: [{ name: "@cost", as: "@renamedCost" }])
@@ -261,8 +261,8 @@ fn subgraph_with_renamed_cost() -> Subgraph<Initial> {
     "#).unwrap().into_fed2_test_subgraph(false).unwrap()
 }
 
-fn subgraph_with_renamed_listsize() -> Subgraph<Initial> {
-    Subgraph::parse("subgraphWithListSize", "", r#"
+fn subgraph_with_renamed_listsize() -> Subgraph<Source> {
+    Subgraph::from_sdl("subgraphWithListSize", "", r#"
     extend schema
         @link(url: "https://specs.apollo.dev/link/v1.0")
         @link(url: "https://specs.apollo.dev/cost/v0.1", import: [{ name: "@listSize", as: "@renamedListSize" }])
@@ -278,8 +278,8 @@ fn subgraph_with_renamed_listsize() -> Subgraph<Initial> {
     "#).unwrap().into_fed2_test_subgraph(false).unwrap()
 }
 
-fn subgraph_with_cost_from_federation_spec() -> Subgraph<Initial> {
-    Subgraph::parse(
+fn subgraph_with_cost_from_federation_spec() -> Subgraph<Source> {
+    Subgraph::from_sdl(
         "subgraphWithCost",
         "",
         r#"
@@ -313,8 +313,8 @@ fn subgraph_with_cost_from_federation_spec() -> Subgraph<Initial> {
     .unwrap()
 }
 
-fn subgraph_with_listsize_from_federation_spec() -> Subgraph<Initial> {
-    Subgraph::parse("subgraphWithListSize", "", r#"
+fn subgraph_with_listsize_from_federation_spec() -> Subgraph<Source> {
+    Subgraph::from_sdl("subgraphWithListSize", "", r#"
     type HasInts {
       ints: [Int!]
     }
@@ -326,8 +326,8 @@ fn subgraph_with_listsize_from_federation_spec() -> Subgraph<Initial> {
     "#).unwrap().into_fed2_test_subgraph(true).unwrap()
 }
 
-fn subgraph_with_renamed_cost_from_federation_spec() -> Subgraph<Initial> {
-    Subgraph::parse("subgraphWithCost", "", r#"
+fn subgraph_with_renamed_cost_from_federation_spec() -> Subgraph<Source> {
+    Subgraph::from_sdl("subgraphWithCost", "", r#"
       extend schema @link(url: "https://specs.apollo.dev/federation/v2.9", import: [{ name: "@cost", as: "@renamedCost" }])
 
       enum AorB @renamedCost(weight: 15) {
@@ -356,8 +356,8 @@ fn subgraph_with_renamed_cost_from_federation_spec() -> Subgraph<Initial> {
     "#).unwrap()
 }
 
-fn subgraph_with_renamed_listsize_from_federation_spec() -> Subgraph<Initial> {
-    Subgraph::parse("subgraphWithListSize", "", r#"
+fn subgraph_with_renamed_listsize_from_federation_spec() -> Subgraph<Source> {
+    Subgraph::from_sdl("subgraphWithListSize", "", r#"
       extend schema @link(url: "https://specs.apollo.dev/federation/v2.9", import: [{ name: "@listSize", as: "@renamedListSize" }])
 
       type HasInts {
@@ -371,8 +371,8 @@ fn subgraph_with_renamed_listsize_from_federation_spec() -> Subgraph<Initial> {
     "#).unwrap()
 }
 
-fn subgraph_with_unimported_cost() -> Subgraph<Initial> {
-    Subgraph::parse(
+fn subgraph_with_unimported_cost() -> Subgraph<Source> {
+    Subgraph::from_sdl(
         "subgraphWithCost",
         "",
         r#"
@@ -409,8 +409,8 @@ fn subgraph_with_unimported_cost() -> Subgraph<Initial> {
     .unwrap()
 }
 
-fn subgraph_with_unimported_listsize() -> Subgraph<Initial> {
-    Subgraph::parse("subgraphWithListSize", "", r#"
+fn subgraph_with_unimported_listsize() -> Subgraph<Source> {
+    Subgraph::from_sdl("subgraphWithListSize", "", r#"
         extend schema
             @link(url: "https://specs.apollo.dev/link/v1.0")
             @link(url: "https://specs.apollo.dev/federation/v2.9")
@@ -485,7 +485,7 @@ fn composes_fully_qualified_directive_names() {
 
 #[test]
 fn errors_when_subgraphs_use_different_names() {
-    let subgraph_with_default_name = Subgraph::parse(
+    let subgraph_with_default_name = Subgraph::from_sdl(
         "subgraphWithDefaultName",
         "",
         r#"
@@ -500,7 +500,7 @@ fn errors_when_subgraphs_use_different_names() {
     "#,
     )
     .unwrap();
-    let subgraph_with_different_name = Subgraph::parse("subgraphWithDifferentName", "", r#"
+    let subgraph_with_different_name = Subgraph::from_sdl("subgraphWithDifferentName", "", r#"
         extend schema
             @link(url: "https://specs.apollo.dev/link/v1.0")
             @link(url: "https://specs.apollo.dev/federation/v2.9")
@@ -528,7 +528,7 @@ fn errors_when_subgraphs_use_different_names() {
 
 #[test]
 fn hints_when_merging_cost_arguments() {
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraph-a",
         "",
         r#"
@@ -542,7 +542,7 @@ fn hints_when_merging_cost_arguments() {
     "#,
     )
     .unwrap();
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraph-b",
         "",
         r#"
@@ -579,7 +579,7 @@ fn hints_when_merging_cost_arguments() {
 
 #[test]
 fn hints_when_merging_listsize_arguments() {
-    let subgraph_a = Subgraph::parse(
+    let subgraph_a = Subgraph::from_sdl(
         "subgraph-a",
         "",
         r#"
@@ -594,7 +594,7 @@ fn hints_when_merging_listsize_arguments() {
     "#,
     )
     .unwrap();
-    let subgraph_b = Subgraph::parse(
+    let subgraph_b = Subgraph::from_sdl(
         "subgraph-b",
         "",
         r#"

--- a/apollo-federation/tests/composition/external.rs
+++ b/apollo-federation/tests/composition/external.rs
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn type_level_external_preserves_join_field_with_external_arg() {
         // s1: owns T, provides field a
-        let s1 = Subgraph::parse(
+        let s1 = Subgraph::from_sdl(
             "s1",
             "http://s1",
             r#"
@@ -230,7 +230,7 @@ mod tests {
         .unwrap();
 
         // s2: also owns T, provides field b
-        let s2 = Subgraph::parse(
+        let s2 = Subgraph::from_sdl(
             "s2",
             "http://s2",
             r#"
@@ -256,7 +256,7 @@ mod tests {
 
         // s3: references T as an external stub (type-level @external).
         // Extends S from s1 and uses @requires on x.
-        let s3 = Subgraph::parse(
+        let s3 = Subgraph::from_sdl(
             "s3",
             "http://s3",
             r#"

--- a/apollo-federation/tests/composition/fed1_shareability.rs
+++ b/apollo-federation/tests/composition/fed1_shareability.rs
@@ -21,10 +21,10 @@ fn test_fed1_fields_are_implicitly_shareable() {
         }
     "#;
 
-    let subgraph1 =
-        Subgraph::parse("fed1", "http://fed1", fed1_subgraph).expect("Fed 1 subgraph should parse");
-    let subgraph2 =
-        Subgraph::parse("fed2", "http://fed2", fed2_subgraph).expect("Fed 2 subgraph should parse");
+    let subgraph1 = Subgraph::from_sdl("fed1", "http://fed1", fed1_subgraph)
+        .expect("Fed 1 subgraph should parse");
+    let subgraph2 = Subgraph::from_sdl("fed2", "http://fed2", fed2_subgraph)
+        .expect("Fed 2 subgraph should parse");
 
     // This should succeed because Fed 1 fields are implicitly shareable
     let result = compose(vec![subgraph1, subgraph2]);
@@ -53,10 +53,10 @@ fn test_fed1_with_custom_root_type_names() {
         }
     "#;
 
-    let subgraph1 =
-        Subgraph::parse("fed1", "http://fed1", fed1_subgraph).expect("Fed 1 subgraph should parse");
-    let subgraph2 =
-        Subgraph::parse("fed2", "http://fed2", fed2_subgraph).expect("Fed 2 subgraph should parse");
+    let subgraph1 = Subgraph::from_sdl("fed1", "http://fed1", fed1_subgraph)
+        .expect("Fed 1 subgraph should parse");
+    let subgraph2 = Subgraph::from_sdl("fed2", "http://fed2", fed2_subgraph)
+        .expect("Fed 2 subgraph should parse");
 
     // This should succeed even though root types have different names
     // The upgrader should recognize that Query and RootQueryType are both query root types
@@ -98,10 +98,10 @@ fn test_fed1_non_root_types_are_shareable() {
         }
     "#;
 
-    let subgraph1 =
-        Subgraph::parse("fed1", "http://fed1", fed1_subgraph).expect("Fed 1 subgraph should parse");
-    let subgraph2 =
-        Subgraph::parse("fed2", "http://fed2", fed2_subgraph).expect("Fed 2 subgraph should parse");
+    let subgraph1 = Subgraph::from_sdl("fed1", "http://fed1", fed1_subgraph)
+        .expect("Fed 1 subgraph should parse");
+    let subgraph2 = Subgraph::from_sdl("fed2", "http://fed2", fed2_subgraph)
+        .expect("Fed 2 subgraph should parse");
 
     // This should succeed - Fed 1 types are implicitly shareable
     let result = compose(vec![subgraph1, subgraph2]);
@@ -128,9 +128,9 @@ fn test_multiple_fed1_subgraphs_sharing_fields() {
         }
     "#;
 
-    let subgraph1 = Subgraph::parse("fed1a", "http://fed1a", fed1_subgraph_a)
+    let subgraph1 = Subgraph::from_sdl("fed1a", "http://fed1a", fed1_subgraph_a)
         .expect("Fed 1 subgraph A should parse");
-    let subgraph2 = Subgraph::parse("fed1b", "http://fed1b", fed1_subgraph_b)
+    let subgraph2 = Subgraph::from_sdl("fed1b", "http://fed1b", fed1_subgraph_b)
         .expect("Fed 1 subgraph B should parse");
 
     // This should succeed - all Fed 1 fields are implicitly shareable

--- a/apollo-federation/tests/composition/hints.rs
+++ b/apollo-federation/tests/composition/hints.rs
@@ -404,7 +404,7 @@ mod value_type_fields {
 
     #[test]
     fn use_of_federation_key_does_not_raise_hint() {
-        let subgraph1 = Subgraph::parse(
+        let subgraph1 = Subgraph::from_sdl(
             "subgraph1",
             "http://localhost:4001",
             r#"
@@ -425,7 +425,7 @@ mod value_type_fields {
         )
         .unwrap();
 
-        let subgraph2 = Subgraph::parse(
+        let subgraph2 = Subgraph::from_sdl(
             "subgraph2",
             "http://localhost:4002",
             r#"
@@ -1957,7 +1957,7 @@ type Query @shareable {
     http: {
       GET: "/resources"
     }
-    selection: ""
+    selection: "id description"
   )
 }
 
@@ -1967,14 +1967,14 @@ type Resource {
 }
         "#;
 
-        let already_newest = Subgraph::parse(
+        let already_newest = Subgraph::from_sdl(
             "already-newest",
             "http://localhost:4001",
             newer_federation_schema,
         )
         .unwrap();
 
-        let old_but_not_upgraded = Subgraph::parse(
+        let old_but_not_upgraded = Subgraph::from_sdl(
             "old-but-not-upgraded",
             "http://localhost:4002",
             older_federation_schema,
@@ -1982,14 +1982,14 @@ type Resource {
         .unwrap();
 
         let upgraded =
-            Subgraph::parse("upgraded", "http://localhost:4003", auto_upgraded_schema).unwrap();
+            Subgraph::from_sdl("upgraded", "http://localhost:4003", auto_upgraded_schema).unwrap();
 
         let result = compose(vec![already_newest, old_but_not_upgraded, upgraded]).unwrap();
 
         assert_has_hint(
             &result,
             "IMPLICITLY_UPGRADED_FEDERATION_VERSION",
-            "Subgraph upgraded has been implicitly upgraded from federation v2.5 to v2.10",
+            "Subgraph upgraded has been implicitly upgraded from federation v2.5 to v2.11",
         );
     }
 
@@ -2010,7 +2010,16 @@ type Query @shareable {
     http: {
       GET: "/resources"
     }
-    selection: ""
+    selection: "id description"
+  )
+
+  resource(id: ID!): Resource @connect(
+    source: "v1"
+    http: {
+      GET: "/resources/{$args.id}"
+    }
+    selection: "id description"
+    entity: true
   )
 }
 
@@ -2021,22 +2030,24 @@ type Resource @shareable @key(fields: "id") {
         "#;
 
         let upgraded_1 =
-            Subgraph::parse("upgraded-1", "http://localhost:4001", auto_upgraded_schema).unwrap();
+            Subgraph::from_sdl("upgraded-1", "http://localhost:4001", auto_upgraded_schema)
+                .unwrap();
 
         let upgraded_2 =
-            Subgraph::parse("upgraded-2", "http://localhost:4002", auto_upgraded_schema).unwrap();
+            Subgraph::from_sdl("upgraded-2", "http://localhost:4002", auto_upgraded_schema)
+                .unwrap();
 
         let result = compose(vec![upgraded_1, upgraded_2]).unwrap();
 
         assert_has_hint(
             &result,
             "IMPLICITLY_UPGRADED_FEDERATION_VERSION",
-            "Subgraph upgraded-1 has been implicitly upgraded from federation v2.5 to v2.10",
+            "Subgraph upgraded-1 has been implicitly upgraded from federation v2.5 to v2.11",
         );
         assert_has_hint(
             &result,
             "IMPLICITLY_UPGRADED_FEDERATION_VERSION",
-            "Subgraph upgraded-2 has been implicitly upgraded from federation v2.5 to v2.10",
+            "Subgraph upgraded-2 has been implicitly upgraded from federation v2.5 to v2.11",
         );
     }
 
@@ -2060,14 +2071,14 @@ type Query {
 }
         "#;
 
-        let already_newest = Subgraph::parse(
+        let already_newest = Subgraph::from_sdl(
             "already-newest",
             "http://localhost:4001",
             newer_federation_schema,
         )
         .unwrap();
 
-        let old_but_not_upgraded = Subgraph::parse(
+        let old_but_not_upgraded = Subgraph::from_sdl(
             "old-but-not-upgraded",
             "http://localhost:4002",
             older_federation_schema,

--- a/apollo-federation/tests/composition/mod.rs
+++ b/apollo-federation/tests/composition/mod.rs
@@ -33,7 +33,7 @@ pub(crate) mod test_helpers {
     use apollo_federation::error::CompositionError;
     use apollo_federation::error::FederationError;
     use apollo_federation::subgraph::test_utils::remove_indentation;
-    use apollo_federation::subgraph::typestate::Initial;
+    use apollo_federation::subgraph::typestate::Source;
     use apollo_federation::subgraph::typestate::Subgraph;
     use apollo_federation::supergraph::CompositionHint;
     use apollo_federation::supergraph::Satisfiable;
@@ -47,7 +47,7 @@ pub(crate) mod test_helpers {
     /// Thin wrapper around [`apollo_federation::composition::compose`] that passes
     /// [`CompositionOptions::default()`], so tests don't have to spell it out.
     pub(crate) fn compose(
-        subgraphs: Vec<Subgraph<Initial>>,
+        subgraphs: Vec<Subgraph<Source>>,
     ) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
         apollo_federation::composition::compose(subgraphs, CompositionOptions::default())
     }
@@ -71,39 +71,49 @@ pub(crate) mod test_helpers {
         apollo_federation::composition::compose(fed2_subgraphs, options)
     }
 
+    /// Composes a set of connectors subgraphs as if they had the latest federation 2 spec link in
+    /// them, importing only the directives fed v2.4 auto-expanded.
+    ///
+    /// [`compose_as_fed2_subgraphs`] imports every federation directive, including `@context` and
+    /// `@fromContext`, which the connectors validations reject outright — so connectors tests
+    /// can't use it.
+    pub(crate) fn compose_as_fed2_connectors_subgraphs(
+        service_list: &[ServiceDefinition<'_>],
+    ) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
+        let fed2_subgraphs = as_fed2_subgraphs_with_imports(service_list, false)?;
+        apollo_federation::composition::compose(fed2_subgraphs, CompositionOptions::default())
+    }
+
     /// Parses the given service definitions and converts them into fed2-ready subgraphs, ready to
     /// be fed into [`compose`]. Mirrors the `asFed2Service` conversion from the JS implementation.
     ///
     /// Use this when a test needs to call [`compose`] directly with custom [`CompositionOptions`].
     pub(crate) fn as_fed2_subgraphs(
         service_list: &[ServiceDefinition<'_>],
-    ) -> Result<Vec<Subgraph<Initial>>, Vec<CompositionError>> {
-        let mut subgraphs = Vec::new();
+    ) -> Result<Vec<Subgraph<Source>>, Vec<CompositionError>> {
+        as_fed2_subgraphs_with_imports(service_list, true)
+    }
+
+    fn as_fed2_subgraphs_with_imports(
+        service_list: &[ServiceDefinition<'_>],
+        include_all_imports: bool,
+    ) -> Result<Vec<Subgraph<Source>>, Vec<CompositionError>> {
+        let mut fed2_subgraphs = Vec::new();
         let mut errors = Vec::new();
         for service in service_list {
-            let result = Subgraph::parse(
+            let result = Subgraph::from_sdl(
                 service.name,
                 &format!("http://{}", service.name),
                 service.type_defs,
-            );
+            )
+            .and_then(|subgraph| subgraph.into_fed2_test_subgraph(include_all_imports));
             match result {
                 Ok(subgraph) => {
-                    subgraphs.push(subgraph);
+                    fed2_subgraphs.push(subgraph);
                 }
                 Err(err) => {
                     errors.extend(err.to_composition_errors());
                 }
-            }
-        }
-        if !errors.is_empty() {
-            return Err(errors);
-        }
-
-        let mut fed2_subgraphs = Vec::new();
-        for subgraph in subgraphs {
-            match subgraph.into_fed2_test_subgraph(true) {
-                Ok(subgraph) => fed2_subgraphs.push(subgraph),
-                Err(err) => errors.extend(err.to_composition_errors()),
             }
         }
         if !errors.is_empty() {
@@ -210,6 +220,7 @@ pub(crate) use test_helpers::ServiceDefinition;
 pub(crate) use test_helpers::assert_composition_errors;
 pub(crate) use test_helpers::assert_hints_equal;
 pub(crate) use test_helpers::compose;
+pub(crate) use test_helpers::compose_as_fed2_connectors_subgraphs;
 pub(crate) use test_helpers::compose_as_fed2_subgraphs;
 pub(crate) use test_helpers::compose_as_fed2_subgraphs_with_options;
 pub(crate) use test_helpers::extract_subgraphs_from_supergraph_result;

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_2.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_2.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_2_], args: {url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_2_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_, WITH_CONNECTORS_V0_2_], args: {url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_2_], args: {name: "v1", http: {baseURL: "http://v1", path: "$(['v1'])", queryParams: "$({ locale: 'en' })"}, errors: {message: "error.message", extensions: "code: error.code"}}) {
   query: Query
 }
 
@@ -54,8 +54,10 @@ input join__ContextArgument {
 }
 
 type Query @join__type(graph: WITH_CONNECTORS_V0_1_) @join__type(graph: WITH_CONNECTORS_V0_2_) {
-  widgets: [Widget!]! @join__field(graph: WITH_CONNECTORS_V0_1_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_1_], args: {source: "v1", http: {GET: "/widgets"}, selection: ""})
-  resources: [Resource!]! @join__field(graph: WITH_CONNECTORS_V0_2_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_2_], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
+  widgets: [Widget!]! @join__field(graph: WITH_CONNECTORS_V0_1_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_1_], args: {source: "v1", http: {GET: "/widgets"}, selection: "id name"})
+  widget(id: ID!): Widget @join__field(graph: WITH_CONNECTORS_V0_1_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_1_], args: {source: "v1", http: {GET: "/widgets/{$args.id}"}, selection: "id name", entity: true})
+  resources: [Resource!]! @join__field(graph: WITH_CONNECTORS_V0_2_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_2_], args: {source: "v1", http: {GET: "/resources"}, selection: "id name"})
+  resource(id: ID!): Resource @join__field(graph: WITH_CONNECTORS_V0_2_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_2_], args: {source: "v1", http: {GET: "/resources/{$args.id}"}, selection: "id name", entity: true})
 }
 
 type Widget @join__type(graph: WITH_CONNECTORS_V0_1_, key: "id") {
@@ -63,7 +65,7 @@ type Widget @join__type(graph: WITH_CONNECTORS_V0_1_, key: "id") {
   name: String!
 }
 
-type Resource @join__type(graph: WITH_CONNECTORS_V0_2_, key: "id") @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_2_], args: {source: "v1", http: {GET: "/resources", path: "", queryParams: ""}, batch: {maxSize: 5}, errors: {message: "", extensions: ""}, selection: ""}) {
+type Resource @join__type(graph: WITH_CONNECTORS_V0_2_, key: "id") @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_2_], args: {source: "v1", http: {GET: "/resources", path: "$(['v1'])", queryParams: "$({ locale: 'en' })"}, batch: {maxSize: 5}, errors: {message: "error.message", extensions: "code: error.code"}, selection: "id name"}) {
   id: ID!
   name: String!
 }

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_3-2.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_3-2.snap
@@ -4,7 +4,9 @@ expression: api_schema_string
 ---
 type Query {
   widgets: [Widget!]!
+  widget(id: ID!): Widget
   resources: [Resource!]!
+  resource(id: ID!): Resource
 }
 
 type Widget {

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_3.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_3.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_3_], args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_3_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}, isSuccess: ""}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_1_], args: {url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_3_], args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_1_], args: {name: "v1", http: {baseURL: "http://v1"}}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_3_], args: {name: "v1", http: {baseURL: "http://v1", path: "$(['v1'])", queryParams: "$({ locale: 'en' })"}, errors: {message: "error.message", extensions: "code: error.code"}, isSuccess: "$status->eq(200)"}) {
   query: Query
 }
 
@@ -54,8 +54,10 @@ input join__ContextArgument {
 }
 
 type Query @join__type(graph: WITH_CONNECTORS_V0_1_) @join__type(graph: WITH_CONNECTORS_V0_3_) {
-  widgets: [Widget!]! @join__field(graph: WITH_CONNECTORS_V0_1_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_1_], args: {source: "v1", http: {GET: "/widgets"}, selection: ""})
-  resources: [Resource!]! @join__field(graph: WITH_CONNECTORS_V0_3_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
+  widgets: [Widget!]! @join__field(graph: WITH_CONNECTORS_V0_1_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_1_], args: {source: "v1", http: {GET: "/widgets"}, selection: "id name"})
+  widget(id: ID!): Widget @join__field(graph: WITH_CONNECTORS_V0_1_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_1_], args: {source: "v1", http: {GET: "/widgets/{$args.id}"}, selection: "id name", entity: true})
+  resources: [Resource!]! @join__field(graph: WITH_CONNECTORS_V0_3_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {source: "v1", http: {GET: "/resources"}, selection: "id name"})
+  resource(id: ID!): Resource @join__field(graph: WITH_CONNECTORS_V0_3_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {source: "v1", http: {GET: "/resources/{$args.id}"}, selection: "id name", entity: true})
 }
 
 type Widget @join__type(graph: WITH_CONNECTORS_V0_1_, key: "id") {
@@ -63,7 +65,7 @@ type Widget @join__type(graph: WITH_CONNECTORS_V0_1_, key: "id") {
   name: String!
 }
 
-type Resource @join__type(graph: WITH_CONNECTORS_V0_3_, key: "id") @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {id: "conn_id", source: "v1", http: {GET: "/resources", path: "", queryParams: ""}, batch: {maxSize: 5}, errors: {message: "", extensions: ""}, isSuccess: "", selection: ""}) {
+type Resource @join__type(graph: WITH_CONNECTORS_V0_3_, key: "id") @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {id: "conn_id", source: "v1", http: {GET: "/resources", path: "$(['v1'])", queryParams: "$({ locale: 'en' })"}, batch: {maxSize: 5}, errors: {message: "error.message", extensions: "code: error.code"}, isSuccess: "$status->eq(200)", selection: "id name"}) {
   id: ID!
   name: String!
 }

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_4-2.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_4-2.snap
@@ -4,7 +4,9 @@ expression: api_schema_string
 ---
 type Query {
   resources: [Resource!]!
+  resource(id: ID!): Resource
   widgets: [Widget!]!
+  widget(id: ID!): Widget
 }
 
 type Resource {

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_4.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_v0_4.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_3_], args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_4_], args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_3_], args: {name: "v1", http: {baseURL: "http://v1", path: "", queryParams: ""}, errors: {message: "", extensions: ""}, isSuccess: ""}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_4_], args: {name: "v4", http: {baseURL: "http://v4"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_3_], args: {url: "https://specs.apollo.dev/connect/v0.3", import: ["@connect", "@source"]}) @join__directive(name: "link", graphs: [WITH_CONNECTORS_V0_4_], args: {url: "https://specs.apollo.dev/connect/v0.4", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_3_], args: {name: "v1", http: {baseURL: "http://v1", path: "$(['v1'])", queryParams: "$({ locale: 'en' })"}, errors: {message: "error.message", extensions: "code: error.code"}, isSuccess: "$status->eq(200)"}) @join__directive(name: "source", graphs: [WITH_CONNECTORS_V0_4_], args: {name: "v4", http: {baseURL: "http://v4"}}) {
   query: Query
 }
 
@@ -54,11 +54,13 @@ input join__ContextArgument {
 }
 
 type Query @join__type(graph: WITH_CONNECTORS_V0_3_) @join__type(graph: WITH_CONNECTORS_V0_4_) {
-  resources: [Resource!]! @join__field(graph: WITH_CONNECTORS_V0_3_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
-  widgets: [Widget!]! @join__field(graph: WITH_CONNECTORS_V0_4_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_4_], args: {source: "v4", http: {GET: "/widgets"}, selection: ""})
+  resources: [Resource!]! @join__field(graph: WITH_CONNECTORS_V0_3_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {source: "v1", http: {GET: "/resources"}, selection: "id name"})
+  resource(id: ID!): Resource @join__field(graph: WITH_CONNECTORS_V0_3_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {source: "v1", http: {GET: "/resources/{$args.id}"}, selection: "id name", entity: true})
+  widgets: [Widget!]! @join__field(graph: WITH_CONNECTORS_V0_4_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_4_], args: {source: "v4", http: {GET: "/widgets"}, selection: "id name"})
+  widget(id: ID!): Widget @join__field(graph: WITH_CONNECTORS_V0_4_) @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_4_], args: {source: "v4", http: {GET: "/widgets/{$args.id}"}, selection: "id name", entity: true})
 }
 
-type Resource @join__type(graph: WITH_CONNECTORS_V0_3_, key: "id") @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {id: "conn_id", source: "v1", http: {GET: "/resources", path: "", queryParams: ""}, batch: {maxSize: 5}, errors: {message: "", extensions: ""}, isSuccess: "", selection: ""}) {
+type Resource @join__type(graph: WITH_CONNECTORS_V0_3_, key: "id") @join__directive(name: "connect", graphs: [WITH_CONNECTORS_V0_3_], args: {id: "conn_id", source: "v1", http: {GET: "/resources", path: "$(['v1'])", queryParams: "$({ locale: 'en' })"}, batch: {maxSize: 5}, errors: {message: "error.message", extensions: "code: error.code"}, isSuccess: "$status->eq(200)", selection: "id name"}) {
   id: ID!
   name: String!
 }

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_with_renames.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__composes_with_renames.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", as: "http", import: [{name: "@connect", as: "@http"}, {name: "@source", as: "@api"}]}) @join__directive(name: "api", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.2", as: "http", import: [{name: "@connect", as: "@http"}, {name: "@source", as: "@api"}]}) @join__directive(name: "api", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
   query: Query
 }
 
@@ -53,7 +53,8 @@ input join__ContextArgument {
 }
 
 type Query @join__type(graph: WITH_CONNECTORS) {
-  resources: [Resource!]! @join__directive(name: "http", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
+  resources: [Resource!]! @join__directive(name: "http", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources"}, selection: "id name"})
+  resource(id: ID!): Resource @join__directive(name: "http", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources/{$args.id}"}, selection: "id name", entity: true})
 }
 
 type Resource @join__type(graph: WITH_CONNECTORS, key: "id") {

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__connect_spec_and_join_directive_composes.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__connect_spec_and_join_directive_composes.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.2", import: ["@connect", "@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
   query: Query
 }
 
@@ -53,7 +53,8 @@ input join__ContextArgument {
 }
 
 type Query @join__type(graph: WITH_CONNECTORS) {
-  resources: [Resource!]! @join__directive(name: "connect", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
+  resources: [Resource!]! @join__directive(name: "connect", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources"}, selection: "id name"})
+  resource(id: ID!): Resource @join__directive(name: "connect", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources/{$args.id}"}, selection: "id name", entity: true})
 }
 
 type Resource @join__type(graph: WITH_CONNECTORS, key: "id") {

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__does_not_require_importing_connect.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__does_not_require_importing_connect.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.2", import: ["@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
   query: Query
 }
 
@@ -53,7 +53,8 @@ input join__ContextArgument {
 }
 
 type Query @join__type(graph: WITH_CONNECTORS) {
-  resources: [Resource!]! @join__directive(name: "connect", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
+  resources: [Resource!]! @join__directive(name: "connect", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources"}, selection: "id name"})
+  resource(id: ID!): Resource @join__directive(name: "connect", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources/{$args.id}"}, selection: "id name", entity: true})
 }
 
 type Resource @join__type(graph: WITH_CONNECTORS, key: "id") {

--- a/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__using_as_alias.snap
+++ b/apollo-federation/tests/composition/snapshots/main__composition__connectors__tests__using_as_alias.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/tests/composition/connectors.rs
 expression: schema_string
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.1", as: "http", import: ["@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION) @link(url: "https://specs.apollo.dev/connect/v0.4", for: EXECUTION) @join__directive(name: "link", graphs: [WITH_CONNECTORS], args: {url: "https://specs.apollo.dev/connect/v0.2", as: "http", import: ["@source"]}) @join__directive(name: "source", graphs: [WITH_CONNECTORS], args: {name: "v1", http: {baseURL: "http://v1"}}) {
   query: Query
 }
 
@@ -53,7 +53,8 @@ input join__ContextArgument {
 }
 
 type Query @join__type(graph: WITH_CONNECTORS) {
-  resources: [Resource!]! @join__directive(name: "http", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources"}, selection: ""})
+  resources: [Resource!]! @join__directive(name: "http", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources"}, selection: "id name"})
+  resource(id: ID!): Resource @join__directive(name: "http", graphs: [WITH_CONNECTORS], args: {source: "v1", http: {GET: "/resources/{$args.id}"}, selection: "id name", entity: true})
 }
 
 type Resource @join__type(graph: WITH_CONNECTORS, key: "id") {


### PR DESCRIPTION
Connectors were validated by the `HybridComposer` in the federation-rs repo, which wrapped the individual `apollo-federation` phases. Move that logic into `compose` so the crate owns the whole pipeline, as a step toward deprecating federation-rs.

`compose` now takes `Vec<Subgraph<Source>>` instead of `Vec<Subgraph<Initial>>`. `Source` is a new typestate holding the schema document before it is parsed, and `validate_connectors` is the only transition out of it. Document-level validations belong there: they report locations against what the user wrote, and they may rewrite the document — today by auto-upgrading `connect/v0.1` to `v0.2`, which is why parsing is part of that transition. Making it the only path to `Initial` means composition cannot skip connectors validation.

Also ports `validate_overrides`, which rejects `@override(from:)` targeting a connector-enabled subgraph, as
`validate_override_on_connector`. It runs against `Subgraph<Validated>` rather than the raw parses the federation-rs version used, so the `@override` name resolves through the federation spec instead of a hardcoded list — a subgraph importing it under an alias is now caught where it previously slipped through. Merging consumes the subgraphs, so the check runs before it but is only reported once merging succeeds, preserving the original behavior of not burying merge errors.

Satisfiability now expands connectors first, and two bugs in the pre-existing `validate_satisfiability_with_connectors` are fixed in the process:

- it returned the connector-expanded supergraph as the composition result; expansion is only an input to the check, so the merged supergraph is returned instead, matching `experimental_compose`
- merge hints were dropped on the expanded-success path, since satisfiability drained them from a freshly parsed supergraph that had none

That function is folded into `validate_satisfiability` in `satisfiability.rs`, and `compose_with_connectors` — an incomplete earlier attempt at this integration — is deleted.

Connectors diagnostics reach composition through
`CompositionError::ConnectorsError` and `HintCode::Connectors`, both keyed by the existing connectors `Code` enum so the code strings GraphOS consumes are unchanged.

Test fixtures: nine composition tests were composing invalid connectors schemas that nothing had been checking (empty `selection`, `path`, `queryParams`, `errors.message`, `isSuccess`, and `@key` types with no entity connector). Two hint tests move from federation v2.10 to v2.11, which the `connect/v0.2` upgrade now pulls in.
