### PR TITLE
test: mint license JWTs at runtime instead of pinning expired tokens (backport #10019)

### DIFF
--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -89,6 +89,63 @@ pub static TEST_JWKS_ENDPOINT: LazyLock<PathBuf> = LazyLock::new(|| {
         .join("license.jwks.json")
 });
 
+/// HS256 test secret bundled in `apollo-router/src/uplink/testdata/license.jwks.json`.
+/// JWK format (`oct`/`HS256`/`use=sig`) with `k` base64url-encoded.
+/// Decoded value is the byte string `make_a_long_secret_for_rfc_7518_256_bits_requirement_blah`.
+const TEST_LICENSE_JWKS_SECRET_BASE64URL: &str =
+    "bWFrZV9hX2xvbmdfc2VjcmV0X2Zvcl9yZmNfNzUxOF8yNTZfYml0c19yZXF1aXJlbWVudF9ibGFo";
+
+/// ~6 months in seconds: far enough out that a minted JWT stays valid through
+/// any reasonable test session, and well within tokio's `DelayQueue`
+/// scheduler cap (about a year — see `mint_license_jwt`).
+#[allow(dead_code)]
+pub const LICENSE_SIX_MONTHS_SECS: i64 = 60 * 60 * 24 * 180;
+
+/// Mint a test license JWT signed with the bundled HS256 test secret.
+///
+/// `allowed_features` is the `allowedFeatures` claim: `None` omits the claim
+/// entirely (which `LicenseLimits` interprets as "all features allowed"),
+/// `Some(&[])` is an empty allow-list. `warn_at_offset_secs` and
+/// `halt_at_offset_secs` are relative to now — negative values put the claim
+/// in the past. Keep future offsets under about a year: the license stream
+/// schedules `haltAt`/`warnAt` on a tokio `DelayQueue`, which cannot schedule
+/// `Instant`s derived from far-future `SystemTime`s.
+#[allow(dead_code)]
+pub fn mint_license_jwt(
+    allowed_features: Option<&[&str]>,
+    warn_at_offset_secs: i64,
+    halt_at_offset_secs: i64,
+) -> String {
+    use std::time::SystemTime;
+    use std::time::UNIX_EPOCH;
+
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_secs() as i64;
+
+    let secret_bytes = URL_SAFE_NO_PAD
+        .decode(TEST_LICENSE_JWKS_SECRET_BASE64URL)
+        .expect("test JWKS secret is valid base64url");
+    let key = jsonwebtoken::EncodingKey::from_secret(&secret_bytes);
+    let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256);
+    let mut claims = serde_json::json!({
+        "exp": 10000000000_u64,
+        "iss": "https://www.apollographql.com/",
+        "sub": "apollo",
+        "aud": "SELF_HOSTED",
+        "warnAt": now + warn_at_offset_secs,
+        "haltAt": now + halt_at_offset_secs,
+    });
+    if let Some(features) = allowed_features {
+        claims["allowedFeatures"] = serde_json::json!(features);
+    }
+    jsonwebtoken::encode(&header, &claims, &key).expect("sign test license JWT")
+}
+
 fn get_allocated_ports() -> &'static Arc<Mutex<HashMap<u16, String>>> {
     ALLOCATED_PORTS.get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
 }

--- a/apollo-router/tests/integration/allowed_features.rs
+++ b/apollo-router/tests/integration/allowed_features.rs
@@ -1,45 +1,117 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 use http::StatusCode;
 
 use crate::integration::IntegrationTest;
+use crate::integration::common::LICENSE_SIX_MONTHS_SECS;
 use crate::integration::common::TEST_JWKS_ENDPOINT;
-
-// NOTE: if these tests fail for haltAt/warnAt related reasons (that they're in the past), go to
-// jwt.io and doublecheck that those claims are still sensible. There's an issue when using
-// Instants to schedule things (like we do for license streams) if those Instants are derived from
-// some far-future SystemTime: tokio has an upper bound for how far out it schedules, putting a
-// pretty hard limit (about a year) for what we can set the haltAt/warnAt values in JWTs to
+use crate::integration::common::mint_license_jwt;
 
 const LICENSE_ALLOWED_FEATURES_DOES_NOT_INCLUDE_FEATURE_MSG: &str =
     "license violation, the router is using features not available for your license";
 const LICENSE_EXPIRED_MESSAGE: &str =
     "License has expired. The Router will no longer serve requests.";
 
