### PR TITLE
chore: remove `failfast` feature

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -40,11 +40,6 @@ global-allocator = ["tikv-jemallocator/profiling", "tikv-jemalloc-ctl/stats", "t
 dhat-heap = ["dhat"]
 dhat-ad-hoc = ["dhat"]
 
-# Prevents the query execution to continue if any error occurs while fetching
-# the data of a subgraph. This is useful in development as you want to be
-# alerted early when something is wrong instead of receiving an invalid result.
-failfast = []
-
 # Enables the use of new telemetry features that are under development
 # and not yet ready for production use.
 telemetry_next = []

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -195,10 +195,12 @@ impl ValueExt for Value {
             }
             (_, Value::Null) => {}
             (Value::Object(_), Value::Array(_)) => {
-                failfast_debug!("trying to replace an object with an array");
+                // XXX(@goto-bus-stop): this should be fallible..?
+                tracing::debug!("trying to replace an object with an array");
             }
             (Value::Array(_), Value::Object(_)) => {
-                failfast_debug!("trying to replace an array with an object");
+                // XXX(@goto-bus-stop): this should be fallible..?
+                tracing::debug!("trying to replace an array with an object");
             }
             (a, b) => {
                 if b != Value::Null {
@@ -242,10 +244,12 @@ impl ValueExt for Value {
             }
             (_, Value::Null) => {}
             (Value::Object(_), Value::Array(_)) => {
-                failfast_debug!("trying to replace an object with an array");
+                // XXX(@goto-bus-stop): this should be fallible..?
+                tracing::debug!("trying to replace an object with an array");
             }
             (Value::Array(_), Value::Object(_)) => {
-                failfast_debug!("trying to replace an array with an object");
+                // XXX(@goto-bus-stop): this should be fallible..?
+                tracing::debug!("trying to replace an array with an object");
             }
             (a, b) => {
                 if b != Value::Null {

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -16,7 +16,6 @@
 //! * [`services`] - the various services handling a GraphQL requests,
 //!   and APIs for plugins to intercept them
 
-#![cfg_attr(feature = "failfast", allow(unreachable_code))]
 #![warn(unreachable_pub)]
 #![warn(missing_docs)]
 
@@ -29,28 +28,6 @@
 #[ctor::ctor(unsafe)]
 fn install_default_crypto_provider_for_tests() {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-}
-
-macro_rules! failfast_debug {
-    ($($tokens:tt)+) => {{
-        tracing::debug!($($tokens)+);
-        #[cfg(feature = "failfast")]
-        panic!(
-            "failfast triggered. \
-            Please remove the feature failfast if you don't want to see these panics"
-        );
-    }};
-}
-
-macro_rules! failfast_error {
-    ($($tokens:tt)+) => {{
-        tracing::error!($($tokens)+);
-        #[cfg(feature = "failfast")]
-        panic!(
-            "failfast triggered. \
-            Please remove the feature failfast if you don't want to see these panics"
-        );
-    }};
 }
 
 #[macro_use]

--- a/apollo-router/src/plugins/subscription/fetch.rs
+++ b/apollo-router/src/plugins/subscription/fetch.rs
@@ -220,7 +220,7 @@ fn subscription_with_subgraph_service(
                     .map_to_graphql_error(service_name.to_string(), &current_dir)
                 {
                     Err(e) => {
-                        failfast_error!("subgraph call fetch error: {}", e);
+                        tracing::error!("subgraph call fetch error: {}", e);
                         vec![e]
                     }
                     Ok(response) => response.response.into_parts().1.errors,

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -1609,35 +1609,28 @@ where
                             }
                         },
                     };
-                    match static_instruments
+                    let counter = static_instruments
                         .get(instrument_name)
                         .expect(
                             "cannot get static instrument for supergraph; this should not happen",
                         )
                         .as_counter_f64()
                         .cloned()
-                    {
-                        Some(counter) => {
-                            let counter = CustomCounterInner {
-                                increment,
-                                condition: instrument.condition.clone(),
-                                counter: Some(counter),
-                                attributes: Vec::new(),
-                                selector,
-                                selectors: Some(instrument.attributes.clone()),
-                                incremented: false,
-                                _phantom: PhantomData,
-                            };
-                            counters.push(CustomCounter {
-                                inner: Mutex::new(counter),
-                            })
-                        }
-                        None => {
-                            failfast_debug!(
-                                "cannot convert static instrument into a counter, this is an error; please fill an issue on GitHub"
-                            );
-                        }
-                    }
+                        .expect("cannot convert static instrument into a counter, this is a bug");
+
+                    let counter = CustomCounterInner {
+                        increment,
+                        condition: instrument.condition.clone(),
+                        counter: Some(counter),
+                        attributes: Vec::new(),
+                        selector,
+                        selectors: Some(instrument.attributes.clone()),
+                        incremented: false,
+                        _phantom: PhantomData,
+                    };
+                    counters.push(CustomCounter {
+                        inner: Mutex::new(counter),
+                    })
                 }
                 InstrumentType::Histogram => {
                     let (selector, increment) = match (&instrument.value).into() {
@@ -1671,36 +1664,29 @@ where
                         },
                     };
 
-                    match static_instruments
+                    let histogram = static_instruments
                         .get(instrument_name)
                         .expect(
                             "cannot get static instrument for supergraph; this should not happen",
                         )
                         .as_histogram()
                         .cloned()
-                    {
-                        Some(histogram) => {
-                            let histogram = CustomHistogramInner {
-                                increment,
-                                condition: instrument.condition.clone(),
-                                histogram: Some(histogram),
-                                attributes: Vec::new(),
-                                selector,
-                                selectors: Some(instrument.attributes.clone()),
-                                updated: false,
-                                _phantom: PhantomData,
-                            };
+                        .expect("cannot convert static instrument into a histogram, this is a bug");
 
-                            histograms.push(CustomHistogram {
-                                inner: Mutex::new(histogram),
-                            });
-                        }
-                        None => {
-                            failfast_debug!(
-                                "cannot convert static instrument into a histogram, this is an error; please fill an issue on GitHub"
-                            );
-                        }
-                    }
+                    let histogram = CustomHistogramInner {
+                        increment,
+                        condition: instrument.condition.clone(),
+                        histogram: Some(histogram),
+                        attributes: Vec::new(),
+                        selector,
+                        selectors: Some(instrument.attributes.clone()),
+                        updated: false,
+                        _phantom: PhantomData,
+                    };
+
+                    histograms.push(CustomHistogram {
+                        inner: Mutex::new(histogram),
+                    });
                 }
             }
         }
