### PR TITLE
Add ancillary distroless Docker image

### DIFF
--- a/.changesets/feat_imgood_router_1954_distroless_image.md
+++ b/.changesets/feat_imgood_router_1954_distroless_image.md
@@ -1,0 +1,13 @@
+### Publish a distroless container image alongside the Debian one
+
+Every router release publishes a distroless image, tagged with a `-distroless` suffix:
+
+```bash
+docker pull ghcr.io/apollographql/router:<version>-distroless
+```
+
+It is built from the same router binary as the default image, on a [`distroless/cc`](https://github.com/GoogleContainerTools/distroless) base instead of `debian:bookworm-slim`. It contains the router, the shared libraries it links against, CA certificates, and time zone data, with no shell, package manager, or other userland.
+
+See [Deploying only GraphOS Router in Docker](https://www.apollographql.com/docs/graphos/routing/self-hosted/containerization/docker-router-only#image-flavors) for the comparison between Apollo's published images.
+
+By [@SharkBaitDLS](https://github.com/SharkBaitDLS) in https://github.com/apollographql/router/pull/10069

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -797,10 +797,17 @@ jobs:
                   # Build and push release image
                   docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg ROUTER_RELEASE=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} dockerfiles/.
                   docker push ${ROUTER_TAG}:${VERSION}
+                  # Build and push distroless image
+                  docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg ROUTER_RELEASE=${VERSION} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router.distroless -t ${ROUTER_TAG}:${VERSION}-distroless dockerfiles/.
+                  # There is no shell in the distroless image to debug with, so boot it here and confirm it serves.
+                  ./dockerfiles/verify_distroless_image.sh ${ROUTER_TAG}:${VERSION}-distroless ${BASE_VERSION}
+                  docker push ${ROUTER_TAG}:${VERSION}-distroless
+
                   # save containers for analysis
                   mkdir built-containers
                   docker save -o built-containers/router_${VERSION}-debug.tar ${ROUTER_TAG}:${VERSION}-debug
                   docker save -o built-containers/router_${VERSION}.tar ${ROUTER_TAG}:${VERSION}
+                  docker save -o built-containers/router_${VERSION}-distroless.tar ${ROUTER_TAG}:${VERSION}-distroless
 
             - persist_to_workspace:
                 root: .
@@ -966,10 +973,15 @@ jobs:
                   # If the manifest command succeeds, the images already exist
                   docker manifest inspect ${ROUTER_TAG}:${VERSION}  > /dev/null && exit 1
                   docker manifest inspect ${ROUTER_TAG}:${VERSION}-debug  > /dev/null && exit 1
+                  docker manifest inspect ${ROUTER_TAG}:${VERSION}-distroless  > /dev/null && exit 1
                   # Build and push debug image
                   docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug dockerfiles/.
                   # Build and push release image
                   docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} dockerfiles/.
+                  # Build, smoke test, and push distroless image
+                  docker buildx build --load --platform linux/amd64 --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router.distroless -t ${ROUTER_TAG}:${VERSION}-distroless dockerfiles/.
+                  ./dockerfiles/verify_distroless_image.sh ${ROUTER_TAG}:${VERSION}-distroless ${VERSION#v}
+                  docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router.distroless -t ${ROUTER_TAG}:${VERSION}-distroless dockerfiles/.
             - run:
                 name: Helm build
                 command: |
@@ -1080,9 +1092,15 @@ jobs:
             # Build and push regular image
             docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg ROUTER_RELEASE=${TAG} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${TAG} dockerfiles/.
             docker push ${ROUTER_TAG}:${TAG}
+            # Build and push distroless image
+            docker buildx build --load --platform linux/amd64 --build-arg CIRCLE_TOKEN="${CIRCLE_TOKEN}" --build-arg REPO_URL="${REPO_URL}" --build-arg ARTIFACT_URL="${ARTIFACT_URL}" --build-arg ARTIFACT_URL_SHA256SUM="${ARTIFACT_URL_SHA256SUM}" --build-arg ROUTER_RELEASE=${TAG} --build-arg BASE_VERSION=${BASE_VERSION} -f dockerfiles/Dockerfile.router.distroless -t ${ROUTER_TAG}:${TAG}-distroless dockerfiles/.
+            # There is no shell in the distroless image to debug with so verify it now
+            ./dockerfiles/verify_distroless_image.sh ${ROUTER_TAG}:${TAG}-distroless ${BASE_VERSION}
+            docker push ${ROUTER_TAG}:${TAG}-distroless
 
             echo "Pushed: ${ROUTER_TAG}:${TAG}"
             echo "Pushed: ${ROUTER_TAG}:${TAG}-debug"
+            echo "Pushed: ${ROUTER_TAG}:${TAG}-distroless"
 
 workflows:
   ci_checks:

--- a/dockerfiles/Dockerfile.router.distroless
+++ b/dockerfiles/Dockerfile.router.distroless
@@ -1,0 +1,74 @@
+# Distroless flavor of the Router image, published alongside the Debian-based
+# image built by `Dockerfile.router` under a `-distroless` tag suffix.
+#
+# If a future dependency reintroduces a dynamic library that `distroless/cc`
+# lacks, the binary won't get as far as main() and `verify_distroless_image.sh`
+# will fail on its first check. Re-run the `readelf` above to see what's new.
+#
+# WHAT YOU GIVE UP
+#
+# There is no shell, no package manager, and no coreutils in the image, so
+# `--entrypoint=bash`, `docker exec ... sh`, and the heaptrack-based `-debug`
+# flavor are all unavailable here. Use the Debian image for those.
+
+# Named so the downloader stage below can read the base image's /etc/passwd.
+FROM gcr.io/distroless/cc-debian12:nonroot AS base
+
+FROM debian:bookworm-slim AS downloader
+ARG ROUTER_RELEASE=latest
+ARG ARTIFACT_URL=
+ARG CIRCLE_TOKEN=
+ARG ARTIFACT_URL_SHA256SUM=
+# We will use TARGETPLATFORM inside the download_and_validate_router.sh script
+# It is set automatically by Docker when doing a buildx build, see:
+#  https://docs.docker.com/build/building/multi-platform/
+ARG TARGETPLATFORM
+
+RUN \
+  apt-get update -y \
+  && apt-get install -y \
+    curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# We work in /, and the tarball produces /dist/router after extraction.
+WORKDIR /
+
+# Copy and run the router download script
+COPY download_and_validate_router.sh /tmp/download_and_validate_router.sh
+RUN chmod +x /tmp/download_and_validate_router.sh && /tmp/download_and_validate_router.sh
+
+# Lay out /dist exactly as the Debian image does, so that anything mounting
+# over /dist/config/router.yaml or /dist/schema keeps working across flavors.
+COPY router.yaml /dist/config/router.yaml
+RUN mkdir -p /dist/schema
+
+# Give this image the same `router` user (uid/gid 1000) that the Debian image
+# creates with `useradd`, so that swapping flavors doesn't change the ownership
+# of files written to mounted volumes, and doesn't invalidate a `runAsUser` or
+# `fsGroup` pinned to 1000.
+COPY --from=base /etc/passwd /etc/group /staging/etc/
+RUN \
+  echo 'router:x:1000:1000::/home/router:/sbin/nologin' >> /staging/etc/passwd \
+  && echo 'router:x:1000:' >> /staging/etc/group \
+  && mkdir -p /staging/home/router
+
+FROM base AS distro
+ARG REPO_URL=https://github.com/apollographql/router
+ARG BASE_VERSION
+
+COPY --from=downloader /staging/etc/passwd /staging/etc/group /etc/
+COPY --from=downloader --chown=1000:1000 /staging/home/router /home/router
+COPY --from=downloader /dist /dist
+
+LABEL org.opencontainers.image.authors="Apollo Graph, Inc. ${REPO_URL}"
+LABEL org.opencontainers.image.source="${REPO_URL}"
+LABEL org.opencontainers.image.version="${BASE_VERSION}"
+
+ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
+
+WORKDIR /dist
+
+# The `router` user added above
+USER 1000:1000
+
+ENTRYPOINT ["/dist/router"]

--- a/dockerfiles/verify_distroless_image.sh
+++ b/dockerfiles/verify_distroless_image.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# Smoke-test a built distroless Router image (see Dockerfile.router.distroless).
+#
+# The distroless image has no shell and no package manager, so the usual ways of
+# poking at a container (`docker exec ... sh`, `--entrypoint=bash`) don't work,
+# and a missing shared library shows up as a hard dynamic-loader failure at
+# startup rather than as a warning. This script ensures that we don't ship a broken
+# image because of a new shared library dependency creeping in we weren't aware of.
+#
+# Usage:
+#   verify_distroless_image.sh <image-ref> [expected-version]
+#
+# Expects the image to already exist locally (e.g. after `docker buildx build
+# --load`) or to be pullable. `expected-version` is optional; when given, the
+# version the binary reports must contain it.
+#
+# Everything here goes through the Docker API only because in CI this runs against
+# CircleCI's `setup_remote_docker` daemon, which has its own filesystem and its
+# own network. Fixtures reach the container over `docker cp`, and readiness is
+# read back out of the container's logs.
+
+set -euo pipefail
+
+IMAGE="${1:-}"
+EXPECTED_VERSION="${2:-}"
+
+if [ -z "${IMAGE}" ]; then
+    echo "Usage: $0 <image-ref> [expected-version]" >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SUPERGRAPH="${REPO_ROOT}/examples/graphql/supergraph.graphql"
+
+if [ ! -f "${SUPERGRAPH}" ]; then
+    echo "Error: supergraph fixture not found at ${SUPERGRAPH}" >&2
+    exit 1
+fi
+
+STARTUP_TIMEOUT_SECONDS="${STARTUP_TIMEOUT_SECONDS:-120}"
+READY_LOG_MESSAGE="GraphQL endpoint exposed"
+# The uid the router image runs as
+EXPECTED_UID=1000
+
+WORK_DIR="$(mktemp -d)"
+CONTAINER=""
+PROBE=""
+PRINT_LOGS=false
+
+cleanup () {
+    if [ -n "${CONTAINER}" ]; then
+        if [ "${PRINT_LOGS}" = "true" ]; then
+            echo "--- router container logs ---"
+            docker logs "${CONTAINER}" 2>&1 || true
+            echo "--- end router container logs ---"
+        fi
+        docker rm -f "${CONTAINER}" > /dev/null 2>&1 || true
+    fi
+    if [ -n "${PROBE}" ]; then
+        docker rm -f "${PROBE}" > /dev/null 2>&1 || true
+    fi
+    rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+fail () {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+echo "Verifying distroless image: ${IMAGE}"
+
+###
+# 1. The binary runs at all.
+#
+# This is the check that would have caught the zlib blocker: an unsatisfied
+# NEEDED entry makes the dynamic loader abort before main(), so `--version`
+# failing is how a shared library missing from the base image announces itself.
+###
+echo "==> Checking the Router binary executes"
+if ! VERSION_OUTPUT="$(docker run --rm "${IMAGE}" --version 2>&1)"; then
+    echo "${VERSION_OUTPUT}" >&2
+    fail "the Router binary did not run. If the output above mentions a missing .so, the distroless base is short a library the binary needs"
+fi
+echo "    ${VERSION_OUTPUT}"
+
+if [ -n "${EXPECTED_VERSION}" ]; then
+    case "${VERSION_OUTPUT}" in
+        *"${EXPECTED_VERSION}"*) ;;
+        *) fail "expected the reported version to contain '${EXPECTED_VERSION}', got: ${VERSION_OUTPUT}" ;;
+    esac
+fi
+
+# A created-but-never-started container is a read-only view of the image's
+# filesystem that `docker cp` can pull files out of. It needs a command to be
+# created at all, hence `--version`; nothing ever executes it.
+PROBE="$(docker create "${IMAGE}" --version)"
+
+###
+# 2. The image really is distroless.
+#
+# If a shell shows up in here, either the base image changed or somebody
+# switched to a `:debug` distroless tag, and the smaller-attack-surface claim
+# we make in the docs stops being true.
+###
+echo "==> Checking no shell is present"
+for shell in /bin/sh /bin/bash /bin/dash /bin/ash /bin/busybox /busybox/sh /usr/bin/sh /usr/bin/bash; do
+    if docker cp "${PROBE}:${shell}" - > /dev/null 2>&1; then
+        fail "${shell} exists in the image; this is supposed to be a distroless build"
+    fi
+done
+
+###
+# 3. It runs as the same non-root user as the Debian image.
+#
+# Not just "non-root". The uid is part of the flavors' compatibility promise,
+# because it decides the ownership of anything written to a mounted volume and
+# whether a `runAsUser`/`fsGroup` pinned to 1000 still lines up. The distroless
+# base defaults to its own `nonroot` uid (65532), so this also catches the USER
+# line being dropped and the base's default silently taking over.
+###
+echo "==> Checking the image runs as uid ${EXPECTED_UID}"
+IMAGE_USER="$(docker inspect --format '{{.Config.User}}' "${IMAGE}")"
+case "${IMAGE_USER}" in
+    "${EXPECTED_UID}"|"${EXPECTED_UID}:${EXPECTED_UID}") ;;
+    *) fail "image user is '${IMAGE_USER}'; expected uid ${EXPECTED_UID}, to match the Debian image" ;;
+esac
+echo "    user: ${IMAGE_USER}"
+
+# Docker resolves HOME from /etc/passwd, so a uid with no entry there gets a
+# different environment than the Debian image gives the Router.
+echo "==> Checking uid ${EXPECTED_UID} has an /etc/passwd entry"
+PASSWD_CONTENTS="$(docker cp "${PROBE}:/etc/passwd" - | tar -xO)"
+if ! PASSWD_ENTRY="$(printf '%s\n' "${PASSWD_CONTENTS}" | grep ":x:${EXPECTED_UID}:")"; then
+    fail "no /etc/passwd entry for uid ${EXPECTED_UID}; HOME would not resolve the way it does on the Debian image"
+fi
+echo "    ${PASSWD_ENTRY}"
+
+###
+# 4. It boots and serves.
+#
+# The fixtures go in with `docker cp` into a created-but-not-started container
+# rather than with a bind mount, because bind mounts read from the daemon's
+# filesystem and the daemon here may be remote. `docker cp` also fails loudly
+# if /dist/config and /dist/schema aren't there, which is what the
+# containerization docs tell users to mount over.
+###
+echo "==> Booting the Router and waiting for it to serve GraphQL"
+cp "${SUPERGRAPH}" "${WORK_DIR}/supergraph.graphql"
+cat > "${WORK_DIR}/router.yaml" <<'EOF'
+supergraph:
+  listen: 0.0.0.0:4000
+EOF
+
+CONTAINER="$(docker create "${IMAGE}" --supergraph /dist/schema/supergraph.graphql)"
+docker cp "${WORK_DIR}/router.yaml" "${CONTAINER}:/dist/config/router.yaml"
+docker cp "${WORK_DIR}/supergraph.graphql" "${CONTAINER}:/dist/schema/supergraph.graphql"
+docker start "${CONTAINER}" > /dev/null
+
+DEADLINE=$((SECONDS + STARTUP_TIMEOUT_SECONDS))
+READY=false
+while [ "${SECONDS}" -lt "${DEADLINE}" ]; do
+    if docker logs "${CONTAINER}" 2>&1 | grep -q "${READY_LOG_MESSAGE}"; then
+        READY=true
+        break
+    fi
+    if [ "$(docker inspect --format '{{.State.Running}}' "${CONTAINER}")" != "true" ]; then
+        PRINT_LOGS=true
+        fail "the container exited before serving GraphQL"
+    fi
+    sleep 1
+done
+
+if [ "${READY}" != "true" ]; then
+    PRINT_LOGS=true
+    fail "the Router did not report '${READY_LOG_MESSAGE}' within ${STARTUP_TIMEOUT_SECONDS}s"
+fi
+echo "    ${READY_LOG_MESSAGE}"
+
+IMAGE_SIZE="$(docker image inspect --format '{{.Size}}' "${IMAGE}")"
+echo "==> OK: ${IMAGE} ($((IMAGE_SIZE / 1024 / 1024)) MiB)"