-const JWT_WITH_EMPTY_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiYWxsb3dlZEZlYXR1cmVzIjogW10sCiAgImlzcyI6ICJodHRwczovL3d3dy5hcG9sbG9ncmFwaHFsLmNvbS8iLAogICJzdWIiOiAiYXBvbGxvIiwKICAiYXVkIjogIlNFTEZfSE9TVEVEIiwgCiAgIndhcm5BdCI6IDE3ODcwMDAwMDAsCiAgImhhbHRBdCI6IDE3ODcwMDAwMDAKfQ.nERzNxBzt7KLgBD4ouHydbht6_1jgyCYF8aKzFKGjhI"; // gitleaks:allow
+// The license JWTs below are minted at runtime with `warnAt`/`haltAt` relative
+// to now, so they can never silently expire the way pinned tokens used to.
+// `LICENSE_SIX_MONTHS_SECS` keeps future claims within tokio's DelayQueue
+// scheduler cap (about a year) — see `mint_license_jwt` in common.rs.
 
-const JWT_WITH_COPROCESSORS_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiYWxsb3dlZEZlYXR1cmVzIjogWyJjb3Byb2Nlc3NvcnMiXSwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhdWQiOiAiU0VMRl9IT1NURUQiLCAKICAid2FybkF0IjogMTc4NzAwMDAwMCwKICAiaGFsdEF0IjogMTc4NzAwMDAwMAp9.UD2JZtyvCSY6oXeDOsmWZehNGQjDqdhOiw-1f2TW4Og"; // gitleaks:allow
+static JWT_WITH_EMPTY_ALLOWED_FEATURES: LazyLock<String> =
+    LazyLock::new(|| mint_license_jwt(Some(&[]), LICENSE_SIX_MONTHS_SECS, LICENSE_SIX_MONTHS_SECS));
+
+static JWT_WITH_COPROCESSORS_IN_ALLOWED_FEATURES: LazyLock<String> = LazyLock::new(|| {
+    mint_license_jwt(
+        Some(&["coprocessors"]),
+        LICENSE_SIX_MONTHS_SECS,
+        LICENSE_SIX_MONTHS_SECS,
+    )
+});
 
 // In the CI environment we only install Redis on x86_64 Linux; this jwt is part of testing that
 // flow
 #[cfg(any(not(feature = "ci"), all(target_arch = "x86_64", target_os = "linux")))]
-const JWT_WITH_ENTITY_CACHING_COPROCESSORS_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbImVudGl0eV9jYWNoaW5nIiwgImNvcHJvY2Vzc29ycyJdLAogICJhdWQiOiAiU0VMRl9IT1NURUQiLCAKICAid2FybkF0IjogMTc4NzAwMDAwMCwgCiAgImhhbHRBdCI6IDE3ODcwMDAwMDAKfQ.HD_xzVtrXzXp8PdosAircXWPtnVaPRE-N2ZDlv6Llfo"; // gitleaks:allow
+static JWT_WITH_ENTITY_CACHING_COPROCESSORS_IN_ALLOWED_FEATURES: LazyLock<String> =
+    LazyLock::new(|| {
+        mint_license_jwt(
+            Some(&["entity_caching", "coprocessors"]),
+            LICENSE_SIX_MONTHS_SECS,
+            LICENSE_SIX_MONTHS_SECS,
+        )
+    });
 
-const JWT_WITH_COPROCESSORS_SUBSCRIPTION_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiYWxsb3dlZEZlYXR1cmVzIjogWwogICAgImNvcHJvY2Vzc29ycyIsCiAgICAic3Vic2NyaXB0aW9ucyIKICBdLAogICJpc3MiOiAiaHR0cHM6Ly93d3cuYXBvbGxvZ3JhcGhxbC5jb20vIiwKICAic3ViIjogImFwb2xsbyIsCiAgImF1ZCI6ICJTRUxGX0hPU1RFRCIsIAogICJ3YXJuQXQiOiAxNzg3MDAwMDAwLAogICJoYWx0QXQiOiAxNzg3MDAwMDAwCn0.MxjeQOea7wBjvs1J0-44oEfdoaVwKuEexy-JdgZ-3R8"; // gitleaks:allow
+static JWT_WITH_COPROCESSORS_SUBSCRIPTION_IN_ALLOWED_FEATURES: LazyLock<String> =
+    LazyLock::new(|| {
+        mint_license_jwt(
+            Some(&["coprocessors", "subscriptions"]),
+            LICENSE_SIX_MONTHS_SECS,
+            LICENSE_SIX_MONTHS_SECS,
+        )
+    });
 
