### PR TITLE
test(federation): add proptest coverage for SelectionMap overwrite semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
  "percent-encoding",
  "petgraph",
  "pretty_assertions",
+ "proptest",
  "regex",
  "ron",
  "rstest",
@@ -5560,12 +5561,16 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -5683,6 +5688,12 @@ checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -6452,6 +6463,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ruzstd"
@@ -8148,6 +8171,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ insta = { version = "1.38.0", features = [
     "glob",
 ] }
 once_cell = "1.19.0"
+proptest = "1.10.0"
 reqwest = { version = "0.12.0", default-features = false }
 
 schemars = { version = "1.0.0", features = ["url2"] }

--- a/apollo-federation/CHANGELOG.md
+++ b/apollo-federation/CHANGELOG.md
@@ -22,6 +22,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 🐛 Fixes
 
+### Improve test coverage for selection maps ([PR #10127](https://github.com/apollographql/router/pull/10127))
+
+Adds property-based tests and a focused regression test for selection map
+operations. Also corrects insertion to follow the map's existing overwrite
+contract: replacing a selection with the same key preserves its original position.
+
+By [@inanna-apollo](https://github.com/inanna-apollo) in <https://github.com/apollographql/router/pull/10127>
+
 ### Fix `GROUP_SELECTION_IS_NOT_OBJECT` for union/interface fields in nested `@connect` selections ([PR #9990](https://github.com/apollographql/router/pull/9990))
 
 Connectors validation rejected `->match` results assigned to union- or

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -72,6 +72,7 @@ sha1.workspace = true
 similar.workspace = true
 tempfile.workspace = true
 pretty_assertions = "1.4.0"
+proptest.workspace = true
 rstest = "0.26.0"
 dhat = "0.3.3"
 test-log = { version = "0.2.16", default-features = false, features = [

--- a/apollo-federation/proptest-regressions/operation/selection_map.txt
+++ b/apollo-federation/proptest-regressions/operation/selection_map.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 384f08e5a24b20da17575cebb1c7adae246f7281ed6bf7e7ec6e21e0c63e92e6 # shrinks to commands = [Extend(["b { x }"]), Insert("b { x }")]

--- a/apollo-federation/src/operation/selection_map.rs
+++ b/apollo-federation/src/operation/selection_map.rs
@@ -318,9 +318,17 @@ impl SelectionMap {
         }
     }
 
+    /// Insert a selection into the map. If a selection with an equal key is already present, it
+    /// is overwritten in place (keeping its original position); otherwise the new selection is
+    /// appended.
     pub(crate) fn insert(&mut self, value: Selection) {
-        let hash = self.hash_key(value.key());
-        self.raw_insert(hash, value);
+        let key = value.key();
+        let hash = self.hash_key(key);
+        if let Some(bucket) = self.table.find_mut(hash, key_eq(&self.selections, key)) {
+            self.selections[bucket.index] = value;
+        } else {
+            self.raw_insert(hash, value);
+        }
     }
 
     /// Remove a selection from the map. Returns the selection and its numeric index.
@@ -617,5 +625,228 @@ impl<'a> VacantEntry<'a> {
             )));
         };
         Ok(SelectionValue::new(self.map.raw_insert(self.hash, value)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::operation::tests::parse_operation;
+    use crate::operation::tests::parse_schema;
+
+    const SCHEMA: &str = r#"
+        type Query {
+            a: T
+            b: T
+            c: T
+        }
+
+        type T {
+            x: Int
+            y: Int
+        }
+    "#;
+
+    fn selection_from_source(
+        schema: &crate::schema::ValidFederationSchema,
+        source: &str,
+    ) -> Selection {
+        let query = format!("{{ {source} }}");
+        let operation = parse_operation(schema, &query);
+        operation
+            .selection_set
+            .selections
+            .values()
+            .next()
+            .expect("selection source must produce exactly one top-level selection")
+            .clone()
+    }
+
+    /// Minimized regression for the bug found by `selection_map_matches_last_write_wins_model`:
+    /// inserting a selection under a key that's already present used to append a second entry
+    /// instead of overwriting the first, in violation of the documented last-write-wins contract.
+    #[test]
+    fn insert_overwrites_equal_key_without_changing_position() {
+        let schema = parse_schema(SCHEMA);
+        let mut map = SelectionMap::new();
+
+        map.insert(selection_from_source(&schema, "a { x }"));
+        map.insert(selection_from_source(&schema, "b { x }"));
+        map.insert(selection_from_source(&schema, "b { y }"));
+
+        assert_eq!(
+            map.len(),
+            2,
+            "the second `b` insertion should overwrite the first"
+        );
+        let values: Vec<&Selection> = map.values().collect();
+        assert_eq!(values[0], &selection_from_source(&schema, "a { x }"));
+        assert_eq!(
+            values[1],
+            &selection_from_source(&schema, "b { y }"),
+            "the surviving `b` entry should hold the last-written value, in its original position"
+        );
+    }
+
+    /// A slow, obviously-correct model of `SelectionMap`'s documented last-write-wins overwrite
+    /// semantics: a key that already exists keeps its position but gets the new value.
+    fn model_insert(model: &mut Vec<(OwnedSelectionKey, Selection)>, value: Selection) {
+        let key = value.key().to_owned_key();
+        if let Some(existing) = model.iter_mut().find(|(k, _)| *k == key) {
+            existing.1 = value;
+        } else {
+            model.push((key, value));
+        }
+    }
+
+    fn response_name() -> impl Strategy<Value = &'static str> {
+        prop_oneof![Just("a"), Just("b"), Just("c")]
+    }
+
+    fn key_name() -> impl Strategy<Value = &'static str> {
+        prop_oneof![Just("a"), Just("b"), Just("c"), Just("z")]
+    }
+
+    fn sub_selection() -> impl Strategy<Value = &'static str> {
+        prop_oneof![Just("x"), Just("y"), Just("x y")]
+    }
+
+    fn selection_source() -> impl Strategy<Value = String> {
+        (response_name(), sub_selection()).prop_map(|(name, sub)| format!("{name} {{ {sub} }}"))
+    }
+
+    #[derive(Debug, Clone)]
+    enum Command {
+        Insert(String),
+        Get(String),
+        Remove(String),
+        Retain(Vec<String>),
+        Extend(Vec<String>),
+    }
+
+    fn command() -> impl Strategy<Value = Command> {
+        prop_oneof![
+            3 => selection_source().prop_map(Command::Insert),
+            2 => key_name().prop_map(|n| Command::Get(n.to_string())),
+            2 => key_name().prop_map(|n| Command::Remove(n.to_string())),
+            1 => prop::collection::vec(key_name(), 0..3)
+                .prop_map(|names| Command::Retain(names.into_iter().map(String::from).collect())),
+            2 => prop::collection::vec(selection_source(), 0..3).prop_map(Command::Extend),
+        ]
+    }
+
+    /// Compares production state against the model: length, iteration order and content,
+    /// structural (order-independent) equality against a freshly reconstructed map, and
+    /// lookups for every name in the small generated key universe.
+    fn assert_map_matches_model(map: &SelectionMap, model: &[(OwnedSelectionKey, Selection)]) {
+        let actual: Vec<&Selection> = map.values().collect();
+        let expected: Vec<&Selection> = model.iter().map(|(_, value)| value).collect();
+        assert_eq!(actual, expected, "iteration order/content mismatch");
+        assert_eq!(map.len(), model.len());
+        assert_eq!(map.is_empty(), model.is_empty());
+
+        let rebuilt: SelectionMap = model.iter().map(|(_, value)| value.clone()).collect();
+        assert_eq!(
+            map, &rebuilt,
+            "map should equal a freshly reconstructed map"
+        );
+
+        for name in ["a", "b", "c", "z"] {
+            let name = Name::new(name).unwrap();
+            let key = SelectionKey::field_name(&name);
+            let owned_key = key.to_owned_key();
+            let expected = model
+                .iter()
+                .find(|(k, _)| *k == owned_key)
+                .map(|(_, value)| value);
+            assert_eq!(map.get(key), expected, "lookup mismatch for {name}");
+            assert_eq!(map.contains_key(key), expected.is_some());
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        #[test]
+        fn selection_map_matches_last_write_wins_model(commands in prop::collection::vec(command(), 0..40)) {
+            let schema = parse_schema(SCHEMA);
+            let mut map = SelectionMap::new();
+            let mut model: Vec<(OwnedSelectionKey, Selection)> = Vec::new();
+
+            for command in commands {
+                match command {
+                    Command::Insert(source) => {
+                        let selection = selection_from_source(&schema, &source);
+                        map.insert(selection.clone());
+                        model_insert(&mut model, selection);
+                    }
+                    Command::Get(name) => {
+                        let name = Name::new(&name).unwrap();
+                        let key = SelectionKey::field_name(&name);
+                        let owned_key = key.to_owned_key();
+                        let expected = model
+                            .iter()
+                            .find(|(k, _)| *k == owned_key)
+                            .map(|(_, value)| value.clone());
+                        prop_assert_eq!(map.get(key).cloned(), expected);
+                    }
+                    Command::Remove(name) => {
+                        let name = Name::new(&name).unwrap();
+                        let key = SelectionKey::field_name(&name);
+                        let owned_key = key.to_owned_key();
+                        let model_index = model.iter().position(|(k, _)| *k == owned_key);
+                        let removed = map.remove(key);
+                        match (removed, model_index) {
+                            (Some((index, selection)), Some(model_index)) => {
+                                prop_assert_eq!(index, model_index);
+                                let (_, model_selection) = model.remove(model_index);
+                                prop_assert_eq!(selection, model_selection);
+                            }
+                            (None, None) => {}
+                            (actual, expected_index) => {
+                                prop_assert!(
+                                    false,
+                                    "remove presence mismatch: actual={:?} expected_index={:?}",
+                                    actual,
+                                    expected_index
+                                );
+                            }
+                        }
+                    }
+                    Command::Retain(names) => {
+                        let keep: HashSet<String> = names.into_iter().collect();
+                        map.retain(|key, _| match key {
+                            SelectionKey::Field { response_name, .. } => {
+                                keep.contains(response_name.as_str())
+                            }
+                            _ => false,
+                        });
+                        model.retain(|(key, _)| match key {
+                            OwnedSelectionKey::Field { response_name, .. } => {
+                                keep.contains(response_name.as_str())
+                            }
+                            _ => false,
+                        });
+                    }
+                    Command::Extend(sources) => {
+                        let selections: Vec<Selection> = sources
+                            .iter()
+                            .map(|source| selection_from_source(&schema, source))
+                            .collect();
+                        let other: SelectionMap = selections.iter().cloned().collect();
+                        map.extend(other);
+                        for selection in selections {
+                            model_insert(&mut model, selection);
+                        }
+                    }
+                }
+
+                assert_map_matches_model(&map, &model);
+            }
+        }
     }
 }


### PR DESCRIPTION
Property: `SelectionMap::insert` should overwrite an existing equal-key selection in place (last-write-wins), matching its documented contract and the pre-#6074 IndexMap-backed implementation.

Oracle: a linear `Vec<(OwnedSelectionKey, Selection)>` model with a straightforward find-and-replace-or-push insert.

Finding: `commands = [Extend(["b { x }"]), Insert("b { x }")]` left two entries for key `b` in the map instead of one.

Fix: `insert()` now looks up the existing bucket for the key and overwrites the selection in place instead of always appending.

Adds proptest as a workspace dependency and apollo-federation dev-dependency.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