--- a/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
@@ -9,6 +9,7 @@ import ElasticNotice from '../../../../shared/elastic-notice.mdx';
 This guide provides the following examples of running an Apollo Router container image in Docker:
 
 * Running a basic example with default configuration.
+* Choosing between the published image flavors.
 * Customizing your configuration to override the default configuration.
 * Debugging your containerized router.
 * Manually specifying a supergraph for your router.
@@ -60,6 +61,26 @@ services:
 Whether you use `docker run` or `docker compose`, make sure to replace `<router-image-version>` with whichever version you want to use, and `<your-graph-ref>` and `<your-graph-api-key>` with your graph reference and API key, respectively.
 
 For more complex configurations, such as overriding subgraph URLs or propagating headers, see [Router Configuration](/graphos/routing/configuration/overview/).
+
+## Image flavors
+
+Every router release publishes the same router binary in three image flavors, which differ only in their base image:
+
+| Tag | Base image | When to use it |
+| --- | --- | --- |
+| `<image version>` | `debian:bookworm-slim` | The default. Includes a shell and a package manager. |
+| `<image version>-distroless` | [`distroless/cc`](https://github.com/GoogleContainerTools/distroless) | For deployments that want a smaller attack surface. About half the size of the Debian image, with no shell, package manager, or other userland. |
+| `<image version>-debug` | `debian:bookworm-slim` | For investigating memory usage. Runs the router under heaptrack, as described in [Running the debug container](#running-the-debug-container-to-investigate-memory-issues). |
+
+Configuration, environment variables, command-line arguments, and the paths you mount over (`/dist/config/router.yaml` and `/dist/schema`) are the same in all three, and all three run as the `router` user (uid and gid `1000`), so switching between the images requires only changing the tag.
+
+### What the distroless image doesn't have
+
+A distroless image contains the router, the shared libraries it links against, CA certificates, and time zone data, and nothing else. As a result:
+
+* There is no shell, so the [debugging techniques](#debugging-your-container) that rely on one (`--entrypoint=bash`, `docker exec <container> sh`) have nothing to run. Reproduce the problem with the Debian image when you need to look around inside a container.
+* Container probes that shell out, such as a Kubernetes `exec` probe running `curl`, won't work. Use the router's [HTTP health check endpoint](/graphos/routing/self-hosted/health-checks) with an `httpGet` probe instead.
+* There is no distroless equivalent of the `-debug` flavor, because heaptrack and its tooling need a userland to run in.
 
 ## Override the configuration
 


### PR DESCRIPTION
This provides an option for customers that want a smaller install/attack
surface in their container.

<!-- start metadata -->

<!-- [ROUTER-1954] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [x] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-1954]: https://apollographql.atlassian.net/browse/ROUTER-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