-const JWT_WITH_ALLOWED_FEATURES_NONE: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhdWQiOiAiU0VMRl9IT1NURUQiLCAKICAid2FybkF0IjogMTc4NzAwMDAwMCwKICAiaGFsdEF0IjogMTc4NzAwMDAwMAp9.LPNJgPY20DH054mXgrzaxEFiME656ZJ-ge5y9Zh3kkc"; // gitleaks:allow
+static JWT_WITH_ALLOWED_FEATURES_NONE: LazyLock<String> =
+    LazyLock::new(|| mint_license_jwt(None, LICENSE_SIX_MONTHS_SECS, LICENSE_SIX_MONTHS_SECS));
 
-const JWT_WITH_ALLOWED_FEATURES_COPROCESSOR_WITH_FEATURE_UNDEFINED_IN_ROUTER: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiYWxsb3dlZEZlYXR1cmVzIjogWwogICAgImNvcHJvY2Vzc29ycyIsCiAgICAicmFuZG9tIiwKICAgICJzdWJzY3JpcHRpb25zIgogIF0sCiAgImlzcyI6ICJodHRwczovL3d3dy5hcG9sbG9ncmFwaHFsLmNvbS8iLAogICJzdWIiOiAiYXBvbGxvIiwKICAiYXVkIjogIlNFTEZfSE9TVEVEIiwgCiAgIndhcm5BdCI6IDE3ODcwMDAwMDAsCiAgImhhbHRBdCI6IDE3ODcwMDAwMDAKfQ.l4O-YLwIu2hjoSq1HseJQMS_9qFNL9v304I7gfLqV3w"; // gitleaks:allow
+static JWT_WITH_ALLOWED_FEATURES_COPROCESSOR_WITH_FEATURE_UNDEFINED_IN_ROUTER: LazyLock<String> =
+    LazyLock::new(|| {
+        mint_license_jwt(
+            Some(&["coprocessors", "random", "subscriptions"]),
+            LICENSE_SIX_MONTHS_SECS,
+            LICENSE_SIX_MONTHS_SECS,
+        )
+    });
 
-const JWT_WITH_ENTITY_CACHING_COPROCESSORS_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbImVudGl0eV9jYWNoaW5nIiwgImNvcHJvY2Vzc29ycyIsICJ0cmFmZmljX3NoYXBpbmciXSwKICAiYXVkIjogIlNFTEZfSE9TVEVEIiwgCiAgIndhcm5BdCI6IDE3ODcwMDAwMDAsIAogICJoYWx0QXQiOiAxNzg3MDAwMDAwCn0.HHfLHmDAjTdQwouAJguvWnpxnHsLzTWswQl70gmkMEM"; // gitleaks:allow
+static JWT_WITH_ENTITY_CACHING_COPROCESSORS_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES: LazyLock<String> =
+    LazyLock::new(|| {
+        mint_license_jwt(
+            Some(&["entity_caching", "coprocessors", "traffic_shaping"]),
+            LICENSE_SIX_MONTHS_SECS,
+            LICENSE_SIX_MONTHS_SECS,
+        )
+    });
 
-const JWT_PAST_EXPIRY_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_SUBSCRIPTIONS_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbImNvcHJvY2Vzc29ycyIsICJlbnRpdHlfY2FjaGluZyIsICJ0cmFmZmljX3NoYXBpbmciLCAic3Vic2NyaXB0aW9ucyJdLAogICJhdWQiOiAiU0VMRl9IT1NURUQiLCAKICAid2FybkF0IjogMTc1NTMwMjQwMCwgCiAgImhhbHRBdCI6IDE3NTUzMDI0MDAKfQ.2TPyUd9BUn3NCc2Kq8WsJS_6V16s2lgitElhf0lNcwg"; // gitleaks:allow
+static JWT_PAST_EXPIRY_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_SUBSCRIPTIONS_IN_ALLOWED_FEATURES:
+    LazyLock<String> = LazyLock::new(|| {
+    mint_license_jwt(
+        Some(&[
+            "coprocessors",
+            "entity_caching",
+            "traffic_shaping",
+            "subscriptions",
+        ]),
+        -LICENSE_SIX_MONTHS_SECS,
+        -LICENSE_SIX_MONTHS_SECS,
+    )
+});
 
-const JWT_PAST_EXPIRY_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbImNvcHJvY2Vzc29ycyIsICJlbnRpdHlfY2FjaGluZyIsICJ0cmFmZmljX3NoYXBpbmciXSwKICAiYXVkIjogIlNFTEZfSE9TVEVEIiwgCiAgIndhcm5BdCI6IDE3NTUzMDI0MDAsIAogICJoYWx0QXQiOiAxNzU1MzAyNDAwCn0.CERblSGfOVmKt6PtfB2LjnY-ahzMsNB4EGajXZfKWU4"; // gitleaks:allow
+static JWT_PAST_EXPIRY_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES:
+    LazyLock<String> = LazyLock::new(|| {
+    mint_license_jwt(
+        Some(&["coprocessors", "entity_caching", "traffic_shaping"]),
+        -LICENSE_SIX_MONTHS_SECS,
+        -LICENSE_SIX_MONTHS_SECS,
+    )
+});
 
