### PR TITLE
Promote `connector_request_service` to the public plugin interface

### DIFF
--- a/.changesets/feat_am_connectors_public_plugin.md
+++ b/.changesets/feat_am_connectors_public_plugin.md
@@ -1,0 +1,3 @@
+### Promote connector_request_service to public plugin interface to allow it to be used in custom rust plugins ([PR #8937](https://github.com/apollographql/router/pull/8937))
+
+Promote connector_request_service to public plugin interface to allow it to be used in custom rust plugins.

--- a/.changesets/feat_am_connectors_public_plugin.md
+++ b/.changesets/feat_am_connectors_public_plugin.md
@@ -20,7 +20,7 @@ On the request:
 - `Request.transport_request` carries the underlying `http::Request`, so a plugin can read and rewrite the URI, method, headers and body.
 - `Request.supergraph_request()` returns the router request that produced this connector call, for reading.
 - `Request.context` is readable and writable for request-scoped state.
-- `Request::into_error_response(message, code)` fails a connector request without making it, for cases like circuit breaking on an upstream the plugin knows to be unhealthy.
+- `Request::into_error_response(message, code, extensions)` fails a connector request without making it, for cases like circuit breaking on an upstream the plugin knows to be unhealthy.
 
 On the response:
 

--- a/.changesets/feat_am_connectors_public_plugin.md
+++ b/.changesets/feat_am_connectors_public_plugin.md
@@ -1,3 +1,20 @@
-### Promote connector_request_service to public plugin interface to allow it to be used in custom rust plugins ([PR #8937](https://github.com/apollographql/router/pull/8937))
+### Promote `connector_request_service` to the public plugin interface ([PR #10049](https://github.com/apollographql/router/pull/10049))
 
-Promote connector_request_service to public plugin interface to allow it to be used in custom rust plugins.
+`connector_request_service` is now available on the public `Plugin` and `PluginUnstable` traits, so a custom Rust plugin can wrap the service that makes individual connector HTTP requests. It receives the boxed service and the `@source` name, matching the shape of `subgraph_service`:
+
+```rust
+fn connector_request_service(
+    &self,
+    service: connector::request_service::BoxService,
+    source_name: String,
+) -> connector::request_service::BoxService {
+    // wrap `service` to inspect or rewrite the outgoing request
+    service
+}
+```
+
+`apollo_router::services::connector::request_service` is public along with the fields a plugin needs: `Request.context`, `Request.transport_request`, `Request.supergraph_request`, and `Response.transport_result`. Because `TransportRequest` carries the underlying `http::Request`, a plugin can read and rewrite the URI, method, headers, and body per connector request.
+
+The coprocessor `ConnectorRequest` stage already covered this, and still does. The difference is that this runs in process, without a round trip per connector request.
+
+By [@andrewmcgivery](https://github.com/andrewmcgivery) in https://github.com/apollographql/router/pull/10049

--- a/.changesets/feat_am_connectors_public_plugin.md
+++ b/.changesets/feat_am_connectors_public_plugin.md
@@ -1,6 +1,6 @@
 ### Promote `connector_request_service` to the public plugin interface ([PR #10049](https://github.com/apollographql/router/pull/10049))
 
-`connector_request_service` is now available on the public `Plugin` and `PluginUnstable` traits, so a custom Rust plugin can wrap the service that makes individual connector HTTP requests. It receives the boxed service and the `@source` name, matching the shape of `subgraph_service`:
+`connector_request_service` is now available on the public `PluginUnstable` trait, so a custom Rust plugin can wrap the service that makes individual connector HTTP requests. It receives the boxed service and the `@source` name, matching the shape of `subgraph_service`:
 
 ```rust
 fn connector_request_service(

--- a/.changesets/feat_am_connectors_public_plugin.md
+++ b/.changesets/feat_am_connectors_public_plugin.md
@@ -13,8 +13,26 @@ fn connector_request_service(
 }
 ```
 
-`apollo_router::services::connector::request_service` is public along with the fields a plugin needs: `Request.context`, `Request.transport_request`, `Request.supergraph_request`, and `Response.transport_result`. Because `TransportRequest` carries the underlying `http::Request`, a plugin can read and rewrite the URI, method, headers, and body per connector request.
+`apollo_router::services::connector::request_service` is public along with what a plugin needs to read and change. One GraphQL operation can produce many connector requests, so this service runs once per outbound HTTP request rather than once per operation.
 
-The coprocessor `ConnectorRequest` stage already covered this, and still does. The difference is that this runs in process, without a round trip per connector request.
+On the request:
+
+- `Request.transport_request` carries the underlying `http::Request`, so a plugin can read and rewrite the URI, method, headers and body.
+- `Request.supergraph_request()` returns the router request that produced this connector call, for reading.
+- `Request.context` is readable and writable for request-scoped state.
+- `Request::into_error_response(message, code)` fails a connector request without making it, for cases like circuit breaking on an upstream the plugin knows to be unhealthy.
+
+On the response:
+
+- `Response.context` is readable and writable.
+- `Response.transport_result` exposes the raw transport outcome: status, headers, and transport-level errors.
+- `Response::data()` / `set_data()` and `Response::error()` / `set_error_message()` / `set_error_code()` read and change what is returned to the client.
+
+Two things are worth knowing when moving a customization between a coprocessor and a plugin:
+
+- The coprocessor `ConnectorRequest` stage cannot change the HTTP method; a plugin can.
+- Changing `Response.transport_result` does not recompute the mapped response, so telemetry will report the transport outcome you set while the client receives the unchanged mapped data. Change both, or neither.
+
+The coprocessor `ConnectorRequest` and `ConnectorResponse` stages already covered this, and still do. The difference is that this runs in process, without a round trip per connector request.
 
 By [@andrewmcgivery](https://github.com/andrewmcgivery) in https://github.com/apollographql/router/pull/10049

--- a/apollo-federation/src/connectors/runtime/errors.rs
+++ b/apollo-federation/src/connectors/runtime/errors.rs
@@ -111,6 +111,12 @@ impl RuntimeError {
         self.code.as_deref().unwrap_or("CONNECTORS_FETCH")
     }
 
+    /// Like [`Self::with_code`], for when the error is already owned by something else
+    /// and cannot be consumed.
+    pub fn set_code(&mut self, code: impl Into<String>) {
+        self.code = Some(code.into());
+    }
+
     pub fn span_event_emitted(&self) -> bool {
         self.span_event_emitted
     }

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -492,6 +492,15 @@ pub trait PluginUnstable: Send + Sync + 'static {
         service
     }
 
+    /// This service handles individual requests to Apollo Connectors
+    fn connector_request_service(
+        &self,
+        service: crate::services::connector::request_service::BoxService,
+        _source_name: String,
+    ) -> crate::services::connector::request_service::BoxService {
+        service
+    }
+
     /// Return the name of the plugin.
     fn name(&self) -> &'static str
     where
@@ -543,6 +552,14 @@ where
         service: subgraph::BoxService,
     ) -> subgraph::BoxService {
         Plugin::subgraph_service(self, subgraph_name, service)
+    }
+
+    fn connector_request_service(
+        &self,
+        service: crate::services::connector::request_service::BoxService,
+        source_name: String,
+    ) -> crate::services::connector::request_service::BoxService {
+        Plugin::connector_request_service(self, service, source_name)
     }
 
     /// Return the name of the plugin.
@@ -692,6 +709,14 @@ where
         service: subgraph::BoxService,
     ) -> subgraph::BoxService {
         PluginUnstable::subgraph_service(self, subgraph_name, service)
+    }
+
+    fn connector_request_service(
+        &self,
+        service: crate::services::connector::request_service::BoxService,
+        source_name: String,
+    ) -> crate::services::connector::request_service::BoxService {
+        PluginUnstable::connector_request_service(self, service, source_name)
     }
 
     /// Return the name of the plugin.

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -407,6 +407,17 @@ pub trait Plugin: Send + Sync + 'static {
         service
     }
 
