### PR TITLE
feat(connectors): add a `->withError` mapping method

### DIFF
--- a/.changesets/feat_connectors_with_error_mapping_method.md
+++ b/.changesets/feat_connectors_with_error_mapping_method.md
@@ -1,0 +1,22 @@
+### Add the `->withError` mapping method for connectors
+
+Connector mappings can now report a problem without failing the field. `->withError` returns its input unchanged and records its arguments as a mapping error, so a mapping that recognizes a value it cannot vouch for can say so and still return the data:
+
+```graphql
+@connect(
+  http: { GET: "/v1/accounts/{$args.id}" }
+  selection: """
+  id
+  status: type_code->match(
+    ["2", $("VAN")],
+    [@, @->withError("Unrecognized type code:", @, "for", $args.id)]
+  )
+  """
+)
+```
+
+Any number of arguments is allowed, and they may be of any type. String arguments are interpolated as written, every other value is serialized as `->jsonStringify` would serialize it, and the parts are joined with single spaces into one message. Use `??` to supply a fallback where a path may be missing, since an argument that produces no value short-circuits the method rather than recording a partial message.
+
+Recorded messages travel the same path as any other mapping problem: they appear in the connectors debugger and are available to telemetry, with identical messages collapsed into a single problem carrying a count.
+
+By [@benjamn](https://github.com/benjamn) in https://github.com/apollographql/router/pull/10050

--- a/apollo-federation/src/connectors/json_selection/methods.rs
+++ b/apollo-federation/src/connectors/json_selection/methods.rs
@@ -67,6 +67,7 @@ pub(super) enum ArrowMethod {
     Trim,
     TrimStart,
     TrimEnd,
+    WithError,
 
     // Future methods:
     TypeOf,
@@ -74,7 +75,6 @@ pub(super) enum ArrowMethod {
     Has,
     Keys,
     Values,
-    WithError,
 }
 
 #[macro_export]
@@ -189,6 +189,7 @@ impl std::ops::Deref for ArrowMethod {
             Self::Trim => &public::TrimMethod,
             Self::TrimStart => &public::TrimStartMethod,
             Self::TrimEnd => &public::TrimEndMethod,
+            Self::WithError => &public::WithErrorMethod,
 
             // Future methods:
             Self::TypeOf => &future::TypeOfMethod,
@@ -196,7 +197,6 @@ impl std::ops::Deref for ArrowMethod {
             Self::Has => &future::HasMethod,
             Self::Keys => &future::KeysMethod,
             Self::Values => &future::ValuesMethod,
-            Self::WithError => &public::WithErrorMethod,
         }
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods.rs
+++ b/apollo-federation/src/connectors/json_selection/methods.rs
@@ -74,6 +74,7 @@ pub(super) enum ArrowMethod {
     Has,
     Keys,
     Values,
+    WithError,
 }
 
 #[macro_export]
@@ -195,6 +196,7 @@ impl std::ops::Deref for ArrowMethod {
             Self::Has => &future::HasMethod,
             Self::Keys => &future::KeysMethod,
             Self::Values => &future::ValuesMethod,
+            Self::WithError => &public::WithErrorMethod,
         }
     }
 }
@@ -252,6 +254,7 @@ impl ArrowMethod {
             "trim" => Some(Self::Trim),
             "trimStart" => Some(Self::TrimStart),
             "trimEnd" => Some(Self::TrimEnd),
+            "withError" => Some(Self::WithError),
             _ => None,
         };
 
@@ -306,6 +309,7 @@ impl ArrowMethod {
                 | Self::Trim
                 | Self::TrimStart
                 | Self::TrimEnd
+                | Self::WithError
         )
     }
 }

--- a/apollo-federation/src/connectors/json_selection/methods/public/mod.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/mod.rs
@@ -71,3 +71,5 @@ pub(crate) use arithmetic::DivMethod;
 pub(crate) use arithmetic::ModMethod;
 pub(crate) use arithmetic::MulMethod;
 pub(crate) use arithmetic::SubMethod;
+mod with_error;
+pub(crate) use with_error::WithErrorMethod;

--- a/apollo-federation/src/connectors/json_selection/methods/public/with_error.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/with_error.rs
@@ -8,7 +8,6 @@ use crate::connectors::json_selection::MethodArgs;
 use crate::connectors::json_selection::PrettyPrintable;
 use crate::connectors::json_selection::ShapeContext;
 use crate::connectors::json_selection::VarsWithPathsMap;
-use crate::connectors::json_selection::helpers::vec_push;
 use crate::connectors::json_selection::immutable::InputPath;
 use crate::connectors::json_selection::location::Ranged;
 use crate::connectors::json_selection::location::WithRange;
@@ -39,12 +38,13 @@ impl_arrow_method!(WithErrorMethod, with_error_method, with_error_shape);
 /// the tail applies to it exactly as if the method were absent. If any argument
 /// produces no value the method produces none either, short-circuiting without
 /// recording the author's message, the way every other method in the language
-/// propagates an absent argument. Two errors are reported in that case: the one
-/// from evaluating the argument, saying why it produced nothing, and a distinct
-/// one from this method, saying that the message it was asked to record never
-/// happened. That second error carries the syntax of the call and of the
-/// argument that failed, so a discarded diagnostic can be traced back to the
-/// expression meant to produce it.
+/// propagates an absent argument. Two errors are reported for each argument
+/// that fails: the one from evaluating it, saying why it produced nothing, and
+/// a distinct one from this method, saying that the message it was asked to
+/// record never happened. That second error carries the syntax of the call and
+/// of the argument that failed, so a discarded diagnostic can be traced back to
+/// the expression meant to produce it. Every argument is evaluated either way,
+/// so an author who broke more than one hears about all of them.
 ///
 /// An author who wants the message reported even when a path may be missing
 /// says so with `??`, which supplies a value where there would have been none:
