### PR TITLE
fix(cicd): make crates.io publish idempotent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -930,14 +930,28 @@ jobs:
             - run:
                 name: Publish to Crates.io
                 command: |
+                  set -euo pipefail
                   # Remove leading 'v' which is present on the Git tag; Cargo doesn't want that leading 'v'
                   VERSION_WITHOUT_LEADING_V="${VERSION#v}"
                   echo "Publishing apollo-federation@${VERSION_WITHOUT_LEADING_V} and apollo-router@${VERSION_WITHOUT_LEADING_V}"
-                  # Just do a dry-run for now on apollo-federation, since that's a leading
-                  # indicator that the publish is going to work.  We don't do the attempt for
-                  # router because it's dependent on apollo-federation, so it'll definitely fail.
-                  cargo publish -p apollo-federation@${VERSION_WITHOUT_LEADING_V}
-                  cargo publish -p apollo-router@${VERSION_WITHOUT_LEADING_V}
+
+                  # Idempotent: a prior run of this job may have already published one
+                  # crate and then failed on the other (e.g. a transient linker error).
+                  # Re-running must not error out trying to re-publish a version that's
+                  # already live -- crates.io versions are immutable, so that always
+                  # fails and blocks the rest of the job from ever making progress.
+                  publish_if_missing() {
+                    local crate="$1"
+                    local version="$2"
+                    if curl -sf -A "apollo-router-release-ci" "https://crates.io/api/v1/crates/${crate}/${version}" > /dev/null; then
+                      echo "${crate}@${version} is already published on crates.io -- skipping."
+                    else
+                      cargo publish -p "${crate}@${version}"
+                    fi
+                  }
+
+                  publish_if_missing apollo-federation "${VERSION_WITHOUT_LEADING_V}"
+                  publish_if_missing apollo-router "${VERSION_WITHOUT_LEADING_V}"
 
             - run:
                 name: Create GitHub Release


### PR DESCRIPTION
The "Publish to Crates.io" step in `publish_github_release` published `apollo-federation` and `apollo-router` unconditionally. When the job fails partway through (e.g. the `.eh_frame`/`rust-lld` linker error just hit on the v2.16.3 release, which failed verifying the `apollo-router` tarball), a retry immediately fails trying to re-publish `apollo-federation` since crates.io versions are immutable — permanently blocking that job from ever reaching `apollo-router` again.

Each crate is now published only if that exact version isn't already live on crates.io (checked via the crates.io API), so a retry picks up wherever the previous attempt actually left off.

Note: this only fixes the script for future releases — the currently-stuck v2.16.3 tag's CircleCI build is pinned to the config at that tag's commit, so it needs a separate resolution.