+    /// This service handles individual requests to Apollo Connectors
+    /// Define `connector_request_service` to configure this communication (for example, to dynamically add headers to pass to a REST API).
+    /// The `_source_name` parameter is useful if you need to apply a customization only specific connectors.
+    fn connector_request_service(
+        &self,
+        service: crate::services::connector::request_service::BoxService,
+        _source_name: String,
+    ) -> crate::services::connector::request_service::BoxService {
+        service
+    }
+
     /// Return the name of the plugin.
     fn name(&self) -> &'static str
     where

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -487,13 +487,37 @@ pub trait PluginUnstable: Send + Sync + 'static {
     /// dynamically add headers to pass to a REST API. The `source_name` parameter is useful if
     /// you need to apply a customization only to specific connectors.
     ///
-    /// A plugin can read and mutate the outbound HTTP request through
-    /// [`Request::transport_request`], and read the router request that produced it through
-    /// [`Request::supergraph_request`]. One GraphQL operation may produce many connector
-    /// requests, so this service is called once per outbound request, not once per operation.
+    /// One GraphQL operation may produce many connector requests, so this service is
+    /// called once per outbound request, not once per operation.
+    ///
+    /// On the request, a plugin can:
+    ///
+    /// - read and rewrite the outbound HTTP request — URI, headers, body and method —
+    ///   through [`Request::transport_request`]. Note that the method is *not*
+    ///   rewritable through the coprocessor `ConnectorRequest` stage, so a plugin that
+    ///   changes it has no coprocessor equivalent;
+    /// - read the router request that produced it, through
+    ///   [`Request::supergraph_request`];
+    /// - read and write request-scoped state through [`Request::context`];
+    /// - fail the request without making it, through
+    ///   [`Request::into_error_response`] — the equivalent of a coprocessor returning
+    ///   `Control::Break`.
+    ///
+    /// On the response, a plugin can read and write [`Response::context`], read and
+    /// rewrite the raw transport outcome through [`Response::transport_result`], and
+    /// read or replace what is returned to the client through [`Response::data`],
+    /// [`Response::error`] and their setters. Rewriting `transport_result` does not
+    /// recompute the mapped response, so changing one without the other makes
+    /// telemetry disagree with what the client receives.
     ///
     /// [`Request::transport_request`]: crate::services::connector::request_service::Request::transport_request
     /// [`Request::supergraph_request`]: crate::services::connector::request_service::Request::supergraph_request
+    /// [`Request::context`]: crate::services::connector::request_service::Request::context
+    /// [`Request::into_error_response`]: crate::services::connector::request_service::Request::into_error_response
+    /// [`Response::context`]: crate::services::connector::request_service::Response::context
+    /// [`Response::transport_result`]: crate::services::connector::request_service::Response::transport_result
+    /// [`Response::data`]: crate::services::connector::request_service::Response::data
+    /// [`Response::error`]: crate::services::connector::request_service::Response::error
     fn connector_request_service(
         &self,
         service: crate::services::connector::request_service::BoxService,

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -407,17 +407,6 @@ pub trait Plugin: Send + Sync + 'static {
         service
     }
 
-    /// This service handles individual requests to Apollo Connectors
-    /// Define `connector_request_service` to configure this communication (for example, to dynamically add headers to pass to a REST API).
-    /// The `_source_name` parameter is useful if you need to apply a customization only specific connectors.
-    fn connector_request_service(
-        &self,
-        service: crate::services::connector::request_service::BoxService,
-        _source_name: String,
-    ) -> crate::services::connector::request_service::BoxService {
-        service
-    }
-
     /// Return the name of the plugin.
     fn name(&self) -> &'static str
     where
@@ -492,7 +481,19 @@ pub trait PluginUnstable: Send + Sync + 'static {
         service
     }
 
-    /// This service handles individual requests to Apollo Connectors
+    /// This service handles individual requests to Apollo Connectors.
+    ///
+    /// Define `connector_request_service` to configure this communication, for example to
+    /// dynamically add headers to pass to a REST API. The `source_name` parameter is useful if
+    /// you need to apply a customization only to specific connectors.
+    ///
+    /// A plugin can read and mutate the outbound HTTP request through
+    /// [`Request::transport_request`], and read the router request that produced it through
+    /// [`Request::supergraph_request`]. One GraphQL operation may produce many connector
+    /// requests, so this service is called once per outbound request, not once per operation.
+    ///
+    /// [`Request::transport_request`]: crate::services::connector::request_service::Request::transport_request
+    /// [`Request::supergraph_request`]: crate::services::connector::request_service::Request::supergraph_request
     fn connector_request_service(
         &self,
         service: crate::services::connector::request_service::BoxService,
@@ -554,13 +555,9 @@ where
         Plugin::subgraph_service(self, subgraph_name, service)
     }
 
-    fn connector_request_service(
-        &self,
-        service: crate::services::connector::request_service::BoxService,
-        source_name: String,
-    ) -> crate::services::connector::request_service::BoxService {
-        Plugin::connector_request_service(self, service, source_name)
-    }
+    // No `connector_request_service` forwarding here on purpose: the hook is only on
+    // `PluginUnstable`, so a plugin that implements the stable `Plugin` trait gets the
+    // passthrough default rather than a customization point that is still settling.
 
     /// Return the name of the plugin.
     fn name(&self) -> &'static str

--- a/apollo-router/src/plugins/connectors/tests/mod.rs
+++ b/apollo-router/src/plugins/connectors/tests/mod.rs
@@ -44,6 +44,7 @@ mod content_type;
 mod error_handling;
 mod mock_api;
 mod progressive_override;
+mod public_plugin;
 mod query_plan;
 mod quickstart;
 mod req_asserts;
@@ -2292,6 +2293,61 @@ mod quickstart_tests {
         }
         "###);
     }
