### PR TITLE
ci: don't mark 2.16.x GitHub releases as latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -959,8 +959,8 @@ jobs:
                     # This is in-line with SemVer's expectations/designations!
                     *-*) gh release create $VERSION --prerelease --notes-file /dev/null --title $VERSION artifacts/* ;;
 
-                    # In all other cases, publish it as the latest version.
-                    *) gh release create $VERSION --notes-file /dev/null --title $VERSION artifacts/* ;;
+                    # LTS branch: don't publish it as latest, but don't publish it as a pre-release either.
+                    *) gh release create $VERSION --latest=false --notes-file /dev/null --title $VERSION artifacts/* ;;
 
                   esac
             - run:


### PR DESCRIPTION
1.x and 2.10.x both explicitly pass `--latest=false` when publishing their GitHub release, so a maintenance-line release never displaces the mainline "Latest" tag. 2.16.x never got the same line — it's a per-branch copy of `.circleci/config.yml`, so nothing carried it forward when this line was cut.

This is live right now: `v2.16.3` (published Aug 27) is GitHub's currently-flagged "latest" release, ahead of `v2.17.0` (Jul 24) — the actual mainline tip. Latent gap in how we document/carry over new LTS steps, not a change in intent — matches the existing pattern on `1.x` and `main-v2.10.x`.