### PR TITLE
fix: close field-drop-order race in subscription pubsub closing signal

### DIFF
--- a/.changesets/fix_zach_subscription_closing_signal_race.md
+++ b/.changesets/fix_zach_subscription_closing_signal_race.md
@@ -1,0 +1,7 @@
+### Fix a race that could leave subscription reconnect/forwarding tasks hung after all clients disconnect
+
+When every client of a router-side subgraph subscription disconnected, the pubsub notification system was supposed to detect that no receivers were left and send a "closing" signal to tear down the subscription's forwarding task. Because of struct field drop order, the "a client unsubscribed" notification could be sent to the pubsub task *before* the broadcast receiver it depended on was actually dropped and its count decremented. Under real concurrent scheduling, the pubsub task could process that notification while still seeing a live receiver, conclude a subscriber was still present, and never send the closing signal — leaving the forwarding task hung indefinitely (e.g. sleeping out a reconnect delay, or stuck on a subgraph's reconnect handshake) instead of shutting down.
+
+`Handle` and `HandleStream` in the subscription notification module now drop their broadcast receiver before the guard that sends the unsubscribe notification, closing the race.
+
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/PULL_NUMBER

--- a/.changesets/fix_zach_subscription_closing_signal_race.md
+++ b/.changesets/fix_zach_subscription_closing_signal_race.md
@@ -1,7 +1,5 @@
-### Fix a race that could leave subscription reconnect/forwarding tasks hung after all clients disconnect
+### Fix a subscription cleanup race that could leave stale subgraph connections and background tasks running
 
-When every client of a router-side subgraph subscription disconnected, the pubsub notification system was supposed to detect that no receivers were left and send a "closing" signal to tear down the subscription's forwarding task. Because of struct field drop order, the "a client unsubscribed" notification could be sent to the pubsub task *before* the broadcast receiver it depended on was actually dropped and its count decremented. Under real concurrent scheduling, the pubsub task could process that notification while still seeing a live receiver, conclude a subscriber was still present, and never send the closing signal — leaving the forwarding task hung indefinitely (e.g. sleeping out a reconnect delay, or stuck on a subgraph's reconnect handshake) instead of shutting down.
-
-`Handle` and `HandleStream` in the subscription notification module now drop their broadcast receiver before the guard that sends the unsubscribe notification, closing the race.
+When every client of a router-side subscription disconnected, a race condition could occasionally prevent the router from noticing, so it never tore down the corresponding subgraph connection. The subgraph-facing task would keep running in the background — retrying its reconnect delay or handshake — even though no client was left to receive events, until some other event eventually cleaned it up.
 
 By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/10061

--- a/.changesets/fix_zach_subscription_closing_signal_race.md
+++ b/.changesets/fix_zach_subscription_closing_signal_race.md
@@ -4,4 +4,4 @@ When every client of a router-side subgraph subscription disconnected, the pubsu
 
 `Handle` and `HandleStream` in the subscription notification module now drop their broadcast receiver before the guard that sends the unsubscribe notification, closing the race.
 
-By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/PULL_NUMBER
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/10061

--- a/.changesets/fix_zach_subscription_closing_signal_race.md
+++ b/.changesets/fix_zach_subscription_closing_signal_race.md
@@ -2,4 +2,4 @@
 
 When every client of a router-side subscription disconnected, a race condition could occasionally prevent the router from noticing, so it never tore down the corresponding subgraph connection. The subgraph-facing task would keep running in the background — retrying its reconnect delay or handshake — even though no client was left to receive events, until some other event eventually cleaned it up.
 
-By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/10061
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/10075

--- a/apollo-federation/src/composition/satisfiability.rs
+++ b/apollo-federation/src/composition/satisfiability.rs
@@ -31,7 +31,7 @@ pub fn validate_satisfiability(
 ) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
     let supergraph_schema = supergraph.schema().clone();
     let mut errors = vec![];
-    let mut hints = supergraph.hints_mut().drain(..).collect();
+    let mut hints = std::mem::take(supergraph.hints_mut());
     if let Err(e) = validate_satisfiability_inner(supergraph, options, &mut errors, &mut hints) {
         return Err(CompositionFailure {
             errors: vec![CompositionError::InternalError {

--- a/apollo-router/src/plugins/subscription/notification.rs
+++ b/apollo-router/src/plugins/subscription/notification.rs
@@ -487,11 +487,15 @@ pub struct Handle<K, V>
 where
     K: Clone,
 {
-    handle_guard: HandleGuard<K, V>,
     #[pin]
     msg_sender: broadcast::Sender<Option<V>>,
+    // Must be dropped before `handle_guard`: dropping `handle_guard` sends an
+    // async Unsubscribe notification, and the pubsub task only honors it once
+    // `receiver_count()` has already hit zero. Field drop order is declaration
+    // order, so this receiver has to be declared (and thus dropped) first.
     #[pin]
     msg_receiver: BroadcastStream<Option<V>>,
+    handle_guard: HandleGuard<K, V>,
 }
 }
 
@@ -563,9 +567,13 @@ pub struct HandleStream<K, V>
 where
     K: Clone,
 {
-    handle_guard: HandleGuard<K, V>,
+    // Must be dropped before `handle_guard`: dropping `handle_guard` sends an
+    // async Unsubscribe notification, and the pubsub task only honors it once
+    // `receiver_count()` has already hit zero. Field drop order is declaration
+    // order, so this receiver has to be declared (and thus dropped) first.
     #[pin]
     msg_receiver: BroadcastStream<Option<V>>,
+    handle_guard: HandleGuard<K, V>,
 }
 }
 


### PR DESCRIPTION
## Summary
- Retargets #10061 from `dev-v3.x` to `dev` (that branch had diverged too far to simply change the PR base).
- `Handle` and `HandleStream` dropped their `handle_guard` (which async-sends an `Unsubscribe` notification) before their `msg_receiver`, so the pubsub task could see a stale `receiver_count()` and never emit the closing signal — hanging the subscription forwarding task and causing flaky test timeouts in `test_websocket_reconnect_closing_signal_during_delay`/`handshake`.

## Test plan
- [ ] `cargo nextest run -p apollo-router subscription` passes reliably (previously flaky)