### PR TITLE
fix(correctness): pass narrowed type context down to child selection set

### DIFF
--- a/apollo-federation/src/correctness/mod.rs
+++ b/apollo-federation/src/correctness/mod.rs
@@ -10,6 +10,7 @@ pub mod response_shape_compare;
 pub mod response_shape_compare_test;
 #[cfg(test)]
 pub mod response_shape_test;
+mod schema_constraint;
 mod subgraph_constraint;
 
 use std::fmt;
@@ -51,6 +52,37 @@ impl fmt::Display for CorrectnessError {
     }
 }
 
+/// Check if `this` response shape is a subset of `other` under a single schema.
+/// - Both response shapes must be derived from the given schema.
+pub fn compare_response_shapes(
+    schema: &ValidFederationSchema,
+    this: &response_shape::ResponseShape,
+    other: &response_shape::ResponseShape,
+) -> Result<(), ComparisonError> {
+    let path_constraint = schema_constraint::SchemaConstraint::new(schema);
+    let assumption = response_shape::Clause::default(); // empty assumption at the top level
+    compare_response_shapes_with_constraint(&path_constraint, &assumption, this, other)
+}
+
+/// Check if `this` response shape is a subset of `other` in a federated context (supergraph
+/// schema plus subgraph schemas).
+/// - The response shapes may use any fields from the supergraph schema.
+/// - The schema constraint (from the supergraph schema) is the base; the subgraph constraint
+///   is an extra oracle on top.
+pub fn compare_response_shapes_in_supergraph(
+    supergraph_schema: &ValidFederationSchema,
+    subgraphs_by_name: &IndexMap<Arc<str>, ValidFederationSchema>,
+    this: &response_shape::ResponseShape,
+    other: &response_shape::ResponseShape,
+) -> Result<(), ComparisonError> {
+    let path_constraint = (
+        schema_constraint::SchemaConstraint::new(supergraph_schema),
+        subgraph_constraint::SubgraphConstraint::new(subgraphs_by_name),
+    );
+    let assumption = response_shape::Clause::default(); // empty assumption at the top level
+    compare_response_shapes_with_constraint(&path_constraint, &assumption, this, other)
+}
+
 /// Check if `this`'s response shape is a subset of `other`'s response shape.
 pub fn compare_operations(
     schema: &ValidFederationSchema,
@@ -62,9 +94,7 @@ pub fn compare_operations(
     tracing::debug!(
         "compare_operations:\nResponse shape (left): {this_rs}\nResponse shape (right): {other_rs}"
     );
-    Ok(response_shape_compare::compare_response_shapes(
-        &this_rs, &other_rs,
-    )?)
+    Ok(compare_response_shapes(schema, &this_rs, &other_rs)?)
 }
 
 /// Check the correctness of the query plan against the schema and input operation by comparing
@@ -98,12 +128,14 @@ pub fn check_plan(
         "check_plan:\nOperation response shape: {op_rs}\nQuery plan response shape: {plan_rs}"
     );
 
-    let path_constraint = subgraph_constraint::SubgraphConstraint::at_root(subgraphs_by_name);
-    let assumption = response_shape::Clause::default(); // empty assumption at the top level
-    compare_response_shapes_with_constraint(&path_constraint, &assumption, &op_rs, &plan_rs).map_err(|e| {
-        ComparisonError::new(format!(
-            "Response shape from query plan does not match response shape from input operation:\n{e}"
-        ))
-    })?;
+    // Note: The comparison must use the supergraph schema (not the API schema), since `plan_rs`
+    //       may contain any fields from the supergraph schema. The `op_rs` side is indeed
+    //       constrained to the API schema, which is a subset of the supergraph schema.
+    compare_response_shapes_in_supergraph(supergraph_schema, subgraphs_by_name, &op_rs, &plan_rs)
+        .map_err(|e| {
+            ComparisonError::new(format!(
+                "Response shape from query plan does not match response shape from input operation:\n{e}"
+            ))
+        })?;
     Ok(())
 }