+}
+
+/// Like [`execute`], but registers an out-of-tree-style plugin through the public
+/// [`PluginUnstable`][crate::plugin::PluginUnstable] interface.
+///
+/// This goes through `TestHarness` rather than `YamlRouterFactory` directly, because
+/// `extra_unstable_plugin` is the only way to reach the `DynPlugin` ->
+/// `PluginUnstable` forwarding that the public plugin hooks depend on. `TestHarness`
+/// builds through `YamlRouterFactory::inner_create_supergraph`, so connectors are
+/// extracted the same way they are in [`execute`].
+async fn execute_with_unstable_plugin<P: crate::plugin::PluginUnstable>(
+    schema: &str,
+    uri: &str,
+    query: &str,
+    plugin: P,
+) -> serde_json::Value {
+    let config = serde_json::json!({
+        "include_subgraph_errors": { "all": true },
+        "override_subgraph_url": { "graphql": format!("{uri}/graphql") },
+        "connectors": {
+            "sources": {
+                "connectors.json": {
+                    "override_url": format!("{uri}/"),
+                    // `Query.me` in the steel thread schema is `/users/{$config.id}`.
+                    "$config": { "id": 1 }
+                }
+            }
+        }
+    });
+
+    let service = crate::TestHarness::builder()
+        .schema(schema)
+        .configuration_json(config)
+        .unwrap()
+        .extra_unstable_plugin(plugin)
+        .with_subgraph_network_requests()
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .query(query)
+        .header("x-client-header", "client-header-value")
+        .build()
+        .unwrap();
+
+    let response = service
+        .oneshot(request)
+        .await
+        .unwrap()
+        .next_response()
+        .await
+        .unwrap();
+
+    serde_json::to_value(response).unwrap()
 }
 
 async fn execute(

--- a/apollo-router/src/plugins/connectors/tests/public_plugin.rs
+++ b/apollo-router/src/plugins/connectors/tests/public_plugin.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use apollo_federation::connectors::runtime::http_json_transport::TransportRequest;
+use apollo_federation::connectors::runtime::http_json_transport::TransportResponse;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::BoxError;
@@ -214,5 +215,374 @@ async fn public_unstable_plugin_can_break_a_connector_request() {
     assert!(
         mock_server.received_requests().await.unwrap().is_empty(),
         "the connector request should never have reached the upstream"
+    );
+}
+
+/// Asserts that a plugin can read and rewrite a *successful* connector
+/// [`request_service::Response`] through its public accessors:
+/// [`Response::data`]/[`Response::set_data`] (the hit branch), the false-return
+/// no-op branch of [`Response::set_error_message`]/[`Response::set_error_code`],
+/// the newly-public `transport_result` field (read *and* written), and the
+/// `context` read-write path shared between [`request_service::Request`] and
+/// [`request_service::Response`].
+///
+/// [`Response::data`]: request_service::Response::data
+/// [`Response::set_data`]: request_service::Response::set_data
+/// [`Response::set_error_message`]: request_service::Response::set_error_message
+/// [`Response::set_error_code`]: request_service::Response::set_error_code
+#[tokio::test]
+async fn public_unstable_plugin_can_wrap_a_connector_response_with_data() {
+    let mock_server = MockServer::start().await;
+    mock_api::user_1().mount(&mock_server).await;
+
+    /// What the plugin observed on the response side, read out after the
+    /// router has finished — the wrapped service runs inside a buffered
+    /// worker task, so assertions belong out here rather than inline.
+    #[derive(Debug, Default)]
+    struct Observed {
+        /// Read back from `Response::context`: proves it's the same shared
+        /// context that `Request::context` was written to, on the request side.
+        context_value_written_on_request: Option<String>,
+        /// Written directly into `Response::context`, then read back immediately.
+        context_value_written_on_response: Option<String>,
+        /// The status recorded on the (`Ok`) `Response::transport_result`, before
+        /// the plugin rewrites it.
+        transport_status_before: Option<u16>,
+        /// `transport_result`'s status and a header the plugin adds to it,
+        /// read back immediately after the rewrite.
+        transport_status_after: Option<u16>,
+        transport_header_after: Option<String>,
+        data_before: Option<serde_json_bytes::Value>,
+        error_before_is_some: bool,
+        set_error_message_result: bool,
+        set_error_code_result: bool,
+        error_after_noop_setters_is_some: bool,
+        set_data_result: bool,
+        data_after: Option<serde_json_bytes::Value>,
+    }
+
+    #[derive(Clone)]
+    struct ResponseWrappingPlugin {
+        observed: Arc<Mutex<Observed>>,
+    }
+
+    #[async_trait::async_trait]
+    impl PluginUnstable for ResponseWrappingPlugin {
+        type Config = Conf;
+
+        async fn new(_: PluginInit<Self::Config>) -> Result<Self, BoxError> {
+            unreachable!("added via TestHarness::extra_unstable_plugin")
+        }
+
+        fn connector_request_service(
+            &self,
+            service: request_service::BoxService,
+            _source_name: String,
+        ) -> request_service::BoxService {
+            let observed = self.observed.clone();
+            BoxService::new(
+                service
+                    .map_request(|request: request_service::Request| {
+                        request
+                            .context
+                            .insert("from-request", String::from("hello-from-request"))
+                            .unwrap();
+                        request
+                    })
+                    .map_response(move |mut response: request_service::Response| {
+                        let mut observed = observed.lock().unwrap();
+
+                        observed.context_value_written_on_request =
+                            response.context.get::<_, String>("from-request").unwrap();
+                        response
+                            .context
+                            .insert("from-response", String::from("hello-from-response"))
+                            .unwrap();
+                        observed.context_value_written_on_response =
+                            response.context.get::<_, String>("from-response").unwrap();
+
+                        observed.transport_status_before = match &response.transport_result {
+                            Ok(TransportResponse::Http(http_response)) => {
+                                Some(http_response.inner.status.as_u16())
+                            }
+                            _ => None,
+                        };
+
+                        // `transport_result` is writable: rewrite the status and
+                        // add a header to the raw transport outcome.
+                        if let Ok(TransportResponse::Http(http_response)) =
+                            &mut response.transport_result
+                        {
+                            http_response.inner.status = http::StatusCode::IM_A_TEAPOT;
+                            http_response.inner.headers.insert(
+                                http::HeaderName::from_static("x-rewritten-by-plugin"),
+                                http::HeaderValue::from_static("yes"),
+                            );
+                        }
+                        if let Ok(TransportResponse::Http(http_response)) =
+                            &response.transport_result
+                        {
+                            observed.transport_status_after =
+                                Some(http_response.inner.status.as_u16());
+                            observed.transport_header_after = http_response
+                                .inner
+                                .headers
+                                .get("x-rewritten-by-plugin")
+                                .and_then(|v| v.to_str().ok())
+                                .map(str::to_string);
+                        }
+
+                        observed.data_before = response.data().cloned();
+                        observed.error_before_is_some = response.error().is_some();
+
+                        // No-op branches: a success can't be turned into a
+                        // failure through the error setters.
+                        observed.set_error_message_result =
+                            response.set_error_message("should not apply");
+                        observed.set_error_code_result =
+                            response.set_error_code("SHOULD_NOT_APPLY");
+                        observed.error_after_noop_setters_is_some = response.error().is_some();
+
+                        // Hit branch: `set_data` replaces the mapped data.
+                        observed.set_data_result = response.set_data(serde_json_bytes::json!({
+                            "id": 1,
+                            "name": "Rewritten By Plugin",
+                            "username": "Bret",
+                        }));
+                        observed.data_after = response.data().cloned();
+
+                        drop(observed);
+                        response
+                    }),
+            )
+        }
+
+        fn unstable_method(&self) {}
+    }
+
+    let observed = Arc::new(Mutex::new(Observed::default()));
+    let plugin = ResponseWrappingPlugin {
+        observed: observed.clone(),
+    };
+
+    let response = execute_with_unstable_plugin(
+        STEEL_THREAD_SCHEMA,
+        &mock_server.uri(),
+        "query { me { id name username } }",
+        plugin,
+    )
+    .await;
+
+    // The rewrite made through `set_data` reached the client.
+    assert_eq!(
+        response,
+        serde_json::json!({
+            "data": { "me": { "id": 1, "name": "Rewritten By Plugin", "username": "Bret" } }
+        })
+    );
+
+    let observed = std::mem::take(&mut *observed.lock().unwrap());
+
+    // `Request::context` and `Response::context` are the same shared context.
+    assert_eq!(
+        observed.context_value_written_on_request,
+        Some("hello-from-request".to_string())
+    );
+    // `Response::context` is itself readable and writable.
+    assert_eq!(
+        observed.context_value_written_on_response,
+        Some("hello-from-response".to_string())
+    );
+
+    // `Response::transport_result` reports the raw transport outcome...
+    assert_eq!(observed.transport_status_before, Some(200));
+    // ...and is itself writable: the rewritten status and header stuck.
+    assert_eq!(observed.transport_status_after, Some(418));
+    assert_eq!(observed.transport_header_after, Some("yes".to_string()));
+
+    // Hit branches: this is a data response.
+    assert!(observed.data_before.is_some());
+    assert!(!observed.error_before_is_some);
+
+    // No-op branches: the error setters can't turn a success into a failure.
+    assert!(!observed.set_error_message_result);
+    assert!(!observed.set_error_code_result);
+    assert!(!observed.error_after_noop_setters_is_some);
+
+    // Hit branch: `set_data` actually applied.
+    assert!(observed.set_data_result);
+    assert_eq!(
+        observed.data_after,
+        Some(serde_json_bytes::json!({
+            "id": 1,
+            "name": "Rewritten By Plugin",
+            "username": "Bret",
+        }))
+    );
+}
+
+/// Asserts that a plugin can read and rewrite a *failed* connector
+/// [`request_service::Response`] through its public accessors: the false-return
+/// no-op branch of [`Response::set_data`], the hit branch of
+/// [`Response::error`]/[`Response::set_error_message`]/[`Response::set_error_code`],
+/// and `transport_result` (read *and* written) for a call whose transport
+/// succeeded (a real HTTP 404) even though the mapped response is an error.
+/// Also asserts the documented independence of the two: rewriting
+/// `transport_result`'s status does not change the `http.status` already baked
+/// into the client-visible error's extensions, since the mapped response is not
+/// recomputed from it.
+///
+/// [`Response::set_data`]: request_service::Response::set_data
+/// [`Response::error`]: request_service::Response::error
+/// [`Response::set_error_message`]: request_service::Response::set_error_message
+/// [`Response::set_error_code`]: request_service::Response::set_error_code
+#[tokio::test]
+async fn public_unstable_plugin_can_wrap_a_connector_response_with_error() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/users/1"))
+        .respond_with(
+            ResponseTemplate::new(404).set_body_json(serde_json::json!({"error": "not found"})),
+        )
+        .mount(&mock_server)
+        .await;
+
+    #[derive(Debug, Default)]
+    struct Observed {
+        transport_status_before: Option<u16>,
+        transport_status_after: Option<u16>,
+        data_before_is_some: bool,
+        error_before: Option<(String, String)>,
+        set_data_result: bool,
+        data_after_noop_is_some: bool,
+        set_error_message_result: bool,
+        set_error_code_result: bool,
+        error_after: Option<(String, String)>,
+    }
+
+    #[derive(Clone)]
+    struct ResponseWrappingPlugin {
+        observed: Arc<Mutex<Observed>>,
+    }
+
+    #[async_trait::async_trait]
+    impl PluginUnstable for ResponseWrappingPlugin {
+        type Config = Conf;
+
+        async fn new(_: PluginInit<Self::Config>) -> Result<Self, BoxError> {
+            unreachable!("added via TestHarness::extra_unstable_plugin")
+        }
+
+        fn connector_request_service(
+            &self,
+            service: request_service::BoxService,
+            _source_name: String,
+        ) -> request_service::BoxService {
+            let observed = self.observed.clone();
+            BoxService::new(
+                service.map_response(move |mut response: request_service::Response| {
+                    let mut observed = observed.lock().unwrap();
+
+                    observed.transport_status_before = match &response.transport_result {
+                        Ok(TransportResponse::Http(http_response)) => {
+                            Some(http_response.inner.status.as_u16())
+                        }
+                        _ => None,
+                    };
+
+                    // `transport_result` is writable here too. This does *not*
+                    // change the client-visible error, which was already mapped
+                    // from the original (404) status.
+                    if let Ok(TransportResponse::Http(http_response)) =
+                        &mut response.transport_result
+                    {
+                        http_response.inner.status = http::StatusCode::IM_A_TEAPOT;
+                    }
+                    observed.transport_status_after = match &response.transport_result {
+                        Ok(TransportResponse::Http(http_response)) => {
+                            Some(http_response.inner.status.as_u16())
+                        }
+                        _ => None,
+                    };
+
+                    observed.data_before_is_some = response.data().is_some();
+                    observed.error_before = response
+                        .error()
+                        .map(|error| (error.message.clone(), error.code().to_string()));
+
+                    // No-op branch: a failure can't be turned into data here.
+                    observed.set_data_result =
+                        response.set_data(serde_json_bytes::json!({ "nope": true }));
+                    observed.data_after_noop_is_some = response.data().is_some();
+
+                    // Hit branches: rewrite the error returned to the client.
+                    observed.set_error_message_result =
+                        response.set_error_message("rewritten by plugin");
+                    observed.set_error_code_result = response.set_error_code("REWRITTEN_CODE");
+                    observed.error_after = response
+                        .error()
+                        .map(|error| (error.message.clone(), error.code().to_string()));
+
+                    drop(observed);
+                    response
+                }),
+            )
+        }
+
+        fn unstable_method(&self) {}
+    }
+
+    let observed = Arc::new(Mutex::new(Observed::default()));
+    let plugin = ResponseWrappingPlugin {
+        observed: observed.clone(),
+    };
+
+    let response = execute_with_unstable_plugin(
+        STEEL_THREAD_SCHEMA,
+        &mock_server.uri(),
+        "query { me { id name username } }",
+        plugin,
+    )
+    .await;
+
+    // The plugin's rewrite of the error reached the client.
+    let errors = response
+        .get("errors")
+        .and_then(|e| e.as_array())
+        .expect("expected the failed connector request to produce an error");
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0]["message"], "rewritten by plugin");
+    assert_eq!(errors[0]["extensions"]["code"], "REWRITTEN_CODE");
+    // The client-visible error still reports the *original* transport status:
+    // rewriting `transport_result` after the fact doesn't reach it, because the
+    // mapped response was already built from the real 404.
+    assert_eq!(errors[0]["extensions"]["http"]["status"], 404);
+
+    let observed = std::mem::take(&mut *observed.lock().unwrap());
+
+    // The transport itself succeeded (a real HTTP 404 came back); only the
+    // *mapped* response is an error.
+    assert_eq!(observed.transport_status_before, Some(404));
+    // `transport_result` is writable: the rewritten status stuck...
+    assert_eq!(observed.transport_status_after, Some(418));
+    // ...independently of the mapped response asserted above.
+
+    // Hit branches: this is an error response.
+    assert!(!observed.data_before_is_some);
+    assert!(observed.error_before.is_some());
+
+    // No-op branch: `set_data` can't turn a failure into a success.
+    assert!(!observed.set_data_result);
+    assert!(!observed.data_after_noop_is_some);
+
+    // Hit branches: the error setters actually applied.
+    assert!(observed.set_error_message_result);
+    assert!(observed.set_error_code_result);
+    assert_eq!(
+        observed.error_after,
+        Some((
+            "rewritten by plugin".to_string(),
+            "REWRITTEN_CODE".to_string()
+        ))
     );
 }

