### PR TITLE
refactor: split off explicit layers for `include_subgraph_errors` and `headers` plugins

### DIFF
--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -21,6 +21,7 @@ use crate::layers::map_future_with_request_data::MapFutureWithRequestDataService
 use crate::layers::rust_plugins::RustPluginsLayer;
 use crate::layers::unconstrained_buffer::UnconstrainedBufferLayer;
 use crate::plugin::DynPlugin;
+use crate::plugin::PluginPrivate;
 use crate::services::Plugins;
 use crate::services::supergraph;
 
@@ -417,6 +418,9 @@ pub trait ServiceExt<Request>: Service<Request> {
 }
 impl<T: ?Sized, Request> ServiceExt<Request> for T where T: Service<Request> {}
 
+/// Helper type to name layers produced by [`ServiceBuilder::option_layer()`].
+type OptionLayer<L> = tower::util::Either<L, tower::layer::util::Identity>;
+
 /// Extension to [`ServiceBuilder`] for pipeline utilities that are not exposed to crate consumers.
 pub(crate) trait InternalServiceBuilderExt<L>: Sized {
     /// Apply plugins to a service stack.
@@ -440,6 +444,29 @@ pub(crate) trait InternalServiceBuilderExt<L>: Sized {
             &dyn DynPlugin,
             tower::util::BoxCloneService<R, Resp, Err>,
         ) -> tower::util::BoxCloneService<R, Resp, Err>;
+
+    /// Apply a plugin layer to a service stack.
+    ///
+    /// Provide the plugin layer to apply as a method reference.
+    ///
+    /// If the plugin isn't available in the `plugins` registry, this function is a no-op.
+    ///
+    /// ## Example
+    ///
+    /// To apply the execution span layer from the Telemetry plugin:
+    ///
+    /// ```rust,ignore
+    /// ServiceBuilder::new()
+    ///     .apply_plugin_layer(plugins.clone(), Telemetry::execution_span_layer)
+    ///     .service(execution_service)
+    /// ```
+    fn apply_plugin_layer<P, OutLayer>(
+        self,
+        plugins: &Plugins,
+        get_layer: impl FnOnce(&P) -> OutLayer,
+    ) -> ServiceBuilder<Stack<OptionLayer<OutLayer>, L>>
+    where
+        P: PluginPrivate;
 }
 
 impl<L> InternalServiceBuilderExt<L> for ServiceBuilder<L> {
@@ -455,5 +482,20 @@ impl<L> InternalServiceBuilderExt<L> for ServiceBuilder<L> {
         ) -> tower::util::BoxCloneService<R, Resp, Err>,
     {
         self.layer(RustPluginsLayer::new(plugins, apply))
+    }
+
+    fn apply_plugin_layer<P, OutLayer>(
+        self,
+        plugins: &Plugins,
+        get_layer: impl FnOnce(&P) -> OutLayer,
+    ) -> ServiceBuilder<Stack<OptionLayer<OutLayer>, L>>
+    where
+        P: PluginPrivate,
+    {
+        let layer = plugins
+            .values()
+            .find_map(|plugin| plugin.as_any().downcast_ref::<P>())
+            .map(get_layer);
+        self.option_layer(layer)
     }
 }

