### PR TITLE
Automate release-candidate tagging and converge workflow names on the 2.16.x line

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,19 +1,15 @@
 # Auto-tag a release after the version branch merges to main / main-v*.
 #
-# Sandbox naming convention while we're still validating the logic on
-# real release merges.  Once we've seen a few clean dry-runs, this gets
-# renamed to `auto-tag-release.yml` and the dry-run guard comes out.
-#
 # Two trigger paths:
 #
-#   - `push: branches: [main, 'main-v*']` — fires automatically on every
-#     merge to a release line's main branch.  Always dry-run.  Logs the
-#     decision; does not push the tag.  Use this output to confirm the
-#     workflow picks the right SHA + version before we flip the switch.
+#   - `push: branches: [main, 'main-v*']` — fires on every merge to a
+#     release line's main branch and pushes the tag.  The version gate
+#     below means an ordinary merge that doesn't change the version is a
+#     no-op, so this only acts on an actual release.
 #
-#   - `workflow_dispatch` with `dry_run` input (default `true`).  Set to
-#     `false` to actually push the tag.  Use this when the push-triggered
-#     dry-run printed the right answer and you want to commit to it.
+#   - `workflow_dispatch` with `dry_run` input (default `true`).  Use it
+#     to preview the decision, or with `dry_run=false` to tag a merge that
+#     the push trigger didn't act on.
 #
 # Safety properties:
 #
@@ -30,7 +26,7 @@
 #   - PAT scoped: uses `APOLLO_BOT2_GITHUB_PAT` so the tag is attributed
 #     to apollo-bot2 and bypasses tag-creation rules.
 
-name: Test auto-tag release
+name: "Release: auto-tag"
 
 on:
   push:
@@ -58,9 +54,9 @@ jobs:
           fetch-depth: 0
           # Use apollo-bot2's PAT so the tag push is attributed to bot2
           # (not github-actions[bot]) and bypasses tag-creation rules.
-          # Falls back to the workflow token when the secret isn't set
-          # so push-trigger dry-runs still work in forks / unconfigured
-          # environments.
+          # Falls back to the workflow token when the secret isn't set,
+          # which is enough to reach the dry-run summary in a fork; an
+          # actual tag push needs the PAT and fails without it.
           token: ${{ secrets.APOLLO_BOT2_GITHUB_PAT || github.token }}
 
       - name: Resolve dry-run mode
@@ -70,9 +66,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             DRY_RUN='${{ inputs.dry_run }}'
           else
-            # Push trigger is always dry-run.  To actually push the tag,
-            # use workflow_dispatch with dry_run=false.
-            DRY_RUN=true
+            DRY_RUN=false
           fi
           echo "Resolved dry_run=$DRY_RUN"
           echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
@@ -150,7 +144,7 @@ jobs:
           echo "::endgroup::"
           echo
           echo "To execute for real:"
-          echo "  gh workflow run test-auto-tag-release.yml --ref ${{ github.ref_name }} -f dry_run=false"
+          echo "  gh workflow run auto-tag-release.yml --ref ${{ github.ref_name }} -f dry_run=false"
 
       - name: Push tag
         if: steps.target.outputs.skip != 'true' && steps.vars.outputs.dry_run != 'true'

--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -1,5 +1,5 @@
 # Test workflow — exercises `cargo xtask release new` on a GitHub Actions
-# runner.  Same shape as `test-release-prep.yml`: side-branch sandbox now,
+# runner.  Same shape as `release-prep.yml`: side-branch sandbox now,
 # graduates to `release-dispatch-new.yml` on the default branch later.
 #
 # Two trigger paths:
@@ -27,7 +27,7 @@
 # and open the draft release PR.  workflow_dispatch defaults dry_run to
 # true.
 
-name: Test release new
+name: "Release: new"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -16,7 +16,7 @@
 # Defaults to **dry-run**: prepares, diffs, logs auto-tag would-do — does
 # not commit, push, or open a PR unless explicitly opted in.
 
-name: Test release prep
+name: "Release: prep"
 
 on:
   workflow_dispatch:
@@ -366,7 +366,7 @@ jobs:
           >  - Version bumps (see _Files Changed_ for the true reality)
           >  - That it targets the right release branch (\`$VERSION\` in this case!)
           >
-          > Opened automatically by the \`test-release-prep\` workflow.
+          > Opened automatically by the \`release-prep\` workflow.
           EOF
           )
           gh pr create \

--- a/.github/workflows/test-release-prep.yml
+++ b/.github/workflows/test-release-prep.yml
@@ -200,6 +200,7 @@ jobs:
       # For now: log what auto-tag WOULD do, including the exact commit SHA.
       # ---------------------------------------------------------------------
       - name: Log what auto-tag would do (including exact SHA)
+        if: steps.vars.outputs.pre_release != 'true'
         run: |
           set -euo pipefail
           VERSION='${{ steps.vars.outputs.version }}'
@@ -281,16 +282,22 @@ jobs:
       # `git push` and the token is left out of any persistent config.
       # =====================================================================
 
-      - name: Commit prep on the dispatched branch (pre-release)
+      - name: Commit and tag prep on the dispatched branch (pre-release)
         if: steps.vars.outputs.dry_run != 'true' && steps.vars.outputs.pre_release == 'true'
         run: |
           set -euo pipefail
+          VERSION='${{ steps.vars.outputs.version }}'
           git config user.name "apollo-bot2"
           git config user.email "apollo-bot2@users.noreply.github.com"
           git add -A
-          git commit -m "prep release: v${{ steps.vars.outputs.version }}"
+          git commit -m "prep release: v$VERSION"
+          git tag --annotate --message "$VERSION" "v$VERSION" HEAD
 
-      - name: Push prep commit directly to ${{ github.ref_name }} (pre-release)
+      # Tag and commit go up in one atomic push: the tag is what triggers
+      # CircleCI to build the release, so it must never land without the
+      # commit it points at (or vice versa).  A re-run of an already-cut
+      # version is rejected here, leaving nothing behind to clean up.
+      - name: Push prep commit and tag to ${{ github.ref_name }} (pre-release)
         if: steps.vars.outputs.dry_run != 'true' && steps.vars.outputs.pre_release == 'true'
         env:
           APOLLO_BOT2_GITHUB_PAT: ${{ secrets.APOLLO_BOT2_GITHUB_PAT }}
@@ -300,12 +307,14 @@ jobs:
             echo "::error::APOLLO_BOT2_GITHUB_PAT secret is required to push to a protected release branch."
             exit 1
           fi
+          TAG="v${{ steps.vars.outputs.version }}"
           # PAT-bearing URL only used for this single push command — never
           # persisted into the local repo's git config.
-          git push \
+          git push --atomic \
             "https://x-access-token:${APOLLO_BOT2_GITHUB_PAT}@github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/tags/$TAG" \
             "HEAD:${GITHUB_REF_NAME}"
-          echo "Pushed prep commit directly to ${GITHUB_REF_NAME} as apollo-bot2."
+          echo "::notice::Pushed $TAG at $(git rev-parse HEAD) and updated ${GITHUB_REF_NAME}."
 
       # =====================================================================
       # Final-release path: existing fresh-branch + open-PR flow.  Reviewers
@@ -372,7 +381,8 @@ jobs:
           if [ '${{ steps.vars.outputs.dry_run }}' = 'true' ]; then
             echo "Dry-run complete.  No commit, push, or PR."
           elif [ '${{ steps.vars.outputs.pre_release }}' = 'true' ]; then
-            echo "Pre-release prep pushed directly to ${GITHUB_REF_NAME} as apollo-bot2."
+            echo "Pre-release prep pushed to ${GITHUB_REF_NAME} and tagged v${{ steps.vars.outputs.version }} as apollo-bot2."
+            echo "CircleCI builds the release from that tag; it appears in GitHub Releases when that finishes."
           else
             echo "Prep PR opened from $PREP_BRANCH into ${{ steps.vars.outputs.version }}."
           fi


### PR DESCRIPTION
With this change, an RC can be cut on the `2.16.x` line with automation, using CI-driven workflows — and the final release gets tagged automatically when it merges. The beginning and end of the release are covered; what's left in the middle is the release-notes extraction, which already has a solution on the tip line and is called out below.

Three things here.

**Tagging release candidates** (backport of #10064). The prep commit is tagged in the same job, and the tag and commit go up in a single atomic push so one can't land without the other. Re-running an already-cut version is rejected by that push, leaving nothing behind to clean up. The prep workflow itself has 22 successful runs behind it and has cut real pre-releases on this line already, most recently `v2.16.2-rc.1` — the only change is that it now finishes the job instead of stopping one step short, so I'd expect this to just work.

**Converging on the same workflow filenames as the tip line.** These three kept their sandbox `test-` names while the tip line graduated to the real ones, which left the same tooling living under two sets of filenames and made every backport a rename to resolve by hand. Renaming them means the two lines share paths, so future backports are ordinary cherry-picks. Their display names also pick up the quoting the tip line turned out to need — an unquoted plain scalar can't contain `": "`, and without quotes GitHub can't parse the file at all, so these use `name: "Release: prep"` rather than the tip's current unquoted form. Three references to the old filenames are updated to match, including the prep PR body and the auto-tag summary, which both named workflows that no longer exist under those names.

**Auto-tagging the final release.** `auto-tag-release.yml` now pushes the tag on its `push` trigger rather than only logging what it would do. It has decided the right thing on the last eight release merges, from `v2.14.1` through `v2.16.2` — the version gate keeps it a no-op on any merge that doesn't change `apollo-router`'s version, and it refuses to move a tag that already exists at a different commit. Where it has failed, it has failed by refusing and exiting non-zero without pushing, which is the direction you want from a tagger. It'll be nice when the ceremonious merging of the release PR actually just puts the release up.

## Deliberately not here

- **Release notes.** `cargo xtask release notes` doesn't exist on this line (no `notes.rs`) and `.circleci/config.yml` has no step calling it, so populating a GitHub Release body is still the `perl` extraction from `RELEASE_CHECKLIST.md`.  The tip line's copy skips pre-releases anyway, so this only ever mattered for finals — and it's more than we need today.
- **A reconcile trigger.** `cargo xtask release reconcile` is present and complete, but nothing calls it, so it stays a command to remember after the release lands. Practically the least finished of the three, so it's the one I'd least want to backport untested.

No changeset as nothing user-facing.