@@ -61,11 +61,7 @@ fn with_error_method(
     input_path: &InputPath<JSON>,
     spec: ConnectSpec,
 ) -> (Option<JSON>, Vec<ApplyToError>) {
-    let mut errors = Vec::new();
-
-    let args = method_args.map_or(&[][..], |method_args| method_args.args.as_slice());
-
-    if args.is_empty() {
+    if method_args.is_none_or(|method_args| method_args.args.is_empty()) {
         // A malformed call produces no value, the same as any other method
         // called wrongly. The shape function reports this too, so a schema this
         // wrong does not compose in the first place.
@@ -81,87 +77,99 @@ fn with_error_method(
                 spec,
             )],
         );
-    } else {
-        // The call's own syntax, so a discarded message can be traced back to
-        // the expression that was supposed to produce it. Without this, an
-        // author reading the problems sees that some ->withError somewhere
-        // reported nothing, which is exactly the opacity the method exists to
-        // avoid.
-        let printed_args = method_args
+    }
+
+    let args = method_args.map_or(&[][..], |method_args| method_args.args.as_slice());
+
+    let mut errors = Vec::new();
+    let mut parts = Vec::with_capacity(args.len());
+
+    // Whether the author's message can still be recorded. An argument that
+    // produces no value, or a value that cannot be serialized, costs the whole
+    // message, but the loop runs to the end regardless, so an author who broke
+    // two arguments hears about both rather than only the first. This is tracked
+    // separately because it cannot be read off `errors`: an argument can produce
+    // a value and report errors from inside it (a subselection over an array
+    // where one element lacks a field, say), and the message is still recorded
+    // in that case.
+    let mut can_record_message = true;
+
+    // The call's own syntax, so a discarded message can be traced back to the
+    // expression that was supposed to produce it. Without this, an author
+    // reading the problems sees that some ->withError somewhere reported
+    // nothing, which is exactly the opacity the method exists to avoid. Behind a
+    // closure because pretty-printing allocates and only a failing argument ever
+    // reads it, and this method is meant to be cheap enough to drop into a ->map
+    // over a large array.
+    let printed_args = || {
+        method_args
             .map(|method_args| method_args.pretty_print_with_indentation(true, 0))
-            .unwrap_or_default();
-        let mut parts = Vec::with_capacity(args.len());
+            .unwrap_or_default()
+    };
 