--- a/apollo-router/src/plugins/connectors/tests/public_plugin.rs
+++ b/apollo-router/src/plugins/connectors/tests/public_plugin.rs
@@ -1,0 +1,212 @@
+//! Tests that `connector_request_service` is reachable from the *public* plugin
+//! interface, i.e. from an out-of-tree plugin implementing [`PluginUnstable`].
+//!
+//! Every other test of this hook implements [`PluginPrivate`] directly, which does
+//! not exercise the `DynPlugin` -> `PluginUnstable` forwarding in `plugin/mod.rs`.
+//! That forwarding is the entire feature, so it gets its own coverage here.
+//!
+//! [`PluginPrivate`]: crate::plugin::PluginPrivate
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use apollo_federation::connectors::runtime::http_json_transport::TransportRequest;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower::BoxError;
+use tower::ServiceExt;
+use tower::util::BoxService;
+
+use super::*;
+use crate::plugin::PluginInit;
+use crate::plugin::PluginUnstable;
+use crate::services::connector::request_service;
+
+/// What the plugin under test observed, so assertions can be made on the router's
+/// side of the wire rather than only on what the mock API received.
+#[derive(Debug, Default)]
+struct Observed {
+    /// One entry per `connector_request_service` call, i.e. per source the router
+    /// built a service for.
+    source_names: Vec<String>,
+    /// One entry per connector request that actually flowed through the wrapped
+    /// service.
+    request_uris: Vec<String>,
+    /// The operation body read back off `Request::supergraph_request`.
+    supergraph_queries: Vec<String>,
+}
+
+#[derive(Clone)]
+struct ObservingPlugin {
+    observed: Arc<Mutex<Observed>>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct Conf {}
+
+#[async_trait::async_trait]
+impl PluginUnstable for ObservingPlugin {
+    type Config = Conf;
+
+    async fn new(_: PluginInit<Self::Config>) -> Result<Self, BoxError> {
+        unreachable!("added via TestHarness::extra_unstable_plugin, never constructed from config")
+    }
+
+    fn connector_request_service(
+        &self,
+        service: request_service::BoxService,
+        source_name: String,
+    ) -> request_service::BoxService {
+        self.observed
+            .lock()
+            .unwrap()
+            .source_names
+            .push(source_name.clone());
+
+        let observed = self.observed.clone();
+        BoxService::new(
+            service.map_request(move |mut request: request_service::Request| {
+                // Read the originating operation through the public accessor.
+                let query = request.supergraph_request().body().query.clone();
+
+                // Read the outbound HTTP request, and rewrite it, through the
+                // public `transport_request` field.
+                let TransportRequest::Http(http_request) = &mut request.transport_request else {
+                    return request;
+                };
+                let mut observed = observed.lock().unwrap();
+                observed
+                    .request_uris
+                    .push(http_request.inner.uri().to_string());
+                if let Some(query) = query {
+                    observed.supergraph_queries.push(query);
+                }
+                http_request
+                    .inner
+                    .headers_mut()
+                    .insert("x-from-plugin", "yes".parse().unwrap());
+                drop(observed);
+                request
+            }),
+        )
+    }
+
+    fn unstable_method(&self) {}
+}
+
+/// Registers a plugin through the public `PluginUnstable` interface and asserts the
+/// connector hook actually runs: the plugin sees the source name and the outbound
+/// request, and its rewrite reaches the upstream API.
+#[tokio::test]
+async fn public_unstable_plugin_wraps_connector_request_service() {
+    let mock_server = MockServer::start().await;
+    mock_api::user_1().mount(&mock_server).await;
+
+    let observed = Arc::new(Mutex::new(Observed::default()));
+    let plugin = ObservingPlugin {
+        observed: observed.clone(),
+    };
+
+    let query = "query { me { id name username } }";
+    let response =
+        execute_with_unstable_plugin(STEEL_THREAD_SCHEMA, &mock_server.uri(), query, plugin).await;
+
+    // The request still succeeded end to end.
+    assert_eq!(
+        response,
+        serde_json::json!({
+            "data": { "me": { "id": 1, "name": "Leanne Graham", "username": "Bret" } }
+        })
+    );
+
+    // The router's side of the wire: the hook ran, with the source name, and the
+    // plugin could read both the outbound request and the originating operation.
+    // Taken by value so the guard is not held across the await below.
+    let observed = std::mem::take(&mut *observed.lock().unwrap());
+    assert_eq!(
+        observed.source_names,
+        vec!["connectors.json".to_string()],
+        "connector_request_service should be called once per connector source"
+    );
+    assert_eq!(
+        observed.request_uris.len(),
+        1,
+        "the wrapped service should see exactly one connector request"
+    );
+    assert!(
+        observed.request_uris[0].ends_with("/users/1"),
+        "unexpected connector URI: {}",
+        observed.request_uris[0]
+    );
+    assert_eq!(observed.supergraph_queries, vec![query.to_string()]);
+
+    // The upstream's side of the wire: the plugin's rewrite actually went out.
+    req_asserts::matches(
+        &mock_server.received_requests().await.unwrap(),
+        vec![Matcher::new().method("GET").path("/users/1").header(
+            HeaderName::from_static("x-from-plugin"),
+            HeaderValue::from_static("yes"),
+        )],
+    );
+}
+
+/// Asserts that a plugin can fail a connector request without making it, using
+/// [`request_service::Request::into_error_response`] — the in-process equivalent of
+/// a coprocessor returning `Control::Break` from the `ConnectorRequest` stage.
+#[tokio::test]
+async fn public_unstable_plugin_can_break_a_connector_request() {
+    let mock_server = MockServer::start().await;
+    mock_api::user_1().mount(&mock_server).await;
+
+    #[derive(Clone)]
+    struct BreakingPlugin;
+
+    #[async_trait::async_trait]
+    impl PluginUnstable for BreakingPlugin {
+        type Config = Conf;
+
+        async fn new(_: PluginInit<Self::Config>) -> Result<Self, BoxError> {
+            unreachable!("added via TestHarness::extra_unstable_plugin")
+        }
+
+        fn connector_request_service(
+            &self,
+            service: request_service::BoxService,
+            _source_name: String,
+        ) -> request_service::BoxService {
+            BoxService::new(tower::service_fn(
+                move |request: request_service::Request| {
+                    // `service` is intentionally dropped: the upstream call is never made.
+                    let _ = &service;
+                    async move {
+                        Ok(request.into_error_response("upstream is unhealthy", "CIRCUIT_OPEN"))
+                    }
+                },
+            ))
+        }
+
+        fn unstable_method(&self) {}
+    }
+
+    let response = execute_with_unstable_plugin(
+        STEEL_THREAD_SCHEMA,
+        &mock_server.uri(),
+        "query { me { id name username } }",
+        BreakingPlugin,
+    )
+    .await;
+
+    let errors = response
+        .get("errors")
+        .and_then(|e| e.as_array())
+        .expect("expected the broken connector request to produce an error");
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0]["message"], "upstream is unhealthy");
+    assert_eq!(errors[0]["extensions"]["code"], "CIRCUIT_OPEN");
+
+    // The plugin broke the request before it was made, so the upstream saw nothing.
+    assert!(
+        mock_server.received_requests().await.unwrap().is_empty(),
+        "the connector request should never have reached the upstream"
+    );
+}

