### PR TITLE
fix(correctness): case-split over the union of Boolean variable groups

### DIFF
--- a/apollo-federation/src/correctness/response_shape_compare.rs
+++ b/apollo-federation/src/correctness/response_shape_compare.rs
@@ -278,10 +278,11 @@ fn compare_possible_definitions_per_type_condition<T: PathConstraint>(
 ///   individual matching variant. Thus, this function tries to collect/merge all implied variants
 ///   and then compare.
 /// - Note that we may need to case-split over Boolean variables. It happens when there are more
-///   Boolean variables used in the `other`'s variants. This function tries to find the smallest
-///   set of missing Boolean variables to case-split. It starts with the empty set, then tries
-///   increasingly larger sets until a matching subset is found. For each set of variables, it
-///   checks if every possible combination of Boolean values (hypothesis) has a match.
+///   Boolean variables used in the `other`'s variants. Each variant's own variable set is tried
+///   first (fewer hypotheses to check), then the union of all variable sets as a fallback, since
+///   full coverage may require combining variables from different variants. For each set of
+///   variables, it checks if every possible combination of Boolean values (hypothesis) has a
+///   match.
 fn solve_boolean_constraints<T: PathConstraint>(
     path_constraint: &T,
     assumption: &Clause,
@@ -352,17 +353,23 @@ type BooleanVariables = Vec<Name>;
 
 /// Generate sets of hypotheses to case-split over that are applicable to the target `defs`.
 /// - Construct hypotheses based on the variables used in the Boolean conditions in `defs`.
-/// - Excludes the literals in the `assumption` since it's already assumed to be true.
+/// - Excludes the literals in the `base_clause` since it's already assumed to be true.
 /// - If there are variants with no extra Boolean variables, it will generate a no-hypothesis
 ///   group, which contains only one empty clause.
+/// - When there are multiple distinct variable groups, the union of all groups is added as the
+///   last (fallback) group. Individual variants' groups may each be insufficient when full
+///   coverage requires combining variables from different variants (e.g. groups `[v0, v1]` and
+///   `[v0, v2]` jointly covering all cases). The union group is the complete case-split: every
+///   hypothesis fully determines each variant's condition, so it can verify any coverage the
+///   smaller groups miss.
 fn extract_boolean_hypotheses(
-    assumption: &Clause,
+    base_clause: &Clause,
     defs: &PossibleDefinitionsPerTypeCondition,
 ) -> Vec<Vec<Clause>> {
     // Collect sets of variables that can be used to case-split over.
     let mut variable_groups = IndexSet::default();
     for variant in defs.conditional_variants() {
-        let Some(remaining_condition) = variant.boolean_clause().subtract(assumption) else {
+        let Some(remaining_condition) = variant.boolean_clause().subtract(base_clause) else {
             // Skip unsatisfiable variants.
             continue;
         };
@@ -375,6 +382,14 @@ fn extract_boolean_hypotheses(
             .cloned()
             .collect();
         variable_groups.insert(vars);
+    }
+    // Add the union of all variable groups as the fallback group (see doc comment above).
+    // With zero or one group, the union adds nothing new.
+    if variable_groups.len() > 1 {
+        let mut union_vars: BooleanVariables = variable_groups.iter().flatten().cloned().collect();
+        union_vars.sort();
+        union_vars.dedup();
+        variable_groups.insert(union_vars); // no-op if some group already equals the union
     }
     // Generate groups of Boolean hypotheses.
     variable_groups

--- a/apollo-federation/src/correctness/response_shape_compare_test.rs
+++ b/apollo-federation/src/correctness/response_shape_compare_test.rs
@@ -340,3 +340,128 @@ fn test_boolean_condition_case_split_5() {
     "#;
     assert_compare_operation_docs(x, y);
 }
+
+#[test]
+fn test_disjunctive_coverage_across_variables() {
+    // x requires `id` unconditionally.
+    let x = r#"
+        query {
+            test_i {
+                id
+            }
+        }
+    "#;
+    // y fetches `id` under three mutually exclusive conditions on two
+    // variables that form a tautology: ($v0) ∨ ($v1 ∧ ¬$v0) ∨ (¬$v0 ∧ ¬$v1).
+    let y = r#"
+        query($v0: Boolean!, $v1: Boolean!) {
+            test_i @include(if: $v0) {
+                id
+            }
+            ... @skip(if: $v0) {
+                test_i @include(if: $v1) {
+                    id
+                }
+                ... @skip(if: $v1) {
+                    test_i {
+                        id
+                    }
+                }
+            }
+        }
+    "#;
+    assert_compare_operation_docs(x, y);
+}
+
+#[test]
+fn test_disjunctive_coverage_incomplete() {
+    // x requires `id` unconditionally.
+    let x = r#"
+        query {
+            test_i {
+                id
+            }
+        }
+    "#;
+    // y only fetches `id` under $v0 or ($v1 ∧ ¬$v0), but not when both are
+    // false. This must fail — y doesn't cover all cases.
+    let y = r#"
+        query($v0: Boolean!, $v1: Boolean!) {
+            test_i @include(if: $v0) {
+                id
+            }
+            ... @skip(if: $v0) {
+                test_i @include(if: $v1) {
+                    id
+                }
+            }
+        }
+    "#;
+    assert!(compare_operation_docs(x, y).is_err());
+}
+
+#[test]
+fn test_cross_variable_group_coverage() {
+    // x requires `id` unconditionally.
+    let x = r#"
+        query {
+            test_i {
+                id
+            }
+        }
+    "#;
+    // y fetches `id` under four conditions using three variables:
+    //   (v0 ∧ v1) ∨ (v0 ∧ ¬v1) ∨ (¬v0 ∧ v2) ∨ (¬v0 ∧ ¬v2) = true
+    // The variables are split across variant groups — [v0,v1] vs [v0,v2] —
+    // so no single variant's variable group covers all hypotheses. Only the
+    // union group [v0,v1,v2] can verify full coverage.
+    let y = r#"
+        query($v0: Boolean!, $v1: Boolean!, $v2: Boolean!) {
+            ... @include(if: $v0) {
+                test_i @include(if: $v1) {
+                    id
+                }
+                test_i @skip(if: $v1) {
+                    id
+                }
+            }
+            ... @skip(if: $v0) {
+                test_i @include(if: $v2) {
+                    id
+                }
+                test_i @skip(if: $v2) {
+                    id
+                }
+            }
+        }
+    "#;
+    assert_compare_operation_docs(x, y);
+}
+
+#[test]
+fn test_nested_partial_coverage_should_fail() {
+    // x requires `data` unconditionally.
+    let x = r#"
+        query {
+            test_i {
+                id
+                data(arg: 1)
+            }
+        }
+    "#;
+    // y's `test_i` variants jointly cover all cases at the top level, but
+    // `data` is only fetched when $v0 is true. The per-hypothesis case-split
+    // must catch the nested gap under ¬v0.
+    let y = r#"
+        query($v0: Boolean!) {
+            test_i @include(if: $v0) {
+                id
+                data(arg: 1)
+            }
+            test_i @skip(if: $v0) {
+                id
+            }
+        }
+    "#;
+    assert!(compare_operation_docs(x, y).is_err());
+}


### PR DESCRIPTION
This is an alternative fix for https://github.com/apollographql/router/pull/10016.

I kept the existing Clause design, but fixed a case-splitting bug.

- extract_boolean_hypotheses only tried each variant's own variable group, so coverage that combines variables from different variants (e.g. groups [v0,v1] and [v0,v2]) was falsely rejected with "no variants found for Boolean condition"
- add the union of all variable groups as a fallback case-split group; per-variant groups are still tried first, so passing cases are unaffected and the union only runs on would-be errors
- rename the misleading `assumption` parameter to `base_clause` and fix the stale doc comment on solve_boolean_constraints
- add tests: cross-variable-group coverage (fails without this fix), disjunctive coverage positive/negative, and a nested partial-coverage negative test guarding the per-hypothesis case-split behavior

<!-- start metadata -->