--- a/apollo-federation/src/correctness/query_plan_analysis_test.rs
+++ b/apollo-federation/src/correctness/query_plan_analysis_test.rs
@@ -137,11 +137,15 @@ pub(crate) fn plan_response_shape_with_schema(schema_str: &str, op_str: &str) ->
         .collect();
     let context = AnalysisContext::new(supergraph_schema.clone(), &subgraphs_by_name);
     let plan_rs = interpret_query_plan(&context, &root_type, &query_plan).unwrap();
-    let path_constraint = subgraph_constraint::SubgraphConstraint::at_root(&subgraphs_by_name);
-    let assumption = response_shape::Clause::default(); // empty assumption at the top level
+    // Same comparison as `check_plan`.
     assert!(
-        compare_response_shapes_with_constraint(&path_constraint, &assumption, &op_rs, &plan_rs)
-            .is_ok()
+        compare_response_shapes_in_supergraph(
+            supergraph_schema,
+            &subgraphs_by_name,
+            &op_rs,
+            &plan_rs
+        )
+        .is_ok()
     );
 
     plan_rs

--- a/apollo-federation/src/correctness/query_plan_soundness.rs
+++ b/apollo-federation/src/correctness/query_plan_soundness.rs
@@ -7,14 +7,13 @@ use apollo_compiler::executable::FieldSet;
 use apollo_compiler::executable::Name;
 use itertools::Itertools;
 
+use super::compare_response_shapes_in_supergraph;
 use super::query_plan_analysis::AnalysisContext;
 use super::response_shape::Clause;
 use super::response_shape::PossibleDefinitions;
 use super::response_shape::ResponseShape;
 use super::response_shape::compute_response_shape_for_selection_set;
 use super::response_shape_compare::compare_representative_field;
-use super::response_shape_compare::compare_response_shapes_with_constraint;
-use super::subgraph_constraint::SubgraphConstraint;
 use crate::FederationError;
 use crate::bail;
 use crate::internal_error;
@@ -276,11 +275,10 @@ fn key_directive_matches(
         .into());
     }
     let final_require_shape = condition.add_boolean_conditions(boolean_clause);
