### PR TITLE
fix: address new lint warnings due to #9851

### DIFF
--- a/apollo-federation/src/composition/satisfiability.rs
+++ b/apollo-federation/src/composition/satisfiability.rs
@@ -31,7 +31,7 @@ pub fn validate_satisfiability(
 ) -> Result<Supergraph<Satisfiable>, CompositionFailure> {
     let supergraph_schema = supergraph.schema().clone();
     let mut errors = vec![];
-    let mut hints = supergraph.hints_mut().drain(..).collect();
+    let mut hints = std::mem::take(supergraph.hints_mut());
     if let Err(e) = validate_satisfiability_inner(supergraph, options, &mut errors, &mut hints) {
         return Err(CompositionFailure {
             errors: vec![CompositionError::InternalError {

--- a/apollo-federation/tests/composition/compose_directive.rs
+++ b/apollo-federation/tests/composition/compose_directive.rs
@@ -185,9 +185,7 @@ mod federation_directives {
         assert_eq!(hint.code(), "DIRECTIVE_COMPOSITION_INFO");
         assert_eq!(
             hint.message,
-            format!(
-                "Directive \"@apolloDirective\" should not be explicitly manually composed since it is a federation directive composed by default"
-            )
+            "Directive \"@apolloDirective\" should not be explicitly manually composed since it is a federation directive composed by default".to_string()
         );
     }
 
@@ -267,9 +265,7 @@ mod federation_directives {
         );
         assert_eq!(
             error.to_string(),
-            format!(
-                "Composing federation directive \"@apolloDirective\" in subgraph \"subgraphA\" is not supported"
-            )
+            "Composing federation directive \"@apolloDirective\" in subgraph \"subgraphA\" is not supported".to_string()
         );
     }
 

--- a/apollo-router/src/axum_factory/compression.rs
+++ b/apollo-router/src/axum_factory/compression.rs
@@ -168,7 +168,6 @@ mod tests {
     use async_compression::tokio::write::DeflateDecoder;
     use async_compression::tokio::write::GzipDecoder;
     use async_compression::tokio::write::ZstdDecoder;
-    use futures::StreamExt as _;
     use futures::stream;
     use rand::RngExt as _;
     use rstest::rstest;

--- a/apollo-router/src/plugins/subscription/execution.rs
+++ b/apollo-router/src/plugins/subscription/execution.rs
@@ -357,7 +357,7 @@ async fn dispatch_subscription_event(
     context: Context,
     mut val: graphql::Response,
     sender: mpsc::Sender<Response>,
-) -> Result<(), SendError<Response>> {
+) -> Result<(), SendError<Box<Response>>> {
     let start = Instant::now();
     let span = Span::current();
     let res = match query_plan {
@@ -395,12 +395,18 @@ async fn dispatch_subscription_event(
                 val.errors.append(&mut next_response.errors);
                 next_response.errors = val.errors;
 
-                sender.send(next_response).await
+                sender
+                    .send(next_response)
+                    .await
+                    .map_err(|SendError(unboxed)| SendError(Box::new(unboxed)))
             } else {
                 Ok(())
             }
         }
-        None => sender.send(val).await,
+        None => sender
+            .send(val)
+            .await
+            .map_err(|SendError(unboxed)| SendError(Box::new(unboxed))),
     };
     span.record(
         APOLLO_PRIVATE_DURATION_NS,

--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -187,6 +187,7 @@ impl ApolloExporter {
         Sender::Apollo(tx)
     }
 
+    #[expect(clippy::result_large_err, reason = "error can return the input report")]
     pub(crate) async fn submit_report(&self, report: Report) -> Result<(), ApolloExportError> {
         // We may be sending traces but with no operation count
         if report.licensed_operation_count_by_type.is_empty() && report.traces_per_query.is_empty()

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1528,10 +1528,9 @@ impl Telemetry {
                                                 start.elapsed(),
                                                 operation_kind,
                                                 Some(OperationSubType::SubscriptionRequest),
-                                                local_stat_recorder
-                                                    .local_type_stats
-                                                    .drain()
-                                                    .collect(),
+                                                std::mem::take(
+                                                    &mut local_stat_recorder.local_type_stats,
+                                                ),
                                                 enabled_features.clone(),
                                             );
                                         }
@@ -1548,7 +1547,9 @@ impl Telemetry {
                                                 .unwrap_or_else(|| start.elapsed()),
                                             operation_kind,
                                             Some(OperationSubType::SubscriptionEvent),
-                                            local_stat_recorder.local_type_stats.drain().collect(),
+                                            std::mem::take(
+                                                &mut local_stat_recorder.local_type_stats,
+                                            ),
                                             enabled_features.clone(),
                                         );
                                     }
@@ -1563,7 +1564,9 @@ impl Telemetry {
                                             start.elapsed(),
                                             operation_kind,
                                             None,
-                                            local_stat_recorder.local_type_stats.drain().collect(),
+                                            std::mem::take(
+                                                &mut local_stat_recorder.local_type_stats,
+                                            ),
                                             enabled_features.clone(),
                                         );
                                     }

--- a/apollo-router/src/protocols/websocket.rs
+++ b/apollo-router/src/protocols/websocket.rs
@@ -297,6 +297,10 @@ where
         + std::marker::Send
         + 'static,
 {
+    #[expect(
+        clippy::result_large_err,
+        reason = "in practice the generic Self and error are not significantly different in size"
+    )]
     pub(crate) async fn new(
         mut stream: S,
         id: String,
@@ -359,6 +363,10 @@ where
         })
     }
 
+    #[expect(
+        clippy::result_large_err,
+        reason = "function is infrequently used, ergonomics more important"
+    )]
     pub(crate) async fn into_subscription(
         mut self,
         request: graphql::Request,

--- a/apollo-router/src/services/execution/service.rs
+++ b/apollo-router/src/services/execution/service.rs
@@ -555,6 +555,7 @@ fn filter_stream(
 ) -> ReceiverStream<Response> {
     let (mut sender, receiver) = mpsc::channel(10);
 
+    // XXX(@goto-bus-stop): we ignore the error here, doesn't seem great?
     tokio::task::spawn(async move {
         let mut seen_last_message =
             consume_responses(first, &mut stream, &mut sender, stream_mode).await?;
@@ -571,10 +572,10 @@ fn filter_stream(
                 StreamMode::Defer => Response::builder().has_next(false).build(),
                 StreamMode::Subscription => Response::builder().subscribed(false).build(),
             };
-            sender.send(res).await?;
+            sender.send(res).await.map_err(|_| SendError(()))?;
         }
 
-        Ok::<_, SendError<Response>>(())
+        Ok::<_, SendError<()>>(())
     });
 
     receiver.into()
@@ -586,7 +587,7 @@ async fn consume_responses(
     stream: &mut Receiver<Response>,
     sender: &mut Sender<Response>,
     stream_mode: StreamMode,
-) -> Result<bool, SendError<Response>> {
+) -> Result<bool, SendError<()>> {
     loop {
         match stream.try_recv() {
             Err(err) => {
@@ -594,7 +595,10 @@ async fn consume_responses(
                     // no messages available, but the channel is not closed
                     // this means more deferred responses can come
                     TryRecvError::Empty => {
-                        sender.send(current_response).await?;
+                        sender
+                            .send(current_response)
+                            .await
+                            .map_err(|_| SendError(()))?;
                         return Ok(false);
                     }
                     // the channel is closed
@@ -606,7 +610,10 @@ async fn consume_responses(
                             StreamMode::Subscription => current_response.subscribed = Some(false),
                         }
 
-                        sender.send(current_response).await?;
+                        sender
+                            .send(current_response)
+                            .await
+                            .map_err(|_| SendError(()))?;
                         return Ok(true);
                     }
                 }
@@ -614,7 +621,10 @@ async fn consume_responses(
             // there might be other deferred responses after this one,
             // so we should call `try_next` again
             Ok(response) => {
-                sender.send(current_response).await?;
+                sender
+                    .send(current_response)
+                    .await
+                    .map_err(|_| SendError(()))?;
                 current_response = response;
             }
         }

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -90,6 +90,7 @@ impl APQLayer {
     /// This functions similarly to a checkpoint service, short-circuiting the pipeline on error
     /// (using an `Err()` return value).
     /// The user of this function is responsible for propagating short-circuiting.
+    #[expect(clippy::result_large_err, reason = "err is smaller than ok")]
     pub(crate) async fn supergraph_request(
         &self,
         request: SupergraphRequest,
@@ -110,6 +111,7 @@ impl APQLayer {
 /// If the request contains only a hash, attempts to read the query from the APQ cache, and
 /// populates the query string in the request body.
 /// The request is rejected if the hash is not present in the cache.
+#[expect(clippy::result_large_err, reason = "err is smaller than ok")]
 async fn apq_request(
     cache: &DeduplicatingCache<String, String>,
     mut request: SupergraphRequest,
@@ -205,6 +207,7 @@ pub(crate) fn calculate_hash_for_query(query: &str) -> String {
 }
 
 /// Used when APQ is disabled. Rejects requests that try to use a persisted query hash anyways.
+#[expect(clippy::result_large_err, reason = "err is smaller than ok")]
 async fn disabled_apq_request(
     request: SupergraphRequest,
 ) -> Result<SupergraphRequest, SupergraphResponse> {

--- a/apollo-router/src/services/layers/persisted_queries/mod.rs
+++ b/apollo-router/src/services/layers/persisted_queries/mod.rs
@@ -226,6 +226,7 @@ impl PersistedQueryLayer {
     /// This functions similarly to a checkpoint service, short-circuiting the pipeline on error
     /// (using an `Err()` return value).
     /// The user of this function is responsible for propagating short-circuiting.
+    #[expect(clippy::result_large_err, reason = "err is smaller than ok")]
     pub(crate) async fn supergraph_request_with_analyzed_query(
         &self,
         request: SupergraphRequest,

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -259,6 +259,7 @@ impl QueryAnalysisLayer {
     /// - authorization details (required scopes, policies), if any
     /// - [`Arc`]`<`[`UsageReporting`]`>` if there was an error; normally, this would be populated
     ///   by the caching query planner, but we do not reach that code if we fail early here.
+    #[expect(clippy::result_large_err, reason = "err is smaller than ok")]
     pub(crate) async fn supergraph_request(
         &self,
         request: SupergraphRequest,

--- a/xtask/src/commands/release/prepare.rs
+++ b/xtask/src/commands/release/prepare.rs
@@ -87,7 +87,7 @@ impl Prepare {
                 replace_in_file!(
                     "./helm/chart/router/values.yaml",
                     "^  repository: ghcr.io/apollographql/router$",
-                    format!("  repository: ghcr.io/apollographql/nightly/router")
+                    "  repository: ghcr.io/apollographql/nightly/router".to_string()
                 );
 
                 // Update the version string for nightly builds


### PR DESCRIPTION
I should have updated the #9851 branch before I merged it. Basically, these are changes that happened on `dev` _while_ the renovate PR was open, so after a merge the new rust lints took effect on code that wasn't ready for it.

To fix them, I ran:
```
cargo clippy --fix --workspace --examples --tests
```

Unblocks https://github.com/apollographql/router/pull/10075