### PR TITLE
feat(incremental-planner): add @defer support

### DIFF
--- a/apollo-federation/src/query_plan/incremental_planner/defer.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/defer.rs
@@ -170,6 +170,12 @@ fn collect_deferred_blocks(
                     .flatten();
 
                 if let Some(args) = defer_args {
+                    // Upstream normalization guarantees every @defer has a label
+                    // by the time we reach plan building.
+                    debug_assert!(
+                        args.label.is_some(),
+                        "unlabeled @defer should have been assigned a label during normalization"
+                    );
                     if let Some(ref label) = args.label {
                         // The type condition stays out of the query path:
                         // the chunk is delivered at the enclosing field's

--- a/apollo-federation/src/query_plan/incremental_planner/defer.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/defer.rs
@@ -1,0 +1,436 @@
+//! @defer helpers for the BULB planner: extract @defer metadata from
+//! operations into the `DeferInfo` / `DeferBlockInfo` structures that
+//! `to_query_plan_with_defer` uses to wrap fetch nodes in `DeferNode`s.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::operation::InlineFragment;
+use crate::operation::Selection;
+use crate::operation::SelectionSet;
+use crate::query_plan::QueryPathElement;
+
+/// @defer block info for plan generation, constructed from the original
+/// (un-stripped) operation after search.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct DeferInfo {
+    /// Sub-selection string for the primary (non-deferred) response.
+    pub(crate) primary_sub_selection: Option<String>,
+    /// Per-label deferred block info.
+    pub(crate) blocks: HashMap<String, DeferBlockInfo>,
+    /// Labels synthesized by defer normalization (`qp__N`) to track
+    /// unlabeled @defer blocks internally. They must not leak into the
+    /// emitted plan because clients never wrote them.
+    pub(crate) assigned_labels: Arc<apollo_compiler::collections::IndexSet<String>>,
+}
+
+/// Metadata for a single @defer block in the operation.
+#[derive(Clone, Debug)]
+pub(crate) struct DeferBlockInfo {
+    /// Path to the @defer in the query (for DeferredDeferBlock.query_path).
+    pub(crate) query_path: Vec<QueryPathElement>,
+    /// The sub-selection string for this deferred response chunk.
+    pub(crate) sub_selection: Option<String>,
+    /// Label of the enclosing @defer block, if this @defer is nested.
+    pub(crate) parent_label: Option<String>,
+}
+
+/// Extract the @defer label from an inline fragment, if present.
+pub(super) fn extract_defer_label(inline_fragment: &InlineFragment) -> Option<String> {
+    inline_fragment
+        .defer_directive_arguments()
+        .ok()
+        .flatten()
+        .and_then(|args| args.label)
+}
+
+/// Clone an inline fragment with the @defer directive removed.
+pub(super) fn strip_defer_directive(inline_fragment: &InlineFragment) -> InlineFragment {
+    InlineFragment {
+        schema: inline_fragment.schema.clone(),
+        parent_type_position: inline_fragment.parent_type_position.clone(),
+        type_condition_position: inline_fragment.type_condition_position.clone(),
+        directives: inline_fragment
+            .directives
+            .iter()
+            .filter(|d| d.name != "defer")
+            .cloned()
+            .collect(),
+        selection_id: inline_fragment.selection_id,
+    }
+}
+
+/// Detect @defer on an inline fragment selection: returns the label plus a
+/// copy of the fragment with @defer stripped (so subgraph operations don't
+/// include it), or `(None, None)`.
+pub(super) fn defer_context(selection: &Selection) -> (Option<String>, Option<InlineFragment>) {
+    let Selection::InlineFragment(frag_sel) = selection else {
+        return (None, None);
+    };
+    let has_defer = frag_sel
+        .inline_fragment
+        .directives
+        .iter()
+        .any(|d| d.name == "defer");
+    if !has_defer {
+        return (None, None);
+    }
+    let label = extract_defer_label(&frag_sel.inline_fragment);
+    (
+        label,
+        Some(strip_defer_directive(&frag_sel.inline_fragment)),
+    )
+}
+
+/// Build a `DeferInfo` from the original operation's selection set,
+/// separating primary (non-deferred) selections from deferred blocks.
+/// `assigned_labels` are the normalization-synthesized labels for unlabeled
+/// `@defer`, tracked so plan generation can suppress them from the plan.
+pub(super) fn build_defer_info(
+    selection_set: &SelectionSet,
+    assigned_labels: Arc<apollo_compiler::collections::IndexSet<String>>,
+) -> DeferInfo {
+    let mut info = DeferInfo {
+        assigned_labels,
+        ..DeferInfo::default()
+    };
+    let primary = collect_non_deferred_selection(selection_set);
+    info.primary_sub_selection = (!primary.is_empty()).then(|| format!("{{ {primary} }}"));
+    collect_deferred_blocks(selection_set, &mut info.blocks, &[], None);
+
+    info
+}
+
+/// Collect a string representation of non-deferred selections.
+fn collect_non_deferred_selection(selection_set: &SelectionSet) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for sel in selection_set.selections.values() {
+        match sel {
+            Selection::Field(field_sel) => {
+                let response_name = field_sel.field.response_name();
+                if let Some(sub_sel) = field_sel.selection_set.as_ref() {
+                    let inner = collect_non_deferred_selection(sub_sel);
+                    // A composite field whose entire sub-selection is
+                    // deferred contributes nothing to the primary.
+                    if !inner.is_empty() {
+                        parts.push(format!("{response_name} {{ {inner} }}"));
+                    }
+                } else {
+                    parts.push(response_name.to_string());
+                }
+            }
+            Selection::InlineFragment(frag_sel) => {
+                if extract_defer_label(&frag_sel.inline_fragment).is_some() {
+                    continue;
+                }
+                let type_cond = frag_sel
+                    .inline_fragment
+                    .type_condition_position
+                    .as_ref()
+                    .map(|t| format!("... on {} ", t.type_name()));
+                let inner = collect_non_deferred_selection(&frag_sel.selection_set);
+                if !inner.is_empty() {
+                    if let Some(tc) = type_cond {
+                        parts.push(format!("{tc}{{ {inner} }}"));
+                    } else {
+                        parts.push(inner);
+                    }
+                }
+            }
+        }
+    }
+    parts.join(" ")
+}
+
+/// Recursively find @defer blocks and populate the DeferInfo blocks map;
+/// `parent_defer_label` records nesting in `DeferBlockInfo::parent_label`.
+fn collect_deferred_blocks(
+    selection_set: &SelectionSet,
+    blocks: &mut HashMap<String, DeferBlockInfo>,
+    current_path: &[QueryPathElement],
+    parent_defer_label: Option<&str>,
+) {
+    for sel in selection_set.selections.values() {
+        match sel {
+            Selection::Field(field_sel) => {
+                let response_name = field_sel.field.response_name();
+                let mut child_path = current_path.to_vec();
+                child_path.push(QueryPathElement::Field {
+                    response_key: response_name.clone(),
+                });
+                if let Some(sub_sel) = field_sel.selection_set.as_ref() {
+                    collect_deferred_blocks(sub_sel, blocks, &child_path, parent_defer_label);
+                }
+            }
+            Selection::InlineFragment(frag_sel) => {
+                let defer_args = frag_sel
+                    .inline_fragment
+                    .defer_directive_arguments()
+                    .ok()
+                    .flatten();
+
+                if let Some(args) = defer_args {
+                    if let Some(ref label) = args.label {
+                        // The type condition stays out of the query path:
+                        // the chunk is delivered at the enclosing field's
+                        // path, the condition wrapping the sub-selection.
+                        let query_path = current_path.to_vec();
+                        let inner = serialize_selection_set(&frag_sel.selection_set);
+                        let sub_sel_str = match &frag_sel.inline_fragment.type_condition_position {
+                            Some(tc) => format!("{{ ... on {} {} }}", tc.type_name(), inner),
+                            None => inner,
+                        };
+
+                        blocks.insert(
+                            label.clone(),
+                            DeferBlockInfo {
+                                query_path,
+                                sub_selection: Some(sub_sel_str),
+                                parent_label: parent_defer_label.map(|s| s.to_owned()),
+                            },
+                        );
+
+                        // Recurse for nested @defer with this label as parent.
+                        collect_deferred_blocks(
+                            &frag_sel.selection_set,
+                            blocks,
+                            current_path,
+                            Some(label),
+                        );
+                    }
+                } else {
+                    let mut child_path = current_path.to_vec();
+                    if let Some(tc) = &frag_sel.inline_fragment.type_condition_position {
+                        child_path.push(QueryPathElement::InlineFragment {
+                            type_condition: tc.type_name().clone(),
+                        });
+                    }
+                    collect_deferred_blocks(
+                        &frag_sel.selection_set,
+                        blocks,
+                        &child_path,
+                        parent_defer_label,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Serialize a SelectionSet into a brace-wrapped (`{ ... }`) string for
+/// `DeferredDeferBlock.sub_selection`.
+pub(super) fn serialize_selection_set(selection_set: &SelectionSet) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for sel in selection_set.selections.values() {
+        match sel {
+            Selection::Field(field_sel) => {
+                let response_name = field_sel.field.response_name();
+                if let Some(sub_sel) = field_sel.selection_set.as_ref() {
+                    let inner = serialize_selection_set(sub_sel);
+                    parts.push(format!("{response_name} {inner}"));
+                } else {
+                    parts.push(response_name.to_string());
+                }
+            }
+            Selection::InlineFragment(frag_sel) => {
+                let tc = frag_sel
+                    .inline_fragment
+                    .type_condition_position
+                    .as_ref()
+                    .map(|t| format!("... on {} ", t.type_name()))
+                    .unwrap_or_default();
+                let inner = serialize_selection_set(&frag_sel.selection_set);
+                parts.push(format!("{tc}{inner}"));
+            }
+        }
+    }
+    format!("{{ {} }}", parts.join(" "))
+}
+
+#[cfg(test)]
+mod tests {
+    use apollo_compiler::name;
+
+    use super::*;
+    use crate::operation::Operation;
+    use crate::schema::ValidFederationSchema;
+
+    const SCHEMA: &str = r#"
+        directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+        type Query {
+          user: User
+          node: Node
+        }
+
+        interface Node {
+          id: ID
+        }
+
+        type User implements Node {
+          id: ID
+          name: String
+          address: Address
+        }
+
+        type Address {
+          street: String
+          city: String
+        }
+    "#;
+
+    fn parse(query: &str) -> Operation {
+        let schema = apollo_compiler::schema::Schema::parse_and_validate(SCHEMA, "schema.graphql")
+            .expect("valid schema");
+        let schema = ValidFederationSchema::new(schema).expect("valid federation schema");
+        Operation::parse(schema, query, "query.graphql").expect("valid operation")
+    }
+
+    /// The first selection nested under the operation's first (field) selection.
+    fn first_child_selection(op: &Operation) -> Selection {
+        let Some(Selection::Field(field_sel)) = op.selection_set.selections.values().next() else {
+            panic!("expected a field selection at the top level");
+        };
+        field_sel
+            .selection_set
+            .as_ref()
+            .expect("field has sub-selections")
+            .selections
+            .values()
+            .next()
+            .expect("sub-selection exists")
+            .clone()
+    }
+
+    #[test]
+    fn defer_context_extracts_label_and_strips_directive() {
+        let op = parse(r#"{ user { ... on User @defer(label: "d1") { name } } }"#);
+        let fragment_sel = first_child_selection(&op);
+
+        let (label, stripped) = defer_context(&fragment_sel);
+
+        assert_eq!(label.as_deref(), Some("d1"));
+        let stripped = stripped.expect("stripped fragment present");
+        assert!(stripped.directives.iter().all(|d| d.name != "defer"));
+        // The type condition survives the strip.
+        assert_eq!(
+            stripped
+                .type_condition_position
+                .as_ref()
+                .map(|tc| tc.type_name().clone()),
+            Some(name!("User"))
+        );
+    }
+
+    #[test]
+    fn defer_context_unlabeled_defer_still_strips_directive() {
+        let op = parse(r#"{ user { ... on User @defer { name } } }"#);
+        let fragment_sel = first_child_selection(&op);
+
+        let (label, stripped) = defer_context(&fragment_sel);
+
+        assert_eq!(label, None);
+        let stripped = stripped.expect("stripped fragment present");
+        assert!(stripped.directives.iter().all(|d| d.name != "defer"));
+    }
+
+    #[test]
+    fn defer_context_ignores_fields_and_plain_fragments() {
+        let op = parse(r#"{ user { name } }"#);
+        let field_sel = op
+            .selection_set
+            .selections
+            .values()
+            .next()
+            .expect("selection exists")
+            .clone();
+        let (label, stripped) = defer_context(&field_sel);
+        assert_eq!(label, None);
+        assert!(stripped.is_none());
+
+        let op = parse(r#"{ node { ... on User { name } } }"#);
+        let fragment_sel = first_child_selection(&op);
+        let (label, stripped) = defer_context(&fragment_sel);
+        assert_eq!(label, None);
+        assert!(stripped.is_none());
+    }
+
+    #[test]
+    fn build_defer_info_separates_primary_from_deferred() {
+        let op = parse(
+            r#"{
+              node { ... on User { name } }
+              user {
+                name
+                ... on User @defer(label: "d2") { address { street } }
+              }
+            }"#,
+        );
+
+        let info = build_defer_info(&op.selection_set, Default::default());
+
+        // Non-deferred inline fragments stay in the primary with their type
+        // condition; the deferred fragment is excluded from it.
+        assert_eq!(
+            info.primary_sub_selection.as_deref(),
+            Some("{ node { ... on User { name } } user { name } }")
+        );
+
+        let block = info.blocks.get("d2").expect("deferred block recorded");
+        assert_eq!(
+            block.query_path,
+            vec![QueryPathElement::Field {
+                response_key: name!("user"),
+            }]
+        );
+        assert_eq!(
+            block.sub_selection.as_deref(),
+            Some("{ ... on User { address { street } } }")
+        );
+        assert_eq!(block.parent_label, None);
+    }
+
+    #[test]
+    fn build_defer_info_fully_deferred_field_has_no_primary() {
+        let op = parse(r#"{ user { ... on User @defer(label: "d3") { name } } }"#);
+
+        let info = build_defer_info(&op.selection_set, Default::default());
+
+        // `user`'s entire sub-selection is deferred, so it contributes
+        // nothing to the primary.
+        assert_eq!(info.primary_sub_selection, None);
+        assert!(info.blocks.contains_key("d3"));
+    }
+
+    #[test]
+    fn deferred_block_inside_plain_fragment_records_fragment_in_path() {
+        let op = parse(
+            r#"{
+              node {
+                ... on User {
+                  name
+                  ... on User @defer(label: "d4") { address { street } }
+                }
+              }
+            }"#,
+        );
+
+        let info = build_defer_info(&op.selection_set, Default::default());
+
+        let block = info.blocks.get("d4").expect("deferred block recorded");
+        // The enclosing non-defer fragment contributes an InlineFragment
+        // path element; the deferred fragment's own condition does not.
+        assert_eq!(
+            block.query_path,
+            vec![
+                QueryPathElement::Field {
+                    response_key: name!("node"),
+                },
+                QueryPathElement::InlineFragment {
+                    type_condition: name!("User"),
+                },
+            ]
+        );
+        assert_eq!(block.parent_label, None);
+    }
+}

--- a/apollo-federation/src/query_plan/incremental_planner/fetch_graph/mod.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/fetch_graph/mod.rs
@@ -71,6 +71,10 @@ pub(crate) struct FetchNode {
     pub(crate) subgraph: Arc<str>,
     pub(crate) kind: FetchGroupKind,
     pub(crate) selection_builder: SelectionBuilder,
+    /// The @defer label this fetch belongs to; `None` for the primary
+    /// (non-deferred) response. Fetch nodes with a defer_ref are partitioned
+    /// into deferred blocks during plan generation.
+    pub(crate) defer_ref: Option<String>,
 }
 
 impl FetchNode {
@@ -79,6 +83,7 @@ impl FetchNode {
             subgraph,
             kind,
             selection_builder: SelectionBuilder::default(),
+            defer_ref: None,
         }
     }
 
@@ -110,7 +115,7 @@ enum FetchGraphOp {
     /// entry.
     AddNode {
         node_index: NodeIndex,
-        root_key: Option<Arc<str>>,
+        root_key: Option<(Arc<str>, Option<String>)>,
     },
     /// An edge was added. Undo: remove_edge.
     AddEdge(EdgeIndex),
@@ -124,10 +129,14 @@ enum FetchGraphOp {
     /// A node's depth was raised by an edge insertion. Undo: restore the
     /// previous depth and stage counts.
     RaiseDepth { node_index: NodeIndex, prev: u32 },
+    /// A node claimed the entity_groups slot for its key. Undo: remove the
+    /// entry. Always logged directly after the node's AddNode, so LIFO
+    /// undo clears the slot before removing the node.
+    RegisterEntityGroup { key: EntityGroupKey },
 }
 
-/// Index key for entity fetch group reuse.
-type EntityGroupKey = (Arc<str>, Vec<FetchDataPathElement>);
+/// Index key for entity fetch group reuse: (subgraph, merge_at, defer_ref).
+type EntityGroupKey = (Arc<str>, Vec<FetchDataPathElement>, Option<String>);
 
 /// Lightweight fetch graph for BULB search.
 ///
@@ -138,13 +147,14 @@ type EntityGroupKey = (Arc<str>, Vec<FetchDataPathElement>);
 #[derive(Clone, Debug)]
 pub(crate) struct FetchGraph {
     graph: StableDiGraph<FetchNode, FetchEdgeWeight>,
-    /// Root groups keyed by subgraph name.
-    root_groups: HashMap<Arc<str>, NodeIndex>,
-    /// First-created entity group per (subgraph, merge_at), so
-    /// `get_or_create_entity_group` (run on every key hop) is a lookup
-    /// instead of a node scan. Only the first node with a key claims the
-    /// slot (earliest-index-wins); undo is LIFO, so a later duplicate can
-    /// never outlive the slot owner. Stale after post-search sibling
+    /// Root groups keyed by (subgraph, defer_ref): a deferred root fetch is
+    /// a separate group from the primary root in the same subgraph.
+    root_groups: HashMap<(Arc<str>, Option<String>), NodeIndex>,
+    /// First-created entity group per (subgraph, merge_at, defer_ref), so
+    /// `get_or_create_entity_group_with_defer` (run on every key hop) is a
+    /// lookup instead of a node scan. Only the first node with a key claims
+    /// the slot (earliest-index-wins); undo is LIFO, so a later duplicate
+    /// can never outlive the slot owner. Stale after post-search sibling
     /// merging, which is fine since nothing creates groups after search.
     entity_groups: HashMap<EntityGroupKey, NodeIndex>,
     undo_log: Vec<FetchGraphOp>,
@@ -260,6 +270,9 @@ impl FetchGraph {
                     self.bump_stage_count(prev, 1);
                     self.depth[node_index.index()] = prev;
                 }
+                FetchGraphOp::RegisterEntityGroup { key } => {
+                    self.entity_groups.remove(&key);
+                }
             }
         }
     }
@@ -267,9 +280,17 @@ impl FetchGraph {
     /// Add a `FetchNode`, registering its depth and logging for rollback.
     /// With `root_key` set, also registers it as a root group. Entity nodes
     /// claim the `entity_groups` reuse slot for their key if free.
-    fn insert_node(&mut self, node: FetchNode, root_key: Option<Arc<str>>) -> NodeIndex {
+    fn insert_node(
+        &mut self,
+        node: FetchNode,
+        root_key: Option<(Arc<str>, Option<String>)>,
+    ) -> NodeIndex {
         let entity_key = match &node.kind {
-            FetchGroupKind::Entity { merge_at } => Some((node.subgraph.clone(), merge_at.clone())),
+            FetchGroupKind::Entity { merge_at } => Some((
+                node.subgraph.clone(),
+                merge_at.clone(),
+                node.defer_ref.clone(),
+            )),
             _ => None,
         };
         let id = self.graph.add_node(node);
@@ -281,42 +302,72 @@ impl FetchGraph {
             node_index: id,
             root_key,
         });
-        // Claim the entity_groups reuse slot if this is the first node for
-        // this (subgraph, merge_at) pair. The undo log entry for AddNode
-        // already handles removing the node; cleaning up the entity_groups
-        // slot is handled inline in rollback by checking whether the slot
-        // points to the removed node.
-        if let Some(key) = entity_key {
-            self.entity_groups.entry(key).or_insert(id);
+        if let Some(key) = entity_key
+            && !self.entity_groups.contains_key(&key)
+        {
+            self.entity_groups.insert(key.clone(), id);
+            self.undo_log
+                .push(FetchGraphOp::RegisterEntityGroup { key });
         }
         id
     }
 
-    /// Get or create the root fetch group for a subgraph.
+    /// Get or create the root fetch group for a subgraph (no defer scope).
     pub(crate) fn get_or_create_root_group(
         &mut self,
         subgraph: &Arc<str>,
         root_type: CompositeTypeDefinitionPosition,
     ) -> NodeIndex {
-        if let Some(&id) = self.root_groups.get(subgraph) {
+        self.get_or_create_root_group_with_defer(subgraph, root_type, None)
+    }
+
+    /// Get or create the root fetch group for a (subgraph, defer_ref) pair.
+    pub(crate) fn get_or_create_root_group_with_defer(
+        &mut self,
+        subgraph: &Arc<str>,
+        root_type: CompositeTypeDefinitionPosition,
+        defer_ref: Option<String>,
+    ) -> NodeIndex {
+        let root_key = (subgraph.clone(), defer_ref.clone());
+        if let Some(&id) = self.root_groups.get(&root_key) {
             return id;
         }
         self.insert_node(
-            FetchNode::new(subgraph.clone(), FetchGroupKind::Root { root_type }),
-            Some(subgraph.clone()),
+            FetchNode {
+                subgraph: subgraph.clone(),
+                kind: FetchGroupKind::Root { root_type },
+                selection_builder: SelectionBuilder::default(),
+                defer_ref,
+            },
+            Some(root_key),
         )
     }
 
-    /// Create a new entity fetch group.
+    /// Create a new entity fetch group with an explicit defer scope.
+    pub(crate) fn add_entity_group_with_defer(
+        &mut self,
+        subgraph: &Arc<str>,
+        merge_at: Vec<FetchDataPathElement>,
+        defer_ref: Option<String>,
+    ) -> NodeIndex {
+        self.insert_node(
+            FetchNode {
+                subgraph: subgraph.clone(),
+                kind: FetchGroupKind::Entity { merge_at },
+                selection_builder: SelectionBuilder::default(),
+                defer_ref,
+            },
+            None,
+        )
+    }
+
+    /// Create a new entity fetch group (no defer scope).
     pub(crate) fn add_entity_group(
         &mut self,
         subgraph: &Arc<str>,
         merge_at: Vec<FetchDataPathElement>,
     ) -> NodeIndex {
-        self.insert_node(
-            FetchNode::new(subgraph.clone(), FetchGroupKind::Entity { merge_at }),
-            None,
-        )
+        self.add_entity_group_with_defer(subgraph, merge_at, None)
     }
 
     pub(crate) fn add_root_hop_group(
@@ -337,21 +388,31 @@ impl FetchGraph {
         )
     }
 
+    /// Get or create the entity fetch group for (subgraph, merge_at, defer_ref).
+    pub(crate) fn get_or_create_entity_group_with_defer(
+        &mut self,
+        subgraph: &Arc<str>,
+        merge_at: Vec<FetchDataPathElement>,
+        defer_ref: Option<String>,
+    ) -> NodeIndex {
+        let key = (subgraph.clone(), merge_at, defer_ref);
+        if let Some(&id) = self.entity_groups.get(&key) {
+            if self.graph.contains_node(id) {
+                return id;
+            }
+            self.entity_groups.remove(&key);
+        }
+        self.add_entity_group_with_defer(subgraph, key.1, key.2)
+    }
+
     /// Get or create the entity fetch group for (subgraph, merge_at).
+    #[allow(dead_code)]
     pub(crate) fn get_or_create_entity_group(
         &mut self,
         subgraph: &Arc<str>,
         merge_at: Vec<FetchDataPathElement>,
     ) -> NodeIndex {
-        let key = (subgraph.clone(), merge_at);
-        if let Some(&id) = self.entity_groups.get(&key) {
-            if self.graph.contains_node(id) {
-                return id;
-            }
-            // Stale entry from a rolled-back node; remove and fall through.
-            self.entity_groups.remove(&key);
-        }
-        self.add_entity_group(subgraph, key.1)
+        self.get_or_create_entity_group_with_defer(subgraph, merge_at, None)
     }
 
     /// Whether a directed edge from `parent` to `child` exists.
@@ -725,10 +786,10 @@ mod tests {
         let sg: Arc<str> = Arc::from("sg");
         g.get_or_create_root_group(&sg, dummy_root_type());
         assert_eq!(g.node_count(), 1);
-        assert!(g.root_groups.contains_key(&sg));
+        assert!(g.root_groups.contains_key(&(sg.clone(), None)));
         g.rollback(cp);
         assert_eq!(g.node_count(), 0);
-        assert!(!g.root_groups.contains_key(&sg));
+        assert!(!g.root_groups.contains_key(&(sg.clone(), None)));
 
         // Re-creating after rollback should work.
         g.get_or_create_root_group(&sg, dummy_root_type());

--- a/apollo-federation/src/query_plan/incremental_planner/fetch_graph/plan_builder.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/fetch_graph/plan_builder.rs
@@ -1,7 +1,8 @@
 //! Materializing the winning fetch graph into a query plan: a topological
-//! sort into depth layers, one subgraph operation per fetch group, and
-//! entity representations from edge inputs.
+//! sort into depth layers, one subgraph operation per fetch group, entity
+//! representations from edge inputs, and @defer partitioning.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use apollo_compiler::Name;
@@ -15,6 +16,7 @@ use petgraph::stable_graph::NodeIndex;
 use petgraph::visit::EdgeRef;
 use petgraph::visit::NodeIndexable;
 
+use super::super::defer::DeferInfo;
 use super::FETCH_COST;
 use super::FetchGraph;
 use super::FetchGroupKind;
@@ -26,9 +28,13 @@ use crate::operation::SelectionSet;
 use crate::operation::VariableCollector;
 use crate::query_graph::QueryGraph;
 use crate::query_graph::graph_path::operation::OpGraphPathContext;
+use crate::query_plan::DeferNode;
+use crate::query_plan::DeferredDeferBlock;
+use crate::query_plan::DeferredDependency;
 use crate::query_plan::FetchDataPathElement;
 use crate::query_plan::FetchDataRewrite;
 use crate::query_plan::PlanNode;
+use crate::query_plan::PrimaryDeferBlock;
 use crate::query_plan::QueryPlanCost;
 use crate::query_plan::conditions::ConditionKind;
 use crate::query_plan::conditions::Conditions;
@@ -58,12 +64,29 @@ pub(crate) struct PlanBuildContext<'a> {
     pub(crate) operation_counter: u32,
 }
 
+/// Stamp a fetch ID on the innermost FetchNode (bare or Flatten-wrapped).
+fn stamp_fetch_id(plan_node: &mut PlanNode, id: u64) {
+    match plan_node {
+        PlanNode::Fetch(fetch) => {
+            fetch.id = Some(id);
+        }
+        PlanNode::Flatten(flatten) => {
+            stamp_fetch_id(&mut flatten.node, id);
+        }
+        _ => {}
+    }
+}
+
 impl FetchGraph {
-    /// Generate a PlanNode tree from the winning fetch graph.
-    pub(crate) fn to_query_plan(
+    /// Generate a PlanNode tree, wrapped in a DeferNode when defer info is
+    /// provided.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn to_query_plan_with_defer(
         &self,
         ctx: &mut PlanBuildContext<'_>,
+        defer_info: Option<&DeferInfo>,
     ) -> Result<(Option<PlanNode>, QueryPlanCost), FederationError> {
+        // Step 1: Topological sort and depth computation.
         let sorted = toposort(&self.graph, None).map_err(|cycle| {
             let node = cycle.node_id();
             let subgraph = &self.graph[node].subgraph;
@@ -92,17 +115,144 @@ impl FetchGraph {
             }
         }
 
-        self.build_plan_for_nodes(ctx, &sorted, &depth, max_depth)
+        // A Defer wrapper is needed whenever the operation has @defer
+        // blocks, even if no fetch node carries a defer_ref: a deferred
+        // selection whose data rides the primary fetches still needs a
+        // data-only block so the router delivers it as a separate chunk.
+        let has_defer_blocks = defer_info.is_some_and(|di| !di.blocks.is_empty());
+
+        if !has_defer_blocks {
+            return self.build_plan_for_nodes(ctx, &sorted, &depth, max_depth, None);
+        }
+
+        let defer_info = defer_info.unwrap();
+
+        // Step 2: Partition nodes by defer_ref.
+        let mut primary_nodes: Vec<NodeIndex> = Vec::new();
+        let mut deferred_nodes: IndexMap<String, Vec<NodeIndex>> = IndexMap::new();
+        for &node_idx in &sorted {
+            match &self.graph[node_idx].defer_ref {
+                None => primary_nodes.push(node_idx),
+                Some(label) => {
+                    deferred_nodes
+                        .entry(label.clone())
+                        .or_default()
+                        .push(node_idx);
+                }
+            }
+        }
+
+        let mut fetch_id_counter = 0u64;
+
+        // Step 3: Assign fetch IDs to nodes that parent a node with a
+        // different defer_ref (None->Some and Some->Some alike), covering
+        // primary-to-deferred and deferred-to-nested-deferred edges.
+        let mut node_fetch_ids: HashMap<NodeIndex, u64> = HashMap::new();
+        for &node_idx in &sorted {
+            let this_defer = self.graph[node_idx].defer_ref.as_deref();
+            for edge in self.graph.edges_directed(node_idx, Direction::Outgoing) {
+                let child_defer = self.graph[edge.target()].defer_ref.as_deref();
+                if child_defer != this_defer {
+                    node_fetch_ids.entry(node_idx).or_insert_with(|| {
+                        let id = fetch_id_counter;
+                        fetch_id_counter += 1;
+                        id
+                    });
+                    break;
+                }
+            }
+        }
+
+        // Every label in the operation gets a block, even with no fetch
+        // nodes of its own: data riding an enclosing fetch still needs a
+        // data-only block (node: None). Labels with fetch nodes keep their
+        // deterministic (commit-order) position; node-less labels are
+        // appended in sorted order.
+        let all_labels: Vec<String> = {
+            let mut labels: Vec<String> = deferred_nodes.keys().cloned().collect();
+            let mut node_less: Vec<&String> = defer_info
+                .blocks
+                .keys()
+                .filter(|label| !deferred_nodes.contains_key(*label))
+                .collect();
+            node_less.sort();
+            labels.extend(node_less.into_iter().cloned());
+            labels
+        };
+        let top_level_labels: Vec<String> = all_labels
+            .iter()
+            .filter(|label| {
+                defer_info
+                    .blocks
+                    .get(label.as_str())
+                    .and_then(|bi| bi.parent_label.as_ref())
+                    .is_none()
+            })
+            .cloned()
+            .collect();
+
+        // Build child label index: parent_label -> [child_labels]
+        let mut children_of: HashMap<String, Vec<String>> = HashMap::new();
+        for label in &all_labels {
+            if let Some(parent) = defer_info
+                .blocks
+                .get(label.as_str())
+                .and_then(|bi| bi.parent_label.as_ref())
+            {
+                children_of
+                    .entry(parent.clone())
+                    .or_default()
+                    .push(label.clone());
+            }
+        }
+
+        // Step 4: Build primary plan.
+        let (primary_plan, total_cost) = self.build_plan_for_nodes(
+            ctx,
+            &primary_nodes,
+            &depth,
+            max_depth,
+            Some(&node_fetch_ids),
+        )?;
+
+        // Step 5: Recursively build deferred blocks.
+        let deferred_blocks = self.build_deferred_blocks(
+            ctx,
+            &top_level_labels,
+            &deferred_nodes,
+            defer_info,
+            &node_fetch_ids,
+            &children_of,
+            &depth,
+            max_depth,
+        )?;
+
+        let primary_sub_selection = defer_info
+            .primary_sub_selection
+            .as_deref()
+            .map(|s| s.to_owned());
+
+        let defer_node = PlanNode::Defer(DeferNode {
+            primary: PrimaryDeferBlock {
+                sub_selection: primary_sub_selection,
+                node: primary_plan.map(Box::new),
+            },
+            deferred: deferred_blocks,
+        });
+
+        Ok((Some(defer_node), total_cost))
     }
 
-    /// Build a plan from a subset of nodes, grouping by depth into
-    /// parallel layers and sequencing those layers.
+    /// Build a plan from a subset of nodes (shared by primary and deferred
+    /// block plans).
+    #[allow(clippy::too_many_arguments)]
     fn build_plan_for_nodes(
         &self,
         ctx: &mut PlanBuildContext<'_>,
         nodes: &[NodeIndex],
         depth: &[u32],
         max_depth: u32,
+        fetch_ids: Option<&HashMap<NodeIndex, u64>>,
     ) -> Result<(Option<PlanNode>, QueryPlanCost), FederationError> {
         let handled_conditions = Conditions::Boolean(true);
         let mut sequence: Vec<PlanNode> = Vec::new();
@@ -116,9 +266,15 @@ impl FetchGraph {
                 if depth[node_idx.index()] != d {
                     continue;
                 }
-                if let Some((plan_node, node_cost)) =
+                if let Some((mut plan_node, node_cost)) =
                     self.node_to_plan_node(ctx, node_idx, &handled_conditions)?
                 {
+                    // Fetch IDs are used for defer dependency tracking.
+                    if let Some(ids) = fetch_ids
+                        && let Some(&fetch_id) = ids.get(&node_idx)
+                    {
+                        stamp_fetch_id(&mut plan_node, fetch_id);
+                    }
                     parallel.push(plan_node);
                     parallel_cost += node_cost;
                 }
@@ -151,6 +307,113 @@ impl FetchGraph {
         };
 
         Ok((plan, total_cost))
+    }
+
+    /// Recursively build `DeferredDeferBlock`s for a set of labels; a label
+    /// with children (nested @defer) wraps its fetch nodes and child blocks
+    /// in a nested `DeferNode`.
+    #[allow(clippy::too_many_arguments)]
+    fn build_deferred_blocks(
+        &self,
+        ctx: &mut PlanBuildContext<'_>,
+        labels: &[String],
+        deferred_nodes: &IndexMap<String, Vec<NodeIndex>>,
+        defer_info: &DeferInfo,
+        node_fetch_ids: &HashMap<NodeIndex, u64>,
+        children_of: &HashMap<String, Vec<String>>,
+        depth: &[u32],
+        max_depth: u32,
+    ) -> Result<Vec<DeferredDeferBlock>, FederationError> {
+        let mut blocks: Vec<DeferredDeferBlock> = Vec::new();
+
+        for label in labels {
+            // A label with no fetch nodes (data rides an enclosing fetch)
+            // is emitted with node: None; the router delivers the chunk
+            // from already-fetched data via the block's sub_selection.
+            let nodes = deferred_nodes.get(label).map(Vec::as_slice).unwrap_or(&[]);
+            let block_info = defer_info.blocks.get(label.as_str());
+            let child_labels = children_of.get(label);
+
+            // Dependencies: parent-scope nodes feeding this label's nodes.
+            let mut depends: Vec<DeferredDependency> = Vec::new();
+            for &deferred_idx in nodes {
+                for edge in self.graph.edges_directed(deferred_idx, Direction::Incoming) {
+                    let parent_idx = edge.source();
+                    if let Some(&fetch_id) = node_fetch_ids.get(&parent_idx)
+                        && !depends.iter().any(|d| d.id == fetch_id.to_string())
+                    {
+                        depends.push(DeferredDependency {
+                            id: fetch_id.to_string(),
+                        });
+                    }
+                }
+            }
+
+            let query_path = block_info
+                .map(|bi| bi.query_path.clone())
+                .unwrap_or_default();
+
+            let visible_label = if defer_info.assigned_labels.contains(label.as_str()) {
+                None
+            } else {
+                Some(label.clone())
+            };
+
+            let node_plan = if let Some(child_labels) = child_labels
+                && !child_labels.is_empty()
+            {
+                let (inner_plan, _cost) =
+                    self.build_plan_for_nodes(ctx, nodes, depth, max_depth, Some(node_fetch_ids))?;
+                let inner_deferred = self.build_deferred_blocks(
+                    ctx,
+                    child_labels,
+                    deferred_nodes,
+                    defer_info,
+                    node_fetch_ids,
+                    children_of,
+                    depth,
+                    max_depth,
+                )?;
+
+                // The outer block's sub_selection describes the whole chunk;
+                // the nested DeferNode's primary carries none (its deferred
+                // children re-select their pieces via their blocks).
+                let nested_defer = PlanNode::Defer(DeferNode {
+                    primary: PrimaryDeferBlock {
+                        sub_selection: None,
+                        node: inner_plan.map(Box::new),
+                    },
+                    deferred: inner_deferred,
+                });
+                Some(Box::new(nested_defer))
+            } else if nodes.is_empty() {
+                None
+            } else {
+                let (deferred_plan, _cost) =
+                    self.build_plan_for_nodes(ctx, nodes, depth, max_depth, None)?;
+                deferred_plan.map(Box::new)
+            };
+
+            // For nested DeferNodes, sub_selection was consumed above;
+            // leaf blocks use it directly.
+            let sub_selection = if child_labels.is_some_and(|c| !c.is_empty()) {
+                None
+            } else {
+                block_info
+                    .and_then(|bi| bi.sub_selection.as_deref())
+                    .map(|s| s.to_owned())
+            };
+
+            blocks.push(DeferredDeferBlock {
+                depends,
+                label: visible_label,
+                query_path,
+                sub_selection,
+                node: node_plan,
+            });
+        }
+
+        Ok(blocks)
     }
 
     /// Convert a single FetchGraph node into a PlanNode.

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/commit.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/commit.rs
@@ -8,6 +8,8 @@ use petgraph::graph::EdgeIndex;
 use petgraph::graph::NodeIndex;
 use tracing::trace;
 
+use super::super::defer;
+use super::super::defer::strip_defer_directive;
 use super::super::fetch_graph::InputContribution;
 use super::super::fetch_graph::InputRewriteInfo;
 use super::super::shared_path::SharedPath;
@@ -248,6 +250,7 @@ impl FieldRoutingSearchSpace {
             state,
             first_subgraph,
             merge_at.clone(),
+            pending.defer_ref.clone(),
             pending.fetch_node,
             pending.ordering_dependent(),
         );
@@ -371,6 +374,7 @@ impl FieldRoutingSearchSpace {
                 state,
                 next_subgraph,
                 merge_at.clone(),
+                pending.defer_ref.clone(),
                 prev_group,
                 pending.ordering_dependent(),
             );
@@ -444,16 +448,21 @@ impl FieldRoutingSearchSpace {
         state: &mut PlanState,
         subgraph: &Arc<str>,
         merge_at: Vec<FetchDataPathElement>,
+        defer_ref: Option<String>,
         anchor_fetch: NodeIndex,
         ordering_dependent: Option<NodeIndex>,
     ) -> NodeIndex {
-        let group = state
-            .graph
-            .get_or_create_entity_group(subgraph, merge_at.clone());
+        let group = state.graph.get_or_create_entity_group_with_defer(
+            subgraph,
+            merge_at.clone(),
+            defer_ref.clone(),
+        );
         let conflicts_with_dependent = ordering_dependent
             .is_some_and(|dep| group == dep || state.graph.is_reachable(dep, group));
         if conflicts_with_dependent || state.graph.is_reachable(group, anchor_fetch) {
-            return state.graph.add_entity_group(subgraph, merge_at);
+            return state
+                .graph
+                .add_entity_group_with_defer(subgraph, merge_at, defer_ref);
         }
         group
     }
@@ -566,9 +575,11 @@ impl FieldRoutingSearchSpace {
             let subgraph_node = qg.node_weight(field_source)?;
             let root_type: CompositeTypeDefinitionPosition =
                 subgraph_node.type_.clone().try_into()?;
-            return Ok(state
-                .graph
-                .get_or_create_root_group(&subgraph_node.source, root_type));
+            return Ok(state.graph.get_or_create_root_group_with_defer(
+                &subgraph_node.source,
+                root_type,
+                pending.defer_ref.clone(),
+            ));
         }
 
         Ok(pending.fetch_node)
@@ -652,7 +663,7 @@ impl FieldRoutingSearchSpace {
                         Arc::new(OpPathElement::Field(field_sel.field.clone()))
                     }
                     Selection::InlineFragment(frag_sel) => Arc::new(OpPathElement::InlineFragment(
-                        frag_sel.inline_fragment.clone(),
+                        strip_defer_directive(&frag_sel.inline_fragment),
                     )),
                 };
                 base.pushed(op_element)
@@ -663,6 +674,7 @@ impl FieldRoutingSearchSpace {
                     .op_path
                     .pushed(Arc::new(OpPathElement::Field(field_sel.field.clone()))),
                 Selection::InlineFragment(frag_sel) => {
+                    let stripped = strip_defer_directive(&frag_sel.inline_fragment);
                     let edge = qg.edge_weight(choice.edge_index())?;
                     if matches!(
                         edge.transition,
@@ -670,11 +682,10 @@ impl FieldRoutingSearchSpace {
                     ) {
                         // @interfaceObject fake downcast: the concrete type
                         // doesn't exist in this subgraph.
-                        if frag_sel.inline_fragment.directives.is_empty() {
+                        if stripped.directives.is_empty() {
                             pending.op_path.clone()
                         } else {
-                            let updated =
-                                frag_sel.inline_fragment.with_updated_type_condition(None);
+                            let updated = stripped.with_updated_type_condition(None);
                             pending
                                 .op_path
                                 .pushed(Arc::new(OpPathElement::InlineFragment(updated)))
@@ -682,9 +693,7 @@ impl FieldRoutingSearchSpace {
                     } else {
                         pending
                             .op_path
-                            .pushed(Arc::new(OpPathElement::InlineFragment(
-                                frag_sel.inline_fragment.clone(),
-                            )))
+                            .pushed(Arc::new(OpPathElement::InlineFragment(stripped)))
                     }
                 }
             },
@@ -824,6 +833,13 @@ impl FieldRoutingSearchSpace {
         let child_provides_anchor =
             self.child_provides_anchor(pending, target_qg_node, target.entity_root)?;
 
+        // When the committed selection is an inline fragment carrying
+        // @defer, extract the label and propagate it to children so fetch
+        // nodes created downstream land in the deferred partition.
+        let child_defer_ref = defer::defer_context(&pending.selection)
+            .0
+            .or_else(|| pending.defer_ref.clone());
+
         for sub_sel in sub_ss.selections.values().rev().cloned() {
             state.push_pending(
                 pending
@@ -831,7 +847,8 @@ impl FieldRoutingSearchSpace {
                     .at(target_qg_node, fetch_node)
                     .with_op_path(target.op_path.clone())
                     .with_response_path(target.response_path.clone())
-                    .with_provides_anchor(child_provides_anchor),
+                    .with_provides_anchor(child_provides_anchor)
+                    .with_defer(child_defer_ref.clone()),
             );
         }
         Ok(())

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/state.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/state.rs
@@ -54,6 +54,9 @@ pub(crate) struct PendingSelection {
     /// own edges carry the provenance (inside a copy layer) or no @provides
     /// is in scope.
     pub(crate) provides_anchor: Option<NodeIndex>,
+    /// The @defer label this selection is inside, if any. Propagated to
+    /// fetch nodes so they can be partitioned into primary vs deferred.
+    pub(crate) defer_ref: Option<String>,
     /// Best-effort selection: dropping it (zero routing options, or a failed
     /// commit) is tolerated silently instead of counting toward
     /// `dropped_fields` and failing the plan. Inherited by forks, so
@@ -76,6 +79,7 @@ impl PendingSelection {
             path_in_fetch: self.path_in_fetch.clone(),
             condition: self.condition,
             provides_anchor: self.provides_anchor,
+            defer_ref: self.defer_ref.clone(),
             best_effort: self.best_effort,
         }
     }
@@ -101,6 +105,11 @@ impl PendingSelection {
 
     pub(super) fn with_provides_anchor(mut self, provides_anchor: Option<NodeIndex>) -> Self {
         self.provides_anchor = provides_anchor;
+        self
+    }
+
+    pub(super) fn with_defer(mut self, defer_ref: Option<String>) -> Self {
+        self.defer_ref = defer_ref;
         self
     }
 

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/tests.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/tests.rs
@@ -1,6 +1,7 @@
 use crate::Supergraph;
 use crate::query_plan::TopLevelPlanNode;
 use crate::query_plan::query_planner::IncrementalPlannerConfig;
+use crate::query_plan::query_planner::QueryPlanIncrementalDeliveryConfig;
 use crate::query_plan::query_planner::QueryPlanOptions;
 use crate::query_plan::query_planner::QueryPlanner;
 use crate::query_plan::query_planner::QueryPlannerConfig;
@@ -39,6 +40,14 @@ fn plan_query_with_options(
         .build_query_plan(&document, None, plan_options)
         .expect("query plan");
     format!("{plan}")
+}
+
+fn plan_query_with_defer(schema: &str, query: &str) -> String {
+    let config = QueryPlannerConfig {
+        incremental_delivery: QueryPlanIncrementalDeliveryConfig { enable_defer: true },
+        ..default_config()
+    };
+    plan_query_with_options(schema, query, config, Default::default())
 }
 
 const SINGLE_SUBGRAPH_SCHEMA: &str = include_str!("../fixtures/single_subgraph.graphql");
@@ -1686,5 +1695,98 @@ fn constant_skip_and_root_type_condition_fragments() {
     assert!(
         rooted.contains("name"),
         "Root type condition should pass through: {rooted}"
+    );
+}
+
+/// Cross-subgraph @defer: the deferred fragment's fields live in a different
+/// subgraph from the primary, producing a Defer node with a key-hop fetch
+/// in the deferred block.
+#[test]
+fn defer_produces_defer_node() {
+    let plan_str = plan_query_with_defer(
+        CROSS_SUBGRAPH_SCHEMA,
+        "{ user { name ... @defer { email } } }",
+    );
+    assert!(
+        plan_str.contains("Defer"),
+        "Plan should contain a Defer node: {plan_str}"
+    );
+    assert!(
+        plan_str.contains("name"),
+        "Primary should fetch 'name': {plan_str}"
+    );
+    assert!(
+        plan_str.contains("email"),
+        "Deferred should fetch 'email': {plan_str}"
+    );
+}
+
+/// Labels synthesized by defer normalization for unlabeled @defer
+/// (`qp__N`) are internal bookkeeping and must not leak into the plan;
+/// user-written labels must be preserved.
+#[test]
+fn synthesized_defer_labels_do_not_leak_into_plan() {
+    let plan_str = plan_query_with_defer(
+        CROSS_SUBGRAPH_SCHEMA,
+        "{ user { name ... @defer { email } } }",
+    );
+    assert!(
+        plan_str.contains("Defer"),
+        "Plan should contain a Defer node: {plan_str}"
+    );
+    assert!(
+        !plan_str.contains("qp__"),
+        "Synthesized defer label must not appear in the plan: {plan_str}"
+    );
+
+    let labeled_plan_str = plan_query_with_defer(
+        CROSS_SUBGRAPH_SCHEMA,
+        "{ user { name ... @defer(label: \"mine\") { email } } }",
+    );
+    assert!(
+        labeled_plan_str.contains("mine"),
+        "User-written defer label must be preserved: {labeled_plan_str}"
+    );
+}
+
+/// Same-subgraph @defer still produces a Defer node so the executor can
+/// send a multipart response even when no cross-subgraph fetch is needed.
+#[test]
+fn defer_same_subgraph_produces_defer_node() {
+    let plan_str = plan_query_with_defer(
+        SINGLE_SUBGRAPH_SCHEMA,
+        "{ user { name ... @defer { email } } }",
+    );
+    assert!(
+        plan_str.contains("Defer"),
+        "Plan should contain a Defer node even for same-subgraph @defer: {plan_str}"
+    );
+}
+
+const THREE_SUBGRAPH_SCHEMA: &str = include_str!("../fixtures/three_subgraph.graphql");
+
+/// Multiple @defer siblings at the same level produce distinct deferred
+/// blocks inside a single Defer node.
+#[test]
+fn defer_sibling_blocks_produces_multiple_deferred() {
+    let plan_str = plan_query_with_defer(
+        THREE_SUBGRAPH_SCHEMA,
+        "{ user { name ... @defer { email } ... @defer { address } } }",
+    );
+    assert!(
+        plan_str.contains("Defer"),
+        "Plan should contain a Defer node: {plan_str}"
+    );
+    assert!(
+        plan_str.contains("name"),
+        "Primary should fetch 'name': {plan_str}"
+    );
+    assert!(
+        plan_str.contains("email"),
+        "A deferred block should fetch 'email': {plan_str}"
+    );
+    assert!(
+        plan_str.contains("address"),
+        "A deferred block should fetch 'address': {plan_str}"
     );
 }

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/type_conditions.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/type_conditions.rs
@@ -9,6 +9,8 @@ use std::sync::Arc;
 use tracing::debug;
 use tracing::trace;
 
+use super::super::defer::extract_defer_label;
+use super::super::defer::strip_defer_directive;
 use super::FieldRoutingSearchSpace;
 use super::state::PendingSelection;
 use super::state::PlanState;
@@ -60,6 +62,7 @@ fn push_concrete_type_fragments<'a>(
 impl FieldRoutingSearchSpace {
     /// For an inline fragment with no type condition (which has no query
     /// graph edge), push its sub-selections at the same query graph node.
+    /// Handles @defer on the fragment.
     pub(super) fn try_pass_through_fragment(
         &self,
         state: &mut PlanState,
@@ -68,25 +71,28 @@ impl FieldRoutingSearchSpace {
         if let Selection::InlineFragment(frag_sel) = &pending.selection
             && frag_sel.inline_fragment.type_condition_position.is_none()
         {
+            let child_defer_ref = extract_defer_label(&frag_sel.inline_fragment)
+                .or_else(|| pending.defer_ref.clone());
             // Preserve remaining directives (@skip/@include): the fragment
             // has no edge, but its conditions gate every child, so a
             // condition-carrying element must ride the children's op path.
             // Constant conditions resolve statically: always-false drops
             // the children, always-true is a plain pass-through.
-            let child_op_path =
-                match Conditions::from_directives(&frag_sel.inline_fragment.directives)? {
-                    Conditions::Boolean(false) => return Ok(true),
-                    Conditions::Boolean(true) => pending.op_path.clone(),
-                    Conditions::Variables(_) => {
-                        pending
-                            .op_path
-                            .pushed(Arc::new(OpPathElement::InlineFragment(
-                                frag_sel.inline_fragment.clone(),
-                            )))
-                    }
-                };
+            let stripped = strip_defer_directive(&frag_sel.inline_fragment);
+            let child_op_path = match Conditions::from_directives(&stripped.directives)? {
+                Conditions::Boolean(false) => return Ok(true),
+                Conditions::Boolean(true) => pending.op_path.clone(),
+                Conditions::Variables(_) => pending
+                    .op_path
+                    .pushed(Arc::new(OpPathElement::InlineFragment(stripped))),
+            };
             for sub_sel in frag_sel.selection_set.selections.values().rev().cloned() {
-                state.push_pending(pending.fork(sub_sel).with_op_path(child_op_path.clone()));
+                state.push_pending(
+                    pending
+                        .fork(sub_sel)
+                        .with_defer(child_defer_ref.clone())
+                        .with_op_path(child_op_path.clone()),
+                );
             }
             return Ok(true);
         }
@@ -96,7 +102,7 @@ impl FieldRoutingSearchSpace {
     /// Vacuous type condition: the current node's runtime types are a subset
     /// of the condition's (e.g. `...on Node` when every union member
     /// implements Node), so treat the fragment as pass-through, preserving
-    /// non-routing directives by pushing them onto the op_path.
+    /// directives by pushing it onto the op_path.
     pub(super) fn try_vacuous_type_condition(
         &self,
         state: &mut PlanState,
@@ -125,11 +131,31 @@ impl FieldRoutingSearchSpace {
             if is_vacuous {
                 trace!(
                     type_condition = %type_cond,
-                    "vacuous type condition -- treating as pass-through",
+                    "vacuous type condition — treating as pass-through",
                 );
-                let directives = &frag_sel.inline_fragment.directives;
-                let child_op_path = if !directives.is_empty() {
-                    let stripped = frag_sel.inline_fragment.with_updated_type_condition(None);
+                let has_defer = frag_sel
+                    .inline_fragment
+                    .directives
+                    .iter()
+                    .any(|d| d.name == "defer");
+                let child_defer_ref = if has_defer {
+                    extract_defer_label(&frag_sel.inline_fragment)
+                        .or_else(|| pending.defer_ref.clone())
+                } else {
+                    pending.defer_ref.clone()
+                };
+                let non_defer_directives: DirectiveList = frag_sel
+                    .inline_fragment
+                    .directives
+                    .iter()
+                    .filter(|d| d.name != "defer")
+                    .cloned()
+                    .collect();
+                let child_op_path = if !non_defer_directives.is_empty() {
+                    let stripped = frag_sel
+                        .inline_fragment
+                        .with_updated_directives(non_defer_directives);
+                    let stripped = stripped.with_updated_type_condition(None);
                     pending
                         .op_path
                         .pushed(Arc::new(OpPathElement::InlineFragment(stripped)))
@@ -137,7 +163,12 @@ impl FieldRoutingSearchSpace {
                     pending.op_path.clone()
                 };
                 for sub_sel in frag_sel.selection_set.selections.values().rev().cloned() {
-                    state.push_pending(pending.fork(sub_sel).with_op_path(child_op_path.clone()));
+                    state.push_pending(
+                        pending
+                            .fork(sub_sel)
+                            .with_op_path(child_op_path.clone())
+                            .with_defer(child_defer_ref.clone()),
+                    );
                 }
                 return Ok(true);
             }

--- a/apollo-federation/src/query_plan/incremental_planner/fixtures/three_subgraph.graphql
+++ b/apollo-federation/src/query_plan/incremental_planner/fixtures/three_subgraph.graphql
@@ -1,0 +1,48 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "http://a")
+  B @join__graph(name: "b", url: "http://b")
+  C @join__graph(name: "c", url: "http://c")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: A)
+{
+  user: User @join__field(graph: A)
+}
+
+type User
+  @join__type(graph: A, key: "id")
+  @join__type(graph: B, key: "id")
+  @join__type(graph: C, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: A)
+  email: String @join__field(graph: B)
+  address: String @join__field(graph: C)
+}

--- a/apollo-federation/src/query_plan/incremental_planner/mod.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/mod.rs
@@ -41,6 +41,7 @@
 //! the plan builder.
 
 pub mod bulb_search;
+pub(crate) mod defer;
 pub(crate) mod fetch_graph;
 pub(crate) mod field_routing;
 pub mod shared_path;
@@ -78,7 +79,7 @@ pub(crate) fn build_bulb_plan(
     parameters: &QueryPlanningParameters,
     selection_set: &SelectionSet,
     root_kind: SchemaRootDefinitionKind,
-    _has_defers: bool,
+    has_defers: bool,
 ) -> Result<BulbPlan, FederationError> {
     debug!(
         selections = selection_set.selections.len(),
@@ -117,11 +118,22 @@ pub(crate) fn build_bulb_plan(
             let fetch_node = graph.get_or_create_root_group(&root_node_data.source, root_type);
             let pending = root_pending_selections(selection_set, root_qg_node, fetch_node);
             let initial = PlanState::with_graph(graph, pending);
-            run_bulb_and_finalize(&search_space, parameters, initial, root_kind)
+            run_bulb_and_finalize(
+                &search_space,
+                parameters,
+                selection_set,
+                initial,
+                root_kind,
+                has_defers,
+            )
         }
-        QueryGraphNodeType::FederatedRootType(_) => {
-            build_bulb_plan_from_federated_root(&search_space, parameters, selection_set, root_kind)
-        }
+        QueryGraphNodeType::FederatedRootType(_) => build_bulb_plan_from_federated_root(
+            &search_space,
+            parameters,
+            selection_set,
+            root_kind,
+            has_defers,
+        ),
     }
 }
 
@@ -133,6 +145,7 @@ fn build_bulb_plan_from_federated_root(
     parameters: &QueryPlanningParameters,
     selection_set: &SelectionSet,
     root_kind: SchemaRootDefinitionKind,
+    has_defers: bool,
 ) -> Result<BulbPlan, FederationError> {
     let root_qg_node = parameters.head;
 
@@ -140,7 +153,14 @@ fn build_bulb_plan_from_federated_root(
     // actual root fetch group from the chosen subgraph.
     let pending = root_pending_selections(selection_set, root_qg_node, NodeIndex::end());
     let initial = PlanState::new(pending);
-    run_bulb_and_finalize(search_space, parameters, initial, root_kind)
+    run_bulb_and_finalize(
+        search_space,
+        parameters,
+        selection_set,
+        initial,
+        root_kind,
+        has_defers,
+    )
 }
 
 /// Run BULB search on the initial state and finalize into a `BulbPlan`.
@@ -148,8 +168,10 @@ fn build_bulb_plan_from_federated_root(
 fn run_bulb_and_finalize(
     search_space: &FieldRoutingSearchSpace,
     parameters: &QueryPlanningParameters,
+    selection_set: &SelectionSet,
     initial: PlanState,
     root_kind: SchemaRootDefinitionKind,
+    has_defers: bool,
 ) -> Result<BulbPlan, FederationError> {
     let config = BulbConfig {
         beam_width: parameters.config.incremental_planner.beam_width,
@@ -215,6 +237,13 @@ fn run_bulb_and_finalize(
         SubgraphOperationCompression::Disabled
     };
 
+    // Build DeferInfo from the selection set actually being planned (already
+    // typename-restored): for mutations that is a single top-level field
+    // split from the operation, so each sequential step only sees its own
+    // defer blocks.
+    let defer_info = has_defers
+        .then(|| defer::build_defer_info(selection_set, parameters.assigned_defer_labels.clone()));
+
     let mut build_ctx = fetch_graph::plan_builder::PlanBuildContext {
         supergraph_schema: &parameters.supergraph_schema,
         query_graph: &parameters.federated_query_graph,
@@ -225,7 +254,9 @@ fn run_bulb_and_finalize(
         operation_compression: &mut operation_compression,
         operation_counter: 0,
     };
-    let (plan, cost) = result.graph.to_query_plan(&mut build_ctx)?;
+    let (plan, cost) = result
+        .graph
+        .to_query_plan_with_defer(&mut build_ctx, defer_info.as_ref())?;
 
     Ok(BulbPlan { plan, cost })
 }
@@ -248,6 +279,7 @@ fn root_pending_selections(
             op_path: Default::default(),
             path_in_fetch: Default::default(),
             condition: None,
+            defer_ref: None,
             provides_anchor: None,
             best_effort: false,
         })

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -512,12 +512,13 @@ impl QueryPlanner {
         } else {
             SubgraphOperationCompression::Disabled
         };
+        let assigned_defer_labels = Arc::new(assigned_defer_labels);
         let mut processor = FetchDependencyGraphToQueryPlanProcessor::new(
             normalized_operation.variables.clone(),
             normalized_operation.directives.clone(),
             operation_compression,
             operation.name.clone(),
-            assigned_defer_labels,
+            assigned_defer_labels.as_ref().clone(),
         );
         let mut parameters = QueryPlanningParameters {
             supergraph_schema: self.supergraph_schema.clone(),
@@ -550,6 +551,7 @@ impl QueryPlanner {
                     }
                 })
                 .collect(),
+            assigned_defer_labels: assigned_defer_labels.clone(),
         };
 
         let mut non_local_selection_state = options

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -90,6 +90,10 @@ pub(crate) struct QueryPlanningParameters<'a> {
     pub(crate) override_conditions: OverrideConditions,
     pub(crate) check_for_cooperative_cancellation: Option<&'a dyn Fn() -> ControlFlow<()>>,
     pub(crate) disabled_subgraphs: IndexSet<Arc<str>>,
+    /// Labels assigned by defer normalization (e.g. `qp__N` for unlabeled
+    /// @defer blocks). The BULB planner threads these into DeferInfo so
+    /// plan generation can suppress synthesized labels from the output.
+    pub(crate) assigned_defer_labels: Arc<IndexSet<String>>,
 }
 
 impl QueryPlanningParameters<'_> {
@@ -1163,6 +1167,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             fetch_id_generator: self.parameters.fetch_id_generator.clone(),
             check_for_cooperative_cancellation: self.parameters.check_for_cooperative_cancellation,
             disabled_subgraphs: self.parameters.disabled_subgraphs.clone(),
+            assigned_defer_labels: self.parameters.assigned_defer_labels.clone(),
         };
         let best_plan_opt = QueryPlanningTraversal::new_inner(
             &parameters,

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/incremental_planner.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/incremental_planner.rs
@@ -1,4 +1,5 @@
 use apollo_federation::query_plan::query_planner::IncrementalPlannerConfig;
+use apollo_federation::query_plan::query_planner::QueryPlanIncrementalDeliveryConfig;
 use apollo_federation::query_plan::query_planner::QueryPlanOptions;
 use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
 
@@ -10,6 +11,19 @@ fn incremental_config() -> QueryPlannerConfig {
             fuel: 100_000,
             ..Default::default()
         },
+        ..Default::default()
+    }
+}
+
+fn incremental_defer_config() -> QueryPlannerConfig {
+    QueryPlannerConfig {
+        incremental_planner: IncrementalPlannerConfig {
+            enabled: true,
+            beam_width: 4,
+            fuel: 100_000,
+            ..Default::default()
+        },
+        incremental_delivery: QueryPlanIncrementalDeliveryConfig { enable_defer: true },
         ..Default::default()
     }
 }
@@ -1962,6 +1976,89 @@ fn inc_conditionless_fragment_skip_preserved() {
             }
           }
         }
+      },
+    }
+    "###
+    );
+}
+
+// ---------------------------------------------------------------------------
+// @defer: deferred fragment across subgraphs produces a Defer plan node
+// with primary and deferred blocks. The @defer directive is stripped from
+// subgraph operations since subgraph schemas do not define it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inc_defer_cross_subgraph_produces_defer_plan() {
+    let planner = planner!(
+        config = incremental_defer_config(),
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            x: Int
+          }
+        "#,
+        Subgraph2: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            y: Int
+          }
+        "#,
+    );
+
+    assert_plan!(
+        &planner,
+        r#"
+          {
+            t {
+              ...OnT @defer
+              x
+            }
+          }
+
+          fragment OnT on T {
+            y
+            __typename
+          }
+        "#,
+        @r###"
+    QueryPlan {
+      Defer {
+        Primary {
+          { t { x } }:
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              t {
+                __typename
+                id
+                x
+              }
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "t") {
+            { ... on T { __typename y } }:
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    y
+                  }
+                }
+              },
+            },
+          },
+        ]
       },
     }
     "###

--- a/apollo-federation/tests/query_plan/supergraphs/inc_defer_cross_subgraph_produces_defer_plan.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/inc_defer_cross_subgraph_produces_defer_plan.graphql
@@ -1,0 +1,71 @@
+# Composed from subgraphs with hash: 22e24356e106228bb20c17c7dabbf476fde27e22
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH1)
+  y: Int @join__field(graph: SUBGRAPH2)
+}


### PR DESCRIPTION
## Summary

Implements `@defer` directive support in the incremental planner.

- New `defer.rs` module: `extract_defer_label`, `strip_defer_directive`, deferred path tracking
- Commit logic creates deferred fetch nodes with proper label/path wiring
- Tests for `@defer` on fields, inline fragments, and nested defers

Replaces erroneously merged PR #10143.