### PR TITLE
chore(deps): update rust crate lru to v0.18.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,6 +3235,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4217,11 +4228,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -138,7 +138,7 @@ jsonschema = { version = "0.36.0", default-features = false }
 jsonwebtoken = "9.3.0"
 libc = "0.2.155"
 linkme = "0.3.30"
-lru = "0.16.0"
+lru = "0.18.0"
 mediatype = "0.21.0"
 mockall = "0.14.0"
 mime = "0.3.17"


### PR DESCRIPTION
Fixes RUSTSEC-2026-0253: `LruCache::pop()` in `lru` <0.18.2 was not panic-safe, leaving dangling pointers in the internal linked list if a stored key's `Drop` implementation panicked mid-pop, risking use-after-free or double-free on a subsequent eviction.

`dev-v2.10.x` was still on `lru` `0.16.3`. `dev`/`dev-v2.16.x` have already taken this exact bump (in four incremental steps: #9193, #9275, #9812, #9981 — each `Cargo.lock`/`Cargo.toml`-only per their commit history), so the API is proven compatible with this codebase's usage in `cache/storage.rs`, `response_cache/plugin.rs`, `telemetry/tracing/apollo_telemetry.rs`, and `layers/query_analysis.rs`. No source changes needed here either.

`cargo update -p lru --precise 0.18.2` also pulled in incidental `windows-sys`/`socket2` version drift on unrelated dependencies (resolver noise from re-solving the whole graph); reverted those by hand to keep this change scoped to the actual fix.

Verified locally with `cargo xtask check-compliance` — the `lru` advisory (RUSTSEC-2026-0253) clears. The separate h2 advisory (RUSTSEC-2026-0258, tracked in #10039) is unrelated and still present on this branch until that PR lands.