--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -451,7 +451,7 @@ pub(crate) trait InternalServiceBuilderExt<L>: Sized {
     ///
     /// If the plugin isn't available in the `plugins` registry, this function is a no-op.
     /// For a plugin that `create_plugins` always registers, prefer
-    /// [`Self::apply_required_plugin_layer`], which reports the miss instead of silently
+    /// [`Self::apply_required_plugin_layer`], which panics on a miss instead of silently
     /// dropping the layer.
     ///
     /// ## Example
@@ -474,15 +474,8 @@ pub(crate) trait InternalServiceBuilderExt<L>: Sized {
     /// Apply the layer of a *mandatory* plugin to a service stack.
     ///
     /// Same as [`Self::apply_plugin_layer`], except that a missing plugin is treated as a
-    /// bug rather than a supported configuration: the miss is logged at `error` level
-    /// instead of quietly reducing the stack to a no-op. Several of these layers are
-    /// security-relevant -- losing `IncludeSubgraphErrors::redact_subgraph_errors_layer`
-    /// means every subgraph error reaches clients unredacted -- so a silent drop is the
-    /// worst possible failure mode.
-    ///
-    /// This deliberately does not panic. Test fixtures legitimately build pipelines from an
-    /// empty plugin registry, and those are not what this is guarding against, so a wholly
-    /// empty registry is not reported at all.
+    /// bug rather than a supported configuration: the miss panics instead of quietly
+    /// reducing the stack to a no-op.
     fn apply_required_plugin_layer<P, OutLayer>(
         self,
         plugins: &Plugins,
@@ -534,12 +527,41 @@ impl<L> InternalServiceBuilderExt<L> for ServiceBuilder<L> {
         P: PluginPrivate,
     {
         if find_plugin::<P>(plugins).is_none() && !plugins.is_empty() {
-            tracing::error!(
-                plugin = std::any::type_name::<P>(),
-                "mandatory plugin is missing from the plugin registry, so its layer will not \
-                 be applied to the pipeline; this is a router bug"
+            panic!(
+                "mandatory plugin {} is missing from the plugin registry, so its layer will not \
+                 be applied to the pipeline; this is a router bug",
+                std::any::type_name::<P>()
             );
         }
         self.apply_plugin_layer(plugins, get_layer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower::ServiceBuilder;
+
+    use super::InternalServiceBuilderExt;
+    use crate::plugins::headers::Headers;
+    use crate::services::Plugins;
+    use crate::test_harness::MockedSubgraphs;
+
+    #[test]
+    fn apply_required_plugin_layer_skips_empty_registry() {
+        let plugins = Plugins::default();
+        let _ = ServiceBuilder::new()
+            .apply_required_plugin_layer(&plugins, Headers::router_masking_layer);
+    }
+
+    #[test]
+    #[should_panic(expected = "mandatory plugin")]
+    fn apply_required_plugin_layer_panics_when_mandatory_plugin_is_missing() {
+        let mut plugins = Plugins::default();
+        plugins.insert(
+            "unrelated".to_string(),
+            Box::new(MockedSubgraphs::default()),
+        );
+        let _ = ServiceBuilder::new()
+            .apply_required_plugin_layer(&plugins, Headers::router_masking_layer);
     }
 }

--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -450,15 +450,18 @@ pub(crate) trait InternalServiceBuilderExt<L>: Sized {
     /// Provide the plugin layer to apply as a method reference.
     ///
     /// If the plugin isn't available in the `plugins` registry, this function is a no-op.
+    /// For a plugin that `create_plugins` always registers, prefer
+    /// [`Self::apply_required_plugin_layer`], which reports the miss instead of silently
+    /// dropping the layer.
     ///
     /// ## Example
     ///
-    /// To apply the execution span layer from the Telemetry plugin:
+    /// To apply the masking-context layer from the Headers plugin:
     ///
     /// ```rust,ignore
     /// ServiceBuilder::new()
-    ///     .apply_plugin_layer(plugins.clone(), Telemetry::execution_span_layer)
-    ///     .service(execution_service)
+    ///     .apply_plugin_layer(&plugins, Headers::router_masking_layer)
+    ///     .service(router_service)
     /// ```
     fn apply_plugin_layer<P, OutLayer>(
         self,
@@ -467,6 +470,33 @@ pub(crate) trait InternalServiceBuilderExt<L>: Sized {
     ) -> ServiceBuilder<Stack<OptionLayer<OutLayer>, L>>
     where
         P: PluginPrivate;
+
+    /// Apply the layer of a *mandatory* plugin to a service stack.
+    ///
+    /// Same as [`Self::apply_plugin_layer`], except that a missing plugin is treated as a
+    /// bug rather than a supported configuration: the miss is logged at `error` level
+    /// instead of quietly reducing the stack to a no-op. Several of these layers are
+    /// security-relevant -- losing `IncludeSubgraphErrors::redact_subgraph_errors_layer`
+    /// means every subgraph error reaches clients unredacted -- so a silent drop is the
+    /// worst possible failure mode.
+    ///
+    /// This deliberately does not panic. Test fixtures legitimately build pipelines from an
+    /// empty plugin registry, and those are not what this is guarding against, so a wholly
+    /// empty registry is not reported at all.
+    fn apply_required_plugin_layer<P, OutLayer>(
+        self,
+        plugins: &Plugins,
+        get_layer: impl FnOnce(&P) -> OutLayer,
+    ) -> ServiceBuilder<Stack<OptionLayer<OutLayer>, L>>
+    where
+        P: PluginPrivate;
+}
+
+/// Find the single instance of plugin type `P` in the registry, if it was built.
+fn find_plugin<P: PluginPrivate>(plugins: &Plugins) -> Option<&P> {
+    plugins
+        .values()
+        .find_map(|plugin| plugin.as_any().downcast_ref::<P>())
 }
 
 impl<L> InternalServiceBuilderExt<L> for ServiceBuilder<L> {
@@ -492,10 +522,24 @@ impl<L> InternalServiceBuilderExt<L> for ServiceBuilder<L> {
     where
         P: PluginPrivate,
     {
-        let layer = plugins
-            .values()
-            .find_map(|plugin| plugin.as_any().downcast_ref::<P>())
-            .map(get_layer);
-        self.option_layer(layer)
+        self.option_layer(find_plugin::<P>(plugins).map(get_layer))
+    }
+
+    fn apply_required_plugin_layer<P, OutLayer>(
+        self,
+        plugins: &Plugins,
+        get_layer: impl FnOnce(&P) -> OutLayer,
+    ) -> ServiceBuilder<Stack<OptionLayer<OutLayer>, L>>
+    where
+        P: PluginPrivate,
+    {
+        if find_plugin::<P>(plugins).is_none() && !plugins.is_empty() {
+            tracing::error!(
+                plugin = std::any::type_name::<P>(),
+                "mandatory plugin is missing from the plugin registry, so its layer will not \
+                 be applied to the pipeline; this is a router bug"
+            );
+        }
+        self.apply_plugin_layer(plugins, get_layer)
     }
 }

--- a/apollo-router/src/pipeline/stages.rs
+++ b/apollo-router/src/pipeline/stages.rs
@@ -8,7 +8,6 @@ use apollo_federation::query_plan::query_planner::QueryPlanner;
 use indexmap::IndexMap;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
-use tower::util::BoxCloneSyncService;
 
 use super::acquire::HttpClientInputsMaps;
 use crate::Configuration;
@@ -195,13 +194,13 @@ pub(crate) fn build_subgraph_service(
     plugins: &Arc<Plugins>,
     configuration: &Configuration,
 ) -> BufferedSubgraphService {
-    use crate::layers::ServiceBuilderExt as _;
-
     let subscription_config = subscription_plugin_config(plugins).map(Arc::new);
     let apq_enabled = configuration.apq.subgraph.get(name).enabled;
 
+    // Box *inside* the buffer, as [`build_connector_request_services`] does: it erases the
+    // stack's type without a second box on the way out of [`SubgraphServices::get`], which
+    // runs once per fetch node per request.
     let service = ServiceBuilder::new()
-        .buffered()
         .apply_required_plugin_layer(plugins, |p: &IncludeSubgraphErrors| {
             p.tag_errors_with_subgraph_name_layer(Arc::from(name))
         })
@@ -216,9 +215,10 @@ pub(crate) fn build_subgraph_service(
         ))
         .layer(SubgraphApqLayer::new(apq_enabled))
         .layer(content_negotiation::SubgraphContentNegotiationLayer::default())
-        .service(SubgraphService::new(name, http_service));
+        .service(SubgraphService::new(name, http_service))
+        .boxed_clone();
 
-    BoxCloneSyncService::new(service)
+    UnconstrainedBuffer::new(service, DEFAULT_BUFFER_SIZE)
 }
 
 /// Builds the full service stack for every subgraph, keyed by subgraph name.

--- a/apollo-router/src/pipeline/stages.rs
+++ b/apollo-router/src/pipeline/stages.rs
@@ -202,10 +202,9 @@ pub(crate) fn build_subgraph_service(
 
     let service = ServiceBuilder::new()
         .buffered()
-        .apply_plugin_layer(
-            plugins,
-            IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer,
-        )
+        .apply_plugin_layer(plugins, |p: &IncludeSubgraphErrors| {
+            p.tag_errors_with_subgraph_name_layer(Arc::from(name))
+        })
         .apply_plugin_layer(plugins, |h: &Headers| h.subgraph_headers_layer(name))
         .rust_plugins(plugins.clone(), |plugin, service| {
             plugin.subgraph_service(name, service)

--- a/apollo-router/src/pipeline/stages.rs
+++ b/apollo-router/src/pipeline/stages.rs
@@ -26,6 +26,7 @@ use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 use crate::plugins::authorization::AuthorizationPlugin;
 use crate::plugins::authorization::extract_authorization_checks_layer::ExtractAuthorizationChecksLayer;
 use crate::plugins::connectors::tracing::connect_spec_version_instrument;
+use crate::plugins::headers::Headers;
 use crate::plugins::include_subgraph_errors::IncludeSubgraphErrors;
 use crate::plugins::limits::operation_limits_layer::EnforceOperationLimitsLayer;
 use crate::plugins::limits::response_size_limit::SubgraphResponseSizeLimitLayer;
@@ -205,6 +206,7 @@ pub(crate) fn build_subgraph_service(
             &plugins,
             IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer,
         )
+        .apply_plugin_layer(&plugins, |h: &Headers| h.subgraph_headers_layer(name))
         .rust_plugins(plugins.clone(), |plugin, service| {
             plugin.subgraph_service(name, service)
         })
@@ -248,10 +250,13 @@ fn build_connector_request_services(
         // required for correct LoadShed / RateLimit behaviour from traffic-shaping
         // plugins (mirrors the per-subgraph buffer in [`build_subgraph_service`]).
         let service = UnconstrainedBuffer::new(
-            plugins.iter().rev().fold(
-                ConnectorRequestService { http_client }.boxed_clone(),
-                |acc, (_, e)| e.connector_request_service(acc, source.clone()),
-            ),
+            ServiceBuilder::new()
+                .apply_plugin_layer(plugins, |h: &Headers| h.connector_headers_layer(&source))
+                .rust_plugins(plugins.clone(), |plugin, service| {
+                    plugin.connector_request_service(service, source.clone())
+                })
+                .service(ConnectorRequestService { http_client }.boxed_clone())
+                .boxed_clone(),
             DEFAULT_BUFFER_SIZE,
         );
         map.insert(source, service);
@@ -481,6 +486,7 @@ pub(crate) fn build_router_service(
 
     ServiceBuilder::new()
         .layer(StaticPageLayer::new(configuration))
+        .apply_plugin_layer(&plugins, Headers::router_masking_layer)
         .rust_plugins(plugins, |plugin, service| plugin.router_service(service))
         .layer(content_negotiation::RouterContentNegotiationLayer::default())
         .layer(DisplayRouterRequestLayer)

--- a/apollo-router/src/pipeline/stages.rs
+++ b/apollo-router/src/pipeline/stages.rs
@@ -203,10 +203,10 @@ pub(crate) fn build_subgraph_service(
     let service = ServiceBuilder::new()
         .buffered()
         .apply_plugin_layer(
-            &plugins,
+            plugins,
             IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer,
         )
-        .apply_plugin_layer(&plugins, |h: &Headers| h.subgraph_headers_layer(name))
+        .apply_plugin_layer(plugins, |h: &Headers| h.subgraph_headers_layer(name))
         .rust_plugins(plugins.clone(), |plugin, service| {
             plugin.subgraph_service(name, service)
         })

--- a/apollo-router/src/pipeline/stages.rs
+++ b/apollo-router/src/pipeline/stages.rs
@@ -202,10 +202,10 @@ pub(crate) fn build_subgraph_service(
 
     let service = ServiceBuilder::new()
         .buffered()
-        .apply_plugin_layer(plugins, |p: &IncludeSubgraphErrors| {
+        .apply_required_plugin_layer(plugins, |p: &IncludeSubgraphErrors| {
             p.tag_errors_with_subgraph_name_layer(Arc::from(name))
         })
-        .apply_plugin_layer(plugins, |h: &Headers| h.subgraph_headers_layer(name))
+        .apply_required_plugin_layer(plugins, |h: &Headers| h.subgraph_headers_layer(name))
         .rust_plugins(plugins.clone(), |plugin, service| {
             plugin.subgraph_service(name, service)
         })
@@ -250,7 +250,9 @@ fn build_connector_request_services(
         // plugins (mirrors the per-subgraph buffer in [`build_subgraph_service`]).
         let service = UnconstrainedBuffer::new(
             ServiceBuilder::new()
-                .apply_plugin_layer(plugins, |h: &Headers| h.connector_headers_layer(&source))
+                .apply_required_plugin_layer(plugins, |h: &Headers| {
+                    h.connector_headers_layer(&source)
+                })
                 .rust_plugins(plugins.clone(), |plugin, service| {
                     plugin.connector_request_service(service, source.clone())
                 })
@@ -450,7 +452,7 @@ fn build_supergraph_service(
     ServiceBuilder::new()
         .layer(content_negotiation::SupergraphContentNegotiationLayer::default())
         .layer(crate::compute_job::ComputeJobMetricsLayer::new())
-        .apply_plugin_layer(
+        .apply_required_plugin_layer(
             &plugins,
             IncludeSubgraphErrors::redact_subgraph_errors_layer,
         )
@@ -485,7 +487,7 @@ pub(crate) fn build_router_service(
 
     ServiceBuilder::new()
         .layer(StaticPageLayer::new(configuration))
-        .apply_plugin_layer(&plugins, Headers::router_masking_layer)
+        .apply_required_plugin_layer(&plugins, Headers::router_masking_layer)
         .rust_plugins(plugins, |plugin, service| plugin.router_service(service))
         .layer(content_negotiation::RouterContentNegotiationLayer::default())
         .layer(DisplayRouterRequestLayer)

--- a/apollo-router/src/pipeline/stages.rs
+++ b/apollo-router/src/pipeline/stages.rs
@@ -8,6 +8,7 @@ use apollo_federation::query_plan::query_planner::QueryPlanner;
 use indexmap::IndexMap;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
+use tower::util::BoxCloneSyncService;
 
 use super::acquire::HttpClientInputsMaps;
 use crate::Configuration;
@@ -25,6 +26,7 @@ use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 use crate::plugins::authorization::AuthorizationPlugin;
 use crate::plugins::authorization::extract_authorization_checks_layer::ExtractAuthorizationChecksLayer;
 use crate::plugins::connectors::tracing::connect_spec_version_instrument;
+use crate::plugins::include_subgraph_errors::IncludeSubgraphErrors;
 use crate::plugins::limits::operation_limits_layer::EnforceOperationLimitsLayer;
 use crate::plugins::limits::response_size_limit::SubgraphResponseSizeLimitLayer;
 use crate::plugins::subscription::APOLLO_SUBSCRIPTION_PLUGIN;
@@ -197,8 +199,12 @@ pub(crate) fn build_subgraph_service(
     let subscription_config = subscription_plugin_config(plugins).map(Arc::new);
     let apq_enabled = configuration.apq.subgraph.get(name).enabled;
 
-    ServiceBuilder::new()
+    let service = ServiceBuilder::new()
         .buffered()
+        .apply_plugin_layer(
+            &plugins,
+            IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer,
+        )
         .rust_plugins(plugins.clone(), |plugin, service| {
             plugin.subgraph_service(name, service)
         })
@@ -209,7 +215,9 @@ pub(crate) fn build_subgraph_service(
         ))
         .layer(SubgraphApqLayer::new(apq_enabled))
         .layer(content_negotiation::SubgraphContentNegotiationLayer::default())
-        .service(SubgraphService::new(name, http_service))
+        .service(SubgraphService::new(name, http_service));
+
+    BoxCloneSyncService::new(service)
 }
 
 /// Builds the full service stack for every subgraph, keyed by subgraph name.
@@ -438,6 +446,10 @@ fn build_supergraph_service(
     ServiceBuilder::new()
         .layer(content_negotiation::SupergraphContentNegotiationLayer::default())
         .layer(crate::compute_job::ComputeJobMetricsLayer::new())
+        .apply_plugin_layer(
+            &plugins,
+            IncludeSubgraphErrors::redact_subgraph_errors_layer,
+        )
         .rust_plugins(plugins, |plugin, service| {
             plugin.supergraph_service(service)
         })

--- a/apollo-router/src/plugins/headers/mod.rs
+++ b/apollo-router/src/plugins/headers/mod.rs
@@ -45,7 +45,6 @@ use crate::plugin::serde::deserialize_regex;
 use crate::services::SubgraphRequest;
 use crate::services::connector;
 use crate::services::router;
-use crate::services::subgraph;
 
 register_private_plugin!("apollo", "headers", Headers);
 
@@ -251,7 +250,7 @@ struct GlobalHeadersConfiguration {
 #[derive(Clone, JsonSchema, Default, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields, default)]
 #[schemars(rename = "HeadersConfig")]
-struct Config {
+pub(crate) struct Config {
     /// Rules to apply to all subgraphs (global defaults)
     #[serde(default)]
     all: Option<GlobalHeadersConfiguration>,
@@ -265,7 +264,7 @@ struct Config {
     connector: ConnectorHeadersConfiguration,
 }
 
-struct Headers {
+pub(crate) struct Headers {
     all_operations: Arc<Vec<Operation>>,
     subgraph_operations: HashMap<String, Arc<Vec<Operation>>>,
     all_connector_operations: Arc<Vec<Operation>>,
@@ -450,47 +449,64 @@ impl PluginPrivate for Headers {
             masking_rules_map,
         })
     }
+}
 
-    fn subgraph_service(
-        &self,
-        name: &str,
-        service: subgraph::BoxCloneService,
-    ) -> subgraph::BoxCloneService {
-        // Get operations for this subgraph (fallback to global)
+impl Headers {
+    /// Returns a layer that applies this subgraph's header operations.
+    ///
+    /// Note: masking rules aren't installed here — they're inserted into request context
+    /// once by [`Headers::router_masking_layer`], and consumers resolve per-subgraph rules
+    /// at read time via `MaskingRulesMap::get_request(Some(name))` / `get_response(...)`.
+    pub(crate) fn subgraph_headers_layer(&self, name: &str) -> HeadersLayer {
         let operations = self
             .subgraph_operations
             .get(name)
             .cloned()
             .unwrap_or_else(|| self.all_operations.clone());
 
-        // Note: masking rules aren't installed here — they're inserted into
-        // request context once in `router_service` below, and consumers
-        // resolve per-subgraph rules at read time via
-        // `MaskingRulesMap::get_request(Some(name))` / `get_response(...)`.
-        ServiceBuilder::new()
-            .layer(HeadersLayer::new(operations))
-            .service(service)
-            .boxed_clone()
+        HeadersLayer::new(operations)
     }
 
-    fn connector_request_service(
-        &self,
-        service: crate::services::connector::request_service::BoxCloneService,
-        source_name: String,
-    ) -> crate::services::connector::request_service::BoxCloneService {
+    /// Returns a layer that applies this connector source's header operations (falling back
+    /// to the global connector operations if the source has none of its own).
+    pub(crate) fn connector_headers_layer(&self, source_name: &str) -> HeadersLayer {
         let operations = self
             .connector_source_operations
-            .get(&source_name)
+            .get(source_name)
             .cloned()
             .unwrap_or_else(|| self.all_connector_operations.clone());
 
-        ServiceBuilder::new()
-            .layer(HeadersLayer::new(operations))
-            .service(service)
-            .boxed_clone()
+        HeadersLayer::new(operations)
     }
 
-    fn router_service(&self, service: router::BoxCloneService) -> router::BoxCloneService {
+    /// Returns a layer that inserts a [`MaskingRulesMap`] into the request context.
+    pub(crate) fn router_masking_layer(&self) -> MaskingContextLayer {
+        MaskingContextLayer::new(self.masking_rules_map.clone())
+    }
+}
+
+/// Layer type for [`Headers::router_masking_layer`].
+pub(crate) struct MaskingContextLayer {
+    masking_rules_map: Arc<crate::services::header_masking::MaskingRulesMap>,
+}
+
+impl MaskingContextLayer {
+    fn new(masking_rules_map: Arc<crate::services::header_masking::MaskingRulesMap>) -> Self {
+        Self { masking_rules_map }
+    }
+}
+
+impl<S> Layer<S> for MaskingContextLayer
+where
+    S: Service<router::Request, Response = router::Response, Error = BoxError>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Service = router::BoxCloneService;
+
+    fn layer(&self, inner: S) -> Self::Service {
         let masking_rules_map = self.masking_rules_map.clone();
 
         ServiceBuilder::new()
@@ -500,12 +516,12 @@ impl PluginPrivate for Headers {
                 });
                 req
             })
-            .service(service)
+            .service(inner)
             .boxed_clone()
     }
 }
 
-struct HeadersLayer {
+pub(crate) struct HeadersLayer {
     operations: Arc<Vec<Operation>>,
 }
 
@@ -527,7 +543,7 @@ impl<S> Layer<S> for HeadersLayer {
 }
 
 #[derive(Clone)]
-struct HeadersService<S> {
+pub(crate) struct HeadersService<S> {
     inner: S,
     operations: Arc<Vec<Operation>>,
 }
@@ -866,6 +882,7 @@ mod test {
     use crate::query_planner::fetch::OperationKind;
     use crate::services::SubgraphRequest;
     use crate::services::SubgraphResponse;
+    use crate::services::subgraph;
 
     #[test]
     fn test_subgraph_config() {
@@ -2185,25 +2202,29 @@ mod test {
         input: Vec<(&'static str, &'static str)>,
         output: Vec<(&'static str, &'static str)>,
     ) {
-        let test_harness = PluginTestHarness::<Headers>::builder()
+        let harness = PluginTestHarness::<Headers>::builder()
             .config(config)
             .build()
             .await
             .expect("test harness");
-        let service = test_harness.subgraph_service("test", move |r| {
-            let output = output.clone();
-            async move {
-                // Assert the headers here
-                let headers = r.subgraph_request.headers();
-                for (name, value) in output.iter() {
-                    if let Some(header) = headers.get(*name) {
-                        assert_eq!(header.to_str().unwrap(), *value);
-                    } else {
-                        panic!("missing header {name}");
-                    }
+
+        let (mock, mut handle) = tower_test::mock::pair::<subgraph::Request, subgraph::Response>();
+
+        let mut service = ServiceBuilder::new()
+            .layer(harness.subgraph_headers_layer("test"))
+            .service(mock);
+
+        let driver = tokio::spawn(async move {
+            let (request, responder) = handle.next_request().await.unwrap();
+            let headers = request.subgraph_request.headers();
+            for (name, value) in output.iter() {
+                if let Some(header) = headers.get(*name) {
+                    assert_eq!(header.to_str().unwrap(), *value);
+                } else {
+                    panic!("missing header {name}");
                 }
-                Ok(subgraph::Response::fake_builder().build())
             }
+            responder.send_response(subgraph::Response::fake_builder().build());
         });
 
         let mut req = http::Request::builder();
@@ -2212,6 +2233,9 @@ mod test {
         }
 
         service
+            .ready()
+            .await
+            .unwrap()
             .call(
                 subgraph::Request::fake_builder()
                     .supergraph_request(Arc::new(
@@ -2222,6 +2246,8 @@ mod test {
             )
             .await
             .unwrap();
+
+        crate::plugin::test::await_mock_driver(driver).await;
     }
 
     #[tokio::test]

--- a/apollo-router/src/plugins/include_subgraph_errors/mod.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/mod.rs
@@ -31,7 +31,7 @@ static REDACTED_ERROR_MESSAGE: &str = "Subgraph errors redacted";
 
 register_plugin!("apollo", "include_subgraph_errors", IncludeSubgraphErrors);
 
-/// Layer type for [IncludeSubgraphErrors::redact_subgraph_errors_layer].
+/// Layer type for [`IncludeSubgraphErrors::redact_subgraph_errors_layer`].
 pub(crate) struct RedactSubgraphErrorsLayer {
     config: Arc<EffectiveConfig>,
 }
@@ -74,7 +74,8 @@ where
     }
 }
 
-/// Layer type for [IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer].
+/// Layer type for [`IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer`], which
+/// documents which extension the tag uses and why filtering happens at the supergraph stage.
 pub(crate) struct TagSubgraphErrorsLayer {
     _private: (),
 }
@@ -97,7 +98,7 @@ where
     }
 }
 
-/// Service type for [IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer].
+/// Service type for [`IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer`].
 pub(crate) struct TagSubgraphErrorsService<S> {
     inner: S,
 }
@@ -144,7 +145,18 @@ impl IncludeSubgraphErrors {
         RedactSubgraphErrorsLayer::new(self.config.clone())
     }
 
-    /// Returns a layer that adds a `service` extension to each error, containing the subgraph name.
+    /// Returns a layer that tags each subgraph error with the name of the subgraph it came
+    /// from, so that [`Self::redact_subgraph_errors_layer`] can apply that subgraph's
+    /// redaction config once the error reaches the supergraph response.
+    ///
+    /// The tag is the private `apollo.private.subgraph.name` extension (see
+    /// [`AddSubgraphNameExt`]), *not* the user-facing `service` extension: `process_error`
+    /// removes the private one during redaction and adds `service` separately, subject to the
+    /// configured allow/deny lists.
+    ///
+    /// Filtering deliberately does not happen here. Other kinds of request also generate
+    /// errors that need filtering, so pushing the filtering out to the supergraph response
+    /// ensures everything gets filtered.
     pub(crate) fn tag_errors_with_subgraph_name_layer(&self) -> TagSubgraphErrorsLayer {
         TagSubgraphErrorsLayer::new()
     }

--- a/apollo-router/src/plugins/include_subgraph_errors/mod.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/mod.rs
@@ -77,12 +77,12 @@ where
 /// Layer type for [`IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer`], which
 /// documents which extension the tag uses and why filtering happens at the supergraph stage.
 pub(crate) struct TagSubgraphErrorsLayer {
-    _private: (),
+    subgraph_name: Arc<str>,
 }
 
 impl TagSubgraphErrorsLayer {
-    fn new() -> Self {
-        Self { _private: () }
+    fn new(subgraph_name: Arc<str>) -> Self {
+        Self { subgraph_name }
     }
 }
 
@@ -94,13 +94,21 @@ where
     type Service = TagSubgraphErrorsService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        TagSubgraphErrorsService { inner }
+        TagSubgraphErrorsService {
+            inner,
+            subgraph_name: self.subgraph_name.clone(),
+        }
     }
 }
 
 /// Service type for [`IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer`].
 pub(crate) struct TagSubgraphErrorsService<S> {
     inner: S,
+    /// The subgraph this service stack was built for. Taken from the pipeline rather than
+    /// from `request.subgraph_name` so that it cannot disagree with the stack it is
+    /// installed on -- a mis-tagged error silently falls back to the default redaction
+    /// config in `process_error`.
+    subgraph_name: Arc<str>,
 }
 
 impl<S> tower::Service<subgraph::Request> for TagSubgraphErrorsService<S>
@@ -120,7 +128,7 @@ where
     }
 
     fn call(&mut self, req: subgraph::Request) -> Self::Future {
-        let subgraph_name = req.subgraph_name.clone();
+        let subgraph_name = self.subgraph_name.clone();
         self.inner
             .call(req)
             .map_ok(move |mut response| {
@@ -157,8 +165,11 @@ impl IncludeSubgraphErrors {
     /// Filtering deliberately does not happen here. Other kinds of request also generate
     /// errors that need filtering, so pushing the filtering out to the supergraph response
     /// ensures everything gets filtered.
-    pub(crate) fn tag_errors_with_subgraph_name_layer(&self) -> TagSubgraphErrorsLayer {
-        TagSubgraphErrorsLayer::new()
+    pub(crate) fn tag_errors_with_subgraph_name_layer(
+        &self,
+        subgraph_name: Arc<str>,
+    ) -> TagSubgraphErrorsLayer {
+        TagSubgraphErrorsLayer::new(subgraph_name)
     }
 }
 

--- a/apollo-router/src/plugins/include_subgraph_errors/mod.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/mod.rs
@@ -102,6 +102,7 @@ where
 }
 
 /// Service type for [`IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer`].
+#[derive(Clone)]
 pub(crate) struct TagSubgraphErrorsService<S> {
     inner: S,
     /// The subgraph this service stack was built for. Taken from the pipeline rather than

--- a/apollo-router/src/plugins/include_subgraph_errors/mod.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/mod.rs
@@ -11,6 +11,9 @@ use config::Config;
 use config::ErrorMode;
 use config::SubgraphConfig;
 use effective_config::EffectiveConfig;
+use futures::FutureExt as _;
+use futures::TryFutureExt as _;
+use futures::future::BoxFuture;
 use tower::BoxError;
 use tower::ServiceExt;
 
@@ -19,18 +22,132 @@ use crate::graphql;
 use crate::json_ext::Object;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
-use crate::services::SupergraphResponse;
 use crate::services::fetch::AddSubgraphNameExt;
 use crate::services::fetch::SubgraphNameExt;
-use crate::services::supergraph::BoxCloneService;
+use crate::services::subgraph;
+use crate::services::supergraph;
 
 static REDACTED_ERROR_MESSAGE: &str = "Subgraph errors redacted";
 
 register_plugin!("apollo", "include_subgraph_errors", IncludeSubgraphErrors);
 
-struct IncludeSubgraphErrors {
+/// Layer type for [IncludeSubgraphErrors::redact_subgraph_errors_layer].
+pub(crate) struct RedactSubgraphErrorsLayer {
+    config: Arc<EffectiveConfig>,
+}
+
+impl RedactSubgraphErrorsLayer {
+    fn new(config: Arc<EffectiveConfig>) -> Self {
+        Self { config }
+    }
+}
+
+impl<S> tower::Layer<S> for RedactSubgraphErrorsLayer
+where
+    S: tower::Service<supergraph::Request, Response = supergraph::Response, Error = BoxError>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Service = supergraph::BoxCloneService;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        let config = self.config.clone();
+
+        inner
+            .map_response(move |response: supergraph::Response| {
+                response.map_stream(move |mut graphql_response: graphql::Response| {
+                    for error in &mut graphql_response.errors {
+                        IncludeSubgraphErrors::process_error(&config, error);
+                    }
+                    for incremental in &mut graphql_response.incremental {
+                        for error in &mut incremental.errors {
+                            IncludeSubgraphErrors::process_error(&config, error);
+                        }
+                    }
+
+                    graphql_response
+                })
+            })
+            .boxed_clone()
+    }
+}
+
+/// Layer type for [IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer].
+pub(crate) struct TagSubgraphErrorsLayer {
+    _private: (),
+}
+
+impl TagSubgraphErrorsLayer {
+    fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+impl<S> tower::Layer<S> for TagSubgraphErrorsLayer
+where
+    S: tower::Service<subgraph::Request, Response = subgraph::Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Service = TagSubgraphErrorsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TagSubgraphErrorsService { inner }
+    }
+}
+
+/// Service type for [IncludeSubgraphErrors::tag_errors_with_subgraph_name_layer].
+pub(crate) struct TagSubgraphErrorsService<S> {
+    inner: S,
+}
+
+impl<S> tower::Service<subgraph::Request> for TagSubgraphErrorsService<S>
+where
+    S: tower::Service<subgraph::Request, Response = subgraph::Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: subgraph::Request) -> Self::Future {
+        let subgraph_name = req.subgraph_name.clone();
+        self.inner
+            .call(req)
+            .map_ok(move |mut response| {
+                let body = response.response.body_mut();
+                for error in &mut body.errors {
+                    error.add_subgraph_name(&subgraph_name);
+                }
+                response
+            })
+            .boxed()
+    }
+}
+
+pub(crate) struct IncludeSubgraphErrors {
     // Store the calculated effective configuration
     config: Arc<EffectiveConfig>,
+}
+
+impl IncludeSubgraphErrors {
+    /// Returns a layer that redacts subgraph errors from a supergraph response.
+    pub(crate) fn redact_subgraph_errors_layer(&self) -> RedactSubgraphErrorsLayer {
+        RedactSubgraphErrorsLayer::new(self.config.clone())
+    }
+
+    /// Returns a layer that adds a `service` extension to each error, containing the subgraph name.
+    pub(crate) fn tag_errors_with_subgraph_name_layer(&self) -> TagSubgraphErrorsLayer {
+        TagSubgraphErrorsLayer::new()
+    }
 }
 
 #[async_trait::async_trait]
@@ -54,47 +171,6 @@ impl Plugin for IncludeSubgraphErrors {
         let config = Arc::new(init.config.try_into()?);
 
         Ok(IncludeSubgraphErrors { config })
-    }
-
-    fn supergraph_service(&self, service: BoxCloneService) -> BoxCloneService {
-        let config = Arc::clone(&self.config);
-
-        service
-            .map_response(move |response: SupergraphResponse| {
-                response.map_stream(move |mut graphql_response: graphql::Response| {
-                    for error in &mut graphql_response.errors {
-                        Self::process_error(&config, error);
-                    }
-                    for incremental in &mut graphql_response.incremental {
-                        for error in &mut incremental.errors {
-                            Self::process_error(&config, error);
-                        }
-                    }
-
-                    graphql_response
-                })
-            })
-            .boxed_clone()
-    }
-
-    fn subgraph_service(
-        &self,
-        subgraph_name: &str,
-        service: crate::services::subgraph::BoxCloneService,
-    ) -> crate::services::subgraph::BoxCloneService {
-        // We need to attach the subgraph name to each error so that we can do the filtering in the supergraph service.
-        // The reason filtering is not done here is that other types of request may also generate errors that need filtering.
-        // Pushing the error filtering to supergraph will ensure that everything gets filtered.
-        let subgraph_name = subgraph_name.to_string();
-        service
-            .map_response(move |mut r| {
-                let body = r.response.body_mut();
-                for error in &mut body.errors {
-                    error.add_subgraph_name(&subgraph_name);
-                }
-                r
-            })
-            .boxed_clone()
     }
 }
 

--- a/apollo-router/src/plugins/include_subgraph_errors/mod.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/mod.rs
@@ -157,15 +157,6 @@ impl IncludeSubgraphErrors {
     /// Returns a layer that tags each subgraph error with the name of the subgraph it came
     /// from, so that [`Self::redact_subgraph_errors_layer`] can apply that subgraph's
     /// redaction config once the error reaches the supergraph response.
-    ///
-    /// The tag is the private `apollo.private.subgraph.name` extension (see
-    /// [`AddSubgraphNameExt`]), *not* the user-facing `service` extension: `process_error`
-    /// removes the private one during redaction and adds `service` separately, subject to the
-    /// configured allow/deny lists.
-    ///
-    /// Filtering deliberately does not happen here. Other kinds of request also generate
-    /// errors that need filtering, so pushing the filtering out to the supergraph response
-    /// ensures everything gets filtered.
     pub(crate) fn tag_errors_with_subgraph_name_layer(
         &self,
         subgraph_name: Arc<str>,

--- a/apollo-router/src/plugins/include_subgraph_errors/tests.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/tests.rs
@@ -4,9 +4,13 @@ use serde_json::Map;
 use serde_json::Value;
 use serde_json::json;
 use tower::BoxError;
+use tower::Service as _;
+use tower::ServiceBuilder;
+use tower::ServiceExt as _;
 
 use super::*; // Import items from mod.rs
 use crate::graphql;
+use crate::plugin::test::await_mock_driver;
 use crate::plugins::test::PluginTestHarness;
 use crate::services::supergraph; // Required for collect
 
@@ -43,26 +47,42 @@ async fn run_test_case(
 ) {
     let harness = build_harness(config).await.expect("plugin should load");
 
-    let mock_response_elements = mock_responses
+    let mock_response_elements: Vec<graphql::Response> = mock_responses
         .iter()
         .map(|response| {
             serde_json::from_str(response).expect("Failed to parse mock response bytes")
         })
-        .collect::<Vec<_>>();
+        .collect();
 
-    let service = harness.supergraph_service(move |req| {
-        let mock_response_elements = mock_response_elements.clone();
-        async {
-            supergraph::Response::fake_stream_builder()
-                .responses(mock_response_elements)
-                .context(req.context)
-                .build()
-        }
+    let (mock_service, mut handle) =
+        tower_test::mock::pair::<supergraph::Request, supergraph::Response>();
+
+    let driver = tokio::spawn(async move {
+        let (req, responder) = handle.next_request().await.unwrap();
+        let response = supergraph::Response::fake_stream_builder()
+            .responses(mock_response_elements)
+            .context(req.context)
+            .build()
+            .expect("valid fake stream response");
+        responder.send_response(response);
     });
-    let mut response = service.call_default().await.unwrap();
+
+    let mut service = ServiceBuilder::new()
+        .layer(harness.redact_subgraph_errors_layer())
+        .service(mock_service);
+
+    let mut response = service
+        .ready()
+        .await
+        .unwrap()
+        .call(supergraph::Request::fake_builder().build().unwrap())
+        .await
+        .unwrap();
 
     // Collect the actual response body (potentially modified by the plugin)
     let actual_responses: Vec<graphql::Response> = response.response.body_mut().collect().await;
+
+    await_mock_driver(driver).await;
 
     let config = serde_yaml::to_string(config).expect("config to yaml");
     let parsed_responses = mock_responses

--- a/apollo-router/src/plugins/include_subgraph_errors/tests.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/tests.rs
@@ -528,8 +528,7 @@ async fn it_processes_incremental_responses() {
 /// `pipeline::stages`, and returns the response the client would see.
 ///
 /// The tests above stack the layers by hand, which says nothing about whether they are
-/// installed in the real pipeline. `apply_required_plugin_layer` can only report a missing
-/// plugin, not prevent one, and a dropped `.apply_required_plugin_layer(..)` call in
+/// installed in the real pipeline. A dropped `.apply_required_plugin_layer(..)` call in
 /// `stages.rs` would leave every error unredacted — so the wiring needs a test of its own.
 async fn error_through_real_pipeline(config: Value) -> graphql::Response {
     let service = crate::TestHarness::builder()

--- a/apollo-router/src/plugins/include_subgraph_errors/tests.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors/tests.rs
@@ -523,3 +523,90 @@ async fn it_processes_incremental_responses() {
     )
     .await;
 }
+
+/// Drives one subgraph error through a pipeline built by `create_plugins` and
+/// `pipeline::stages`, and returns the response the client would see.
+///
+/// The tests above stack the layers by hand, which says nothing about whether they are
+/// installed in the real pipeline. `apply_required_plugin_layer` can only report a missing
+/// plugin, not prevent one, and a dropped `.apply_required_plugin_layer(..)` call in
+/// `stages.rs` would leave every error unredacted — so the wiring needs a test of its own.
+async fn error_through_real_pipeline(config: Value) -> graphql::Response {
+    let service = crate::TestHarness::builder()
+        .configuration_json(json!({ "include_subgraph_errors": config }))
+        .expect("valid config")
+        .schema(include_str!("../../../testing_schema.graphql"))
+        // Replaces the subgraph transport only: this hook is a user plugin, so it sits
+        // *inside* the layers under test.
+        .subgraph_hook(|_name, _service| {
+            let (mock, mut handle) =
+                tower_test::mock::pair::<subgraph::Request, subgraph::Response>();
+            tokio::spawn(async move {
+                while let Some((req, responder)) = handle.next_request().await {
+                    responder.send_response(
+                        subgraph::Response::fake_builder()
+                            .context(req.context)
+                            .error(
+                                graphql::Error::builder()
+                                    .message("the subgraph blew up")
+                                    .extension_code("SUBGRAPH_BOOM")
+                                    .build(),
+                            )
+                            .build(),
+                    );
+                }
+            });
+            mock.boxed_clone()
+        })
+        .build_supergraph()
+        .await
+        .expect("supergraph pipeline");
+
+    let mut response = service
+        .oneshot(
+            supergraph::Request::fake_builder()
+                // `me` resolves against the `accounts` subgraph only.
+                .query("query { me { name } }")
+                .build()
+                .expect("valid request"),
+        )
+        .await
+        .expect("supergraph call");
+
+    response.next_response().await.expect("one response")
+}
+
+#[tokio::test]
+async fn redaction_is_wired_into_the_pipeline() {
+    let response = error_through_real_pipeline(json!({ "all": false })).await;
+
+    let error = response.errors.first().expect("one error");
+    assert_eq!(error.message, REDACTED_ERROR_MESSAGE);
+    assert!(
+        error.extensions.is_empty(),
+        "redaction clears every extension, got {:?}",
+        error.extensions
+    );
+}
+
+#[tokio::test]
+async fn subgraph_name_tagging_is_wired_into_the_pipeline() {
+    let response = error_through_real_pipeline(json!({ "all": true })).await;
+
+    let error = response.errors.first().expect("one error");
+    assert_eq!(error.message, "the subgraph blew up");
+    // `service` is derived from the tag the subgraph-stage layer applied, so it is only
+    // present — and only correct — if that layer ran on the `accounts` stack.
+    assert_eq!(
+        error.extensions.get("service").and_then(|v| v.as_str()),
+        Some("accounts"),
+    );
+    // The private tag itself must never reach a client.
+    assert!(
+        !error
+            .extensions
+            .contains_key("apollo.private.subgraph.name"),
+        "the private subgraph-name tag leaked to the client: {:?}",
+        error.extensions
+    );
+}

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -31,7 +31,7 @@ pub(crate) mod expose_query_plan;
 pub(crate) mod file_uploads;
 mod fleet_detector;
 mod forbid_mutations;
-mod headers;
+pub(crate) mod headers;
 pub(crate) mod healthcheck;
 pub(crate) mod include_subgraph_errors;
 pub(crate) mod license_enforcement;

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -33,7 +33,7 @@ mod fleet_detector;
 mod forbid_mutations;
 mod headers;
 pub(crate) mod healthcheck;
-mod include_subgraph_errors;
+pub(crate) mod include_subgraph_errors;
 pub(crate) mod license_enforcement;
 pub(crate) mod limits;
 pub(crate) mod mock_subgraphs;

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -11,6 +11,7 @@ use http::Method;
 use serde_json_bytes::json;
 use tokio_stream::wrappers::ReceiverStream;
 use tower::ServiceExt;
+use tower::util::BoxCloneSyncService;
 
 use super::DeferredNode;
 use super::Depends;
@@ -173,7 +174,10 @@ fn subgraph_services(graphs: Vec<(String, subgraph::BoxCloneService)>) -> Subgra
                 .map(|(name, service)| {
                     (
                         name,
-                        UnconstrainedBuffer::new(service, crate::layers::DEFAULT_BUFFER_SIZE),
+                        BoxCloneSyncService::new(UnconstrainedBuffer::new(
+                            service,
+                            crate::layers::DEFAULT_BUFFER_SIZE,
+                        )),
                     )
                 })
                 .collect(),

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -11,7 +11,6 @@ use http::Method;
 use serde_json_bytes::json;
 use tokio_stream::wrappers::ReceiverStream;
 use tower::ServiceExt;
-use tower::util::BoxCloneSyncService;
 
 use super::DeferredNode;
 use super::Depends;
@@ -174,10 +173,7 @@ fn subgraph_services(graphs: Vec<(String, subgraph::BoxCloneService)>) -> Subgra
                 .map(|(name, service)| {
                     (
                         name,
-                        BoxCloneSyncService::new(UnconstrainedBuffer::new(
-                            service,
-                            crate::layers::DEFAULT_BUFFER_SIZE,
-                        )),
+                        UnconstrainedBuffer::new(service, crate::layers::DEFAULT_BUFFER_SIZE),
                     )
                 })
                 .collect(),

--- a/apollo-router/src/services/subgraph/service.rs
+++ b/apollo-router/src/services/subgraph/service.rs
@@ -21,7 +21,6 @@ use super::http::http_response_to_graphql_response;
 use crate::error::FetchError;
 use crate::graphql;
 use crate::json_ext::Object;
-use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 use crate::plugins::limits::response_size_limit::ResponseSizeLimitError;
 use crate::plugins::telemetry::config_new::events::log_event;
 use crate::plugins::telemetry::config_new::events::log_subgraph_request_event;
@@ -319,7 +318,7 @@ async fn call_http(
 
 /// The full, buffered service stack for one subgraph.
 pub(crate) type BufferedSubgraphService =
-    UnconstrainedBuffer<subgraph::Request, BoxFuture<'static, subgraph::ServiceResult>>;
+    tower::util::BoxCloneSyncService<subgraph::Request, subgraph::Response, BoxError>;
 
 /// The pre-built subgraph service stack for each subgraph, keyed by subgraph name.
 /// Stacks are built once; [`Self::get`] hands out cheap clones.
@@ -332,6 +331,8 @@ impl SubgraphServices {
     /// Retrieves the pre-built subgraph service stack for `name`, or `None` if no subgraph
     /// is registered under that name.
     pub(crate) fn get(&self, name: &str) -> Option<subgraph::BoxCloneService> {
+        // XXX(@goto-bus-stop): double-boxing, would be nice if we could just cast away the
+        // Sync-ness
         self.services.get(name).map(|svc| svc.clone().boxed_clone())
     }
 }

--- a/apollo-router/src/services/subgraph/service.rs
+++ b/apollo-router/src/services/subgraph/service.rs
@@ -21,6 +21,7 @@ use super::http::http_response_to_graphql_response;
 use crate::error::FetchError;
 use crate::graphql;
 use crate::json_ext::Object;
+use crate::layers::unconstrained_buffer::UnconstrainedBuffer;
 use crate::plugins::limits::response_size_limit::ResponseSizeLimitError;
 use crate::plugins::telemetry::config_new::events::log_event;
 use crate::plugins::telemetry::config_new::events::log_subgraph_request_event;
@@ -318,7 +319,7 @@ async fn call_http(
 
 /// The full, buffered service stack for one subgraph.
 pub(crate) type BufferedSubgraphService =
-    tower::util::BoxCloneSyncService<subgraph::Request, subgraph::Response, BoxError>;
+    UnconstrainedBuffer<subgraph::Request, BoxFuture<'static, subgraph::ServiceResult>>;
 
 /// The pre-built subgraph service stack for each subgraph, keyed by subgraph name.
 /// Stacks are built once; [`Self::get`] hands out cheap clones.
@@ -331,8 +332,8 @@ impl SubgraphServices {
     /// Retrieves the pre-built subgraph service stack for `name`, or `None` if no subgraph
     /// is registered under that name.
     pub(crate) fn get(&self, name: &str) -> Option<subgraph::BoxCloneService> {
-        // XXX(@goto-bus-stop): double-boxing, would be nice if we could just cast away the
-        // Sync-ness
+        // Note: we have to box our cloned service to erase the type of the Buffer. The stack
+        // inside the buffer is already boxed, so this is the only box on the way out.
         self.services.get(name).map(|svc| svc.clone().boxed_clone())
     }
 }


### PR DESCRIPTION
Prep work for https://github.com/apollographql/router/pull/10074

The `telemetry` plugin actually isn't quite the first plugin in the list, so some snapshot tests are breaking in #10074. By migrating these two plugins first, #10074 should be able to be picked up after. See that PR for a little bit more description of the change.

<!-- start metadata -->

<!-- [ROUTER-2070] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-2070]: https://apollographql.atlassian.net/browse/ROUTER-2070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