@@ -1930,8 +1916,8 @@ where
                 Increment::EventCustom(None) => Increment::EventCustom(Some(selected_value)),
                 Increment::Custom(None) => Increment::Custom(Some(selected_value)),
                 other => {
-                    failfast_error!(
-                        "this is a bug and should not happen, the increment should only be Custom or EventCustom, please open an issue: {other:?}"
+                    tracing::error!(
+                        "this is a bug and should not happen, the increment should only be Custom or EventCustom: {other:?}"
                     );
                     return;
                 }
@@ -1972,8 +1958,8 @@ where
                 Increment::EventCustom(None) => Increment::Custom(Some(selected_value)),
                 Increment::Custom(None) => Increment::Custom(Some(selected_value)),
                 other => {
-                    failfast_error!(
-                        "this is a bug and should not happen, the increment should only be Custom or EventCustom, please open an issue: {other:?}"
+                    tracing::error!(
+                        "this is a bug and should not happen, the increment should only be Custom or EventCustom: {other:?}"
                     );
                     return;
                 }
@@ -2023,8 +2009,8 @@ where
                 Increment::EventCustom(None) => Increment::EventCustom(Some(selected_value)),
                 Increment::Custom(None) => Increment::EventCustom(Some(selected_value)),
                 other => {
-                    failfast_error!(
-                        "this is a bug and should not happen, the increment should only be Custom or EventCustom, please open an issue: {other:?}"
+                    tracing::error!(
+                        "this is a bug and should not happen, the increment should only be Custom or EventCustom: {other:?}"
                     );
                     return;
                 }
@@ -2111,8 +2097,8 @@ where
                 Increment::FieldCustom(None) => Increment::FieldCustom(Some(selected_value)),
                 Increment::Custom(None) => Increment::FieldCustom(Some(selected_value)),
                 other => {
-                    failfast_error!(
-                        "this is a bug and should not happen, the increment should only be Custom or FieldCustom, please open an issue: {other:?}"
+                    tracing::error!(
+                        "this is a bug and should not happen, the increment should only be Custom or FieldCustom: {other:?}"
                     );
                     return;
                 }
@@ -2357,8 +2343,8 @@ where
                 Increment::FieldCustom(None) => Increment::FieldCustom(Some(selected_value)),
                 Increment::Custom(None) => Increment::Custom(Some(selected_value)),
                 other => {
-                    failfast_error!(
-                        "this is a bug and should not happen, the increment should only be Custom or EventCustom, please open an issue: {other:?}"
+                    tracing::error!(
+                        "this is a bug and should not happen, the increment should only be Custom or EventCustom: {other:?}"
                     );
                     return;
                 }
@@ -2398,8 +2384,8 @@ where
                 Increment::FieldCustom(None) => Increment::FieldCustom(Some(selected_value)),
                 Increment::Custom(None) => Increment::Custom(Some(selected_value)),
                 other => {
-                    failfast_error!(
-                        "this is a bug and should not happen, the increment should only be Custom or EventCustom, please open an issue: {other:?}"
+                    tracing::error!(
+                        "this is a bug and should not happen, the increment should only be Custom or EventCustom: {other:?}"
                     );
                     return;
                 }
@@ -2450,8 +2436,8 @@ where
                 Increment::EventCustom(None) => Increment::EventCustom(Some(selected_value)),
                 Increment::Custom(None) => Increment::EventCustom(Some(selected_value)),
                 other => {
-                    failfast_error!(
-                        "this is a bug and should not happen, the increment should only be Custom or EventCustom, please open an issue: {other:?}"
+                    tracing::error!(
+                        "this is a bug and should not happen, the increment should only be Custom or EventCustom: {other:?}"
                     );
                     return;
                 }
@@ -2535,8 +2521,8 @@ where
                 Increment::FieldCustom(None) => Increment::FieldCustom(Some(selected_value)),
                 Increment::Custom(None) => Increment::FieldCustom(Some(selected_value)),
                 other => {
-                    failfast_error!(
-                        "this is a bug and should not happen, the increment should only be Custom or FieldCustom, please open an issue: {other:?}"
+                    tracing::error!(
+                        "this is a bug and should not happen, the increment should only be Custom or FieldCustom: {other:?}"
                     );
                     return;
                 }

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -292,7 +292,8 @@ impl Query {
                 return vec![];
             }
             _ => {
-                failfast_debug!("invalid type for data in response. data: {:#?}", data);
+                // XXX(@goto-bus-stop): this should raise an execution error?
+                tracing::debug!("invalid type for data in response. data: {data:#?}");
             }
         }
 
@@ -1049,7 +1050,13 @@ impl Query {
                         }
                     } else {
                         // the fragment should have been already checked with the schema
-                        failfast_debug!("missing fragment named: {}", name);
+                        // XXX(@goto-bus-stop): can we store a reference to the fragment instead of
+                        // just a name?
+                        tracing::error!(
+                            name = name,
+                            "missing fragment in response formatting, this is a bug"
+                        );
+                        return Err(InvalidValue);
                     }
                 }
             }
@@ -1241,7 +1248,13 @@ impl Query {
                         }
                     } else {
                         // the fragment should have been already checked with the schema
-                        failfast_debug!("missing fragment named: {}", name);
+                        // XXX(@goto-bus-stop): can we store a reference to the fragment instead of
+                        // just a name?
+                        tracing::error!(
+                            name = name,
+                            "missing fragment in response formatting, this is a bug"
+                        );
+                        return Err(InvalidValue);
                     }
                 }
             }
@@ -1276,9 +1289,9 @@ impl Query {
                 .difference(&known_variables)
                 .collect::<Vec<_>>();
             if !unknown_variables.is_empty() {
-                failfast_debug!(
-                    "Received variable unknown to the query: {:?}",
-                    unknown_variables,
+                tracing::debug!(
+                    unknown_variables = ?unknown_variables,
+                    "Received variable unknown to the query",
                 );
             }
         }


### PR DESCRIPTION
Closes https://github.com/apollographql/router/issues/3762

A quick drive-by to replace `failfast` macro usage by tracing calls. The
`failfast` macros are in effect a tracing call anyways because we never
used the  `failfast` feature.

In the static instruments code, I used a panicking `.expect()` instead.
Though it would be better (and maybe possible) to guarantee the
invariant in the type system, a runtime `.expect()` was already used
for the same pattern in other parts of the code.

<!-- start metadata -->

<!-- [ROUTER-2069] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-2069]: https://apollographql.atlassian.net/browse/ROUTER-2069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