-const JWT_PAST_WARN_AT_BUT_NOT_EXPIRED_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbImVudGl0eV9jYWNoaW5nIiwgImNvcHJvY2Vzc29ycyIsICJ0cmFmZmljX3NoYXBpbmciXSwKICAiYXVkIjogIlNFTEZfSE9TVEVEIiwgCiAgIndhcm5BdCI6IDE3NjU5MTA0MDAsIAogICJoYWx0QXQiOiAxNzg3MDAwMDAwCn0.33EWawSaU8dv5KqI8QbAzYFa0KKTcvqTXGaJfRkg-DU"; // gitleaks:allow
-const JWT_PAST_WARN_AT_BUT_NOT_EXPIRED_WITH_COPROCESSORS_SUBSCRIPTIONS_IN_ALLOWED_FEATURES: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJleHAiOiAxMDAwMDAwMDAwMCwKICAiaXNzIjogImh0dHBzOi8vd3d3LmFwb2xsb2dyYXBocWwuY29tLyIsCiAgInN1YiI6ICJhcG9sbG8iLAogICJhbGxvd2VkRmVhdHVyZXMiOiBbInN1YnNjcmlwdGlvbnMiLCAiY29wcm9jZXNzb3JzIl0sCiAgImF1ZCI6ICJTRUxGX0hPU1RFRCIsIAogICJ3YXJuQXQiOiAxNzU1MzAyNDAwLCAKICAiaGFsdEF0IjogMTc4NzAwMDAwMAp9.nxyKlFquWBijtIOtL8FnknNfAwvBaZh9TFIDcG7NtiE"; // gitleaks:allow
+static JWT_PAST_WARN_AT_BUT_NOT_EXPIRED_WITH_COPROCESSORS_ENTITY_CACHING_TRAFFIC_SHAPING_IN_ALLOWED_FEATURES:
+    LazyLock<String> = LazyLock::new(|| {
+    mint_license_jwt(
+        Some(&["entity_caching", "coprocessors", "traffic_shaping"]),
+        -LICENSE_SIX_MONTHS_SECS,
+        LICENSE_SIX_MONTHS_SECS,
+    )
+});
+
+static JWT_PAST_WARN_AT_BUT_NOT_EXPIRED_WITH_COPROCESSORS_SUBSCRIPTIONS_IN_ALLOWED_FEATURES:
+    LazyLock<String> = LazyLock::new(|| {
+    mint_license_jwt(
+        Some(&["subscriptions", "coprocessors"]),
+        -LICENSE_SIX_MONTHS_SECS,
+        LICENSE_SIX_MONTHS_SECS,
+    )
+});
 
 const SUBSCRIPTION_CONFIG: &str = include_str!("subscriptions/fixtures/subscription.router.yaml");
 const SUBSCRIPTION_COPROCESSOR_CONFIG: &str =


### PR DESCRIPTION
Backport of #10019.

The license JWTs in `tests/integration/allowed_features.rs` were hard-coded strings with `warnAt`/`haltAt` pinned to epoch `1787000000` (2026-08-17), which has now passed. Every license those tests treated as valid is now halted, so the router logs `License has expired` instead of the allowed-features violation the tests assert on, and the suite fails.

Mergify's auto-backport of #10019 failed on both `dev-v2.16.x` and `dev-v2.10.x` because the source PR was true-merged (contains merge commit `e40108a`, an accidental `origin/renovate/h2-0.x-lockfile` merge into the feature branch) rather than squash-merged. This PR carries only the actual test change.

`dev-v2.10.x` doesn't have the `mint_test_license_jwt()` helper that #10019 generalizes on `dev`/`dev-v2.16.x` — that helper was added later by an unrelated 360-line refactor (#9333, "lift Uplink mock to tests/common.rs Phase 2") that isn't a good candidate for backporting to an LTS branch. So this backport adds a self-contained `mint_license_jwt(allowed_features, warn_at_offset, halt_at_offset)` directly to this branch's `common.rs` instead, signed with the same HS256 test secret already bundled in `src/uplink/testdata/license.jwks.json` (identical on both branches).

Note: `dev-v2.10.x`'s nightly build has been failing across every integration test platform (amd/arm linux, macos, windows) since the JWTs expired on 2026-08-17, plus `check_compliance` independently (h2 `0.4.13` unpatched for RUSTSEC-2026-0258). This PR addresses the JWT expiry; the h2 bump is tracked separately.

Test-only change — nothing under `src/` is touched.