-        for arg in args {
-            let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
-            errors.extend(arg_errors);
+    for arg in args {
+        let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
+        errors.extend(arg_errors);
 
-            match value_opt {
-                // A string argument is interpolated as written, so prose reads
-                // as prose rather than arriving wrapped in quotes.
-                Some(JSON::String(string)) => parts.push(string.as_str().to_string()),
+        match value_opt {
+            // A string argument is interpolated as written, so prose reads
+            // as prose rather than arriving wrapped in quotes.
+            Some(JSON::String(string)) => parts.push(string.as_str().to_string()),
 
-                // Everything else is serialized the way ->jsonStringify would
-                // serialize it, so a structured argument survives legibly.
-                Some(value) => match serde_json::to_string(&value) {
-                    Ok(json) => parts.push(json),
-                    Err(err) => {
-                        return (
-                            None,
-                            vec_push(
-                                errors,
-                                ApplyToError::new(
-                                    format!(
-                                        "Method ->{}{} recorded no message because argument {} could not be serialized: {err}",
-                                        method_name.as_ref(),
-                                        printed_args,
-                                        arg.pretty_print_with_indentation(true, 0),
-                                    ),
-                                    input_path.to_vec(),
-                                    arg.range(),
-                                    spec,
-                                ),
-                            ),
-                        );
-                    }
-                },
-
-                // An absent argument makes the whole method absent, the way it
-                // does for every other method. arg_errors (already collected)
-                // say why the argument produced nothing, and the error added
-                // here says what that cost: the message the author asked for
-                // was never recorded. Without it, a mapping author reading the
-                // problems sees only a failed path and has no reason to connect
-                // it to their missing diagnostic.
-                None => {
-                    return (
-                        None,
-                        vec_push(
-                            errors,
-                            ApplyToError::new(
-                                format!(
-                                    "Method ->{}{} recorded no message because argument {} produced no value",
-                                    method_name.as_ref(),
-                                    printed_args,
-                                    arg.pretty_print_with_indentation(true, 0),
-                                ),
-                                input_path.to_vec(),
-                                arg.range(),
-                                spec,
-                            ),
+            // Everything else is serialized the way ->jsonStringify would
+            // serialize it, so a structured argument survives legibly.
+            Some(value) => match serde_json::to_string(&value) {
+                Ok(json) => parts.push(json),
+                Err(err) => {
+                    can_record_message = false;
+                    errors.push(ApplyToError::new(
+                        format!(
+                            "Method ->{}{} recorded no message because argument {} could not be serialized: {err}",
+                            method_name.as_ref(),
+                            printed_args(),
+                            arg.pretty_print_with_indentation(true, 0),
                         ),
-                    );
+                        input_path.to_vec(),
+                        arg.range(),
+                        spec,
+                    ));
                 }
+            },
+
+            // An absent argument makes the whole method absent, the way it
+            // does for every other method. arg_errors (already collected)
+            // say why the argument produced nothing, and the error added
+            // here says what that cost: the message the author asked for
+            // was never recorded. Without it, a mapping author reading the
+            // problems sees only a failed path and has no reason to connect
+            // it to their missing diagnostic.
+            None => {
+                can_record_message = false;
+                errors.push(ApplyToError::new(
+                    format!(
+                        "Method ->{}{} recorded no message because argument {} produced no value",
+                        method_name.as_ref(),
+                        printed_args(),
+                        arg.pretty_print_with_indentation(true, 0),
+                    ),
+                    input_path.to_vec(),
+                    arg.range(),
+                    spec,
+                ));
             }
         }
-
-        errors.push(ApplyToError::new(
-            parts.join(" "),
-            input_path.to_vec(),
-            method_args.and_then(Ranged::range),
-            spec,
-        ));
     }
+
+    if !can_record_message {
+        return (None, errors);
+    }
+
+    errors.push(ApplyToError::new(
+        parts.join(" "),
+        input_path.to_vec(),
+        method_args.and_then(Ranged::range),
+        spec,
+    ));
 
     // Every argument produced a value, so the input flows through unchanged and
     // the dispatcher applies the tail to it.
@@ -172,7 +180,6 @@ fn with_error_method(
 // the value. Every argument's shape is still computed so mistakes inside them
 // (unknown fields, mistyped paths) surface at validation time. No argument's
 // shape is constrained, since any value can be part of a message.
-#[allow(dead_code)] // method type-checking disabled until we add name resolution
 fn with_error_shape(
     context: &ShapeContext,
     method_name: &WithRange<String>,
@@ -311,10 +318,6 @@ mod tests {
         );
     }
 
-    /// A call with no arguments is malformed rather than merely absent, and a
-    /// malformed call produces no value, the same as any other method called
-    /// wrongly. The shape function reports it as well, so this should not
-    /// survive composition.
     /// The escape hatch for the short-circuit above, and the reason it is not a
     /// trap: `??` supplies a value for an argument that would otherwise produce
     /// none, so an author who *wants* the message even when a path is missing
@@ -351,6 +354,55 @@ mod tests {
         let none_only = selection!(r#"$->withError("code:", @.code ?! "<absent>")"#);
         assert_eq!(recorded(&none_only, &absent), vec!["code: <absent>"]);
         assert_eq!(recorded(&none_only, &null), vec!["code: null"]);
+    }
+
+    /// Every argument is evaluated even after one has already cost the
+    /// message, so an author who broke two of them is told about both rather
+    /// than fixing the first and rediscovering the second.
+    #[test]
+    fn with_error_should_report_every_argument_that_produced_no_value() {
+        let (value, errors) = selection!(r#"$->withError("missing:", @.nope, "and", @.also_nope)"#)
+            .apply_to(&json!({ "id": 1 }));
+
+        assert_eq!(value, None);
+        assert_eq!(
+            errors.iter().map(ApplyToError::message).collect::<Vec<_>>(),
+            vec![
+                "Property .nope not found in object",
+                concat!(
+                    r#"Method ->withError("missing:", @.nope, "and", @.also_nope) "#,
+                    "recorded no message because argument @.nope produced no value",
+                ),
+                "Property .also_nope not found in object",
+                concat!(
+                    r#"Method ->withError("missing:", @.nope, "and", @.also_nope) "#,
+                    "recorded no message because argument @.also_nope produced no value",
+                ),
+            ],
+        );
+    }
+
+    /// An argument can produce a value *and* report errors from inside it, so
+    /// "did anything go wrong" is not the same question as "can the message be
+    /// recorded". Here the subselection misses a field on one array element and
+    /// still yields a value, and the author's message is recorded alongside
+    /// that error rather than being discarded by it.
+    #[test]
+    fn with_error_should_record_a_message_whose_argument_also_reported_errors() {
+        let (value, errors) = selection!(r#"$->withError("rows:", @.rows { id }) { count }"#)
+            .apply_to(&json!({
+                "count": 2,
+                "rows": [{ "id": "a" }, { "name": "b" }],
+            }));
+
+        assert_eq!(value, Some(json!({ "count": 2 })));
+        assert_eq!(
+            errors.iter().map(ApplyToError::message).collect::<Vec<_>>(),
+            vec![
+                "Property .id not found in object",
+                r#"rows: [{"id":"a"},{}]"#,
+            ],
+        );
     }
 
     /// The method records and steps aside, so dropping a tap into the middle of
@@ -392,6 +444,10 @@ mod tests {
         );
     }
 
+    /// A call with no arguments is malformed rather than merely absent, and a
+    /// malformed call produces no value, the same as any other method called
+    /// wrongly. The shape function reports it as well, so this should not
+    /// survive composition.
     #[test]
     fn with_error_should_report_a_call_with_no_arguments() {
         assert_eq!(

--- a/apollo-federation/src/connectors/json_selection/methods/public/with_error.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/with_error.rs
@@ -1,0 +1,513 @@
+use serde_json_bytes::Value as JSON;
+use shape::Shape;
+use shape::ShapeCase;
+
+use crate::connectors::json_selection::ApplyToError;
+use crate::connectors::json_selection::ApplyToInternal;
+use crate::connectors::json_selection::MethodArgs;
+use crate::connectors::json_selection::PrettyPrintable;
+use crate::connectors::json_selection::ShapeContext;
+use crate::connectors::json_selection::VarsWithPathsMap;
+use crate::connectors::json_selection::helpers::vec_push;
+use crate::connectors::json_selection::immutable::InputPath;
+use crate::connectors::json_selection::location::Ranged;
+use crate::connectors::json_selection::location::WithRange;
+use crate::connectors::spec::ConnectSpec;
+use crate::impl_arrow_method;
+
+impl_arrow_method!(WithErrorMethod, with_error_method, with_error_shape);
+/// Returns its input unmodified, but records an [`ApplyToError`] built from the
+/// method's arguments, each evaluated against the input value (so `@` refers to
+/// the value flowing through). Together with conditional methods like
+/// `->match`, this lets a mapping attach errors to values without interrupting
+/// them:
+///
+///     status: type_code->match(
+///         ["2", $("VAN")],
+///         [@, @->withError("Unrecognized type code")]
+///     )
+///
+/// Any number of arguments is allowed, and they may be of any type, in the
+/// spirit of `console.log`: string arguments are interpolated as written, every
+/// other value is serialized exactly as `->jsonStringify` would serialize it,
+/// and the results are joined with single spaces into one message. So a
+/// diagnostic can carry the offending value along with the prose describing it:
+///
+///     @->withError("Unrecognized type code:", @.type_code, "in", @.id)
+///
+/// If every argument produces a value, the input flows through unchanged, so
+/// the tail applies to it exactly as if the method were absent. If any argument
+/// produces no value the method produces none either, short-circuiting without
+/// recording the author's message, the way every other method in the language
+/// propagates an absent argument. Two errors are reported in that case: the one
+/// from evaluating the argument, saying why it produced nothing, and a distinct
+/// one from this method, saying that the message it was asked to record never
+/// happened. That second error carries the syntax of the call and of the
+/// argument that failed, so a discarded diagnostic can be traced back to the
+/// expression meant to produce it.
+///
+/// An author who wants the message reported even when a path may be missing
+/// says so with `??`, which supplies a value where there would have been none:
+///
+///     @->withError("Unrecognized type code:", @.type_code ?? "<absent>")
+///
+/// That spells the absence out in the message text instead of losing the whole
+/// message to it.
+fn with_error_method(
+    method_name: &WithRange<String>,
+    method_args: Option<&MethodArgs>,
+    data: &JSON,
+    vars: &VarsWithPathsMap,
+    input_path: &InputPath<JSON>,
+    spec: ConnectSpec,
+) -> (Option<JSON>, Vec<ApplyToError>) {
+    let mut errors = Vec::new();
+
+    let args = method_args.map_or(&[][..], |method_args| method_args.args.as_slice());
+
+    if args.is_empty() {
+        // A malformed call produces no value, the same as any other method
+        // called wrongly. The shape function reports this too, so a schema this
+        // wrong does not compose in the first place.
+        return (
+            None,
+            vec![ApplyToError::new(
+                format!(
+                    "Method ->{} requires at least one argument",
+                    method_name.as_ref()
+                ),
+                input_path.to_vec(),
+                method_name.range(),
+                spec,
+            )],
+        );
+    } else {
+        // The call's own syntax, so a discarded message can be traced back to
+        // the expression that was supposed to produce it. Without this, an
+        // author reading the problems sees that some ->withError somewhere
+        // reported nothing, which is exactly the opacity the method exists to
+        // avoid.
+        let printed_args = method_args
+            .map(|method_args| method_args.pretty_print_with_indentation(true, 0))
+            .unwrap_or_default();
+        let mut parts = Vec::with_capacity(args.len());
+
+        for arg in args {
+            let (value_opt, arg_errors) = arg.apply_to_path(data, vars, input_path, spec);
+            errors.extend(arg_errors);
+
+            match value_opt {
+                // A string argument is interpolated as written, so prose reads
+                // as prose rather than arriving wrapped in quotes.
+                Some(JSON::String(string)) => parts.push(string.as_str().to_string()),
+
+                // Everything else is serialized the way ->jsonStringify would
+                // serialize it, so a structured argument survives legibly.
+                Some(value) => match serde_json::to_string(&value) {
+                    Ok(json) => parts.push(json),
+                    Err(err) => {
+                        return (
+                            None,
+                            vec_push(
+                                errors,
+                                ApplyToError::new(
+                                    format!(
+                                        "Method ->{}{} recorded no message because argument {} could not be serialized: {err}",
+                                        method_name.as_ref(),
+                                        printed_args,
+                                        arg.pretty_print_with_indentation(true, 0),
+                                    ),
+                                    input_path.to_vec(),
+                                    arg.range(),
+                                    spec,
+                                ),
+                            ),
+                        );
+                    }
+                },
+
+                // An absent argument makes the whole method absent, the way it
+                // does for every other method. arg_errors (already collected)
+                // say why the argument produced nothing, and the error added
+                // here says what that cost: the message the author asked for
+                // was never recorded. Without it, a mapping author reading the
+                // problems sees only a failed path and has no reason to connect
+                // it to their missing diagnostic.
+                None => {
+                    return (
+                        None,
+                        vec_push(
+                            errors,
+                            ApplyToError::new(
+                                format!(
+                                    "Method ->{}{} recorded no message because argument {} produced no value",
+                                    method_name.as_ref(),
+                                    printed_args,
+                                    arg.pretty_print_with_indentation(true, 0),
+                                ),
+                                input_path.to_vec(),
+                                arg.range(),
+                                spec,
+                            ),
+                        ),
+                    );
+                }
+            }
+        }
+
+        errors.push(ApplyToError::new(
+            parts.join(" "),
+            input_path.to_vec(),
+            method_args.and_then(Ranged::range),
+            spec,
+        ));
+    }
+
+    // Every argument produced a value, so the input flows through unchanged and
+    // the dispatcher applies the tail to it.
+    (Some(data.clone()), errors)
+}
+
+// The output shape is the input shape: this method is an identity function on
+// the value. Every argument's shape is still computed so mistakes inside them
+// (unknown fields, mistyped paths) surface at validation time. No argument's
+// shape is constrained, since any value can be part of a message.
+#[allow(dead_code)] // method type-checking disabled until we add name resolution
+fn with_error_shape(
+    context: &ShapeContext,
+    method_name: &WithRange<String>,
+    method_args: Option<&MethodArgs>,
+    input_shape: Shape,
+    dollar_shape: Shape,
+) -> Shape {
+    let args = method_args.map_or(&[][..], |method_args| method_args.args.as_slice());
+
+    if args.is_empty() {
+        return Shape::error(
+            format!(
+                "Method ->{} requires at least one argument",
+                method_name.as_ref()
+            ),
+            method_name.shape_location(context.source_id()),
+        );
+    }
+
+    for arg in args {
+        let arg_shape =
+            arg.compute_output_shape(context, input_shape.clone(), dollar_shape.clone());
+        if matches!(arg_shape.case(), ShapeCase::Error(_)) {
+            return arg_shape;
+        }
+    }
+
+    input_shape
+}
+
+#[cfg(test)]
+mod tests {
+    use apollo_compiler::ExecutableDocument;
+    use apollo_compiler::Schema;
+    use apollo_compiler::collections::IndexMap;
+    use apollo_compiler::collections::IndexSet;
+    use apollo_compiler::executable::SelectionSet;
+    use apollo_compiler::validation::Valid;
+    use pretty_assertions::assert_eq;
+    use serde_json_bytes::Value as JSON;
+    use serde_json_bytes::json;
+
+    use crate::connectors::JSONSelection;
+    use crate::connectors::json_selection::ApplyToError;
+    use crate::selection;
+
+    /// Apply `selection` to `data`, assert the value flowed through unchanged,
+    /// and hand back the messages that were recorded.
+    fn recorded(selection: &JSONSelection, data: &JSON) -> Vec<String> {
+        let (value, errors) = selection.apply_to(data);
+        assert_eq!(
+            value.as_ref(),
+            Some(data),
+            "->withError must leave the value alone",
+        );
+        errors
+            .iter()
+            .map(|error| error.message().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn with_error_should_return_input_and_record_error() {
+        assert_eq!(
+            selection!("$->withError('This is an error')").apply_to(&json!(null)),
+            (
+                Some(json!(null)),
+                vec![ApplyToError::from_json(&json!({
+                    "message": "This is an error",
+                    "path": ["->withError"],
+                    "range": [12, 32],
+                }))],
+            ),
+        );
+    }
+
+    #[test]
+    fn with_error_should_stringify_non_string_messages() {
+        assert_eq!(
+            selection!("$->withError({ hi: @.name }) { name }").apply_to(&json!({
+                "name": "Alice",
+            })),
+            (
+                Some(json!({ "name": "Alice" })),
+                vec![ApplyToError::from_json(&json!({
+                    "message": "{\"hi\":\"Alice\"}",
+                    "path": ["->withError"],
+                    "range": [12, 28],
+                }))],
+            ),
+        );
+    }
+
+    /// Any number of arguments, of any type, in the spirit of `console.log`:
+    /// strings are interpolated as written, everything else is serialized the
+    /// way ->jsonStringify would serialize it, and the parts are joined with
+    /// single spaces.
+    #[test]
+    fn with_error_should_accept_any_number_of_arguments_of_any_type() {
+        let (value, errors) = selection!(
+            r#"$->withError("Unrecognized type code:", @.type_code, "for", @.id, @.meta) { id }"#
+        )
+        .apply_to(&json!({
+            "id": "acct-1",
+            "type_code": 7,
+            "meta": { "source": "vendor", "retryable": false },
+        }));
+
+        assert_eq!(value, Some(json!({ "id": "acct-1" })));
+        assert_eq!(
+            errors.iter().map(ApplyToError::message).collect::<Vec<_>>(),
+            vec![r#"Unrecognized type code: 7 for acct-1 {"source":"vendor","retryable":false}"#],
+        );
+    }
+
+    /// An absent argument makes the whole method absent, the way it does for
+    /// every other method, rather than contributing a placeholder to the
+    /// message. The author's message is not recorded, and both halves of why
+    /// are reported: the argument's own failure, and the fact that it cost the
+    /// message.
+    #[test]
+    fn with_error_should_short_circuit_when_an_argument_produces_no_value() {
+        let (value, errors) =
+            selection!(r#"$->withError("missing:", @.nope)"#).apply_to(&json!({ "id": 1 }));
+
+        assert_eq!(value, None);
+        assert_eq!(
+            errors.iter().map(ApplyToError::message).collect::<Vec<_>>(),
+            vec![
+                "Property .nope not found in object",
+                concat!(
+                    r#"Method ->withError("missing:", @.nope) recorded no message "#,
+                    "because argument @.nope produced no value",
+                ),
+            ],
+        );
+    }
+
+    /// A call with no arguments is malformed rather than merely absent, and a
+    /// malformed call produces no value, the same as any other method called
+    /// wrongly. The shape function reports it as well, so this should not
+    /// survive composition.
+    /// The escape hatch for the short-circuit above, and the reason it is not a
+    /// trap: `??` supplies a value for an argument that would otherwise produce
+    /// none, so an author who *wants* the message even when a path is missing
+    /// says so, and gets the absence spelled out in the text rather than losing
+    /// the whole message. `??` also swallows the failed path's own error, since
+    /// the fallback counts as a successful evaluation.
+    #[test]
+    fn with_error_should_accept_a_coalesced_argument_in_place_of_a_missing_one() {
+        let (value, errors) = selection!(r#"$->withError("missing:", @.nope ?? "<absent>")"#)
+            .apply_to(&json!({ "id": 1 }));
+
+        assert_eq!(value, Some(json!({ "id": 1 })));
+        assert_eq!(
+            errors.iter().map(ApplyToError::message).collect::<Vec<_>>(),
+            vec!["missing: <absent>"],
+        );
+    }
+
+    /// `??` and `?!` say different things inside a message, and the difference
+    /// is the useful part. `??` treats an explicit null the same as an absent
+    /// path, so both become the fallback. `?!` fills in only for the absent
+    /// one and lets a real null reach the message as `null`. An author who
+    /// needs "the API omitted this field" to read differently from "the API
+    /// sent null" reaches for `?!`.
+    #[test]
+    fn coalescing_operators_should_distinguish_an_absent_field_from_a_null_one() {
+        let absent = json!({ "id": "acct-1" });
+        let null = json!({ "id": "acct-1", "code": null });
+
+        let nullish = selection!(r#"$->withError("code:", @.code ?? "<absent>")"#);
+        assert_eq!(recorded(&nullish, &absent), vec!["code: <absent>"]);
+        assert_eq!(recorded(&nullish, &null), vec!["code: <absent>"]);
+
+        let none_only = selection!(r#"$->withError("code:", @.code ?! "<absent>")"#);
+        assert_eq!(recorded(&none_only, &absent), vec!["code: <absent>"]);
+        assert_eq!(recorded(&none_only, &null), vec!["code: null"]);
+    }
+
+    /// The method records and steps aside, so dropping a tap into the middle of
+    /// a chain cannot change what the chain computes. Asserted against the same
+    /// selection without the tap rather than against a hardcoded result, since
+    /// the claim is an equality between the two.
+    #[test]
+    fn with_error_should_leave_the_rest_of_the_chain_unchanged() {
+        let data = json!({ "cents": 250 });
+
+        let (untapped, no_errors) = selection!("dollars: cents->div(100)").apply_to(&data);
+        let (tapped, errors) =
+            selection!(r#"dollars: cents->withError("saw cents:", @)->div(100)"#).apply_to(&data);
+
+        assert_eq!(tapped, untapped);
+        assert_eq!(no_errors, vec![]);
+        assert_eq!(
+            errors.iter().map(ApplyToError::message).collect::<Vec<_>>(),
+            vec!["saw cents: 250"],
+        );
+    }
+
+    /// A message can draw on the mapping's variables and not only on the value
+    /// flowing through, which is what lets a tap name the request that produced
+    /// the response it is complaining about.
+    #[test]
+    fn with_error_should_evaluate_variables_inside_a_message() {
+        let mut vars = IndexMap::default();
+        vars.insert("$args".to_string(), json!({ "id": "acct-1" }));
+
+        let (value, errors) =
+            selection!(r#"$->withError("no balance for", $args.id, "in", @.region)"#)
+                .apply_with_vars(&json!({ "region": "us-east" }), &vars);
+
+        assert_eq!(value, Some(json!({ "region": "us-east" })));
+        assert_eq!(
+            errors.iter().map(ApplyToError::message).collect::<Vec<_>>(),
+            vec!["no balance for acct-1 in us-east"],
+        );
+    }
+
+    #[test]
+    fn with_error_should_report_a_call_with_no_arguments() {
+        assert_eq!(
+            selection!("$->withError").apply_to(&json!("value")),
+            (
+                None,
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Method ->withError requires at least one argument",
+                    "path": ["->withError"],
+                    "range": [3, 12],
+                }))],
+            ),
+        );
+    }
+
+    /// The ->match arms give each branch its own ->withError, so which error
+    /// is recorded depends on which branch actually runs — the tap pattern
+    /// this method exists for.
+    #[test]
+    fn with_error_should_fire_only_in_the_taken_match_branch() {
+        let match_error_selection = selection!(
+            r#"
+            result: input->match(
+                ["hi", $("hello")->withError("Ok error")],
+                [@, @->withError({ "unknown": @ })]
+            )
+            "#
+        );
+
+        assert_eq!(
+            match_error_selection.apply_to(&json!({ "input": "hi" })),
+            (
+                Some(json!({ "result": "hello" })),
+                vec![ApplyToError::from_json(&json!({
+                    "message": "Ok error",
+                    "path": ["input", "->match", "->withError"],
+                    "range": [79, 91],
+                }))],
+            ),
+        );
+
+        assert_eq!(
+            match_error_selection.apply_to(&json!({ "input": null })),
+            (
+                Some(json!({ "result": null })),
+                vec![ApplyToError::from_json(&json!({
+                    "message": "{\"unknown\":null}",
+                    "path": ["input", "->match", "->withError"],
+                    "range": [126, 144],
+                }))],
+            ),
+        );
+    }
+
+    /// Parse an operation and hand back the selection set of its first root
+    /// field, the same helper shape selection_set.rs's tests use.
+    fn root_field_selection_set(
+        schema: &Valid<Schema>,
+        query: &str,
+    ) -> (ExecutableDocument, SelectionSet) {
+        let document = ExecutableDocument::parse_and_validate(schema, query, "./").unwrap();
+        let set = document
+            .operations
+            .anonymous
+            .as_ref()
+            .unwrap()
+            .selection_set
+            .fields()
+            .next()
+            .unwrap()
+            .selection_set
+            .clone();
+        (document.into_inner(), set)
+    }
+
+    /// Which errors a mapping reports already depends on the client's query
+    /// shape, and it is worth pinning that here rather than leaving it to be
+    /// discovered and mistaken for something `->withError` introduced. The
+    /// router narrows a mapping to the requested selection set before running
+    /// it, so an expression producing a field nobody asked for is gone before
+    /// evaluation starts, and the error it would have recorded never happens.
+    #[test]
+    fn with_error_does_not_fire_for_a_selection_the_client_did_not_request() {
+        let schema = Schema::parse_and_validate(
+            r#"
+            type Query { t: T }
+            type T { id: ID name: String }
+            "#,
+            "./",
+        )
+        .unwrap();
+
+        let selection =
+            JSONSelection::parse("id name: full_name->withError('name is deprecated')").unwrap();
+        let data = json!({ "id": "1", "full_name": "Alice" });
+
+        // Requested: the error fires.
+        let (document, set) = root_field_selection_set(&schema, "{ t { id name } }");
+        let requested = selection.apply_selection_set(&IndexSet::default(), &document, &set, None);
+        let (value, errors) = requested.apply_to(&data);
+        assert_eq!(value, Some(json!({ "id": "1", "name": "Alice" })));
+        assert_eq!(
+            errors.iter().map(ApplyToError::message).collect::<Vec<_>>(),
+            vec!["name is deprecated"],
+        );
+
+        // Not requested: the narrowed mapping no longer contains the
+        // expression, so there is nothing left to record an error.
+        let (document, set) = root_field_selection_set(&schema, "{ t { id } }");
+        let narrowed = selection.apply_selection_set(&IndexSet::default(), &document, &set, None);
+        let (value, errors) = narrowed.apply_to(&data);
+        assert_eq!(value, Some(json!({ "id": "1" })));
+        assert_eq!(
+            errors,
+            vec![],
+            "a selection the client did not request must not report errors",
+        );
+    }
+}

--- a/apollo-federation/src/connectors/json_selection/mod.rs
+++ b/apollo-federation/src/connectors/json_selection/mod.rs
@@ -16,16 +16,15 @@ mod pretty;
 mod selection_set;
 mod selection_trie;
 
-// Pretty code is currently only used in tests, so this cfg is to suppress the
-// unused lint warning. If pretty code is needed in not test code, feel free to
-// remove the `#[cfg(test)]`.
 #[allow(unused_imports)] // Consumers land in follow-up PRs.
 pub(crate) use analysis::SelectionAnalysis;
 pub use apply_to::*;
 pub(crate) use lit_expr::LitExpr;
 pub(crate) use location::Ranged;
 pub use parser::*;
-#[cfg(test)]
+// Pretty printing is used outside tests now: ->withError renders the syntax of
+// a call whose message it had to discard, so the author can find the expression
+// that was supposed to produce it.
 pub(crate) use pretty::*;
 pub(crate) use selection_trie::SelectionTrie;
 #[cfg(test)]

--- a/apollo-federation/src/connectors/runtime/mapping.rs
+++ b/apollo-federation/src/connectors/runtime/mapping.rs
@@ -68,3 +68,63 @@ pub fn aggregate_apply_to_errors_with_problem_locations(
         .into_iter()
         .flat_map(|(location, errors)| aggregate_apply_to_errors(errors, location))
 }
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools;
+    use serde_json_bytes::json;
+
+    use super::Problem;
+    use super::aggregate_apply_to_errors;
+    use crate::connectors::JSONSelection;
+    use crate::connectors::ProblemLocation;
+
+    /// A tap inside `->map` fires once per element, so a mapping over a large
+    /// array would otherwise report the same sentence hundreds of times.
+    /// Aggregation collapses identical messages into one problem carrying the
+    /// count, and array indices are deliberately not part of the grouping key,
+    /// which is what lets repeats from different elements land in one bucket.
+    #[test]
+    fn repeated_messages_aggregate_into_one_problem_with_a_count() {
+        let (value, errors) =
+            JSONSelection::parse(r#"codes: rows->map(@.code->withError("unrecognized code:", @))"#)
+                .unwrap()
+                .apply_to(&json!({
+                    "rows": [{ "code": 7 }, { "code": 7 }, { "code": 7 }],
+                }));
+
+        assert_eq!(value, Some(json!({ "codes": [7, 7, 7] })));
+
+        let problems =
+            aggregate_apply_to_errors(errors, ProblemLocation::Selection).collect::<Vec<Problem>>();
+
+        assert_eq!(problems.len(), 1);
+        assert_eq!(problems[0].message, "unrecognized code: 7");
+        assert_eq!(problems[0].count, 3);
+        assert_eq!(problems[0].location, ProblemLocation::Selection);
+    }
+
+    /// The counterpart to the test above: grouping is by message, so distinct
+    /// messages stay distinct and the collapsing cannot hide anything.
+    #[test]
+    fn distinct_messages_aggregate_into_distinct_problems() {
+        let (_, errors) =
+            JSONSelection::parse(r#"codes: rows->map(@.code->withError("unrecognized code:", @))"#)
+                .unwrap()
+                .apply_to(&json!({
+                    "rows": [{ "code": 7 }, { "code": 9 }, { "code": 7 }],
+                }));
+
+        let problems = aggregate_apply_to_errors(errors, ProblemLocation::Selection)
+            .sorted_by_key(|problem| problem.message.clone())
+            .collect::<Vec<Problem>>();
+
+        assert_eq!(
+            problems
+                .iter()
+                .map(|problem| (problem.message.as_str(), problem.count))
+                .collect::<Vec<_>>(),
+            vec![("unrecognized code: 7", 2), ("unrecognized code: 9", 1)],
+        );
+    }
+}

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -409,6 +409,27 @@ mod tests {
     use crate::services::router;
     use crate::services::router::body::RouterBody;
 
+    /// `->withError` has to be reachable from a connector schema, and the
+    /// `is_public()` gate that decides so cannot be observed from
+    /// apollo-federation's own tests: `ArrowMethod::lookup` resolves every
+    /// method under `cfg!(test)`, public or not. Here apollo-federation is a
+    /// dependency compiled without `--test`, so the gate is live and demoting
+    /// `->withError` back to the `future` namespace fails this test.
+    #[test]
+    fn with_error_is_available_to_connector_schemas() {
+        let selection =
+            JSONSelection::parse("id status: code->withError('unrecognized type code')").unwrap();
+
+        let (value, errors) = selection.apply_to(&json!({ "id": "1", "code": 7 }));
+
+        // The value flows through untouched: ->withError records, never rewrites.
+        assert_eq!(value, Some(json!({ "id": "1", "status": 7 })));
+        assert_eq!(
+            errors.iter().map(|error| error.message()).collect_vec(),
+            vec!["unrecognized type code"],
+        );
+    }
+
     #[test]
     fn from_runtime_error_transfers_span_event_emitted_flag() {
         let response_key = ResponseKey::RootField {


### PR DESCRIPTION
Connector mappings can report a problem without failing the field. `->withError` returns its input unchanged and records its arguments as a mapping error, so a mapping that recognizes a value it cannot vouch for can say so and keep going.

The pattern this exists for is a validation tap. An API returns a code, a status, or a shape the schema did not anticipate; the mapping should surface that to whoever is operating the graph, and should still return the data.

## What it does

```
status: type_code->match(
  ["2", $("VAN")],
  [@, @->withError("Unrecognized type code")]
)
```

Each argument is an expression evaluated with `@` bound to the value flowing through. When every argument produces a value, `data->withError(...)` returns `data`, so the tail applies to the input exactly as if the method were absent. Dropping a tap into the middle of a chain cannot change what the chain computes.

## Arguments

Any number of arguments is allowed, and they may be of any type, in the spirit of `console.log`. String arguments are interpolated as written so prose reads as prose, every other value is serialized exactly as `->jsonStringify` would serialize it, and the parts are joined with single spaces into one message:

```
@->withError("Unrecognized type code:", @.type_code, "for", @.id, @.meta)
```

recording, for example:

```
Unrecognized type code: 7 for acct-1 {"source":"vendor","retryable":false}
```

A useful diagnostic usually needs both the prose and the offending value, and building that out of a single argument would mean nesting `->jsonStringify` calls or writing an object literal whose keys exist only to be serialized.

Three things are worth knowing about how arguments behave.

**Absent arguments short-circuit, and never quietly.** If any argument produces no value, the method produces no value either and does not record the author's message, which is how every other method in the mapping language treats an argument it cannot evaluate. Two errors are reported in that case: the one from evaluating the argument, saying why it produced nothing, and a distinct one from `->withError`, saying that the message it was asked to record never happened. The second carries the syntax of the call and of the failing argument, so a discarded diagnostic can be traced back to the expression meant to produce it:

```
Method ->withError("missing:", @.nope) recorded no message because argument @.nope produced no value
```

Without it, you would see a failed path with no way to tell that a diagnostic you wrote had gone missing, or which one.

**`??` keeps the message anyway.** To report the diagnostic even when a path may be missing, supply a fallback:

```
@->withError("Unrecognized type code:", @.type_code ?? "<absent>")
```

That spells the absence out in the message text rather than losing the whole message to it. `??` also absorbs the failed path's own error, since the fallback counts as a successful evaluation, so the reported problem is exactly the one you wrote. `?!` is available where "the API omitted this field" and "the API sent null" should read differently: it fills in only for the absent case and lets a real null reach the message as `null`.

**At least one argument is required**, since a message with no content carries no information. No argument's type is constrained, because any value can be part of a message, but every argument's shape is computed, so a mistake inside one (an unknown field, a mistyped path) is reported rather than ignored.

For `connect/v0.3` and later, both of those are reported by the method's shape function, so they surface at composition time. Before v0.3 the router does not consult method shapes at all, returning `Unknown` instead, so on those older specs the same mistakes surface at runtime as mapping errors.

## Why a side effect is acceptable here

Recording a message is a side effect, and mapping expressions are otherwise pure, so this deserves an argument rather than an assumption. Two things make this particular effect harmless.

**Errors were already side-effectful.** Evaluation has always accumulated mapping errors as it goes: a path that misses, a value whose type does not match, a method handed the wrong argument. `->withError` does not introduce that channel. It gives a mapping author a way to write to a channel the language already had, which is also why the method is available in every connect spec version rather than gated to a new one.

**The channel is write-only.** Nothing in the mapping language can read the accumulated errors. No value anywhere in the output can depend on whether a message was recorded, so the effect cannot feed back into evaluation. The mapping computes exactly the same values whether or not any `->withError` fired. Any reasoning elsewhere that leans on expression purity is reasoning about values, and it survives intact.

What does become newly visible is that the set of reported messages depends on the shape of the client's query, which is worth stating plainly rather than leaving to be discovered.

## Reported errors already depend on query shape

The router narrows a mapping to the client's requested selection set before running it. An expression producing a field nobody asked for is therefore gone before evaluation starts, and any error it would have recorded never happens.

So `->withError` does not introduce query-shape-dependent error output. It makes an existing property observable for the first time, since until now everything in that channel described a mapping bug rather than something an author chose to say. A test pins both halves: request the field and the message is reported, omit it and nothing is.

This is the intended behavior rather than a limitation. The message is attached to the expression that produces a field, so a client that did not ask for the field does not receive messages about it.

## Where the messages surface

A recorded message travels the same path as any other mapping problem: aggregated into a `Problem`, reported through the connectors debugger and available to the telemetry selectors. Identical messages are collapsed into one problem carrying a count, so a tap inside `->map` over a large array reports one line with `count: 250` rather than 250 lines.

## Room for lower severity levels later

Every recorded message carries a severity, and the only severity anything produces today is `Error`.

The carrier is fully wired even though one value flows through it. The severity enum keeps `Warning` and `Log` variants, the error type exposes the severity, `Problem` carries it, and the connectors debugger and the telemetry selectors both report it. The constructor that takes a severity is crate private, so nothing outside the crate can widen the distinction in the meantime.

A lower level later therefore needs a method that passes a different variant, and nothing else. No consumer has to change shape to accommodate one.

`->withWarning` and `->withLog` were deliberately left out of this change. Both were implemented and tested, and nothing about them turned out to be wrong, but shipping three ways to record a message would commit us to a severity vocabulary before anyone has asked for one, and the mapping language is easier to add to than to take back. The commit that removes them is separate and self-contained, so the shape of that decision stays legible.

## Availability

Method availability is not scoped by connect spec version. Method lookup takes a name and no spec, so a public method is valid in every version, `connect/v0.2` included. That fits here for the reason above: the reporting channel `->withError` writes to predates all of those versions.

The one behavioral difference across versions is the composition-time checking described under Arguments, which applies from `connect/v0.3` onward because that is when the router began consulting method shapes at all. Runtime behavior is the same in every version.

## Testing

The method's tests cover the value flowing through untouched, string and non-string arguments, several arguments of mixed types, the short-circuit when an argument produces no value, `??` and `?!` in place of a missing or null field, the no-argument case, variables inside a message, firing only in the taken `->match` branch, a tap leaving the rest of a chain unchanged, and the query-shape property described above. Two more cover aggregation: repeated messages collapsing into one problem with a count, and distinct messages staying distinct.

One test lives in `apollo-router` rather than beside the method, on purpose. Method lookup resolves every method under `cfg!(test)`, public or not, so from inside `apollo-federation` the public-method gate cannot be observed at all, and the method's own tests pass whether it is public or not. Compiled as a dependency the gate is live, so the assertion that a connector schema can actually use `->withError` has to be made from a crate that depends on this one. Removing the method from the public set fails that test, which was checked rather than assumed.
