### PR TITLE
Fetch the router entitlement from the OCI registry via graph artifact manifest annotation

### DIFF
--- a/.changesets/feat_oci_entitlement_license.md
+++ b/.changesets/feat_oci_entitlement_license.md
@@ -1,0 +1,5 @@
+### Fetch the router entitlement from the OCI registry
+
+Routers configured with a graph artifact reference (`APOLLO_GRAPH_ARTIFACT_REFERENCE`) now fetch their entitlement from the same OCI registry as their schema, instead of Apollo Uplink. The router discovers the account's entitlement identifier from the graph artifact manifest annotations and polls the entitlement artifact with the same graph API key. License verification and enforcement are unchanged. A manifest without the annotation leaves the router unlicensed until the graph is republished, and a missing entitlement artifact is retried quietly; revocation always arrives as a new license, never as an absence.
+
+By [@samaanghani](https://github.com/samaanghani) in https://github.com/apollographql/router/pull/10159

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -683,7 +683,8 @@ impl Executable {
         // Order of precedence for licenses:
         // 1. explicit path from cli
         // 2. env APOLLO_ROUTER_LICENSE
-        // 3. uplink
+        // 3. the OCI registry, when the schema comes from a graph artifact reference
+        // 4. uplink
 
         let license = if let Some(license) = license {
             license
@@ -706,6 +707,12 @@ impl Executable {
                     }
                 }
                 (Some(_license), _, _, _) => LicenseSource::Env,
+                // OCI-delivered schema implies OCI-delivered license: the entitlement identifier
+                // is discovered from the graph artifact manifest annotations and the license is
+                // fetched from the same registry with the same graph API key.
+                (_, _, Some(_apollo_key), _) if opt.graph_artifact_reference.is_some() => {
+                    LicenseSource::OCI(opt.oci_config()?)
+                }
                 (_, _, Some(_apollo_key), Some(_apollo_graph_ref)) => {
                     LicenseSource::Registry(opt.uplink_config()?)
                 }

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -118,6 +118,8 @@ pub(crate) struct OciContent {
 pub(crate) enum OciError {
     #[error("oci layer does not have a title")]
     LayerMissingTitle,
+    #[error("oci manifest has no entitlement layer")]
+    EntitlementLayerMissing,
     #[error("oci distribution error: {0}")]
     Distribution(OciDistributionError),
     #[error("oci parsing error: {0}")]
@@ -130,6 +132,16 @@ const APOLLO_REGISTRY_ENDING: &str = "apollographql.com";
 const APOLLO_REGISTRY_USERNAME: &str = "apollo-registry";
 const APOLLO_SCHEMA_MEDIA_TYPE: &str = "application/apollo.schema";
 const APOLLO_MANIFEST_LAUNCH_ID_ANNOTATION: &str = "com.apollograph.launch.id";
+/// Annotation on the graph artifact manifest carrying the account's opaque entitlement
+/// identifier. Absent on manifests built before entitlement-over-OCI shipped; the router then
+/// runs unlicensed until the graph is republished.
+const APOLLO_MANIFEST_ENTITLEMENT_ID_ANNOTATION: &str = "com.apollograph.graph.entitlement.id";
+/// Media type of the layer carrying the signed entitlement JWT inside the entitlement artifact.
+const APOLLO_ENTITLEMENT_MEDIA_TYPE: &str = "application/vnd.apollographql.entitlement.v1+jwt";
+/// Repository namespace for entitlement artifacts: `<registry>/entitlements/<identifier>`.
+const ENTITLEMENTS_REPO_PATH: &str = "entitlements";
+/// Entitlement artifacts are always fetched via the moving `latest` tag.
+const ENTITLEMENT_TAG: &str = "latest";
 
 impl From<oci_client::ParseError> for OciError {
     fn from(value: oci_client::ParseError) -> Self {
@@ -373,7 +385,16 @@ impl OciConfig {
 /// Fetch the manifest digest (without fetching the full manifest) to detect changes
 pub(crate) async fn fetch_oci_manifest_digest(oci_config: &OciConfig) -> Result<String, OciError> {
     let reference: Reference = oci_config.reference.as_str().parse()?;
-    let auth = build_auth(&reference, &oci_config.apollo_key);
+    fetch_reference_manifest_digest(oci_config, &reference).await
+}
+
+/// Fetch the manifest digest for an arbitrary reference in the same registry, authenticated with
+/// the graph API key from the config. Lets the entitlement poll reuse the schema path's probe.
+async fn fetch_reference_manifest_digest(
+    oci_config: &OciConfig,
+    reference: &Reference,
+) -> Result<String, OciError> {
+    let auth = build_auth(reference, &oci_config.apollo_key);
     let protocol = oci_config.client_protocol();
 
     let client = Client::new(ClientConfig {
@@ -382,7 +403,7 @@ pub(crate) async fn fetch_oci_manifest_digest(oci_config: &OciConfig) -> Result<
     });
     let before_request = Instant::now();
     let registry = reference.registry().to_string();
-    let result = client.fetch_manifest_digest(&reference, &auth).await;
+    let result = client.fetch_manifest_digest(reference, &auth).await;
     let status = if result.is_ok() { "success" } else { "failure" };
     let duration = before_request.elapsed().as_secs_f64();
 
@@ -548,6 +569,276 @@ pub(crate) fn stream_from_oci(
                             "failed to send error to oci stream. This is likely to be because the router is shutting down: {e}"
                         );
                         break;
+                    }
+                }
+            }
+
+            tokio::time::sleep(polling_time).await;
+            polling_time = oci_config.poll_interval;
+        }
+    };
+    drop(tokio::task::spawn(task.with_current_subscriber()));
+
+    ReceiverStream::new(receiver).boxed()
+}
+
+/// The entitlement JWT fetched for the graph, or `None` when the graph artifact manifest carries
+/// no entitlement identifier annotation (a manifest built before entitlement-over-OCI shipped);
+/// the router then runs unlicensed until the graph is republished.
+type OciLicenseJwt = Option<String>;
+
+/// Type alias for OCI license stream
+type OciLicenseStream = Pin<Box<dyn Stream<Item = Result<OciLicenseJwt, OciError>> + Send>>;
+
+/// Build the reference for the account's entitlement artifact: the same registry the graph
+/// artifact came from, repository `entitlements/<identifier>`, tag `latest`.
+fn entitlement_reference(
+    graph_reference: &Reference,
+    entitlement_id: &str,
+) -> Result<Reference, OciError> {
+    format!(
+        "{}/{}/{}:{}",
+        graph_reference.registry(),
+        ENTITLEMENTS_REPO_PATH,
+        entitlement_id,
+        ENTITLEMENT_TAG
+    )
+    .parse::<Reference>()
+    .map_err(OciError::from)
+}
+
+/// Read the entitlement identifier off the graph artifact manifest annotations. `Ok(None)` means
+/// the manifest predates the annotation.
+async fn fetch_entitlement_id(
+    client: &mut Client,
+    auth: &RegistryAuth,
+    graph_reference: &Reference,
+) -> Result<Option<String>, OciError> {
+    let (manifest, _) = fetch_oci_manifest(client, auth, graph_reference, None).await?;
+    Ok(manifest
+        .annotations
+        .as_ref()
+        .and_then(|annotations| annotations.get(APOLLO_MANIFEST_ENTITLEMENT_ID_ANNOTATION))
+        .cloned())
+}
+
+/// Fetch the signed entitlement JWT: the entitlement artifact's manifest, then its JWT layer.
+async fn fetch_entitlement_jwt(
+    client: &mut Client,
+    auth: &RegistryAuth,
+    entitlement_ref: &Reference,
+) -> Result<String, OciError> {
+    let (manifest, _) = fetch_oci_manifest(client, auth, entitlement_ref, None).await?;
+    let jwt_layer = manifest
+        .layers
+        .iter()
+        .find(|layer| layer.media_type == APOLLO_ENTITLEMENT_MEDIA_TYPE)
+        .ok_or(OciError::EntitlementLayerMissing)?
+        .clone();
+    let jwt = fetch_oci_blob(client, entitlement_ref, &jwt_layer).await?;
+    Ok(String::from_utf8(jwt)?)
+}
+
+/// One-shot license fetch: discover the identifier from the graph artifact manifest, then fetch
+/// the entitlement JWT with the same graph API key.
+pub(crate) async fn fetch_oci_license(oci_config: &OciConfig) -> Result<OciLicenseJwt, OciError> {
+    let graph_reference: Reference = oci_config.reference.as_str().parse()?;
+    let auth = build_auth(&graph_reference, &oci_config.apollo_key);
+    let mut client = Client::new(ClientConfig {
+        protocol: oci_config.client_protocol(),
+        ..Default::default()
+    });
+
+    let Some(entitlement_id) = fetch_entitlement_id(&mut client, &auth, &graph_reference).await?
+    else {
+        tracing::info!(
+            "graph artifact manifest has no entitlement identifier annotation; the router runs unlicensed until the graph is republished"
+        );
+        return Ok(None);
+    };
+    let entitlement_ref = entitlement_reference(&graph_reference, &entitlement_id)?;
+    let jwt = fetch_entitlement_jwt(&mut client, &auth, &entitlement_ref).await?;
+    Ok(Some(jwt))
+}
+
+/// A 404-shaped registry error. For entitlements this is expected during rollout (the account is
+/// not backfilled yet, or the key lacks access; the proxy deliberately serves both as 404), so it
+/// is a quiet retry, never a revocation signal: revocation always arrives as a newer JWT.
+fn is_not_found(error: &OciError) -> bool {
+    match error {
+        OciError::Distribution(OciDistributionError::ImageManifestNotFoundError(_)) => true,
+        OciError::Distribution(OciDistributionError::ServerError { code, .. }) => *code == 404,
+        OciError::Distribution(OciDistributionError::RegistryError { envelope, .. }) => {
+            envelope.errors.iter().any(|error| {
+                matches!(
+                    error.code,
+                    OciErrorCode::ManifestUnknown | OciErrorCode::NotFound
+                )
+            })
+        }
+        _ => false,
+    }
+}
+
+/// Create a license stream from OCI config, gated the same way the schema stream is.
+pub(crate) fn create_oci_license_stream(
+    oci_config: OciConfig,
+) -> Result<OciLicenseStream, anyhow::Error> {
+    let (_, ref_type) = validate_oci_reference(&oci_config.reference)?;
+
+    match (ref_type, oci_config.hot_reload) {
+        (OciReferenceType::Tag, true) => Ok(Box::pin(stream_license_from_oci(oci_config))),
+        (OciReferenceType::Tag, false) => Err(anyhow::anyhow!(
+            "Tag references without --hot-reload are not yet supported."
+        )),
+        (OciReferenceType::Digest, true) => Err(anyhow::anyhow!(
+            "Digest references are immutable so --hot-reload flag is not allowed."
+        )),
+        (OciReferenceType::Digest, false) => {
+            let oci_config_clone = oci_config.clone();
+            let stream = stream::once(async move { fetch_oci_license(&oci_config_clone).await });
+            Ok(Box::pin(stream))
+        }
+    }
+}
+
+/// Poll the registry for license updates. Each tick re-probes the graph artifact manifest (the
+/// entitlement identifier is discovered from its annotations and is stable, but a graph
+/// republished onto a newer manifest scheme can gain the annotation), then probes the entitlement
+/// artifact's `latest` tag and fetches the JWT when its digest moves.
+pub(crate) fn stream_license_from_oci(
+    oci_config: OciConfig,
+) -> impl Stream<Item = Result<OciLicenseJwt, OciError>> {
+    let (sender, receiver) = channel(2);
+
+    let task = async move {
+        let graph_reference: Reference = match oci_config.reference.as_str().parse() {
+            Ok(reference) => reference,
+            Err(err) => {
+                let _ = sender.send(Err(OciError::from(err))).await;
+                return;
+            }
+        };
+        let auth = build_auth(&graph_reference, &oci_config.apollo_key);
+
+        // None until the graph manifest has been read at least once; Some(None) when the manifest
+        // was read and carries no annotation.
+        let mut entitlement_id: Option<Option<String>> = None;
+        let mut last_graph_digest: Option<String> = None;
+        let mut last_entitlement_digest: Option<String> = None;
+        let mut polling_time = oci_config.poll_interval;
+
+        loop {
+            let mut client = Client::new(ClientConfig {
+                protocol: oci_config.client_protocol(),
+                ..Default::default()
+            });
+
+            // Step 1: (re)discover the entitlement identifier when the graph manifest changes.
+            match fetch_reference_manifest_digest(&oci_config, &graph_reference).await {
+                Ok(graph_digest) => {
+                    if last_graph_digest.as_deref() != Some(graph_digest.as_str()) {
+                        match fetch_entitlement_id(&mut client, &auth, &graph_reference).await {
+                            Ok(discovered) => {
+                                if discovered.is_none() {
+                                    tracing::info!(
+                                        "graph artifact manifest has no entitlement identifier annotation; the router runs unlicensed until the graph is republished"
+                                    );
+                                    // The unlicensed state is explicit, not an error, and any
+                                    // previously fetched entitlement no longer applies.
+                                    if entitlement_id != Some(None)
+                                        && sender.send(Ok(None)).await.is_err()
+                                    {
+                                        break;
+                                    }
+                                    last_entitlement_digest = None;
+                                }
+                                entitlement_id = Some(discovered);
+                                last_graph_digest = Some(graph_digest);
+                            }
+                            Err(err) => {
+                                if let Some(retry_after) = parse_rate_limit_error(&err) {
+                                    polling_time = retry_after.max(Duration::from_secs(10));
+                                }
+                                if sender.send(Err(err)).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    if let Some(retry_after) = parse_rate_limit_error(&err) {
+                        polling_time = retry_after.max(Duration::from_secs(10));
+                    }
+                    if sender.send(Err(err)).await.is_err() {
+                        break;
+                    }
+                }
+            }
+
+            // Step 2: poll the entitlement artifact's `latest` tag and fetch the JWT on movement.
+            if let Some(Some(id)) = &entitlement_id {
+                match entitlement_reference(&graph_reference, id) {
+                    Ok(entitlement_ref) => {
+                        match fetch_reference_manifest_digest(&oci_config, &entitlement_ref).await {
+                            Ok(current_digest) => {
+                                if last_entitlement_digest.as_deref()
+                                    == Some(current_digest.as_str())
+                                {
+                                    tracing::debug!(
+                                        "entitlement manifest digest unchanged, skipping license fetch"
+                                    );
+                                } else {
+                                    match fetch_entitlement_jwt(
+                                        &mut client,
+                                        &auth,
+                                        &entitlement_ref,
+                                    )
+                                    .await
+                                    {
+                                        Ok(jwt) => {
+                                            if sender.send(Ok(Some(jwt))).await.is_err() {
+                                                break;
+                                            }
+                                            // Only advance on success so a failed fetch retries.
+                                            last_entitlement_digest = Some(current_digest);
+                                        }
+                                        Err(err) => {
+                                            if let Some(retry_after) = parse_rate_limit_error(&err)
+                                            {
+                                                polling_time =
+                                                    retry_after.max(Duration::from_secs(10));
+                                            }
+                                            if sender.send(Err(err)).await.is_err() {
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            Err(err) if is_not_found(&err) => {
+                                // Expected during rollout (not yet backfilled, or no access; the
+                                // proxy serves both as 404). Never a revocation signal, so the
+                                // current license state is left untouched and the poll retries.
+                                tracing::debug!(
+                                    "entitlement artifact not available yet (404); retrying on the next poll"
+                                );
+                            }
+                            Err(err) => {
+                                if let Some(retry_after) = parse_rate_limit_error(&err) {
+                                    polling_time = retry_after.max(Duration::from_secs(10));
+                                }
+                                if sender.send(Err(err)).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        if sender.send(Err(err)).await.is_err() {
+                            break;
+                        }
                     }
                 }
             }
@@ -832,6 +1123,236 @@ mod tests {
         format!("{}/{graph_id}:{reference}", mock_server.address())
             .parse::<Reference>()
             .expect("url must be valid")
+    }
+
+    const TEST_ENTITLEMENT_ID: &str = "0a1b2c3d4e5f";
+    const TEST_JWT: &str = "header.payload.signature";
+
+    fn entitlement_annotations() -> BTreeMap<String, String> {
+        let mut annotations = generate_manifest_annotations(Some("launch-1"));
+        annotations.insert(
+            APOLLO_MANIFEST_ENTITLEMENT_ID_ANNOTATION.to_string(),
+            TEST_ENTITLEMENT_ID.to_string(),
+        );
+        annotations
+    }
+
+    /// Mounts HEAD/GET manifest and GET blob mocks for `entitlements/<id>:latest`, returning the
+    /// number of blob fetches via the counter.
+    async fn setup_entitlement_mocks(mock_server: &MockServer, jwt: &str) -> Arc<AtomicUsize> {
+        let jwt_layer = ImageLayer {
+            data: jwt.as_bytes().to_vec(),
+            media_type: APOLLO_ENTITLEMENT_MEDIA_TYPE.to_string(),
+            annotations: None,
+        };
+        let blob_digest = jwt_layer.sha256_digest();
+        let oci_manifest = OciManifest::Image(OciImageManifest {
+            schema_version: 2,
+            media_type: Some(IMAGE_MANIFEST_MEDIA_TYPE.to_string()),
+            config: Default::default(),
+            layers: vec![OciDescriptor {
+                media_type: jwt_layer.media_type.clone(),
+                digest: blob_digest.clone(),
+                size: jwt_layer.data.len().try_into().unwrap(),
+                urls: None,
+                annotations: None,
+            }],
+            subject: None,
+            artifact_type: None,
+            annotations: None,
+        });
+        let manifest_digest = calculate_manifest_digest(&oci_manifest);
+        let manifest_path = format!(
+            "/v2/{ENTITLEMENTS_REPO_PATH}/{TEST_ENTITLEMENT_ID}/manifests/{ENTITLEMENT_TAG}"
+        );
+
+        Mock::given(method("HEAD"))
+            .and(path(manifest_path.clone()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .append_header("Docker-Content-Digest", manifest_digest.clone())
+                    .append_header(http::header::CONTENT_TYPE, OCI_IMAGE_MEDIA_TYPE),
+            )
+            .mount(mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(manifest_path))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .append_header("Docker-Content-Digest", manifest_digest)
+                    .append_header(http::header::CONTENT_TYPE, OCI_IMAGE_MEDIA_TYPE)
+                    .set_body_bytes(serde_json::to_vec(&oci_manifest).unwrap()),
+            )
+            .mount(mock_server)
+            .await;
+
+        let blob_fetches = Arc::new(AtomicUsize::new(0));
+        let counter = blob_fetches.clone();
+        let blob_data = jwt_layer.data.clone();
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/v2/{ENTITLEMENTS_REPO_PATH}/{TEST_ENTITLEMENT_ID}/blobs/{blob_digest}"
+            )))
+            .respond_with(move |_: &Request| {
+                counter.fetch_add(1, Ordering::SeqCst);
+                ResponseTemplate::new(200)
+                    .append_header(http::header::CONTENT_TYPE, "application/octet-stream")
+                    .set_body_bytes(blob_data.clone())
+            })
+            .mount(mock_server)
+            .await;
+        blob_fetches
+    }
+
+    #[test]
+    fn test_entitlement_reference() {
+        let graph_reference: Reference = "registry.apollographql.com/my-graph:current"
+            .parse()
+            .unwrap();
+        let reference = entitlement_reference(&graph_reference, TEST_ENTITLEMENT_ID).unwrap();
+        assert_eq!(reference.registry(), "registry.apollographql.com");
+        assert_eq!(
+            reference.repository(),
+            format!("{ENTITLEMENTS_REPO_PATH}/{TEST_ENTITLEMENT_ID}")
+        );
+        assert_eq!(reference.tag(), Some(ENTITLEMENT_TAG));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_license_from_oci_success() {
+        let mock_server = MockServer::start().await;
+        let schema_layer = ImageLayer {
+            data: b"type Query { hello: String }".to_vec(),
+            media_type: APOLLO_SCHEMA_MEDIA_TYPE.to_string(),
+            annotations: None,
+        };
+        let graph_reference = setup_mocks(
+            &mock_server,
+            vec![schema_layer],
+            Some(entitlement_annotations()),
+        )
+        .await;
+        setup_entitlement_mocks(&mock_server, TEST_JWT).await;
+
+        let oci_config = mock_oci_config_with_reference(graph_reference.to_string());
+        let mut stream = Box::pin(stream_license_from_oci(oci_config));
+
+        let jwt = stream
+            .next()
+            .await
+            .expect("stream should yield an item")
+            .expect("item should not be an error");
+        assert_eq!(jwt, Some(TEST_JWT.to_string()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_license_from_oci_missing_annotation_is_unlicensed() {
+        let mock_server = MockServer::start().await;
+        let schema_layer = ImageLayer {
+            data: b"type Query { hello: String }".to_vec(),
+            media_type: APOLLO_SCHEMA_MEDIA_TYPE.to_string(),
+            annotations: None,
+        };
+        // Annotations carry a launch ID but no entitlement identifier.
+        let graph_reference = setup_mocks(
+            &mock_server,
+            vec![schema_layer],
+            Some(generate_manifest_annotations(Some("launch-1"))),
+        )
+        .await;
+
+        let oci_config = mock_oci_config_with_reference(graph_reference.to_string());
+        let mut stream = Box::pin(stream_license_from_oci(oci_config));
+
+        let jwt = stream
+            .next()
+            .await
+            .expect("stream should yield an item")
+            .expect("item should not be an error");
+        assert_eq!(
+            jwt, None,
+            "missing annotation must yield the unlicensed marker"
+        );
+
+        // The unlicensed marker is emitted once, not on every poll.
+        let second = timeout(Duration::from_millis(200), stream.next()).await;
+        assert!(second.is_err(), "no further items while nothing changes");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_license_from_oci_entitlement_not_found_is_quiet() {
+        let mock_server = MockServer::start().await;
+        let schema_layer = ImageLayer {
+            data: b"type Query { hello: String }".to_vec(),
+            media_type: APOLLO_SCHEMA_MEDIA_TYPE.to_string(),
+            annotations: None,
+        };
+        // Annotation present, but no entitlement artifact mocks mounted: the registry answers 404,
+        // which is expected during rollout and must produce neither a license nor an error item.
+        let graph_reference = setup_mocks(
+            &mock_server,
+            vec![schema_layer],
+            Some(entitlement_annotations()),
+        )
+        .await;
+
+        let oci_config = mock_oci_config_with_reference(graph_reference.to_string());
+        let mut stream = Box::pin(stream_license_from_oci(oci_config));
+
+        let item = timeout(Duration::from_millis(300), stream.next()).await;
+        assert!(
+            item.is_err(),
+            "a 404 for the entitlement artifact must not emit items, got {item:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_license_from_oci_digest_unchanged_no_refetch() {
+        let mock_server = MockServer::start().await;
+        let schema_layer = ImageLayer {
+            data: b"type Query { hello: String }".to_vec(),
+            media_type: APOLLO_SCHEMA_MEDIA_TYPE.to_string(),
+            annotations: None,
+        };
+        let graph_reference = setup_mocks(
+            &mock_server,
+            vec![schema_layer],
+            Some(entitlement_annotations()),
+        )
+        .await;
+        let blob_fetches = setup_entitlement_mocks(&mock_server, TEST_JWT).await;
+
+        let oci_config = mock_oci_config_with_reference(graph_reference.to_string());
+        let mut stream = Box::pin(stream_license_from_oci(oci_config));
+
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first, Some(TEST_JWT.to_string()));
+
+        // Let several polls elapse; the unchanged digest must not trigger blob refetches.
+        let second = timeout(Duration::from_millis(300), stream.next()).await;
+        assert!(
+            second.is_err(),
+            "no further items while the digest is unchanged"
+        );
+        assert_eq!(1, blob_fetches.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_create_oci_license_stream_tag_without_hot_reload_errors() {
+        let mut oci_config =
+            mock_oci_config_with_reference("registry.example.com/graph:latest".to_string());
+        oci_config.hot_reload = false;
+        assert!(create_oci_license_stream(oci_config).is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_create_oci_license_stream_digest_with_hot_reload_errors() {
+        let mut oci_config = mock_oci_config_with_reference(
+            "registry.example.com/graph@sha256:0123456789012345678901234567890123456789012345678901234567890123"
+                .to_string(),
+        );
+        oci_config.hot_reload = true;
+        assert!(create_oci_license_stream(oci_config).is_err());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -702,10 +702,16 @@ pub(crate) fn create_oci_license_stream(
     }
 }
 
-/// Poll the registry for license updates. Each tick re-probes the graph artifact manifest (the
-/// entitlement identifier is discovered from its annotations and is stable, but a graph
-/// republished onto a newer manifest scheme can gain the annotation), then probes the entitlement
-/// artifact's `latest` tag and fetches the JWT when its digest moves.
+/// How many poll ticks to wait between re-reading the graph artifact manifest while it carries no
+/// entitlement identifier annotation, so a republished graph eventually gains its license without
+/// the license loop competing with the schema loop's polling of the same manifest.
+const UNLICENSED_REDISCOVERY_TICKS: u32 = 10;
+
+/// Poll the registry for license updates. The entitlement identifier is discovered from the graph
+/// artifact manifest once (it is minted once per account and never changes), after which only the
+/// entitlement artifact's `latest` tag is probed; the graph manifest is re-read on a slow cadence
+/// only while it carried no annotation. The schema stream remains the sole steady-state poller of
+/// the graph manifest.
 pub(crate) fn stream_license_from_oci(
     oci_config: OciConfig,
 ) -> impl Stream<Item = Result<OciLicenseJwt, OciError>> {
@@ -724,8 +730,8 @@ pub(crate) fn stream_license_from_oci(
         // None until the graph manifest has been read at least once; Some(None) when the manifest
         // was read and carries no annotation.
         let mut entitlement_id: Option<Option<String>> = None;
-        let mut last_graph_digest: Option<String> = None;
         let mut last_entitlement_digest: Option<String> = None;
+        let mut ticks_until_rediscovery: u32 = 0;
         let mut polling_time = oci_config.poll_interval;
 
         loop {
@@ -734,45 +740,47 @@ pub(crate) fn stream_license_from_oci(
                 ..Default::default()
             });
 
-            // Step 1: (re)discover the entitlement identifier when the graph manifest changes.
-            match fetch_reference_manifest_digest(&oci_config, &graph_reference).await {
-                Ok(graph_digest) => {
-                    if last_graph_digest.as_deref() != Some(graph_digest.as_str()) {
-                        match fetch_entitlement_id(&mut client, &auth, &graph_reference).await {
-                            Ok(discovered) => {
-                                if discovered.is_none() {
-                                    tracing::info!(
-                                        "graph artifact manifest has no entitlement identifier annotation; the router runs unlicensed until the graph is republished"
-                                    );
-                                    // The unlicensed state is explicit, not an error, and any
-                                    // previously fetched entitlement no longer applies.
-                                    if entitlement_id != Some(None)
-                                        && sender.send(Ok(None)).await.is_err()
-                                    {
-                                        break;
-                                    }
-                                    last_entitlement_digest = None;
-                                }
-                                entitlement_id = Some(discovered);
-                                last_graph_digest = Some(graph_digest);
-                            }
-                            Err(err) => {
-                                if let Some(retry_after) = parse_rate_limit_error(&err) {
-                                    polling_time = retry_after.max(Duration::from_secs(10));
-                                }
-                                if sender.send(Err(err)).await.is_err() {
-                                    break;
-                                }
-                            }
-                        }
+            // Step 1: discover the entitlement identifier. Runs until the first successful read;
+            // after that only while the manifest had no annotation, every
+            // UNLICENSED_REDISCOVERY_TICKS polls.
+            let needs_discovery = match &entitlement_id {
+                None => true,
+                Some(None) => {
+                    if ticks_until_rediscovery == 0 {
+                        true
+                    } else {
+                        ticks_until_rediscovery -= 1;
+                        false
                     }
                 }
-                Err(err) => {
-                    if let Some(retry_after) = parse_rate_limit_error(&err) {
-                        polling_time = retry_after.max(Duration::from_secs(10));
+                Some(Some(_)) => false,
+            };
+            if needs_discovery {
+                ticks_until_rediscovery = UNLICENSED_REDISCOVERY_TICKS;
+                match fetch_entitlement_id(&mut client, &auth, &graph_reference).await {
+                    Ok(discovered) => {
+                        if discovered.is_none() {
+                            tracing::info!(
+                                "graph artifact manifest has no entitlement identifier annotation; the router runs unlicensed until the graph is republished"
+                            );
+                            // The unlicensed state is explicit, not an error; announce it once.
+                            if entitlement_id != Some(None) && sender.send(Ok(None)).await.is_err()
+                            {
+                                break;
+                            }
+                            last_entitlement_digest = None;
+                        }
+                        entitlement_id = Some(discovered);
                     }
-                    if sender.send(Err(err)).await.is_err() {
-                        break;
+                    Err(err) => {
+                        if let Some(retry_after) = parse_rate_limit_error(&err) {
+                            polling_time = retry_after.max(Duration::from_secs(10));
+                        }
+                        // Retry discovery on the next tick rather than after the slow cadence.
+                        entitlement_id = None;
+                        if sender.send(Err(err)).await.is_err() {
+                            break;
+                        }
                     }
                 }
             }

--- a/apollo-router/src/router/event/license.rs
+++ b/apollo-router/src/router/event/license.rs
@@ -7,6 +7,8 @@ use derive_more::Display;
 use derive_more::From;
 use futures::prelude::*;
 
+use crate::registry::OciConfig;
+use crate::registry::create_oci_license_stream;
 use crate::router::Event;
 use crate::router::Event::NoMoreLicense;
 use crate::uplink::UplinkConfig;
@@ -51,6 +53,12 @@ pub enum LicenseSource {
     /// Apollo uplink.
     #[display("Registry")]
     Registry(UplinkConfig),
+
+    /// An OCI registry (graph artifacts). The entitlement identifier is discovered from the graph
+    /// artifact manifest annotations, and the license artifact is fetched from the same registry
+    /// with the same graph API key.
+    #[display("OCI")]
+    OCI(OciConfig),
 }
 
 impl Default for LicenseSource {
@@ -151,6 +159,40 @@ impl LicenseSource {
                         })
                     })
                     .boxed()
+            }
+            LicenseSource::OCI(oci_config) => {
+                tracing::debug!("using oci as license source");
+                match create_oci_license_stream(oci_config) {
+                    Ok(stream) => stream
+                        .filter_map(|res| {
+                            future::ready(match res {
+                                // No entitlement identifier annotation on the graph artifact
+                                // manifest: run unlicensed, without error, until the graph is
+                                // republished with a manifest that carries it.
+                                Ok(None) => Some(License::default()),
+                                Ok(Some(jwt)) => match License::from_str(&jwt) {
+                                    Ok(license) => Some(license),
+                                    Err(err) => {
+                                        tracing::error!(
+                                            code = APOLLO_ROUTER_LICENSE_INVALID,
+                                            "failed to parse license fetched from oci registry: {}",
+                                            err
+                                        );
+                                        None
+                                    }
+                                },
+                                Err(e) => {
+                                    tracing::error!(code = APOLLO_ROUTER_LICENSE_INVALID, "{}", e);
+                                    None
+                                }
+                            })
+                        })
+                        .boxed(),
+                    Err(e) => {
+                        tracing::error!("failed to create OCI license stream: {}", e);
+                        stream::empty().boxed()
+                    }
+                }
             }
             LicenseSource::Env => {
                 // EXPERIMENTAL and not subject to semver.

--- a/apollo-router/tests/integration/oci.rs
+++ b/apollo-router/tests/integration/oci.rs
@@ -315,13 +315,14 @@ async fn setup_mock_oci_server_with_tag(
         .mount(&mock_server)
         .await;
 
-    // Tag - GET returns initial, then next call will return updated (if tag_changes is true)
-    // or 404 (if return_404_after_first is true)
-    let get_count = Arc::new(AtomicUsize::new(0));
+    // Tag - GET serves whichever manifest the last HEAD advertised, keyed off the HEAD counter
+    // rather than an independent GET counter. The schema poll loop is the only HEAD caller, so tag
+    // transitions stay deterministic even when other readers (the license stream discovering the
+    // entitlement identifier) GET the same manifest in between.
     Mock::given(method("GET"))
         .and(path(tag_path.clone()))
         .respond_with({
-            let get_count = get_count.clone();
+            let head_count = head_count.clone();
             let initial_digest = initial_manifest_digest.clone();
             let updated_digest = updated_manifest_digest.clone();
             let initial_manifest_bytes =
@@ -329,10 +330,10 @@ async fn setup_mock_oci_server_with_tag(
             let updated_manifest_bytes =
                 Arc::new(serde_json::to_vec(&updated_oci_manifest).unwrap());
             move |_req: &wiremock::Request| {
-                let count = get_count.fetch_add(1, Ordering::SeqCst);
-                if return_404_after_first && count > 0 {
+                let heads_so_far = head_count.load(Ordering::SeqCst);
+                if return_404_after_first && heads_so_far > 1 {
                     ResponseTemplate::new(404)
-                } else if count == 0 || !tag_changes {
+                } else if heads_so_far <= 1 || !tag_changes {
                     ResponseTemplate::new(200)
                         .append_header("content-type", OCI_IMAGE_MEDIA_TYPE)
                         .append_header("docker-content-digest", initial_digest.as_str())

--- a/docs/source/routing/configuration/cli.mdx
+++ b/docs/source/routing/configuration/cli.mdx
@@ -189,7 +189,7 @@ For default behavior and possible values, see [Apollo Uplink](/federation/manage
 An OCI reference to a graph artifact that contains the supergraph schema for the router to run.<br/><br/>
 
 When you set this option, the router uses the schema from the specified graph artifact instead of Apollo Uplink.
-The router still fetches entitlements and persisted queries from Uplink.<br/><br/>
+The router also fetches its entitlement from the same registry when the graph artifact manifest carries an entitlement identifier; persisted queries still come from Uplink.<br/><br/>
 
 </td>
 </tr>

--- a/docs/source/routing/configuration/envvars.mdx
+++ b/docs/source/routing/configuration/envvars.mdx
@@ -85,7 +85,7 @@ A path to a file containing the [graph API key](/graphos/platform/access-managem
 
 An OCI reference to a graph artifact that contains the supergraph schema. The reference must use a SHA256 digest format.
 
-When you set this option, the router uses the schema from the specified graph artifact instead of Apollo Uplink. The router still fetches entitlements and persisted queries from Uplink.
+When you set this option, the router uses the schema from the specified graph artifact instead of Apollo Uplink. The router also fetches its entitlement from the same registry when the graph artifact manifest carries an entitlement identifier; persisted queries still come from Uplink.
 
 For information on finding graph artifact references, see [Graph Artifacts](/graphos/platform/schema-management/delivery/graph-artifacts/oci#find-oci-artifact-references).
 

--- a/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker-router-only.mdx
@@ -169,7 +169,7 @@ docker run -p 4000:4000 \
 ```
 
 When you set this option, the router uses the schema from the specified graph artifact instead of Apollo Uplink.
-The router still fetches entitlements and persisted queries from Uplink.
+The router also fetches its entitlement from the same registry when the graph artifact manifest carries an entitlement identifier; persisted queries still come from Uplink.
 
 For more information on graph artifacts, see the [Router CLI Configuration Reference](/graphos/routing/configuration/cli#--graph-artifact-reference).
 

--- a/docs/source/routing/self-hosted/containerization/docker.mdx
+++ b/docs/source/routing/self-hosted/containerization/docker.mdx
@@ -116,7 +116,7 @@ docker run -p 4000:4000 \
   ghcr.io/apollographql/apollo-runtime:<runtime-image-version>
 ```
 
-The Router uses the schema from the specified graph artifact instead of Apollo Uplink. The Router still fetches entitlements and persisted queries from Uplink. Learn more in the [Router CLI Configuration Reference](/graphos/routing/configuration/cli#--graph-artifact-reference).
+The Router uses the schema from the specified graph artifact instead of Apollo Uplink. The Router also fetches its entitlement from the same registry when the graph artifact manifest carries an entitlement identifier; persisted queries still come from Uplink. Learn more in the [Router CLI Configuration Reference](/graphos/routing/configuration/cli#--graph-artifact-reference).
 
 ## Running a specific Router and MCP version
 


### PR DESCRIPTION
<!-- start metadata -->

<!-- [REG-2156] -->
---

Routers that fetch their schema from a graph artifact reference (`APOLLO_GRAPH_ARTIFACT_REFERENCE`) now fetch their entitlement from the same OCI registry instead of Uplink.

**How it works**

1. The router reads the account's opaque entitlement identifier from the graph artifact manifest annotation `com.apollograph.graph.entitlement.id`.
2. It then polls a second reference, `<registry>/entitlements/<identifier>:latest`, authenticated with the same graph API key, and pulls the signed license JWT from the layer with media type `application/vnd.apollographql.entitlement.v1+jwt`.
3. The JWT feeds the existing license machinery unchanged: same JWKS verification, same claim enforcement, same warnAt/haltAt handling.

**Semantics**

- Missing annotation (manifest built before entitlement-over-OCI shipped): the router runs unlicensed, without error, until the graph is republished.
- 404 for the entitlement artifact (account not yet backfilled, or no access; the proxy deliberately serves both as 404): quiet retry on the next poll. Absence is never a revocation signal; revocation arrives as a newer JWT with a past haltAt through the same `:latest` tag, handled by existing license code.
- License source precedence becomes: `--license` path, then `APOLLO_ROUTER_LICENSE`, then OCI (when a graph artifact reference is configured), then Uplink.
- Polling mirrors the schema loop: HEAD digest probe, fetch only on movement, rate-limit backoff, and the existing `apollo.router.oci.*` metrics cover the new requests (they are keyed by registry and request kind).

**Implementation notes**

- `LicenseSource::OCI(OciConfig)` mirrors `SchemaSource::OCI`; the registry stream emits the raw JWT and the license event arm parses it, so parse failures log `APOLLO_ROUTER_LICENSE_INVALID` like other sources.
- The entitlement identifier is re-discovered whenever the graph manifest digest changes, so a graph republished onto a newer manifest scheme picks up the annotation without a restart.
- Wire constants match the GraphOS side (graph artifacts entitlement delivery, REG-2147 epic).

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [x] Changes are compatible
- [x] Documentation completed
- [x] Performance impact assessed and acceptable
- [x] Metrics and logs are added and documented
- Tests added and passing
    - [x] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

- Integration tests: unit coverage exercises the full poll loop against wiremock (success, missing annotation, entitlement 404, digest-unchanged no-refetch). An `IntegrationTest`-harness test needs the mock license Uplink plumbing swapped for OCI endpoints plus a signed test JWT; planned as a follow-up alongside the staging validation (REG-2155).
- `cargo clippy --all --all-targets --all-features -- -D warnings` fails on aarch64-apple-darwin with 8 pre-existing `unfulfilled lint expectation` errors in untouched files (`result_large_err` is type-size dependent and differs by platform); the same command is green on the Linux CI base commit.

**Notes**

Server-side counterpart: the entitlement artifacts, annotation embedding, and the account-scoped auth path in ociauthproxy are already deployed from the GraphOS monorepo. Design context lives in the Graph Artifacts entitlements design doc (Option A: annotation-based discovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[REG-2156]: https://apollographql.atlassian.net/browse/REG-2156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