### PR TITLE
fix(cicd): make crates.io publish idempotent (backport)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -941,14 +941,28 @@ jobs:
             - run:
                 name: Publish to Crates.io
                 command: |
+                  set -euo pipefail
                   # Remove leading 'v' which is present on the Git tag; Cargo doesn't want that leading 'v'
                   VERSION_WITHOUT_LEADING_V="${VERSION#v}"
                   echo "Publishing apollo-federation@${VERSION_WITHOUT_LEADING_V} and apollo-router@${VERSION_WITHOUT_LEADING_V}"
-                  # Just do a dry-run for now on apollo-federation, since that's a leading
-                  # indicator that the publish is going to work.  We don't do the attempt for
-                  # router because it's dependent on apollo-federation, so it'll definitely fail.
-                  cargo publish -p apollo-federation@${VERSION_WITHOUT_LEADING_V}
-                  cargo publish -p apollo-router@${VERSION_WITHOUT_LEADING_V}
+
+                  # Idempotent: a prior run of this job may have already published one
+                  # crate and then failed on the other (e.g. a transient linker error).
+                  # Re-running must not error out trying to re-publish a version that's
+                  # already live -- crates.io versions are immutable, so that always
+                  # fails and blocks the rest of the job from ever making progress.
+                  publish_if_missing() {
+                    local crate="$1"
+                    local version="$2"
+                    if curl -sf -A "apollo-router-release-ci" "https://crates.io/api/v1/crates/${crate}/${version}" > /dev/null; then
+                      echo "${crate}@${version} is already published on crates.io -- skipping."
+                    else
+                      cargo publish -p "${crate}@${version}"
+                    fi
+                  }
+
+                  publish_if_missing apollo-federation "${VERSION_WITHOUT_LEADING_V}"
+                  publish_if_missing apollo-router "${VERSION_WITHOUT_LEADING_V}"
 
             - run:
                 name: Create GitHub Release


### PR DESCRIPTION
Backport of #10097 to unblock the v2.16.3 release, which is currently stuck: `apollo-federation@2.16.3` published successfully, but `apollo-router@2.16.3` failed its verification build with a transient `rust-lld` linker error, and the retry then failed immediately trying to re-publish the already-live `apollo-federation@2.16.3` (crates.io versions are immutable).

Once this merges, the plan is to delete and recreate the `v2.16.3` tag against the new tip so the publish step runs with the idempotent version and can pick up where it left off (i.e. just publish `apollo-router@2.16.3`).

Cherry-pick of b4227987e, no conflicts.