### PR TITLE
Tag pre-releases from the prep workflow

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -30,7 +30,7 @@
 #   - PAT scoped: uses `APOLLO_BOT2_GITHUB_PAT` so the tag is attributed
 #     to apollo-bot2 and bypasses tag-creation rules.
 
-name: Release: auto-tag
+name: "Release: auto-tag"
 
 on:
   push:

--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -27,7 +27,7 @@
 # and open the draft release PR.  workflow_dispatch defaults dry_run to
 # true.
 
-name: Release: new
+name: "Release: new"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -16,7 +16,7 @@
 # Defaults to **dry-run**: prepares, diffs, logs auto-tag would-do — does
 # not commit, push, or open a PR unless explicitly opted in.
 
-name: Release: prep
+name: "Release: prep"
 
 on:
   workflow_dispatch:
@@ -200,6 +200,7 @@ jobs:
       # For now: log what auto-tag WOULD do, including the exact commit SHA.
       # ---------------------------------------------------------------------
       - name: Log what auto-tag would do (including exact SHA)
+        if: steps.vars.outputs.pre_release != 'true'
         run: |
           set -euo pipefail
           VERSION='${{ steps.vars.outputs.version }}'
@@ -281,16 +282,22 @@ jobs:
       # `git push` and the token is left out of any persistent config.
       # =====================================================================
 
-      - name: Commit prep on the dispatched branch (pre-release)
+      - name: Commit and tag prep on the dispatched branch (pre-release)
         if: steps.vars.outputs.dry_run != 'true' && steps.vars.outputs.pre_release == 'true'
         run: |
           set -euo pipefail
+          VERSION='${{ steps.vars.outputs.version }}'
           git config user.name "apollo-bot2"
           git config user.email "apollo-bot2@users.noreply.github.com"
           git add -A
-          git commit -m "prep release: v${{ steps.vars.outputs.version }}"
+          git commit -m "prep release: v$VERSION"
+          git tag --annotate --message "$VERSION" "v$VERSION" HEAD
 
-      - name: Push prep commit directly to ${{ github.ref_name }} (pre-release)
+      # Tag and commit go up in one atomic push: the tag is what triggers
+      # CircleCI to build the release, so it must never land without the
+      # commit it points at (or vice versa).  A re-run of an already-cut
+      # version is rejected here, leaving nothing behind to clean up.
+      - name: Push prep commit and tag to ${{ github.ref_name }} (pre-release)
         if: steps.vars.outputs.dry_run != 'true' && steps.vars.outputs.pre_release == 'true'
         env:
           APOLLO_BOT2_GITHUB_PAT: ${{ secrets.APOLLO_BOT2_GITHUB_PAT }}
@@ -300,12 +307,14 @@ jobs:
             echo "::error::APOLLO_BOT2_GITHUB_PAT secret is required to push to a protected release branch."
             exit 1
           fi
+          TAG="v${{ steps.vars.outputs.version }}"
           # PAT-bearing URL only used for this single push command — never
           # persisted into the local repo's git config.
-          git push \
+          git push --atomic \
             "https://x-access-token:${APOLLO_BOT2_GITHUB_PAT}@github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/tags/$TAG" \
             "HEAD:${GITHUB_REF_NAME}"
-          echo "Pushed prep commit directly to ${GITHUB_REF_NAME} as apollo-bot2."
+          echo "::notice::Pushed $TAG at $(git rev-parse HEAD) and updated ${GITHUB_REF_NAME}."
 
       # =====================================================================
       # Final-release path: existing fresh-branch + open-PR flow.  Reviewers
@@ -372,7 +381,8 @@ jobs:
           if [ '${{ steps.vars.outputs.dry_run }}' = 'true' ]; then
             echo "Dry-run complete.  No commit, push, or PR."
           elif [ '${{ steps.vars.outputs.pre_release }}' = 'true' ]; then
-            echo "Pre-release prep pushed directly to ${GITHUB_REF_NAME} as apollo-bot2."
+            echo "Pre-release prep pushed to ${GITHUB_REF_NAME} and tagged v${{ steps.vars.outputs.version }} as apollo-bot2."
+            echo "CircleCI builds the release from that tag; it appears in GitHub Releases when that finishes."
           else
             echo "Prep PR opened from $PREP_BRANCH into ${{ steps.vars.outputs.version }}."
           fi


### PR DESCRIPTION
The action already on the repository was already adding value and working functionally, but only pushed the version bump while not doing the final bit of tagging, leaving someone (me, since I've been testing this all) to tag it by hand afterwards. Since the tag is what CircleCI builds the release from, that manual step was the only thing between a dispatch and a published release candidate using the GitHub Actions automation tooling that now exists.

With this change, the prep commit is now tagged in the same job, and the tag and commit go up in a single atomic push so one can't land without the other. Re-running an already-cut version is rejected by that push, leaving nothing behind to clean up.

Two smaller things while in here:

- The auto-tag preview step is scoped to the final-release path, which is what it was always describing — on a pre-release run it was previewing work this job now does itself.
- Quoted the workflow names. `name: Release: prep` wasn't valid YAML and this broke  `gh workflow list`

This/The pre-release path only runs on a real `dry_run=false` dispatch through GHA. 

<!-- start metadata -->

<!-- [GRAPHOS-292] -->


[GRAPHOS-292]: https://apollographql.atlassian.net/browse/GRAPHOS-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