--- a/apollo-router/src/plugins/connectors/tests/public_plugin.rs
+++ b/apollo-router/src/plugins/connectors/tests/public_plugin.rs
@@ -179,7 +179,11 @@ async fn public_unstable_plugin_can_break_a_connector_request() {
                     // `service` is intentionally dropped: the upstream call is never made.
                     let _ = &service;
                     async move {
-                        Ok(request.into_error_response("upstream is unhealthy", "CIRCUIT_OPEN"))
+                        Ok(request.into_error_response(
+                            "upstream is unhealthy",
+                            "CIRCUIT_OPEN",
+                            [("k1", "v1"), ("code", "dummy"), ("k2", "v2")],
+                        ))
                     }
                 },
             ))
@@ -203,6 +207,8 @@ async fn public_unstable_plugin_can_break_a_connector_request() {
     assert_eq!(errors.len(), 1);
     assert_eq!(errors[0]["message"], "upstream is unhealthy");
     assert_eq!(errors[0]["extensions"]["code"], "CIRCUIT_OPEN");
+    assert_eq!(errors[0]["extensions"]["k1"], "v1");
+    assert_eq!(errors[0]["extensions"]["k2"], "v2");
 
     // The plugin broke the request before it was made, so the upstream saw nothing.
     assert!(

--- a/apollo-router/src/plugins/coprocessor/connector.rs
+++ b/apollo-router/src/plugins/coprocessor/connector.rs
@@ -4,8 +4,6 @@ use std::collections::HashSet;
 use std::ops::ControlFlow;
 use std::sync::Arc;
 
-use apollo_federation::connectors::runtime::errors::Error as ConnectorError;
-use apollo_federation::connectors::runtime::errors::RuntimeError;
 use apollo_federation::connectors::runtime::http_json_transport::HttpRequest as ConnectorsHttpRequest;
 use apollo_federation::connectors::runtime::http_json_transport::TransportRequest;
 use apollo_federation::connectors::runtime::http_json_transport::TransportResponse;
@@ -344,7 +342,7 @@ where
 
         const DEFAULT_BREAK_MESSAGE: &str = "Internal error";
 
-        let (message, code, extra_extensions) = match body {
+        let (message, code, extensions) = match body {
             Value::String(s) if !s.as_str().is_empty() => (
                 s.as_str().to_owned(),
                 COPROCESSOR_ERROR_EXTENSION.to_string(),
@@ -363,21 +361,14 @@ where
             ),
         };
 
-        let mut runtime_error = RuntimeError::new(&message, &request.key).with_code(code);
-        for (k, v) in extra_extensions {
-            runtime_error = runtime_error.extension(k, v);
-        }
-
-        let res = request_service::Response {
-            context: request.context.clone(),
-            subgraph_name: request.connector.id.subgraph_name.to_string(),
-            transport_result: Err(ConnectorError::TransportFailure(message)),
-            mapped_response: MappedResponse::Error {
-                error: runtime_error,
-                key: request.key,
-                problems: Vec::new(),
-            },
-        };
+        let res = request_service::Response::error_from_request(
+            request.context.clone(),
+            request.connector,
+            request.key,
+            message,
+            code,
+            extensions,
+        );
 
         if let Some(context) = co_processor_output.context {
             for (mut key, value) in context.try_into_iter()? {
@@ -614,7 +605,7 @@ where
 
 /// Parse structured error from a coprocessor break response body.
 /// Expects a JSON object with an `"errors"` array containing GraphQL-style errors.
-/// Returns `(message, code, extra_extensions)`.
+/// Returns `(message, code, extensions)`.
 fn parse_connector_break_error(
     obj: &serde_json_bytes::Map<ByteString, Value>,
 ) -> (String, String, serde_json_bytes::Map<ByteString, Value>) {
@@ -638,7 +629,7 @@ fn parse_connector_break_error(
         .map(|s| s.to_string())
         .unwrap_or(default_msg);
 
-    let mut extra_extensions = serde_json_bytes::Map::default();
+    let mut extensions = serde_json_bytes::Map::default();
     let code = if let Some(Value::Object(ext)) = first_error.get("extensions") {
         let code = ext
             .get("code")
@@ -646,14 +637,12 @@ fn parse_connector_break_error(
             .map(|s| s.to_string())
             .unwrap_or(default_code);
         for (k, v) in ext.iter() {
-            if k.as_str() != "code" {
-                extra_extensions.insert(k.clone(), v.clone());
-            }
+            extensions.insert(k.clone(), v.clone());
         }
         code
     } else {
         default_code
     };
 
-    (message, code, extra_extensions)
+    (message, code, extensions)
 }

--- a/apollo-router/src/services/connector.rs
+++ b/apollo-router/src/services/connector.rs
@@ -1,1 +1,1 @@
-pub(crate) mod request_service;
+pub mod request_service;

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -135,26 +135,14 @@ impl Request {
         code: impl Into<String>,
         extensions: impl IntoIterator<Item = (impl Into<ByteString>, impl Into<Value>)>,
     ) -> Response {
-        let message = message.into();
-        let subgraph_name = self.connector.id.subgraph_name.to_string();
-        let mut error = RuntimeError::new(message.clone(), &self.key).with_code(code);
-        for (k, v) in extensions {
-            let k = k.into();
-            if k.as_str() != "code" {
-                error = error.extension(k, v);
-            }
-        }
-
-        Response {
-            context: self.context,
-            subgraph_name,
-            transport_result: Err(Error::TransportFailure(message)),
-            mapped_response: MappedResponse::Error {
-                error,
-                key: self.key,
-                problems: Vec::new(),
-            },
-        }
+        Response::error_from_request(
+            self.context,
+            self.connector,
+            self.key,
+            message,
+            code,
+            extensions,
+        )
     }
 }
 
@@ -276,6 +264,37 @@ impl Response {
             subgraph_name,
             transport_result: Err(error),
             mapped_response,
+        }
+    }
+
+    pub(crate) fn error_from_request(
+        request_context: Context,
+        request_connector: Arc<Connector>,
+        request_key: ResponseKey,
+        message: impl Into<String>,
+        code: impl Into<String>,
+        extensions: impl IntoIterator<Item = (impl Into<ByteString>, impl Into<Value>)>,
+    ) -> Self {
+        let message = message.into();
+        let subgraph_name = request_connector.id.subgraph_name.to_string();
+        let mut error = RuntimeError::new(message.clone(), &request_key).with_code(code);
+        error.subgraph_name = Some(subgraph_name.clone());
+        for (k, v) in extensions {
+            let k = k.into();
+            if k.as_str() != "code" {
+                error = error.extension(k, v);
+            }
+        }
+
+        Response {
+            context: request_context,
+            subgraph_name,
+            transport_result: Err(Error::TransportFailure(message)),
+            mapped_response: MappedResponse::Error {
+                error,
+                key: request_key,
+                problems: Vec::new(),
+            },
         }
     }
 

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -61,16 +61,28 @@ assert_impl_all!(Response: Send);
 /// Request type for a single connector request
 #[derive(Debug)]
 pub struct Request {
-    /// The request context
+    /// The request context, shared with the rest of the router pipeline for this
+    /// operation. Readable and writable: a plugin may store values here for later
+    /// stages, matching what the coprocessor `ConnectorRequest` stage can do.
     pub context: Context,
 
-    /// The connector associated with this request
-    // If this service moves into the public API, consider whether this exposes too much
-    // internal information about the connector. A new type may be needed which exposes only
-    // what is necessary for customizations.
+    /// The connector associated with this request.
+    //
+    // Deliberately kept `pub(crate)` now that this service is public: `Connector`
+    // carries the full expanded connector definition, far more internal detail than a
+    // customization needs. If plugins turn out to need something from it, expose that
+    // through a narrow accessor or a purpose-built type rather than the whole struct.
     pub(crate) connector: Arc<Connector>,
 
-    /// The request to the underlying transport
+    /// The request to the underlying transport.
+    ///
+    /// [`TransportRequest::Http`] holds the outgoing [`http::Request`], so a plugin can
+    /// read and rewrite its URI, headers, body and method.
+    ///
+    /// Note that the method is writable here but *not* through the coprocessor
+    /// `ConnectorRequest` stage, which sends the method to the coprocessor but ignores
+    /// any method it sends back. A plugin that rewrites the method therefore has no
+    /// coprocessor equivalent.
     pub transport_request: TransportRequest,
 
     /// Information about how to map the response to GraphQL
@@ -79,8 +91,9 @@ pub struct Request {
     /// Mapping problems encountered when creating the transport request
     pub(crate) mapping_problems: Vec<Problem>,
 
-    /// Original request to the Router.
-    pub supergraph_request: Arc<http::Request<graphql::Request>>,
+    /// Original request to the Router. Read it through
+    /// [`Request::supergraph_request`].
+    pub(crate) supergraph_request: Arc<http::Request<graphql::Request>>,
 
     /// The operation being executed. Together with
     /// req.connector.schema_subtypes_map, this document enables GraphQL
@@ -88,25 +101,151 @@ pub struct Request {
     pub(crate) operation: Option<Arc<Valid<ExecutableDocument>>>,
 }
 
+impl Request {
+    /// The original request made to the router, which produced this connector request.
+    ///
+    /// Read-only on purpose. `ConnectorRequestService::call` and its callees read this
+    /// request while handling the connector call, and every other plugin on the chain
+    /// sees the same value, so letting one plugin swap it out would change behaviour
+    /// well outside that plugin. Rewrite [`Request::transport_request`] instead to
+    /// change what goes over the wire.
+    pub fn supergraph_request(&self) -> &Arc<http::Request<graphql::Request>> {
+        &self.supergraph_request
+    }
+
+    /// Consume this request and produce a failed [`Response`] for it, without making
+    /// the outbound call.
+    ///
+    /// This is the in-process equivalent of a coprocessor returning `Control::Break`
+    /// from the `ConnectorRequest` stage: the connector call is not made, and `message`
+    /// and `code` are reported to the client as a GraphQL error at this connector's
+    /// path. Use it to fail a connector request deliberately, for example to circuit
+    /// break on an upstream a plugin knows to be unhealthy.
+    ///
+    /// The error's remaining fields are derived from the request and are not settable,
+    /// for the same reason the coprocessor does not let a coprocessor set them: the
+    /// path and response key are what merge the failure back into the right place in
+    /// the GraphQL response.
+    pub fn into_error_response(
+        self,
+        message: impl Into<String>,
+        code: impl Into<String>,
+    ) -> Response {
+        let message = message.into();
+        let subgraph_name = self.connector.id.subgraph_name.to_string();
+        let error = RuntimeError::new(message.clone(), &self.key).with_code(code);
+
+        Response {
+            context: self.context,
+            subgraph_name,
+            transport_result: Err(Error::TransportFailure(message)),
+            mapped_response: MappedResponse::Error {
+                error,
+                key: self.key,
+                problems: Vec::new(),
+            },
+        }
+    }
+}
+
 /// Response type for a connector
 #[derive(Debug)]
 pub struct Response {
-    /// The request context
-    pub(crate) context: Context,
+    /// The request context, shared with the rest of the router pipeline for this
+    /// operation. Readable and writable, matching what the coprocessor
+    /// `ConnectorResponse` stage can do.
+    pub context: Context,
 
     /// Originating federation subgraph name for this connector call. Carried
     /// on the response (rather than passed through shared context) so parallel
     /// connector calls don't race when resolving per-subgraph response rules.
     pub(crate) subgraph_name: String,
 
-    /// The result of the transport request
+    /// The result of the transport request.
+    ///
+    /// This is the raw transport outcome: HTTP status, headers and transport-level
+    /// errors. Telemetry and downstream plugins read it, but the data returned to the
+    /// client comes from the mapped response, which is *not* recomputed when this
+    /// changes. Rewriting the status or headers here therefore makes telemetry
+    /// disagree with what the client actually receives unless you make the
+    /// corresponding change through the mapped-response accessors.
     pub transport_result: Result<TransportResponse, Error>,
 
-    /// The mapped response, including any mapping problems encountered when processing the response
+    /// The mapped response, including any mapping problems encountered when processing
+    /// the response. This is what is merged into the GraphQL response returned to the
+    /// client. Kept private so that only the parts a customization may safely change
+    /// are reachable; see the accessors on [`Response`].
     pub(crate) mapped_response: MappedResponse,
 }
 
 impl Response {
+    /// The mapped response data returned to the client, or `None` if this connector
+    /// call produced an error instead. See [`Response::error`] for that case.
+    pub fn data(&self) -> Option<&serde_json_bytes::Value> {
+        match &self.mapped_response {
+            MappedResponse::Data { data, .. } => Some(data),
+            MappedResponse::Error { .. } => None,
+        }
+    }
+
+    /// Replace the mapped response data returned to the client.
+    ///
+    /// Returns `false` and changes nothing if this is an error response: a
+    /// customization cannot turn a failed connector call into a successful one, which
+    /// is also true of the coprocessor `ConnectorResponse` stage.
+    ///
+    /// This does not touch [`Response::transport_result`], so telemetry continues to
+    /// report the status and headers actually received from the upstream.
+    pub fn set_data(&mut self, data: serde_json_bytes::Value) -> bool {
+        match &mut self.mapped_response {
+            MappedResponse::Data { data: current, .. } => {
+                *current = data;
+                true
+            }
+            MappedResponse::Error { .. } => false,
+        }
+    }
+
+    /// The error returned to the client, or `None` if this connector call produced
+    /// data instead. See [`Response::data`] for that case.
+    pub fn error(&self) -> Option<&RuntimeError> {
+        match &self.mapped_response {
+            MappedResponse::Error { error, .. } => Some(error),
+            MappedResponse::Data { .. } => None,
+        }
+    }
+
+    /// Replace the message of the error returned to the client.
+    ///
+    /// Returns `false` and changes nothing if this is a successful response: a
+    /// customization cannot turn a successful connector call into a failed one here,
+    /// which is also true of the coprocessor `ConnectorResponse` stage. To fail a
+    /// connector call, break it before it is made with
+    /// [`Request::into_error_response`].
+    pub fn set_error_message(&mut self, message: impl Into<String>) -> bool {
+        match &mut self.mapped_response {
+            MappedResponse::Error { error, .. } => {
+                error.message = message.into();
+                true
+            }
+            MappedResponse::Data { .. } => false,
+        }
+    }
+
+    /// Replace the `code` extension of the error returned to the client.
+    ///
+    /// Returns `false` and changes nothing if this is a successful response, as for
+    /// [`Response::set_error_message`].
+    pub fn set_error_code(&mut self, code: impl Into<String>) -> bool {
+        match &mut self.mapped_response {
+            MappedResponse::Error { error, .. } => {
+                error.set_code(code);
+                true
+            }
+            MappedResponse::Data { .. } => false,
+        }
+    }
+
     pub(crate) fn error_new(
         context: Context,
         subgraph_name: String,

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -1,5 +1,4 @@
 //! Service which makes individual requests to Apollo Connectors over some transport
-#![allow(missing_docs)] // FIXME
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -48,7 +47,12 @@ use crate::services::Plugins;
 use crate::services::http::HttpClientServiceFactory;
 use crate::services::router;
 
+/// A boxed service making a single connector request. This is what
+/// [`PluginUnstable::connector_request_service`](crate::plugin::PluginUnstable::connector_request_service)
+/// receives and returns, so a plugin wraps this type to customize connector traffic.
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
+
+/// The result of a single connector request.
 pub type ServiceResult = Result<Response, BoxError>;
 
 assert_impl_all!(Request: Send);

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -24,6 +24,8 @@ use indexmap::IndexMap;
 use opentelemetry::KeyValue;
 use opentelemetry_semantic_conventions::trace::HTTP_REQUEST_METHOD;
 use parking_lot::Mutex;
+use serde_json_bytes::ByteString;
+use serde_json_bytes::Value;
 use static_assertions::assert_impl_all;
 use tower::BoxError;
 use tower::ServiceExt;
@@ -117,10 +119,11 @@ impl Request {
     /// the outbound call.
     ///
     /// This is the in-process equivalent of a coprocessor returning `Control::Break`
-    /// from the `ConnectorRequest` stage: the connector call is not made, and `message`
-    /// and `code` are reported to the client as a GraphQL error at this connector's
-    /// path. Use it to fail a connector request deliberately, for example to circuit
-    /// break on an upstream a plugin knows to be unhealthy.
+    /// from the `ConnectorRequest` stage: the connector call is not made, and `message`,
+    /// `code`, and `extensions` are reported to the client as a GraphQL error at this
+    /// connector's path (an entry for `code` in `extensions` is ignored). Use it to fail
+    /// a connector request deliberately, for example to circuit break on an upstream a
+    /// plugin knows to be unhealthy.
     ///
     /// The error's remaining fields are derived from the request and are not settable,
     /// for the same reason the coprocessor does not let a coprocessor set them: the
@@ -130,10 +133,17 @@ impl Request {
         self,
         message: impl Into<String>,
         code: impl Into<String>,
+        extensions: impl IntoIterator<Item = (impl Into<ByteString>, impl Into<Value>)>,
     ) -> Response {
         let message = message.into();
         let subgraph_name = self.connector.id.subgraph_name.to_string();
-        let error = RuntimeError::new(message.clone(), &self.key).with_code(code);
+        let mut error = RuntimeError::new(message.clone(), &self.key).with_code(code);
+        for (k, v) in extensions {
+            let k = k.into();
+            if k.as_str() != "code" {
+                error = error.extension(k, v);
+            }
+        }
 
         Response {
             context: self.context,

--- a/apollo-router/src/services/connector/request_service.rs
+++ b/apollo-router/src/services/connector/request_service.rs
@@ -1,4 +1,5 @@
 //! Service which makes individual requests to Apollo Connectors over some transport
+#![allow(missing_docs)] // FIXME
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -47,8 +48,8 @@ use crate::services::Plugins;
 use crate::services::http::HttpClientServiceFactory;
 use crate::services::router;
 
-pub(crate) type BoxService = tower::util::BoxService<Request, Response, BoxError>;
-pub(crate) type ServiceResult = Result<Response, BoxError>;
+pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
+pub type ServiceResult = Result<Response, BoxError>;
 
 assert_impl_all!(Request: Send);
 assert_impl_all!(Response: Send);
@@ -57,7 +58,7 @@ assert_impl_all!(Response: Send);
 #[derive(Debug)]
 pub struct Request {
     /// The request context
-    pub(crate) context: Context,
+    pub context: Context,
 
     /// The connector associated with this request
     // If this service moves into the public API, consider whether this exposes too much
@@ -66,7 +67,7 @@ pub struct Request {
     pub(crate) connector: Arc<Connector>,
 
     /// The request to the underlying transport
-    pub(crate) transport_request: TransportRequest,
+    pub transport_request: TransportRequest,
 
     /// Information about how to map the response to GraphQL
     pub(crate) key: ResponseKey,
@@ -75,7 +76,7 @@ pub struct Request {
     pub(crate) mapping_problems: Vec<Problem>,
 
     /// Original request to the Router.
-    pub(crate) supergraph_request: Arc<http::Request<graphql::Request>>,
+    pub supergraph_request: Arc<http::Request<graphql::Request>>,
 
     /// The operation being executed. Together with
     /// req.connector.schema_subtypes_map, this document enables GraphQL
@@ -95,7 +96,7 @@ pub struct Response {
     pub(crate) subgraph_name: String,
 
     /// The result of the transport request
-    pub(crate) transport_result: Result<TransportResponse, Error>,
+    pub transport_result: Result<TransportResponse, Error>,
 
     /// The mapped response, including any mapping problems encountered when processing the response
     pub(crate) mapped_response: MappedResponse,

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -34,7 +34,8 @@ pub(crate) use crate::services::supergraph::Response as SupergraphResponse;
 pub(crate) use crate::services::supergraph::service::SupergraphCreator;
 
 pub(crate) mod connect;
-pub(crate) mod connector;
+/// Services for Apollo Connectors.
+pub mod connector;
 pub(crate) mod connector_service;
 pub mod execution;
 pub(crate) mod external;


### PR DESCRIPTION
Supersedes #8937, which had gone stale (781 commits behind `dev`, conflicting). All four commits are Andrew's, rebased onto current `dev` with authorship preserved. Changes from the original are described below.

### What this does

Adds `connector_request_service` to the public `PluginUnstable` trait, so out-of-tree Rust plugins can wrap the service that makes individual connector HTTP requests. The hook already existed on `PluginPrivate` and `DynPlugin`; this promotes it to the public plugin interface and makes `services::connector::request_service` public along with what a plugin needs to read and change.

Note that one GraphQL operation can produce many connector requests, so this service is called once per outbound HTTP request rather than once per operation.

### What a plugin can reach

The surface is deliberately set to match what the coprocessor `ConnectorRequest` and `ConnectorResponse` stages already allow, so a customization can move between the two without gaining or losing reach.

On the request:

- `transport_request` is `pub`, and `TransportRequest::Http` holds a `pub inner: http::Request<String>`, so the outgoing URI, method, headers and body are all readable and mutable.
- `supergraph_request()` returns the originating router request, for reading.
- `context` is `pub` for reading and writing request-scoped state.
- `into_error_response(message, code)` fails a connector request without making it.

On the response:

- `context` is `pub` for reading and writing.
- `transport_result` is `pub`: the raw transport outcome, status, headers and transport-level errors.
- `data()` / `set_data()` and `error()` / `set_error_message()` / `set_error_code()` read and change what is returned to the client.

`connector`, `key`, `mapping_problems`, `operation` and `mapped_response` remain `pub(crate)`.

Two places where a plugin and a coprocessor genuinely differ, both now documented in rustdoc and the changeset:

- A plugin can rewrite the HTTP method. The coprocessor sends the method to the coprocessor but ignores any method sent back, so it cannot.
- Changing `transport_result` does not recompute the mapped response, so telemetry will report the transport outcome you set while the client receives the unchanged mapped data. The coprocessor has the same trap; naming it is the only real fix.

### Why `PluginUnstable` and not `Plugin`

Deliberately the unstable trait for now. `PluginUnstable` requires an explicit `unstable_method` implementation, which makes adoption a visible opt-in rather than an implied stability promise we already expect to break. The tradeoff is real: a plugin implementing the stable `Plugin` trait gets the passthrough default and no connector hook at all. If the surface settles without changing shape, moving it to `Plugin` later is additive.

### Why

Direct customer ask, from a customer with two custom Rust plugins today (authorization and custom routing, about 350 lines total) and reported measurably better performance from connectors plus native plugins than from the subgraph architecture they are replacing. Their use cases are conditional routing on request arguments, attaching proof-of-possession signatures (RFC 9421) to outgoing REST calls, and circuit breaking.

The coprocessor `ConnectorRequest` stage already covers all three, at the cost of an out-of-process hop per connector request. This gives the same reach without the hop.

### Testing

`apollo-router/src/plugins/connectors/tests/public_plugin.rs` covers the hook through the public interface, which nothing else did: every existing test of `connector_request_service` implements `PluginPrivate` directly and so never exercises the `DynPlugin` -> `PluginUnstable` forwarding that this PR is entirely about.

- `public_unstable_plugin_wraps_connector_request_service` registers a `PluginUnstable` via `TestHarness::extra_unstable_plugin` and asserts on both sides of the wire: that the hook ran with the right `source_name` and could read the outbound request and the originating operation, and that a header it injected actually arrived at the upstream.
- `public_unstable_plugin_can_break_a_connector_request` asserts `into_error_response` reaches the client as a GraphQL error with the given message and code, and that the upstream received nothing at all.

Both fail if the forwarding at `plugin/mod.rs` is removed, which is the regression they exist to catch.

Also: `cargo clippy -p apollo-router -p apollo-federation --all-targets`, `cargo xtask lint --fmt`, `cargo xtask lint`.

### What changed from #8937

The method is on `PluginUnstable` only, per above, and the `#![allow(missing_docs)] // FIXME` on `request_service.rs` is gone: it was hiding exactly two undocumented type aliases, and this module is becoming a public integration contract, so it should not be exempt from the docs lint.

Also dropped the hunk that moved the coprocessor plugin from `PluginPrivate`/`register_private_plugin!` to `Plugin`/`register_plugin!`. When #8937 was written the coprocessor needed that to reach the hook. It no longer does: `PluginPrivate::connector_request_service` is on `dev` today, so the flip is unnecessary, and its only remaining effect was to move a first-party plugin onto the public plugin registry. That is a separate decision from this one, so it is not bundled here.

The dropped hunk is still visible in #8937, which stays open on `am/connectors_public_plugin` as the record of the original.

### Resolved: the open question this PR previously raised

Earlier revisions of this description asked whether a plugin should be able to construct a failure response, since it could observe a `Response` but not build one, leaving an in-process plugin with strictly less reach than the coprocessor it is meant to be a faster alternative to. Circuit breaking was the use case that ruled out.

Sachin's review answered it, and with a better shape than publishing the fields: gate the permitted changes behind accessors rather than exposing `MappedResponse` wholesale. So `key` and `problems` stay unreachable, and only `RuntimeError`'s `message` and `code` are settable, matching what the coprocessor allows. `Request::into_error_response` covers the break case. `RuntimeError::set_code` is new in `apollo-federation`, the by-reference twin of the existing by-value `with_code`.
