### PR TITLE
chore: update codeowners `graphos` to `router-core` team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
-/apollo-federation/ @apollographql/orchestration-language @apollographql/graphos
-/apollo-router/ @apollographql/graphos
-/apollo-router/src/plugins/connectors @apollographql/orchestration-language @apollographql/graphos
-/apollo-router/src/plugins/fleet_detector.rs @apollographql/runtime-readiness @apollographql/graphos
-/apollo-router-benchmarks/ @apollographql/graphos @apollographql/orchestration-language
-/examples/ @apollographql/graphos
-/.github/CODEOWNERS @apollographql/graphos
+/apollo-federation/ @apollographql/orchestration-language @apollographql/router-core
+/apollo-router/ @apollographql/router-core
+/apollo-router/src/plugins/connectors @apollographql/orchestration-language @apollographql/router-core
+/apollo-router/src/plugins/fleet_detector.rs @apollographql/runtime-readiness @apollographql/router-core
+/apollo-router-benchmarks/ @apollographql/router-core @apollographql/orchestration-language
+/examples/ @apollographql/router-core
+/.github/CODEOWNERS @apollographql/router-core


### PR DESCRIPTION
This change updates the `@apollographql/graphos` team name used for code ownership reviews to the `@apollographql/router-core` team name.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