-    let path_constraint = SubgraphConstraint::at_root(context.subgraphs_by_name());
-    let assumption = Clause::default(); // empty assumption at the top level
-    compare_response_shapes_with_constraint(
-        &path_constraint,
-        &assumption,
+    // Note: The response shapes here start at the entity type, not at the query root type.
+    compare_response_shapes_in_supergraph(
+        context.supergraph_schema(),
+        context.subgraphs_by_name(),
         &final_require_shape,
         state,
     )

--- a/apollo-federation/src/correctness/query_plan_soundness_test.rs
+++ b/apollo-federation/src/correctness/query_plan_soundness_test.rs
@@ -45,6 +45,31 @@ enum link__Purpose {
   EXECUTION
 }
 
+interface E
+  @join__type(graph: A)
+  @join__type(graph: S)
+{
+  e_data: Int!
+}
+
+type EA implements E
+  @join__implements(graph: A, interface: "E")
+  @join__implements(graph: S, interface: "E")
+  @join__type(graph: A)
+  @join__type(graph: S)
+{
+  e_data: Int! @join__field(graph: A, external: true) @join__field(graph: S)
+}
+
+type EB implements E
+  @join__implements(graph: A, interface: "E")
+  @join__implements(graph: S, interface: "E")
+  @join__type(graph: A)
+  @join__type(graph: S)
+{
+  e_data: Int! @join__field(graph: A, external: true) @join__field(graph: S)
+}
+
 type P
   @join__type(graph: A)
   @join__type(graph: S, key: "id")
@@ -68,6 +93,9 @@ type T
   data: Int! @join__field(graph: A, requires: "pre(arg: 0)")
   data2: Int! @join__field(graph: A, requires: "pre2(arg: 2)")
   data3: Int! @join__field(graph: A, requires: "p { p_data(arg: 1) }")
+  data4: Int! @join__field(graph: A, requires: "e { ... on EA { e_data } ... on EB { e_data } }")
+  data5: Int! @join__field(graph: A, requires: "e { e_data }")
+  e: E! @join__field(graph: A, external: true) @join__field(graph: S)
   pre(arg: Int!): Int! @join__field(graph: A, external: true) @join__field(graph: S)
   pre2(arg: Int!): Int! @join__field(graph: A, external: true) @join__field(graph: S)
   p: P! @join__field(graph: A)
@@ -157,6 +185,59 @@ fn test_requires_conditional_multiple_variants() {
         pre -may-> pre(arg: 0)
         data -may-> data
         data -may-> data if v0
+      }
+    }
+    "###);
+}
+
+#[test]
+fn test_requires_starting_at_entity_type_with_interface_fragments() {
+    // The `@requires`/`@key` condition shape starts at the entity type `T`, not at the query
+    // root type. Below the entity type, the required data is partitioned per implementer of
+    // the interface `E`, so the path constraint must narrow starting from `T`'s scope.
+    let op_str = r#"
+        query {
+            start_t {
+                data4
+            }
+        }
+    "#;
+    insta::assert_snapshot!(plan_response_shape(op_str), @r###"
+    {
+      start_t -----> start_t {
+        __typename -----> __typename
+        id -----> id
+        e -----> e {
+          __typename -----> __typename
+          e_data -may-> e_data on EA
+          e_data -may-> e_data on EB
+        }
+        data4 -----> data4
+      }
+    }
+    "###);
+}
+
+#[test]
+fn test_requires_starting_at_entity_type_with_interface_scope_field() {
+    // Same as above, but the required field is demanded at the interface scope.
+    let op_str = r#"
+        query {
+            start_t {
+                data5
+            }
+        }
+    "#;
+    insta::assert_snapshot!(plan_response_shape(op_str), @r###"
+    {
+      start_t -----> start_t {
+        __typename -----> __typename
+        id -----> id
+        e -----> e {
+          __typename -----> __typename
+          e_data -----> e_data
+        }
+        data5 -----> data5
       }
     }
     "###);

--- a/apollo-federation/src/correctness/response_shape_compare.rs
+++ b/apollo-federation/src/correctness/response_shape_compare.rs
@@ -71,33 +71,34 @@ where
     fn allows_any(&self, _defs: &PossibleDefinitions) -> bool;
 }
 
-struct DummyPathConstraint;
-
-impl PathConstraint for DummyPathConstraint {
-    fn under_type_condition(&self, _type_cond: &NormalizedTypeCondition) -> Self {
-        DummyPathConstraint
+/// Conjunction of two path constraints: a runtime type is possible only if both constraints
+/// allow it. This is how an extra oracle (e.g. `SubgraphConstraint`) is layered on top of the
+/// base `SchemaConstraint`.
+impl<A: PathConstraint, B: PathConstraint> PathConstraint for (A, B) {
+    fn under_type_condition(&self, type_cond: &NormalizedTypeCondition) -> Self {
+        (
+            self.0.under_type_condition(type_cond),
+            self.1.under_type_condition(type_cond),
+        )
     }
 
-    fn for_field(&self, _representative_field: &Field) -> Result<Self, ComparisonError> {
-        Ok(DummyPathConstraint)
+    fn for_field(&self, representative_field: &Field) -> Result<Self, ComparisonError> {
+        Ok((
+            self.0.for_field(representative_field)?,
+            self.1.for_field(representative_field)?,
+        ))
     }
 
-    fn allows(&self, _ty: &ObjectTypeDefinitionPosition) -> bool {
-        true
+    fn allows(&self, ty: &ObjectTypeDefinitionPosition) -> bool {
+        self.0.allows(ty) && self.1.allows(ty)
     }
 
-    fn allows_any(&self, _defs: &PossibleDefinitions) -> bool {
-        true
+    fn allows_any(&self, defs: &PossibleDefinitions) -> bool {
+        // Note: More precise than `self.0.allows_any(defs) && self.1.allows_any(defs)`, since
+        //       some ground type must satisfy both constraints simultaneously.
+        defs.iter()
+            .any(|(type_cond, _)| type_cond.ground_set().iter().any(|ty| self.allows(ty)))
     }
-}
-
-// Check if `this` is a subset of `other`.
-pub fn compare_response_shapes(
-    this: &ResponseShape,
-    other: &ResponseShape,
-) -> Result<(), ComparisonError> {
-    let assumption = Clause::default(); // empty assumption at the top level
-    compare_response_shapes_with_constraint(&DummyPathConstraint, &assumption, this, other)
 }
 
 /// Check if `this` is a subset of `other`, but also use the `PathConstraint` to ignore infeasible

--- a/apollo-federation/src/correctness/response_shape_compare_test.rs
+++ b/apollo-federation/src/correctness/response_shape_compare_test.rs
@@ -12,6 +12,27 @@ const SCHEMA_STR: &str = r#"
         test_j: J!
         test_u: U!
         test_v: V!
+        test_entity: Entity!
+    }
+
+    interface Entity {
+        id: ID!
+        next: Entity!
+    }
+
+    type ObjectA implements Entity {
+        id: ID!
+        next: ObjectA! # covariant field return
+    }
+
+    type ObjectB implements Entity {
+        id: ID!
+        next: ObjectB! # covariant field return
+    }
+
+    type ObjectC implements Entity {
+        id: ID!
+        next: Entity!
     }
 
     interface I {
@@ -436,6 +457,91 @@ fn test_cross_variable_group_coverage() {
         }
     "#;
     assert_compare_operation_docs(x, y);
+}
+
+#[test]
+fn test_type_condition_case_split_with_covariant_fields() {
+    // x demands `next` at the interface scope, so its sub-selection shape is
+    // computed at the `Entity` scope.
+    let x = r#"
+        query {
+            test_entity {
+                next {
+                    id
+                }
+            }
+        }
+    "#;
+    // y covers the same demand partitioned by runtime type. Each branch's
+    // `next` sub-selection shape lives at the covariantly narrowed object
+    // scope (e.g. `ObjectA.next: ObjectA!`). Matching the `ObjectA` case
+    // requires remembering that case when comparing the sub-selections:
+    // under it, `next` can only be `ObjectA`, so x's `Entity`-scoped child
+    // must only be checked against the `ObjectA` case.
+    let y = r#"
+        query {
+            test_entity {
+                ... on ObjectA { next { id } }
+                ... on ObjectB { next { id } }
+                ... on ObjectC { next { id } }
+            }
+        }
+    "#;
+    assert_compare_operation_docs(x, y);
+    // The two operations are equivalent; the other direction has always worked.
+    assert_compare_operation_docs(y, x);
+}
+
+#[test]
+fn test_type_condition_case_split_with_covariant_fields_nested() {
+    // Same as above, but the type-condition case must survive two levels of
+    // field traversal: under the `ObjectA` case, both `next` and `next.next`
+    // can only be `ObjectA`.
+    let x = r#"
+        query {
+            test_entity {
+                next {
+                    next {
+                        id
+                    }
+                }
+            }
+        }
+    "#;
+    let y = r#"
+        query {
+            test_entity {
+                ... on ObjectA { next { next { id } } }
+                ... on ObjectB { next { next { id } } }
+                ... on ObjectC { next { next { id } } }
+            }
+        }
+    "#;
+    assert_compare_operation_docs(x, y);
+}
+
+#[test]
+fn test_type_condition_case_split_incomplete_coverage_should_fail() {
+    // x demands `next` for every runtime type of `Entity`.
+    let x = r#"
+        query {
+            test_entity {
+                next {
+                    id
+                }
+            }
+        }
+    "#;
+    // y misses the `ObjectB` case — this must still fail.
+    let y = r#"
+        query {
+            test_entity {
+                ... on ObjectA { next { id } }
+                ... on ObjectC { next { id } }
+            }
+        }
+    "#;
+    assert!(compare_operation_docs(x, y).is_err());
 }
 
 #[test]

--- a/apollo-federation/src/correctness/schema_constraint.rs
+++ b/apollo-federation/src/correctness/schema_constraint.rs
@@ -1,0 +1,122 @@
+// Path-specific type constraints imposed by the API schema.
+
+use apollo_compiler::collections::IndexSet;
+use apollo_compiler::executable::Field;
+
+use super::response_shape::NormalizedTypeCondition;
+use super::response_shape::PossibleDefinitions;
+use super::response_shape_compare::ComparisonError;
+use super::response_shape_compare::PathConstraint;
+use crate::ValidFederationSchema;
+use crate::error::FederationError;
+use crate::schema::position::CompositeTypeDefinitionPosition;
+use crate::schema::position::ObjectTypeDefinitionPosition;
+
+/// `PathConstraint` imposed by a schema. This is the base constraint of every comparison lane;
+/// the `SubgraphConstraint` oracle can be layered on top of it via the pair `PathConstraint`
+/// impl.
+///
+/// The schema must define the full type universe of the comparison: every type and field that
+/// either response shape may reference, so that `possible_types` never under-approximates and
+/// narrowing never skips a feasible case. In the query-plan lanes, that is the supergraph
+/// schema (not the API schema): the plan-side shapes and the `@requires`/`@key` condition
+/// shapes may use any fields from the supergraph schema, while the operation side is
+/// constrained to the API schema, a subset of the supergraph schema. In `compare_operations`,
+/// it is the schema both operations are defined against.
+///
+/// This tracks the set of runtime object types that are possible at the current path position.
+/// When `compare_possible_definitions` case-splits a type condition over its ground types, the
+/// case under consideration must remain visible while comparing sub-selection shapes: with a
+/// covariant field return (e.g. `ObjectA.next: ObjectA!` narrowing `Entity.next: Entity!`), the
+/// possible types of a field's response depend on which runtime type its parent turned out to
+/// be. `under_type_condition` records the case and `for_field` re-derives the field's possible
+/// response types from each possible runtime type's own field definition.
+pub(crate) struct SchemaConstraint<'a> {
+    schema: &'a ValidFederationSchema,
+
+    /// The set of object types that are possible under the current context.
+    /// - Note: The empty set means all types are possible (unconstrained).
+    possible_types: IndexSet<ObjectTypeDefinitionPosition>,
+}
+
+impl<'a> SchemaConstraint<'a> {
+    /// A constraint with no type information: all types are possible. The comparison may start
+    /// at any scope (e.g. the entity type for `@requires`/`@key` conditions); the first type
+    /// condition encountered narrows the constraint to that scope.
+    pub(crate) fn new(schema: &'a ValidFederationSchema) -> Self {
+        SchemaConstraint {
+            schema,
+            possible_types: Default::default(),
+        }
+    }
+
+    /// (Parent type & field type consistency) Considering the field's possible parent types
+    /// (`self.possible_types`), find all object types that the field can resolve to.
+    fn possible_types_for_field(&self, field_name: &str) -> Result<Self, FederationError> {
+        let mut possible_types = IndexSet::default();
+        for parent_type in &self.possible_types {
+            let parent_type_def = parent_type.get(self.schema.schema())?;
+            // Skip parent types without the field definition (e.g. meta-fields).
+            let Some(field) = parent_type_def.fields.get(field_name) else {
+                continue;
+            };
+            let field_type_pos = self.schema.get_type(field.ty.inner_named_type())?;
+            if let Ok(composite_type) = CompositeTypeDefinitionPosition::try_from(field_type_pos) {
+                possible_types.extend(self.schema.possible_runtime_types(composite_type)?);
+            }
+        }
+        Ok(SchemaConstraint {
+            schema: self.schema,
+            possible_types,
+        })
+    }
+}
+
+impl PathConstraint for SchemaConstraint<'_> {
+    fn under_type_condition(&self, type_cond: &NormalizedTypeCondition) -> Self {
+        let ground_set = type_cond.ground_set().iter();
+        let possible_types = if self.possible_types.is_empty() {
+            ground_set.cloned().collect()
+        } else {
+            // Both the current constraint and the type condition apply here.
+            // - Callers only use satisfiable type conditions, so the intersection is non-empty.
+            ground_set
+                .filter(|ty| self.possible_types.contains(*ty))
+                .cloned()
+                .collect()
+        };
+        SchemaConstraint {
+            schema: self.schema,
+            possible_types,
+        }
+    }
+
+    fn for_field(&self, representative_field: &Field) -> Result<Self, ComparisonError> {
+        self.possible_types_for_field(&representative_field.name)
+            .map_err(|e| {
+                // Note: This is an internal federation error, not a comparison error.
+                //       But, we are only allowed to return `ComparisonError` to keep the
+                //       response_shape_compare module free from internal errors.
+                ComparisonError::new(format!(
+                    "failed to compute possible types for {} on {:?} due to an error:\n{e}",
+                    representative_field.name, self.possible_types,
+                ))
+            })
+    }
+
+    fn allows(&self, ty: &ObjectTypeDefinitionPosition) -> bool {
+        self.possible_types.is_empty() || self.possible_types.contains(ty)
+    }
+
+    fn allows_any(&self, defs: &PossibleDefinitions) -> bool {
+        if self.possible_types.is_empty() {
+            return true;
+        }
+        let intersects = |ground_set: &[ObjectTypeDefinitionPosition]| {
+            // See if `self.possible_types` and `ground_set` have any intersection.
+            ground_set.iter().any(|ty| self.possible_types.contains(ty))
+        };
+        defs.iter()
+            .any(|(type_cond, _)| intersects(type_cond.ground_set()))
+    }
+}

--- a/apollo-federation/src/correctness/subgraph_constraint.rs
+++ b/apollo-federation/src/correctness/subgraph_constraint.rs
@@ -47,9 +47,10 @@ fn is_resolvable(
 }
 
 impl<'a> SubgraphConstraint<'a> {
-    pub(crate) fn at_root(
-        subgraphs_by_name: &'a IndexMap<Arc<str>, ValidFederationSchema>,
-    ) -> Self {
+    /// A constraint with no type information: all subgraphs and types are possible. The
+    /// comparison may start at any scope (e.g. the entity type for `@requires`/`@key`
+    /// conditions); the first type condition encountered narrows the constraint to that scope.
+    pub(crate) fn new(subgraphs_by_name: &'a IndexMap<Arc<str>, ValidFederationSchema>) -> Self {
         let all_subgraphs = subgraphs_by_name.keys().cloned().collect();
         SubgraphConstraint {
             subgraphs_by_name,


### PR DESCRIPTION
## Summary

When the response shape comparison case-splits a type condition over its ground object types, the case being tried must narrow the type context of the sub-selections below it — but it was not passed down to the child selection set scope.

This causes false errors when the child scope depends on the case, i.e. with covariant field output types (`ObjectA.next: ObjectA!` narrowing `Entity.next: Entity!`). The two operations below are equivalent, but the checker rejected them: in the `ObjectA` case, `next` can only be an `ObjectA`, yet the demand's child bucket was still checked as `Entity {A,B,C}` against a coverage of `{A}`, failing with `no definitions found ... (case: ObjectB)`.

    # left (coverer)                       # right (demand)
    { entity {                             { entity { next { id } } }
        ... on ObjectA { next { id } }
        ... on ObjectB { next { id } }
        ... on ObjectC { next { id } } } }

## Details

- New `SchemaConstraint` helper imposes the narrowing: it tracks the set of possible runtime types at the current path position — `under_type_condition` narrows it by the type condition (or case) in effect, and `for_field` derives the child scope's possible types from each possible runtime type's own field definition (which handles covariant output types).
- Constraints can be combined as a pair `(A, B)`, allowing exactly two modes:
  - single schema: `SchemaConstraint` alone (`compare_operations`);
  - federated: `SchemaConstraint` on the supergraph schema, plus `SubgraphConstraint` as an extra oracle (`check_plan` and the `@requires`/`@key` state check).
- The federated mode uses the supergraph schema, not the API schema: plan-side shapes may contain any fields from the supergraph schema, while the operation side is constrained to any shared schema.
- Renamed `SubgraphConstraint::at_root` → `new`: the constraint starts unconstrained.

## Test plan

- Regression tests for the counterexample above (failed before the fix), plus a nested variant and a negative test that incomplete coverage still fails.
- Full `apollo-federation` suite passes; `cargo fmt` and `clippy` clean.


<!-- start metadata -->
