### PR TITLE
feat(incremental-planner): add @fromContext support

### DIFF
--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -142,20 +142,20 @@ impl TryFrom<QueryGraphNodeType> for ObjectTypeDefinitionPosition {
 /// with the `@fromContext` to its (grand)parent types contain a matching selection.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ContextCondition {
-    context: String,
-    subgraph_name: Arc<str>,
+    pub(crate) context: String,
+    pub(crate) subgraph_name: Arc<str>,
     // This is purposely left unparsed in query graphs, due to @fromContext selection sets being
     // duck-typed.
-    selection: String,
-    types_with_context_set: IndexSet<CompositeTypeDefinitionPosition>,
+    pub(crate) selection: String,
+    pub(crate) types_with_context_set: IndexSet<CompositeTypeDefinitionPosition>,
     // PORT_NOTE: This field was renamed because the JS name (`namedParameter`) left confusion to
     // how it was different from the argument name.
-    argument_name: Name,
+    pub(crate) argument_name: Name,
     // PORT_NOTE: This field was renamed because the JS name (`coordinate`) was too vague.
-    argument_coordinate: ObjectFieldArgumentDefinitionPosition,
+    pub(crate) argument_coordinate: ObjectFieldArgumentDefinitionPosition,
     // PORT_NOTE: This field was renamed from the JS name (`argType`) for consistency with the rest
     // of the naming in this struct.
-    argument_type: Node<Type>,
+    pub(crate) argument_type: Node<Type>,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/apollo-federation/src/query_plan/incremental_planner/defer.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/defer.rs
@@ -225,7 +225,7 @@ fn collect_deferred_blocks(
 
 /// Serialize a SelectionSet into a brace-wrapped (`{ ... }`) string for
 /// `DeferredDeferBlock.sub_selection`.
-pub(super) fn serialize_selection_set(selection_set: &SelectionSet) -> String {
+fn serialize_selection_set(selection_set: &SelectionSet) -> String {
     let mut parts: Vec<String> = Vec::new();
     for sel in selection_set.selections.values() {
         match sel {

--- a/apollo-federation/src/query_plan/incremental_planner/fetch_graph/mod.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/fetch_graph/mod.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use apollo_compiler::Name;
+use apollo_compiler::Node;
 use petgraph::Direction;
 use petgraph::stable_graph::EdgeIndex;
 use petgraph::stable_graph::NodeIndex;
@@ -23,6 +24,7 @@ use super::shared_path::SharedPath;
 use crate::error::FederationError;
 use crate::operation::SelectionSet;
 use crate::query_graph::graph_path::operation::OpPathElement;
+use crate::query_plan::FetchDataKeyRenamer;
 use crate::query_plan::FetchDataPathElement;
 use crate::query_plan::QueryPlanCost;
 use crate::schema::position::CompositeTypeDefinitionPosition;
@@ -75,6 +77,11 @@ pub(crate) struct FetchNode {
     /// (non-deferred) response. Fetch nodes with a defer_ref are partitioned
     /// into deferred blocks during plan generation.
     pub(crate) defer_ref: Option<String>,
+    /// @fromContext rewrite paths that rename entity data keys to
+    /// `$contextualArgument_N_M` variable names.
+    pub(crate) context_rewrites: Vec<FetchDataKeyRenamer>,
+    /// @fromContext variable definitions added to the subgraph operation.
+    pub(crate) context_variables: Vec<(Name, Node<apollo_compiler::ast::Type>)>,
 }
 
 impl FetchNode {
@@ -84,11 +91,12 @@ impl FetchNode {
             kind,
             selection_builder: SelectionBuilder::default(),
             defer_ref: None,
+            context_rewrites: Vec::new(),
+            context_variables: Vec::new(),
         }
     }
 
     /// Get the root type if this is a root fetch group.
-    #[allow(dead_code)]
     pub(crate) fn root_type(&self) -> Option<&CompositeTypeDefinitionPosition> {
         match &self.kind {
             FetchGroupKind::Root { root_type } | FetchGroupKind::RootHop { root_type, .. } => {
@@ -129,6 +137,13 @@ enum FetchGraphOp {
     /// A node's depth was raised by an edge insertion. Undo: restore the
     /// previous depth and stage counts.
     RaiseDepth { node_index: NodeIndex, prev: u32 },
+    /// @fromContext rewrites/variables were appended to a node. Undo:
+    /// truncate both vecs to their prior lengths.
+    AddContext {
+        node_index: NodeIndex,
+        prev_rewrites: usize,
+        prev_variables: usize,
+    },
     /// A node claimed the entity_groups slot for its key. Undo: remove the
     /// entry. Always logged directly after the node's AddNode, so LIFO
     /// undo clears the slot before removing the node.
@@ -270,6 +285,15 @@ impl FetchGraph {
                     self.bump_stage_count(prev, 1);
                     self.depth[node_index.index()] = prev;
                 }
+                FetchGraphOp::AddContext {
+                    node_index,
+                    prev_rewrites,
+                    prev_variables,
+                } => {
+                    let fetch_node = &mut self.graph[node_index];
+                    fetch_node.context_rewrites.truncate(prev_rewrites);
+                    fetch_node.context_variables.truncate(prev_variables);
+                }
                 FetchGraphOp::RegisterEntityGroup { key } => {
                     self.entity_groups.remove(&key);
                 }
@@ -338,6 +362,8 @@ impl FetchGraph {
                 kind: FetchGroupKind::Root { root_type },
                 selection_builder: SelectionBuilder::default(),
                 defer_ref,
+                context_rewrites: Vec::new(),
+                context_variables: Vec::new(),
             },
             Some(root_key),
         )
@@ -356,6 +382,8 @@ impl FetchGraph {
                 kind: FetchGroupKind::Entity { merge_at },
                 selection_builder: SelectionBuilder::default(),
                 defer_ref,
+                context_rewrites: Vec::new(),
+                context_variables: Vec::new(),
             },
             None,
         )
@@ -403,16 +431,6 @@ impl FetchGraph {
             self.entity_groups.remove(&key);
         }
         self.add_entity_group_with_defer(subgraph, key.1, key.2)
-    }
-
-    /// Get or create the entity fetch group for (subgraph, merge_at).
-    #[allow(dead_code)]
-    pub(crate) fn get_or_create_entity_group(
-        &mut self,
-        subgraph: &Arc<str>,
-        merge_at: Vec<FetchDataPathElement>,
-    ) -> NodeIndex {
-        self.get_or_create_entity_group_with_defer(subgraph, merge_at, None)
     }
 
     /// Whether a directed edge from `parent` to `child` exists.
@@ -550,8 +568,42 @@ impl FetchGraph {
         self.graph[node].selection_builder.insert(path, selections);
     }
 
+    /// Append a @fromContext rewrite and variable definition to a node,
+    /// deduplicating by renamer identity / variable name.
+    pub(crate) fn add_context(
+        &mut self,
+        node: NodeIndex,
+        renamer: FetchDataKeyRenamer,
+        context_id: Name,
+        context_type: Node<apollo_compiler::ast::Type>,
+    ) {
+        let fetch_node = &mut self.graph[node];
+        let prev_rewrites = fetch_node.context_rewrites.len();
+        let prev_variables = fetch_node.context_variables.len();
+        if !fetch_node.context_rewrites.contains(&renamer) {
+            fetch_node.context_rewrites.push(renamer);
+        }
+        if !fetch_node
+            .context_variables
+            .iter()
+            .any(|(n, _)| *n == context_id)
+        {
+            fetch_node
+                .context_variables
+                .push((context_id, context_type));
+        }
+        if fetch_node.context_rewrites.len() != prev_rewrites
+            || fetch_node.context_variables.len() != prev_variables
+        {
+            self.undo_log.push(FetchGraphOp::AddContext {
+                node_index: node,
+                prev_rewrites,
+                prev_variables,
+            });
+        }
+    }
+
     /// Get a reference to the node weight.
-    #[allow(dead_code)]
     pub(crate) fn node(&self, node: NodeIndex) -> &FetchNode {
         &self.graph[node]
     }

--- a/apollo-federation/src/query_plan/incremental_planner/fetch_graph/plan_builder.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/fetch_graph/plan_builder.rs
@@ -80,7 +80,6 @@ fn stamp_fetch_id(plan_node: &mut PlanNode, id: u64) {
 impl FetchGraph {
     /// Generate a PlanNode tree, wrapped in a DeferNode when defer info is
     /// provided.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn to_query_plan_with_defer(
         &self,
         ctx: &mut PlanBuildContext<'_>,
@@ -490,6 +489,7 @@ impl FetchGraph {
 
         // 4. Collect variable definitions narrowed to those actually used.
         let (variable_definitions, variable_usages) = Self::collect_used_variable_definitions(
+            &node.context_variables,
             ctx.variable_definitions,
             ctx.operation_directives,
             &finalized_selection,
@@ -542,7 +542,12 @@ impl FetchGraph {
             operation_kind: ctx.root_kind.into(),
             input_rewrites: Arc::new(input_rewrites),
             output_rewrites,
-            context_rewrites: Default::default(),
+            context_rewrites: node
+                .context_rewrites
+                .iter()
+                .cloned()
+                .map(|r| Arc::new(r.into()))
+                .collect(),
         }));
 
         // 8. Wrap entity/root-hop fetches in FlattenNode.
@@ -705,16 +710,33 @@ impl FetchGraph {
     /// Filter the operation's variable definitions to those actually
     /// referenced by the finalized selection and operation directives.
     fn collect_used_variable_definitions(
+        context_variables: &[(Name, Node<apollo_compiler::ast::Type>)],
         operation_variable_definitions: &[Node<VariableDefinition>],
         operation_directives: &DirectiveList,
         finalized_selection: &SelectionSet,
     ) -> (Vec<Node<VariableDefinition>>, Vec<Name>) {
+        let context_var_defs: Vec<Node<VariableDefinition>> = context_variables
+            .iter()
+            .map(|(name, ty)| {
+                Node::new(VariableDefinition {
+                    name: name.clone(),
+                    ty: ty.clone(),
+                    default_value: None,
+                    directives: Default::default(),
+                })
+            })
+            .collect();
+        let all_var_defs: Vec<Node<VariableDefinition>> = operation_variable_definitions
+            .iter()
+            .cloned()
+            .chain(context_var_defs)
+            .collect();
         let variable_definitions = {
             let mut collector = VariableCollector::new();
             collector.visit_directive_list(operation_directives);
             collector.visit_selection_set(finalized_selection);
             let used = collector.into_inner();
-            operation_variable_definitions
+            all_var_defs
                 .iter()
                 .filter(|v| used.contains(&v.name))
                 .cloned()

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/commit.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/commit.rs
@@ -20,6 +20,7 @@ use crate::operation::FieldSelection;
 use crate::operation::HasSelectionKey;
 use crate::operation::Selection;
 use crate::operation::SelectionSet;
+use crate::query_graph::ContextCondition;
 use crate::query_graph::QueryGraphEdgeTransition;
 use crate::query_graph::QueryGraphNodeType;
 use crate::query_graph::graph_path::operation::OpPathElement;
@@ -28,11 +29,13 @@ use crate::schema::position::CompositeTypeDefinitionPosition;
 
 const CONDITION_DEPTH_LIMIT: u8 = 32;
 use super::NodeSource;
+use super::context;
 use super::requires::trailing_condition_fragments;
 use super::requires::unconditioned_input_path;
 use super::routing::HopKind;
 use super::routing::RoutingChoice;
 use super::selection_label;
+use super::state::ContextAnchor;
 use super::state::PendingSelection;
 use super::state::PlanState;
 
@@ -139,6 +142,9 @@ impl FieldRoutingSearchSpace {
         if let Some(requires_conditions) = &edge.conditions {
             target = self.apply_requires(state, &ctx, requires_conditions, target)?;
         }
+        if !edge.required_contexts.is_empty() {
+            target = self.apply_contexts(state, &ctx, &edge.required_contexts, target)?;
+        }
 
         // Condition selections carry an ordering dependent: their consuming
         // group must run after every group they commit into. A would-be
@@ -239,7 +245,7 @@ impl FieldRoutingSearchSpace {
 
         let merge_at = self.pending_merge_at(state, pending);
 
-        // The group the key edge enters: for a chained hop, the FIRST
+        // The group the key edge enters: for a chained hop, the first
         // intermediate, not the final target.
         let (first_subgraph, first_dest_node) = match choice.intermediate_key_hops.first() {
             Some(hop) => (&hop.target_subgraph, Some(hop.target_node)),
@@ -495,14 +501,11 @@ impl FieldRoutingSearchSpace {
         }
     }
 
-    /// The fetch group a direct (non-hop) choice lands in: fields may
-    /// create root groups on demand; inline fragments stay in the current
-    /// group.
     /// The fetch group a direct (non-hop) choice lands in: fields may create
     /// root groups on demand ([`Self::field_fetch_node`]); inline fragments
     /// stay in the current group. An @interfaceObject fake downcast
     /// additionally pushes a best-effort concrete-`__typename` pending:
-    /// execution needs each object's CONCRETE typename to test the condition,
+    /// execution needs each object's concrete typename to test the condition,
     /// which the io subgraph cannot supply
     /// ([`Self::push_interface_object_typename`]).
     fn direct_fetch_node(
@@ -527,7 +530,7 @@ impl FieldRoutingSearchSpace {
     }
 
     /// @interfaceObject subgraph can only report the interface's typename:
-    /// execution needs each object's CONCRETE `__typename` to test the
+    /// execution needs each object's concrete `__typename` to test the
     /// condition. Push a `__typename` pending at the current position and
     /// let the generic routing machinery satisfy it. The "not in this
     /// subgraph" constraint is already encoded in the query graph:
@@ -752,6 +755,31 @@ impl FieldRoutingSearchSpace {
         self.append_typename(state, fetch_node, &input_path, source);
     }
 
+    /// Handle @fromContext on the routed edge: resolve context values from
+    /// ancestors and pass them via entity inputs, possibly redirecting the
+    /// field into a context-isolating entity fetch.
+    pub(super) fn apply_contexts(
+        &self,
+        state: &mut PlanState,
+        ctx: &CommitCtx<'_>,
+        required_contexts: &[ContextCondition],
+        target: CommitTarget,
+    ) -> Result<CommitTarget, FederationError> {
+        let (fetch_node, op_path) = context::handle_from_context(
+            self,
+            state,
+            ctx,
+            target.fetch_node,
+            &target.op_path,
+            required_contexts,
+        )?;
+        Ok(CommitTarget {
+            fetch_node,
+            op_path,
+            ..target
+        })
+    }
+
     pub(super) fn push_condition_pendings(
         &self,
         state: &mut PlanState,
@@ -840,6 +868,44 @@ impl FieldRoutingSearchSpace {
             .0
             .or_else(|| pending.defer_ref.clone());
 
+        // Extend parent_types with the current target type for @fromContext
+        // ancestor resolution.
+        let target_node_data = self.query_graph.node_weight(target_qg_node)?;
+        let child_parent_types = {
+            let mut types = pending.parent_types.clone();
+            // From a FederatedRootType node the root type (e.g. Query) is not
+            // in parent_types yet (resolved per-field at commit time); inject
+            // it so @context on the root type is visible to @fromContext
+            // ancestor lookups.
+            let source_data = self.query_graph.node_weight(pending.query_graph_node)?;
+            if matches!(source_data.type_, QueryGraphNodeType::FederatedRootType(_))
+                && let Some(root_type) = state.graph.node(fetch_node).root_type().cloned()
+            {
+                types = types.pushed(root_type);
+            }
+            if let Ok(target_type) =
+                CompositeTypeDefinitionPosition::try_from(target_node_data.type_.clone())
+            {
+                types.pushed(target_type)
+            } else {
+                types
+            }
+        };
+        // Track the parent fetch for @fromContext across entity boundaries:
+        // children of an entity root may need to add context selections to
+        // the parent fetch that feeds the entity representation.
+        let child_context_anchor = if target.entity_root {
+            let entity_type =
+                CompositeTypeDefinitionPosition::try_from(target_node_data.type_.clone()).ok();
+            ContextAnchor {
+                fetch: Some(pending.fetch_node),
+                op_path: pending.op_path.clone(),
+                entity_type,
+            }
+        } else {
+            pending.context_anchor.clone()
+        };
+
         for sub_sel in sub_ss.selections.values().rev().cloned() {
             state.push_pending(
                 pending
@@ -848,7 +914,9 @@ impl FieldRoutingSearchSpace {
                     .with_op_path(target.op_path.clone())
                     .with_response_path(target.response_path.clone())
                     .with_provides_anchor(child_provides_anchor)
-                    .with_defer(child_defer_ref.clone()),
+                    .with_defer(child_defer_ref.clone())
+                    .with_parent_types(child_parent_types.clone())
+                    .with_context_anchor(child_context_anchor.clone()),
             );
         }
         Ok(())
@@ -861,7 +929,7 @@ impl FieldRoutingSearchSpace {
     /// edges visible. An interface-level @provides applies to every runtime
     /// type, but only the interface node was copied. Other fragments inherit
     /// the anchor; fields reset it (their children draw on the field's own
-    /// target node, which IS a copy whenever the field was provided); entity
+    /// target node, which is a copy whenever the field was provided); entity
     /// roots leave the position entirely.
     fn child_provides_anchor(
         &self,

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/context.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/context.rs
@@ -1,0 +1,509 @@
+//! @context / @fromContext helpers for the BULB planner: classify how a
+//! field with `required_contexts` is isolated (the isolating hop itself is a
+//! generic self-key-hop [`super::routing::RoutingChoice`], committed by the
+//! ordinary key-hop path), add context selections to the parent fetch, build
+//! context rewrite paths, and splice `$contextualArgument_N_M` variables
+//! into field arguments.
+//!
+//! ## Why context selections are direct appends, not condition pendings
+//!
+//! Context selections look like requirements ("context data must exist
+//! before the isolated fetch runs"), and every other requirement in this
+//! planner routes through the pending stack as a condition selection. They
+//! can't, because their anchor is different in kind: a condition pending is
+//! anchored at the pending's own position -- `fork()` keeps the pending's
+//! `query_graph_node`, and the condition fields are selected alongside the
+//! field that needs them. A context selection instead belongs at an
+//! ancestor position: its op path is a strict prefix of the pending's op
+//! path (`op_path_prefix(.., ancestor_idx)`), and its fields are defined on
+//! the ancestor's type, not the pending's. Routing a selection requires the
+//! query-graph node at its anchor, and the pending stack does not retain
+//! ancestor query-graph nodes -- `parent_types` keeps only the supergraph
+//! type positions needed for the backward @context walk. Anchoring the fork
+//! at the pending's node would enumerate options for the ancestor's fields
+//! on the wrong type entirely. Pendings do not currently carry their
+//! ancestor query-graph spine, so the append to the parent fetch at the
+//! ancestor prefix stays direct.
+
+use std::sync::Arc;
+
+use apollo_compiler::Name;
+use apollo_compiler::Node;
+use apollo_compiler::executable::Argument;
+use apollo_compiler::executable::Value;
+use petgraph::graph::NodeIndex;
+
+use super::super::shared_path::SharedPath;
+use super::FieldRoutingSearchSpace;
+use super::PlanState;
+use super::commit::CommitCtx;
+use crate::error::FederationError;
+use crate::operation::Selection;
+use crate::operation::SelectionMap;
+use crate::operation::SelectionSet;
+use crate::query_graph::ContextCondition;
+use crate::query_graph::graph_path::operation::OpPathElement;
+use crate::query_plan::FetchDataKeyRenamer;
+use crate::query_plan::FetchDataPathElement;
+use crate::schema::ValidFederationSchema;
+use crate::schema::position::CompositeTypeDefinitionPosition;
+
+/// Parse a @fromContext selection string (e.g. `" { prop }"`) into a
+/// `SelectionSet` using the supergraph schema and parent type.
+pub(super) fn parse_context_selection(
+    schema: &ValidFederationSchema,
+    parent_type: &CompositeTypeDefinitionPosition,
+    selection_str: &str,
+) -> Result<SelectionSet, FederationError> {
+    let field_value = crate::schema::field_set::parse_field_value_without_validation(
+        schema,
+        parent_type.type_name().clone(),
+        selection_str,
+    )?;
+    crate::schema::field_set::validate_field_value(schema, field_value)
+}
+
+/// The inner selections of a context selection set relevant to one runtime
+/// type: fragments matching `type_name` are unwrapped (the typename fanout
+/// already adds the `TypenameEquals` guard); field selections apply to all
+/// types and are kept as-is.
+fn selections_for_runtime_type(selection_set: &SelectionSet, type_name: &Name) -> SelectionSet {
+    let mut merged = SelectionMap::new();
+    for selection in selection_set.selections.values() {
+        match selection {
+            Selection::Field(_) => {
+                merged.insert(selection.clone());
+            }
+            Selection::InlineFragment(frag_sel) => {
+                let matches = match &frag_sel.inline_fragment.type_condition_position {
+                    Some(tc) => tc.type_name() == type_name,
+                    None => true,
+                };
+                if matches {
+                    for inner_sel in frag_sel.selection_set.selections.values() {
+                        merged.insert(inner_sel.clone());
+                    }
+                }
+            }
+        }
+    }
+    SelectionSet {
+        schema: selection_set.schema.clone(),
+        type_position: selection_set.type_position.clone(),
+        selections: Arc::new(merged),
+    }
+}
+
+/// Build context rewrite path elements from a parsed selection set: each
+/// field becomes a `Key`, each fragment type condition a `TypenameEquals`.
+pub(super) fn build_rewrite_path_from_selections(
+    selection_set: &SelectionSet,
+    path: &mut Vec<FetchDataPathElement>,
+) {
+    for selection in selection_set.selections.values() {
+        match selection {
+            Selection::Field(field_sel) => {
+                let field_name = field_sel.field.field_position.field_name().clone();
+                path.push(FetchDataPathElement::Key(field_name, Default::default()));
+                if let Some(sub) = field_sel.selection_set.as_ref() {
+                    build_rewrite_path_from_selections(sub, path);
+                }
+            }
+            Selection::InlineFragment(frag_sel) => {
+                if let Some(tc) = &frag_sel.inline_fragment.type_condition_position {
+                    path.push(FetchDataPathElement::TypenameEquals(tc.type_name().clone()));
+                }
+                build_rewrite_path_from_selections(&frag_sel.selection_set, path);
+            }
+        }
+    }
+}
+
+/// How a @fromContext field is isolated from siblings that would see
+/// different context values.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ContextPlacement {
+    /// The field arrived via a key hop: the existing entity fetch provides
+    /// the isolation; context selections go on the parent fetch feeding it.
+    EntityRoot,
+    /// The @context ancestor sits at the entity boundary: the context data
+    /// already rides the entity representation; context selections go on
+    /// the fetch feeding this entity fetch.
+    EntityBoundary,
+    /// Same-subgraph field that would need an isolating hop, but routing
+    /// offered none (no locally satisfiable @key): the field stays where
+    /// it is, without context arguments.
+    Unisolated,
+}
+
+/// Whether a @fromContext field at this pending's position needs an
+/// isolating same-subgraph entity hop: true unless the entity boundary
+/// already isolates it (every condition's @context sits at or above the
+/// boundary type). Evaluated at routing-enumeration time; when true, option
+/// enumeration forces a self key hop and the generic key-hop commit creates
+/// the isolation.
+pub(super) fn needs_context_isolation(
+    pending: &super::PendingSelection,
+    required_contexts: &[ContextCondition],
+) -> bool {
+    !at_entity_boundary(pending, required_contexts)
+}
+
+/// Handle @fromContext: resolve context conditions from ancestor types,
+/// pass context values through the isolating entity fetch's inputs, and add
+/// context rewrites/variables. The isolating hop itself was created by the
+/// generic key-hop commit (the routing choice was a self key hop or a
+/// cross-subgraph hop); this only does the context-specific parts. Returns
+/// the fetch node and op_path for the field.
+pub(super) fn handle_from_context(
+    search_space: &FieldRoutingSearchSpace,
+    state: &mut PlanState,
+    ctx: &CommitCtx<'_>,
+    current_fetch_node: NodeIndex,
+    child_op_path: &SharedPath<Arc<OpPathElement>>,
+    required_contexts: &[ContextCondition],
+) -> Result<(NodeIndex, SharedPath<Arc<OpPathElement>>), FederationError> {
+    let pending = ctx.pending;
+    // The field edge's source gives the subgraph defining the @fromContext
+    // field; for key hops this differs from pending.query_graph_node.
+    let (edge_source_node, _) = search_space
+        .query_graph
+        .edge_endpoints(ctx.choice.edge_index())?;
+    let edge_source_data = search_space.query_graph.node_weight(edge_source_node)?;
+    let source_subgraph = &edge_source_data.source;
+
+    let placement = classify_placement(pending, current_fetch_node, required_contexts);
+    let (context_fetch_node, parent_fetch_node) = match placement {
+        ContextPlacement::EntityRoot => (current_fetch_node, pending.fetch_node),
+        ContextPlacement::EntityBoundary => {
+            (current_fetch_node, pending.context_anchor.fetch.unwrap())
+        }
+        // No isolation was possible: leave the field where it is.
+        ContextPlacement::Unisolated => return Ok((current_fetch_node, child_op_path.clone())),
+    };
+
+    // Process each context condition, collecting (argument, context_id)
+    // pairs to splice into the field's arguments.
+    let mut context_args: Vec<(Name, Name)> = Vec::new();
+    for cond in required_contexts {
+        let context_id = search_space
+            .query_graph
+            .context_id_by_source_and_argument(source_subgraph, &cond.argument_coordinate)?;
+
+        let (ancestor_type, ancestor_idx, levels_in_data_path) =
+            find_context_ancestor(pending, cond)?;
+
+        // An ancestor at the entity boundary rides the entity
+        // representation: no Parent elements needed, use the parent fetch's
+        // op_path.
+        let (append_fetch_node, ancestor_op_path, levels_in_data_path) =
+            if placement == ContextPlacement::EntityBoundary {
+                (parent_fetch_node, pending.context_anchor.op_path.clone(), 0)
+            } else {
+                locate_ancestor_site(
+                    state,
+                    pending,
+                    parent_fetch_node,
+                    &ancestor_type,
+                    ancestor_idx,
+                    levels_in_data_path,
+                )?
+            };
+
+        let context_selection = parse_context_selection(
+            &search_space.supergraph_schema,
+            &ancestor_type,
+            &cond.selection,
+        )?;
+        state.graph.append_selection(
+            append_fetch_node,
+            &ancestor_op_path,
+            Some(&Arc::new(context_selection.clone())),
+        );
+
+        add_context_renamers(
+            search_space,
+            state,
+            context_fetch_node,
+            &ancestor_type,
+            &context_selection,
+            levels_in_data_path,
+            context_id,
+            cond,
+        )?;
+
+        context_args.push((cond.argument_name.clone(), context_id.clone()));
+    }
+
+    // The entity fetch already has the right op_path structure: just add
+    // context arguments to the field element.
+    let final_op_path = match child_op_path.last() {
+        Some(last) => pushed_with_context_args(child_op_path.parent(), last, &context_args),
+        None => child_op_path.clone(),
+    };
+    Ok((context_fetch_node, final_op_path))
+}
+
+/// See [`ContextPlacement`].
+fn classify_placement(
+    pending: &super::PendingSelection,
+    current_fetch_node: NodeIndex,
+    required_contexts: &[ContextCondition],
+) -> ContextPlacement {
+    if current_fetch_node != pending.fetch_node {
+        ContextPlacement::EntityRoot
+    } else if at_entity_boundary(pending, required_contexts) {
+        ContextPlacement::EntityBoundary
+    } else {
+        ContextPlacement::Unisolated
+    }
+}
+
+/// Whether every context condition's @context sits at (or above) the
+/// pending's entity boundary type: the context data already rides the
+/// entity representation, so no isolating hop is needed.
+fn at_entity_boundary(
+    pending: &super::PendingSelection,
+    required_contexts: &[ContextCondition],
+) -> bool {
+    let entity_root_type = pending.context_anchor.entity_type.as_ref();
+    pending.context_anchor.fetch.is_some()
+        && entity_root_type.is_some()
+        && required_contexts.iter().all(|cond| {
+            cond.types_with_context_set
+                .iter()
+                .any(|t| Some(t) == entity_root_type)
+        })
+}
+
+/// Walk backward through `parent_types` to the nearest ancestor carrying the
+/// condition's @context. Returns the ancestor type, its index into the
+/// parent-types stack, and how many data-path levels (Field elements only;
+/// inline fragments add no level) separate the pending from it.
+///
+/// `parent_types = [T0..Tn]` has one more element than
+/// `op_path = [E0..En-1]` (T0, the root type, has no incoming transition;
+/// E_i is the transition T_i to T_{i+1}).
+fn find_context_ancestor(
+    pending: &super::PendingSelection,
+    cond: &ContextCondition,
+) -> Result<(CompositeTypeDefinitionPosition, usize, usize), FederationError> {
+    let parent_types_vec = pending.parent_types.to_vec();
+    let op_path_vec: Vec<_> = pending.op_path.iter().collect();
+    let mut levels_in_data_path = 0usize;
+    for (i, ancestor_type) in parent_types_vec.iter().rev().enumerate() {
+        if cond.types_with_context_set.contains(ancestor_type) {
+            let ancestor_idx = parent_types_vec.len() - 1 - i;
+            return Ok((ancestor_type.clone(), ancestor_idx, levels_in_data_path));
+        }
+        // The transition traversed backward is op_path[len - 1 - i]. Guard
+        // against underflow: parent_types has one more element than op_path
+        // (the root type can be the last candidate).
+        if let Some(op_element) = op_path_vec
+            .len()
+            .checked_sub(1 + i)
+            .and_then(|idx| op_path_vec.get(idx))
+            && matches!(op_element.as_ref(), OpPathElement::Field(_))
+        {
+            levels_in_data_path += 1;
+        }
+    }
+    Err(FederationError::internal(format!(
+        "@fromContext argument {} has no ancestor type with the required @context set",
+        cond.argument_coordinate,
+    )))
+}
+
+/// Where a @fromContext ancestor's context selection must be recorded: the
+/// fetch group, op-path prefix, and Parent-level count at which the
+/// ancestor type's data is fetched.
+///
+/// `parent_types` accumulates across entity hops while `op_path` restarts
+/// at each hop (its first element pairs with the boundary type), so an
+/// ancestor index maps onto `op_path` only when the ancestor lies within
+/// the current fetch. An ancestor above the boundary lives in the anchor
+/// fetch, at a prefix of the anchor op path. Anything further up (two or
+/// more hops) has no recorded spine; the commit fails cleanly so the
+/// search backs out instead of recording a selection that cannot rebase at
+/// plan build.
+fn locate_ancestor_site(
+    state: &PlanState,
+    pending: &super::PendingSelection,
+    local_fetch: NodeIndex,
+    ancestor_type: &CompositeTypeDefinitionPosition,
+    ancestor_idx: usize,
+    local_levels: usize,
+) -> Result<(NodeIndex, SharedPath<Arc<OpPathElement>>, usize), FederationError> {
+    let op_len = pending.op_path.len() as isize;
+    let types_len = pending.parent_types.len() as isize;
+    // op_path's last element pairs with the last parent type; walking the
+    // pairing backward puts the ancestor at this prefix length.
+    let local_prefix = op_len + 1 - (types_len - ancestor_idx as isize);
+    let in_entity_fetch = pending.context_anchor.fetch.is_some();
+    if local_prefix > 0 || (local_prefix == 0 && !in_entity_fetch) {
+        let prefix = op_path_prefix(&pending.op_path, local_prefix as usize);
+        verify_prefix_lands_on(state, local_fetch, &prefix, ancestor_type)?;
+        return Ok((local_fetch, prefix, local_levels));
+    }
+    let anchor = &pending.context_anchor;
+    let Some(anchor_fetch) = anchor.fetch else {
+        return Err(FederationError::internal(format!(
+            "@fromContext ancestor {} lies outside the current fetch group with no anchor",
+            ancestor_type.type_name(),
+        )));
+    };
+    // Index of the boundary type, the one paired with op_path's first
+    // element; the anchor op path's last element pairs with it too.
+    let boundary_idx = types_len - op_len;
+    let anchor_prefix = anchor.op_path.len() as isize - (boundary_idx - ancestor_idx as isize);
+    if anchor_prefix < 0 {
+        return Err(FederationError::internal(format!(
+            "@fromContext ancestor {} lies more than one fetch group above its field",
+            ancestor_type.type_name(),
+        )));
+    }
+    let prefix = op_path_prefix(&anchor.op_path, anchor_prefix as usize);
+    verify_prefix_lands_on(state, anchor_fetch, &prefix, ancestor_type)?;
+    // Parent levels span the whole data path back to the ancestor: every
+    // field in the current fetch's op path, plus the anchor-fetch fields
+    // between the ancestor and the boundary.
+    let levels = count_field_elements(pending.op_path.iter())
+        + count_field_elements(anchor.op_path.iter().skip(anchor_prefix as usize));
+    Ok((anchor_fetch, prefix, levels))
+}
+
+/// Guard for [`locate_ancestor_site`]: the computed prefix must land on the
+/// ancestor's type, otherwise the appended context selection would fail to
+/// rebase at plan build.
+fn verify_prefix_lands_on(
+    state: &PlanState,
+    fetch: NodeIndex,
+    prefix: &SharedPath<Arc<OpPathElement>>,
+    ancestor_type: &CompositeTypeDefinitionPosition,
+) -> Result<(), FederationError> {
+    let landing = match prefix.last() {
+        Some(element) => element
+            .sub_selection_type_position()?
+            .map(|t| t.type_name().clone()),
+        None => state
+            .graph
+            .node(fetch)
+            .root_type()
+            .map(|t| t.type_name().clone()),
+    };
+    if landing.as_ref() == Some(ancestor_type.type_name()) {
+        Ok(())
+    } else {
+        Err(FederationError::internal(format!(
+            "@fromContext ancestor {} does not match its computed fetch position",
+            ancestor_type.type_name(),
+        )))
+    }
+}
+
+fn count_field_elements<'a>(iter: impl Iterator<Item = &'a Arc<OpPathElement>>) -> usize {
+    iter.filter(|e| matches!(e.as_ref(), OpPathElement::Field(_)))
+        .count()
+}
+
+/// The first `len` elements of `op_path`, the transitions T0 to T1 up to
+/// the ancestor at index `len`.
+fn op_path_prefix(
+    op_path: &SharedPath<Arc<OpPathElement>>,
+    len: usize,
+) -> SharedPath<Arc<OpPathElement>> {
+    let mut prefix = SharedPath::new();
+    for element in op_path.iter().take(len) {
+        prefix = prefix.pushed(element.clone());
+    }
+    prefix
+}
+
+/// Emit the context rewrite(s) and variable definition on the context
+/// fetch: Parent elements up the data path, then the context field path.
+/// With Parent elements and a non-Query ancestor, fan out over all runtime
+/// types with a TypenameEquals guard each (mirroring
+/// `query_planner.rs::add_context_renamers_for_selection_set`).
+#[allow(clippy::too_many_arguments)]
+fn add_context_renamers(
+    search_space: &FieldRoutingSearchSpace,
+    state: &mut PlanState,
+    context_fetch_node: NodeIndex,
+    ancestor_type: &CompositeTypeDefinitionPosition,
+    context_selection: &SelectionSet,
+    levels_in_data_path: usize,
+    context_id: &Name,
+    cond: &ContextCondition,
+) -> Result<(), FederationError> {
+    let base_rewrite_path: Vec<FetchDataPathElement> =
+        std::iter::repeat_n(FetchDataPathElement::Parent, levels_in_data_path).collect();
+
+    let add_renamer = |state: &mut PlanState, rewrite_path: Vec<FetchDataPathElement>| {
+        let renamer = FetchDataKeyRenamer {
+            path: rewrite_path,
+            rename_key_to: context_id.clone(),
+        };
+        state.graph.add_context(
+            context_fetch_node,
+            renamer,
+            context_id.clone(),
+            cond.argument_type.clone(),
+        );
+    };
+
+    let is_root_type = search_space
+        .supergraph_schema
+        .schema()
+        .root_operation(apollo_compiler::executable::OperationType::Query)
+        .is_some_and(|root| root == ancestor_type.type_name());
+    let needs_typename_fanout = levels_in_data_path > 0 && !is_root_type;
+    if needs_typename_fanout {
+        let runtime_types = search_space
+            .supergraph_schema
+            .possible_runtime_types(ancestor_type.clone())?;
+        for runtime_type in runtime_types {
+            let mut rewrite_path = base_rewrite_path.clone();
+            rewrite_path.push(FetchDataPathElement::TypenameEquals(
+                runtime_type.type_name.clone(),
+            ));
+            let inner = selections_for_runtime_type(context_selection, &runtime_type.type_name);
+            build_rewrite_path_from_selections(&inner, &mut rewrite_path);
+            add_renamer(state, rewrite_path);
+        }
+    } else {
+        let mut rewrite_path = base_rewrite_path;
+        build_rewrite_path_from_selections(context_selection, &mut rewrite_path);
+        add_renamer(state, rewrite_path);
+    }
+    Ok(())
+}
+
+/// Push `last` onto `base`, splicing `$contextualArgument` variables into
+/// its arguments when it is a field. Non-field elements (and empty
+/// context-arg lists) are pushed unchanged.
+fn pushed_with_context_args(
+    base: SharedPath<Arc<OpPathElement>>,
+    last: &Arc<OpPathElement>,
+    context_args: &[(Name, Name)],
+) -> SharedPath<Arc<OpPathElement>> {
+    if context_args.is_empty() {
+        return base.pushed(last.clone());
+    }
+    let OpPathElement::Field(field) = last.as_ref() else {
+        return base.pushed(last.clone());
+    };
+    let mut modified_field = field.clone();
+    let extra_args = context_args.iter().map(|(arg_name, ctx_id)| {
+        Node::new(Argument {
+            name: arg_name.clone(),
+            value: Node::new(Value::Variable(ctx_id.clone())),
+        })
+    });
+    modified_field.arguments = modified_field
+        .arguments
+        .iter()
+        .cloned()
+        .chain(extra_args)
+        .collect();
+    base.pushed(Arc::new(OpPathElement::Field(modified_field)))
+}

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/mod.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/mod.rs
@@ -13,6 +13,7 @@
 
 mod commit;
 mod conditions;
+mod context;
 mod requires;
 mod routing;
 pub(super) mod state;
@@ -50,9 +51,9 @@ use crate::query_plan::QueryPlanCost;
 use crate::schema::ValidFederationSchema;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 
-/// Cache key for routing options. Captures the selection identity at a QG node.
+/// Site key for routing options. Captures the selection identity at a QG node.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(super) enum RoutingCacheKey {
+pub(super) enum RoutingSiteKey {
     Field(Name),
     InlineFragment(Option<Name>),
 }
@@ -78,7 +79,7 @@ pub(crate) struct FieldRoutingSearchSpace {
     /// position is on the call stack; re-entering it would loop
     /// forever, so the guard returns "no hops" (the fixpoint for
     /// circular keys).
-    pub(super) key_hops_in_flight: RefCell<HashSet<(NodeIndex, RoutingCacheKey)>>,
+    pub(super) key_hops_in_flight: RefCell<HashSet<(NodeIndex, RoutingSiteKey)>>,
     pub(super) disabled_subgraphs: apollo_compiler::collections::IndexSet<Arc<str>>,
 }
 
@@ -361,15 +362,15 @@ struct ForcedTrail {
     frames: Vec<ForcedFrame>,
     /// Sites whose every routing option failed during this call. Consulted
     /// before committing so recurring instances fail fast.
-    doomed: HashSet<(NodeIndex, RoutingCacheKey)>,
+    doomed: HashSet<(NodeIndex, RoutingSiteKey)>,
 }
 
 /// Identity of a pending's routing position: the query graph node plus the
 /// selection's field or type-condition name.
-fn pending_site(pending: &PendingSelection) -> (NodeIndex, RoutingCacheKey) {
+fn pending_site(pending: &PendingSelection) -> (NodeIndex, RoutingSiteKey) {
     let key = match &pending.selection {
-        Selection::Field(f) => RoutingCacheKey::Field(f.field.name().clone()),
-        Selection::InlineFragment(f) => RoutingCacheKey::InlineFragment(
+        Selection::Field(f) => RoutingSiteKey::Field(f.field.name().clone()),
+        Selection::InlineFragment(f) => RoutingSiteKey::InlineFragment(
             f.inline_fragment
                 .type_condition_position
                 .as_ref()

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/requires.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/requires.rs
@@ -502,6 +502,9 @@ impl FieldRoutingSearchSpace {
                 condition_alias_rewrites: alias_rewrites,
             };
             let dest = if has_input_conflict || rewrites_collide {
+                // The original target.fetch_node is abandoned: it retains its
+                // key-hop edge and inputs but receives no query selections, so
+                // plan_builder's empty-selection pruning drops it.
                 let merge_at = state.graph.merge_at(target.fetch_node).to_vec();
                 let split_group = state
                     .graph

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/routing.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/routing.rs
@@ -5,7 +5,7 @@ use petgraph::graph::NodeIndex;
 use tracing::trace;
 
 use super::FieldRoutingSearchSpace;
-use super::RoutingCacheKey;
+use super::RoutingSiteKey;
 use super::state::PendingSelection;
 use crate::error::FederationError;
 use crate::operation::FieldSelection;
@@ -52,20 +52,20 @@ pub(crate) struct RoutingChoice {
     /// an intermediate hop.
     pub(crate) conditions_locally_satisfiable: bool,
     /// The key conditions are @external per the subgraph schema, but an
-    /// ancestor's @provides makes them available at THIS position: every
+    /// ancestor's @provides makes them available at this position: every
     /// condition field has a real query-graph edge either at the pending's
     /// node (a provides-copy node) or at the provides-copy anchor the
     /// position descended from via downcasts
-    /// ([`PendingSelection::provides_anchor`]). When true, commit appends the
-    /// conditions to the parent fetch (the subgraph echoes provided fields)
-    /// instead of pushing them as pendings.
+    /// ([`PendingSelection::provides_anchor`]). When true, commit appends
+    /// the conditions to the parent fetch (the subgraph echoes provided
+    /// fields) instead of pushing them as pendings.
     pub(crate) conditions_provided: bool,
     /// When the routed edge carries @requires conditions: whether the fetch
     /// anchoring the field can select the condition fields in place. Commit
     /// applies this verdict instead of re-deriving it. True when the edge
     /// has no conditions.
     pub(crate) requires_resolvable_in_place: bool,
-    /// A key hop back into the CURRENT subgraph (entity re-entry), created
+    /// A key hop back into the current subgraph (entity re-entry), created
     /// so @requires conditions the fetch cannot select in place ride the
     /// entity representation. Ranked above cross-subgraph hops.
     pub(crate) self_entity_reentry: bool,
@@ -283,10 +283,11 @@ impl FieldRoutingSearchSpace {
         node: NodeIndex,
         edge_idx: EdgeIndex,
         target_subgraph: &Arc<str>,
+        force_hop: bool,
     ) -> Result<(), FederationError> {
         let in_place = self.requires_conditions_resolvable_in_place(node, edge_idx)?;
         let key = self.query_graph.get_locally_satisfiable_key(node)?;
-        if in_place {
+        if in_place && !(force_hop && key.is_some()) {
             options.push(RoutingChoice::direct(edge_idx, target_subgraph.clone()));
         }
         if let Some(key) = key {
@@ -721,7 +722,12 @@ impl FieldRoutingSearchSpace {
             let (_, target) = self.query_graph.edge_endpoints(edge_idx)?;
             let target_node = self.query_graph.node_weight(target)?;
             let edge = self.query_graph.edge_weight(edge_idx)?;
-            if edge.conditions.is_none() {
+            // @fromContext at a position the entity boundary does not already
+            // isolate needs a same-subgraph entity re-entry so the context
+            // value rides the representation.
+            let needs_isolation = !edge.required_contexts.is_empty()
+                && super::context::needs_context_isolation(pending, &edge.required_contexts);
+            if edge.conditions.is_none() && !needs_isolation {
                 options.push(RoutingChoice::direct(edge_idx, target_node.source.clone()));
             } else {
                 self.push_requires_strategy_options(
@@ -729,11 +735,12 @@ impl FieldRoutingSearchSpace {
                     pending.query_graph_node,
                     edge_idx,
                     &target_node.source,
+                    needs_isolation,
                 )?;
             }
         }
 
-        let key = RoutingCacheKey::Field(field_selection.field.name().clone());
+        let key = RoutingSiteKey::Field(field_selection.field.name().clone());
         let hops = self.key_hops_guarded(
             pending.query_graph_node,
             pending.provides_anchor,
@@ -805,7 +812,7 @@ impl FieldRoutingSearchSpace {
             type_condition = %type_cond.type_name(),
             "searching key hops for fragment downcast",
         );
-        let key = RoutingCacheKey::InlineFragment(Some(type_cond.type_name().clone()));
+        let key = RoutingSiteKey::InlineFragment(Some(type_cond.type_name().clone()));
         let hops = self.key_hops_guarded(
             pending.query_graph_node,
             pending.provides_anchor,
@@ -818,8 +825,6 @@ impl FieldRoutingSearchSpace {
         Ok(options)
     }
 
-    /// Order options best-first: @provides beats a direct local edge beats a
-    /// key hop whose conditions are locally satisfiable beats a remote hop.
     /// Fallback when normal edge enumeration yields no options: fragment
     /// restructuring for inline fragments, type explosion for fields on
     /// abstract types.
@@ -930,7 +935,7 @@ impl FieldRoutingSearchSpace {
         &self,
         node: NodeIndex,
         provides_anchor: Option<NodeIndex>,
-        key: RoutingCacheKey,
+        key: RoutingSiteKey,
         edge_finder: impl Fn(NodeIndex) -> Option<EdgeIndex>,
     ) -> Result<Vec<RoutingChoice>, FederationError> {
         if !self
@@ -1014,9 +1019,9 @@ impl FieldRoutingSearchSpace {
             // Direct edge exists but its subtree dead-ends; a key hop at
             // this level may still reach it.
         }
-        // No provides anchor: only hop EXISTENCE matters here, which the
+        // No provides anchor: only hop existence matters here, which the
         // anchor never changes (it only refines `conditions_provided`).
-        let key = RoutingCacheKey::Field(field_sel.field.name().clone());
+        let key = RoutingSiteKey::Field(field_sel.field.name().clone());
         let hops = self.key_hops_guarded(node, None, key, |key_target| {
             self.edge_for_field(key_target, &field_sel.field)
         })?;
@@ -1037,7 +1042,7 @@ impl FieldRoutingSearchSpace {
         }
         // No provides anchor: only which subgraphs hops reach matters here,
         // not `conditions_provided`.
-        let key = RoutingCacheKey::InlineFragment(Some(type_cond.type_name().clone()));
+        let key = RoutingSiteKey::InlineFragment(Some(type_cond.type_name().clone()));
         let hops = self.key_hops_guarded(node, None, key, |key_target| {
             self.edge_for_inline_fragment(key_target, &frag_sel.inline_fragment)
         })?;

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/state.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/state.rs
@@ -11,6 +11,7 @@ use super::super::shared_path::SharedPath;
 use crate::operation::Selection;
 use crate::query_graph::graph_path::operation::OpPathElement;
 use crate::query_plan::FetchDataPathElement;
+use crate::schema::position::CompositeTypeDefinitionPosition;
 
 /// Condition bookkeeping for a pending selection that carries a
 /// @requires / @key field set.
@@ -24,6 +25,14 @@ pub(crate) struct ConditionScope {
     /// chains: mutually recursive @requires would otherwise spiral forever,
     /// each round minting fresh entity groups.
     pub(crate) depth: u8,
+}
+
+/// Anchor information for @fromContext across entity boundaries.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ContextAnchor {
+    pub(crate) fetch: Option<NodeIndex>,
+    pub(crate) op_path: SharedPath<Arc<OpPathElement>>,
+    pub(crate) entity_type: Option<CompositeTypeDefinitionPosition>,
 }
 
 #[derive(Clone, Debug)]
@@ -43,12 +52,12 @@ pub(crate) struct PendingSelection {
     pub(crate) condition: Option<ConditionScope>,
     /// @provides provenance across downcasts: the provides-copy query graph
     /// node this position descended from via inline fragments, when the
-    /// current node itself is NOT a copy. An ancestor's `@provides` on an
+    /// current node itself is not a copy. An ancestor's `@provides` on an
     /// interface-typed field applies to every runtime type, but the query
     /// graph only copies the nodes named in the provides field set. A
     /// downcast out of the copy layer lands on the original node, where the
     /// provided fields have no edges. The anchor keeps the copy node (whose
-    /// edges ARE the provided fields) visible to key-hop enumeration, so
+    /// edges are the provided fields) visible to key-hop enumeration, so
     /// "are these key conditions provided here?" stays an exact graph check
     /// instead of a schema-level guess. `None` whenever the current node's
     /// own edges carry the provenance (inside a copy layer) or no @provides
@@ -57,13 +66,19 @@ pub(crate) struct PendingSelection {
     /// The @defer label this selection is inside, if any. Propagated to
     /// fetch nodes so they can be partitioned into primary vs deferred.
     pub(crate) defer_ref: Option<String>,
+    /// Type spine from the operation root through parents of this selection,
+    /// for @fromContext ancestor resolution.
+    pub(crate) parent_types: SharedPath<CompositeTypeDefinitionPosition>,
+    /// @fromContext anchor: the parent fetch feeding this selection's
+    /// entity fetch, when the selection lives inside one.
+    pub(crate) context_anchor: ContextAnchor,
     /// Best-effort selection: dropping it (zero routing options, or a failed
     /// commit) is tolerated silently instead of counting toward
     /// `dropped_fields` and failing the plan. Inherited by forks, so
     /// condition data pushed on a best-effort selection's behalf is equally
     /// tolerant. The only producer is the @interfaceObject
-    /// concrete-`__typename` recovery, whose fused predecessor silently did
-    /// nothing when no candidate subgraph existed.
+    /// concrete-`__typename` recovery, where no subgraph may be able to
+    /// supply the concrete typename.
     pub(crate) best_effort: bool,
 }
 
@@ -80,6 +95,8 @@ impl PendingSelection {
             condition: self.condition,
             provides_anchor: self.provides_anchor,
             defer_ref: self.defer_ref.clone(),
+            parent_types: self.parent_types.clone(),
+            context_anchor: self.context_anchor.clone(),
             best_effort: self.best_effort,
         }
     }
@@ -110,6 +127,19 @@ impl PendingSelection {
 
     pub(super) fn with_defer(mut self, defer_ref: Option<String>) -> Self {
         self.defer_ref = defer_ref;
+        self
+    }
+
+    pub(super) fn with_parent_types(
+        mut self,
+        parent_types: SharedPath<CompositeTypeDefinitionPosition>,
+    ) -> Self {
+        self.parent_types = parent_types;
+        self
+    }
+
+    pub(super) fn with_context_anchor(mut self, context_anchor: ContextAnchor) -> Self {
+        self.context_anchor = context_anchor;
         self
     }
 
@@ -195,7 +225,7 @@ pub(crate) struct PlanState {
     /// Interned ids for @requires condition-field aliases, keyed by the
     /// serialized condition selection: identical conditions share an alias
     /// so sibling entity fetches staging the same @requires can merge;
-    /// distinct conditions get distinct aliases. Append-only; NOT restored
+    /// distinct conditions get distinct aliases. Append-only; not restored
     /// on rollback (aliases only need to be stable, not predictable).
     pub(crate) condition_alias_ids: BTreeMap<String, usize>,
 }

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/tests.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/tests.rs
@@ -50,6 +50,21 @@ fn plan_query_with_defer(schema: &str, query: &str) -> String {
     plan_query_with_options(schema, query, config, Default::default())
 }
 
+fn plan_query_with_router_specs(schema: &str, query: &str) -> String {
+    let supergraph = Supergraph::new_with_router_specs(schema).expect("supergraph parse");
+    let planner = QueryPlanner::new(&supergraph, default_config()).expect("planner creation");
+    let document = apollo_compiler::ExecutableDocument::parse_and_validate(
+        planner.api_schema().schema(),
+        query,
+        "test.graphql",
+    )
+    .expect("query parse");
+    let plan = planner
+        .build_query_plan(&document, None, Default::default())
+        .expect("query plan");
+    format!("{plan}")
+}
+
 const SINGLE_SUBGRAPH_SCHEMA: &str = include_str!("../fixtures/single_subgraph.graphql");
 
 #[test]
@@ -1788,5 +1803,27 @@ fn defer_sibling_blocks_produces_multiple_deferred() {
     assert!(
         plan_str.contains("address"),
         "A deferred block should fetch 'address': {plan_str}"
+    );
+}
+
+const CONTEXT_SCHEMA: &str = include_str!("../fixtures/context.graphql");
+
+/// @fromContext field: the plan must fetch the context-providing field
+/// (`prop`) from the parent and thread it via a contextualArgument to
+/// the subgraph that resolves the @fromContext-bearing field.
+#[test]
+fn context_from_context_produces_valid_plan() {
+    let plan_str = plan_query_with_router_specs(CONTEXT_SCHEMA, "{ t { u { field } } }");
+    assert!(
+        plan_str.contains("field"),
+        "Plan should fetch 'field': {plan_str}"
+    );
+    assert!(
+        plan_str.contains("prop"),
+        "Plan should fetch 'prop' as context value: {plan_str}"
+    );
+    assert!(
+        plan_str.contains("contextualArgument"),
+        "Plan should include context variable argument: {plan_str}"
     );
 }

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/tests.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/tests.rs
@@ -1827,3 +1827,124 @@ fn context_from_context_produces_valid_plan() {
         "Plan should include context variable argument: {plan_str}"
     );
 }
+
+const CONTEXT_BOUNDARY_SCHEMA: &str = r#"
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+enum join__Graph {
+  S1 @join__graph(name: "s1", url: "http://s1")
+  S2 @join__graph(name: "s2", url: "http://s2")
+}
+
+type Query
+  @join__type(graph: S1)
+  @join__type(graph: S2)
+{
+  t: T! @join__field(graph: S1)
+}
+
+type T
+  @join__type(graph: S1, key: "id")
+  @join__type(graph: S2, key: "id")
+  @context(name: "s2__ctx")
+{
+  id: ID!
+  prop: String! @join__field(graph: S1) @join__field(graph: S2)
+  child: T @join__field(graph: S2)
+  field: Int! @join__field(graph: S2, contextArguments: [{context: "s2__ctx", name: "a", type: "String", selection: " { prop }"}])
+}
+"#;
+
+/// @fromContext consumed inside an entity fetch whose entity root type IS
+/// the @context ancestor: the context value rides the entity representation
+/// (no extra isolation hop), the context selection lands on the fetch
+/// feeding the entity fetch, and the rewrite path has no Parent elements.
+#[test]
+fn context_value_rides_entity_representation_at_boundary() {
+    let plan_str =
+        plan_query_with_router_specs(CONTEXT_BOUNDARY_SCHEMA, "{ t { child { field } } }");
+    assert!(
+        plan_str.contains("contextualArgument"),
+        "Plan should pass the context variable: {plan_str}"
+    );
+    insta::assert_snapshot!(plan_str, @r###"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "s1") {
+          {
+            t {
+              __typename
+              id
+              prop
+            }
+          }
+        },
+        Flatten(path: "t") {
+          Fetch(service: "s2") {
+            {
+              ... on T {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on T {
+                child {
+                  field(a: $contextualArgument_2_0)
+                }
+              }
+            }
+          },
+        },
+      },
+    }
+    "###);
+}

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/type_conditions.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/type_conditions.rs
@@ -102,7 +102,7 @@ impl FieldRoutingSearchSpace {
     /// Vacuous type condition: the current node's runtime types are a subset
     /// of the condition's (e.g. `...on Node` when every union member
     /// implements Node), so treat the fragment as pass-through, preserving
-    /// directives by pushing it onto the op_path.
+    /// non-routing directives by pushing the fragment onto the op_path.
     pub(super) fn try_vacuous_type_condition(
         &self,
         state: &mut PlanState,

--- a/apollo-federation/src/query_plan/incremental_planner/fixtures/context.graphql
+++ b/apollo-federation/src/query_plan/incremental_planner/fixtures/context.graphql
@@ -1,0 +1,79 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T! @join__field(graph: SUBGRAPH1)
+  randomId: ID! @join__field(graph: SUBGRAPH2)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @context(name: "Subgraph1__context")
+{
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  b: String!
+  field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "String", selection: " { prop }"}])
+}

--- a/apollo-federation/src/query_plan/incremental_planner/mod.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/mod.rs
@@ -281,6 +281,8 @@ fn root_pending_selections(
             condition: None,
             defer_ref: None,
             provides_anchor: None,
+            parent_types: Default::default(),
+            context_anchor: Default::default(),
             best_effort: false,
         })
         .collect()

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/incremental_planner.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/incremental_planner.rs
@@ -1,3 +1,8 @@
+use apollo_compiler::Name;
+use apollo_federation::query_plan::FetchDataPathElement;
+use apollo_federation::query_plan::FetchDataRewrite;
+use apollo_federation::query_plan::PlanNode;
+use apollo_federation::query_plan::TopLevelPlanNode;
 use apollo_federation::query_plan::query_planner::IncrementalPlannerConfig;
 use apollo_federation::query_plan::query_planner::QueryPlanIncrementalDeliveryConfig;
 use apollo_federation::query_plan::query_planner::QueryPlanOptions;
@@ -1632,6 +1637,96 @@ fn inc_user_field_argument_conflict_with_requires_condition() {
     );
 }
 
+/// Two @requires on the same entity type need different arguments on a
+/// shared condition field `f`. The planner detects the argument conflict,
+/// aliases both condition invocations, and splits into separate entity
+/// fetches so each gets its own input.
+#[test]
+fn inc_requires_conflicting_arguments_splits_group() {
+    let planner = planner!(
+        config = incremental_config(),
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            f(arg: Int!): Int
+          }
+        "#,
+        Subgraph2: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            f(arg: Int!): Int @external
+            a: Int! @requires(fields: "f(arg: 1)")
+            b: Int! @requires(fields: "f(arg: 2)")
+          }
+        "#
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          {
+            t {
+              a
+              b
+            }
+          }
+        "#,
+        @r###"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "Subgraph1") {
+          {
+            t {
+              __typename
+              id
+              __require_0_f: f(arg: 1)
+              __require_1_f: f(arg: 2)
+            }
+          }
+        },
+        Parallel {
+          Flatten(path: "t") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on T {
+                  __typename
+                  id
+                  __require_1_f: f
+                }
+              } =>
+              {
+                ... on T {
+                  b
+                }
+              }
+            },
+          },
+          Flatten(path: "t") {
+            Fetch(service: "Subgraph2") {
+              {
+                ... on T {
+                  __typename
+                  id
+                  __require_0_f: f
+                }
+              } =>
+              {
+                ... on T {
+                  a
+                }
+              }
+            },
+          },
+        },
+      },
+    }
+    "###
+    );
+}
+
 /// A field satisfied by an ancestor's @provides is preferred over hopping
 /// to another subgraph for the same field.
 #[test]
@@ -1789,13 +1884,135 @@ fn inc_interface_object_fake_downcast_fetches_typename() {
     );
 }
 
+/// @interfaceObject fake downcast where the best-effort `__typename` pushed by
+/// `push_interface_object_typename` cannot route: the subgraph owning the real
+/// interface has a non-resolvable key, so no key hop reaches it from the
+/// @interfaceObject subgraph. The planner silently drops the `__typename`
+/// (exercising the `best_effort` branch in `drop_unresolvable` and the
+/// `recover_doomed` short-circuit) without failing the overall plan.
+///
+/// Hand-crafted supergraph SDL because `rover supergraph compose` rejects
+/// schemas where no subgraph can resolve implementation types of an
+/// @interfaceObject interface (SATISFIABILITY_ERROR), yet the incremental
+/// planner must handle the topology gracefully at runtime.
+#[test]
+fn inc_interface_object_best_effort_typename_dropped() {
+    let supergraph_sdl = r#"
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+interface I
+  @join__type(graph: SUBGRAPHA, key: "id", resolvable: false)
+  @join__type(graph: SUBGRAPHB, key: "id", isInterfaceObject: true)
+{
+  id: ID!
+  data: String @join__field(graph: SUBGRAPHB)
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+scalar join__FieldSet
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPHA @join__graph(name: "SubgraphA", url: "none")
+  SUBGRAPHB @join__graph(name: "SubgraphB", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPHB)
+{
+  stuff: [I] @join__field(graph: SUBGRAPHB)
+}
+
+type X implements I
+  @join__implements(graph: SUBGRAPHA, interface: "I")
+  @join__type(graph: SUBGRAPHA, key: "id", resolvable: false)
+{
+  id: ID!
+  data: String @join__field(graph: SUBGRAPHA, external: true)
+}
+
+type Y implements I
+  @join__implements(graph: SUBGRAPHA, interface: "I")
+  @join__type(graph: SUBGRAPHA, key: "id", resolvable: false)
+{
+  id: ID!
+  data: String @join__field(graph: SUBGRAPHA, external: true)
+}
+"#;
+    let supergraph = apollo_federation::Supergraph::new(supergraph_sdl).expect("valid supergraph");
+    let planner = apollo_federation::query_plan::query_planner::QueryPlanner::new(
+        &supergraph,
+        incremental_config(),
+    )
+    .expect("can create query planner");
+    let api_schema = planner.api_schema();
+    let document = apollo_compiler::ExecutableDocument::parse_and_validate(
+        api_schema.schema(),
+        "{ stuff { ... on X { data } } }",
+        "test.graphql",
+    )
+    .expect("valid graphql document");
+    let plan = planner
+        .build_query_plan(&document, None, Default::default())
+        .expect("planning should succeed even when best-effort __typename cannot route");
+    let plan_str = plan.to_string();
+    // Single fetch to SubgraphB; the best-effort __typename was silently
+    // dropped, so there is no key hop to SubgraphA.
+    assert!(
+        !plan_str.contains("SubgraphA"),
+        "Plan must not key-hop to SubgraphA (non-resolvable): {plan_str}"
+    );
+    insta::assert_snapshot!(plan, @r###"
+    QueryPlan {
+      Fetch(service: "SubgraphB") {
+        {
+          stuff {
+            __typename
+            data
+          }
+        }
+      },
+    }
+    "###);
+}
+
 // ---------------------------------------------------------------------------
 // Type explosion: abstract type conditions decomposed into concrete fragments
 // ---------------------------------------------------------------------------
 
-/// Union member implements an interface in the supergraph but not in the
-/// subgraph that owns the root field. The planner must type-explode the
-/// interface condition into concrete-type fragments so no member is excluded.
+/// Union U = {A, B, C} with `... on I` where I's supergraph runtime types
+/// cover all of U (A implements I only in Subgraph2). The condition is
+/// vacuous (try_vacuous_type_condition), then the child field `v` on the
+/// union has no direct edge, triggering try_explode_interface_field to
+/// decompose into per-concrete-type fragments.
 #[test]
 fn inc_type_explosion_union_interface_interaction() {
     let planner = planner!(
@@ -1867,9 +2084,10 @@ fn inc_type_explosion_union_interface_interaction() {
     );
 }
 
-/// Vacuous type condition: all runtime types of the parent position satisfy
-/// the condition, so the fragment is treated as pass-through rather than
-/// exploded. Here U = B | C and both implement I, so `... on I` is vacuous.
+/// Union U = {B, C} where both implement I locally, so `... on I` has a
+/// normal query graph edge (downcast). The fragment routes directly without
+/// entering the type-condition fallback path. The plan retains the type
+/// condition since it gates different runtime behavior for each member.
 #[test]
 fn inc_all_members_implement_interface_routes_directly() {
     let planner = planner!(
@@ -1982,6 +2200,109 @@ fn inc_conditionless_fragment_skip_preserved() {
     );
 }
 
+/// Union U = {A, B, C} with `... on I` where only B and C implement I, and
+/// the interface lives in a different subgraph from U. Because Subgraph1 has
+/// no knowledge of I, there is no downcast edge from U to I in its query
+/// graph. The supergraph runtime types of I are {B, C}, which partially
+/// overlap U's runtime types {A, B, C}. This triggers
+/// `try_explode_abstract_type` to decompose the fragment into per-concrete-type
+/// fragments for only the intersection {B, C}, excluding A.
+#[test]
+fn inc_partial_overlap_explodes_abstract_type() {
+    let planner = planner!(
+        config = incremental_config(),
+        Subgraph1: r#"
+          type Query {
+            u: U
+          }
+
+          union U = A | B | C
+
+          type A {
+            w: Int
+          }
+
+          type B @key(fields: "id") {
+            id: ID!
+          }
+
+          type C @key(fields: "id") {
+            id: ID!
+          }
+        "#,
+        Subgraph2: r#"
+          interface I {
+            v: Int
+          }
+
+          type B implements I @key(fields: "id") {
+            id: ID!
+            v: Int
+          }
+
+          type C implements I @key(fields: "id") {
+            id: ID!
+            v: Int
+          }
+        "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          {
+            u {
+              ... on I {
+                v
+              }
+            }
+          }
+        "#,
+        @r###"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "Subgraph1") {
+          {
+            u {
+              __typename
+              ... on B {
+                __typename
+                id
+              }
+              ... on C {
+                __typename
+                id
+              }
+            }
+          }
+        },
+        Flatten(path: "u") {
+          Fetch(service: "Subgraph2") {
+            {
+              ... on B {
+                __typename
+                id
+              }
+              ... on C {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on B {
+                v
+              }
+              ... on C {
+                v
+              }
+            }
+          },
+        },
+      },
+    }
+    "###
+    );
+}
+
 // ---------------------------------------------------------------------------
 // @defer: deferred fragment across subgraphs produces a Defer plan node
 // with primary and deferred blocks. The @defer directive is stripped from
@@ -2065,6 +2386,358 @@ fn inc_defer_cross_subgraph_produces_defer_plan() {
     );
 }
 
+/// Nested @defer: the outer deferred block itself contains a @defer,
+/// exercising DeferBlockInfo::parent_label, children_of, the recursive
+/// branch of build_deferred_blocks, and nested DeferNode wrapping.
+#[test]
+fn inc_nested_defer_produces_nested_defer_nodes() {
+    let planner = planner!(
+        config = incremental_defer_config(),
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            x: Int
+          }
+        "#,
+        Subgraph2: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            y: Int
+          }
+        "#,
+        Subgraph3: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            z: Int
+          }
+        "#,
+    );
+
+    assert_plan!(
+        &planner,
+        r#"
+          {
+            t {
+              x
+              ... @defer {
+                y
+                ... @defer {
+                  z
+                }
+              }
+            }
+          }
+        "#,
+        @r###"
+    QueryPlan {
+      Defer {
+        Primary {
+          { t { x } }:
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              t {
+                __typename
+                x
+                id
+              }
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "t") {
+            Defer {
+              Primary {
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph2") {
+                    {
+                      ... on T {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        y
+                      }
+                    }
+                  },
+                },
+              }, [
+                Deferred(depends: [0], path: "t") {
+                  { z }:
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph3") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          z
+                        }
+                      }
+                    },
+                  },
+                },
+              ]
+            },
+          },
+        ]
+      },
+    }
+    "###
+    );
+}
+
+// ---------------------------------------------------------------------------
+// @fromContext: context rewrite path includes TypenameEquals guard
+// Based on: context.rs::set_context_one_subgraph
+// ---------------------------------------------------------------------------
+
+fn parse_fetch_data_path_element(value: &str) -> FetchDataPathElement {
+    if value == ".." {
+        FetchDataPathElement::Parent
+    } else if let Some(("", ty)) = value.split_once("... on ") {
+        FetchDataPathElement::TypenameEquals(Name::new(ty).unwrap())
+    } else {
+        FetchDataPathElement::Key(Name::new(value).unwrap(), Default::default())
+    }
+}
+
+#[test]
+fn context_rewrite_path_includes_typename_equals() {
+    let planner = planner!(
+        config = incremental_config(),
+        Subgraph1: r#"
+        type Query {
+          t: T!
+        }
+        type T @key(fields: "id") @context(name: "context") {
+          id: ID!
+          u: U!
+          prop: String!
+        }
+        type U @key(fields: "id") {
+          id: ID!
+          b: String!
+          field(a: String @fromContext(field: "$context { prop }")): Int!
+        }
+        "#,
+        Subgraph2: r#"
+        type Query {
+          randomId: ID!
+        }
+        "#,
+    );
+
+    let api_schema = planner.api_schema();
+    let document = apollo_compiler::ExecutableDocument::parse_and_validate(
+        api_schema.schema(),
+        r#"
+        {
+          t {
+            u {
+              field
+            }
+          }
+        }
+        "#,
+        "operation.graphql",
+    )
+    .expect("valid graphql document");
+    let plan = planner
+        .build_query_plan(&document, None, Default::default())
+        .expect("query plan generated");
+
+    // Extract the context rewrite from the second node (the flatten/fetch).
+    let Some(TopLevelPlanNode::Sequence(node)) = &plan.node else {
+        panic!("expected sequence node");
+    };
+    let Some(PlanNode::Flatten(node)) = node.nodes.get(1) else {
+        panic!("expected flatten node at index 1");
+    };
+    let PlanNode::Fetch(fetch) = &*node.node else {
+        panic!("expected fetch node inside flatten");
+    };
+
+    // The rewrite path must include the TypenameEquals guard:
+    // [Parent, TypenameEquals("T"), Key("prop")], not [Parent, Key("prop")].
+    assert_eq!(fetch.context_rewrites.len(), 1);
+    let FetchDataRewrite::KeyRenamer(renamer) = &*fetch.context_rewrites[0] else {
+        panic!("expected KeyRenamer");
+    };
+    assert_eq!(renamer.rename_key_to.as_str(), "contextualArgument_1_0");
+
+    let expected_path: Vec<FetchDataPathElement> = ["..", "... on T", "prop"]
+        .into_iter()
+        .map(parse_fetch_data_path_element)
+        .collect();
+    assert_eq!(
+        renamer.path, expected_path,
+        "context rewrite path should include TypenameEquals(\"T\")"
+    );
+}
+
+/// Multi-hop ancestor walking: @context is defined on a grandparent type
+/// (A), the @fromContext field lives on type C which is two entity hops
+/// below A. The planner must walk parent_types past B to find A, and the
+/// rewrite path needs Parent elements for each level of nesting.
+#[test]
+fn inc_from_context_multi_hop_ancestor() {
+    let planner = planner!(
+        config = incremental_config(),
+        Subgraph1: r#"
+        type Query {
+          a: A!
+        }
+        type A @key(fields: "id") @context(name: "ctx") {
+          id: ID!
+          b: B!
+          prop: String!
+        }
+        type B @key(fields: "id") {
+          id: ID!
+          c: C!
+        }
+        type C @key(fields: "id") {
+          id: ID!
+          value(arg: String @fromContext(field: "$ctx { prop }")): Int!
+        }
+        "#,
+        Subgraph2: r#"
+        type Query {
+          dummy: ID!
+        }
+        "#,
+    );
+
+    // Verify the full plan: A's fetch includes `prop` for context data,
+    // and C's entity fetch references $contextualArgument_1_0.
+    assert_plan!(
+        &planner,
+        r#"
+        {
+          a {
+            b {
+              c {
+                value
+              }
+            }
+          }
+        }
+        "#,
+        @r###"
+    QueryPlan {
+      Sequence {
+        Fetch(service: "Subgraph1") {
+          {
+            a {
+              b {
+                c {
+                  __typename
+                  id
+                }
+              }
+              prop
+            }
+          }
+        },
+        Flatten(path: "a.b.c") {
+          Fetch(service: "Subgraph1") {
+            {
+              ... on C {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on C {
+                value(arg: $contextualArgument_1_0)
+              }
+            }
+          },
+        },
+      },
+    }
+    "###
+    );
+
+    let api_schema = planner.api_schema();
+    let document = apollo_compiler::ExecutableDocument::parse_and_validate(
+        api_schema.schema(),
+        r#"
+        {
+          a {
+            b {
+              c {
+                value
+              }
+            }
+          }
+        }
+        "#,
+        "operation.graphql",
+    )
+    .expect("valid graphql document");
+    let plan = planner
+        .build_query_plan(&document, None, Default::default())
+        .expect("query plan generated");
+
+    let Some(TopLevelPlanNode::Sequence(seq)) = &plan.node else {
+        panic!("expected sequence node");
+    };
+
+    // Find the deepest flatten/fetch (C's entity fetch with the context
+    // rewrite).
+    let last_flatten = seq.nodes.iter().rev().find_map(|n| {
+        if let PlanNode::Flatten(f) = n {
+            Some(f)
+        } else {
+            None
+        }
+    });
+    let Some(flatten) = last_flatten else {
+        panic!("expected at least one flatten node");
+    };
+    let PlanNode::Fetch(fetch) = &*flatten.node else {
+        panic!("expected fetch node inside flatten");
+    };
+
+    // The rewrite path should walk 2+ Parent elements back to the
+    // grandparent A, with a TypenameEquals guard for A.
+    assert!(
+        !fetch.context_rewrites.is_empty(),
+        "context rewrites must be present on the deepest fetch"
+    );
+    let FetchDataRewrite::KeyRenamer(renamer) = &*fetch.context_rewrites[0] else {
+        panic!("expected KeyRenamer");
+    };
+
+    let parent_count = renamer
+        .path
+        .iter()
+        .filter(|e| matches!(e, FetchDataPathElement::Parent))
+        .count();
+    assert!(
+        parent_count >= 2,
+        "multi-hop context should have at least 2 Parent elements in the rewrite path, got {parent_count}"
+    );
+
+    assert!(
+        renamer
+            .rename_key_to
+            .as_str()
+            .starts_with("contextualArgument_"),
+        "rename key should be a contextualArgument, got {:?}",
+        renamer.rename_key_to
+    );
+}
+
 #[test]
 fn inc_interface_type_explosion_routes_value_type_field() {
     let planner = planner!(
@@ -2073,16 +2746,13 @@ fn inc_interface_type_explosion_routes_value_type_field() {
           type Query {
             i: I
           }
-
           interface I {
             s: S
           }
-
           type T implements I @key(fields: "id") {
             id: ID!
             s: S @shareable
           }
-
           type S @shareable {
             x: Int
           }
@@ -2092,14 +2762,12 @@ fn inc_interface_type_explosion_routes_value_type_field() {
             id: ID!
             s: S @shareable
           }
-
           type S @shareable {
             x: Int
             y: Int
           }
         "#,
     );
-
     assert_plan!(
         &planner,
         r#"

--- a/apollo-federation/tests/query_plan/supergraphs/context_rewrite_path_includes_typename_equals.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/context_rewrite_path_includes_typename_equals.graphql
@@ -1,0 +1,87 @@
+# Composed from subgraphs with hash: 493d78ea411e0726dbfcd63da1534851ed24438d
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T! @join__field(graph: SUBGRAPH1)
+  randomId: ID! @join__field(graph: SUBGRAPH2)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @context(name: "Subgraph1__context")
+{
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  b: String!
+  field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "String", selection: " { prop }"}])
+}

--- a/apollo-federation/tests/query_plan/supergraphs/inc_from_context_multi_hop_ancestor.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/inc_from_context_multi_hop_ancestor.graphql
@@ -1,0 +1,93 @@
+# Composed from subgraphs with hash: a9d837b60f290bc1edaabe873fd91fb9de506520
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1", import: ["@context"], for: SECURITY)
+{
+  query: Query
+}
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+
+directive @context__fromContext(field: context__ContextFieldValue) on ARGUMENT_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @context(name: "Subgraph1__ctx")
+{
+  id: ID!
+  b: B!
+  prop: String!
+}
+
+type B
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  c: C!
+}
+
+type C
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  value: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__ctx", name: "arg", type: "String", selection: " { prop }"}])
+}
+
+scalar context__ContextFieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  a: A! @join__field(graph: SUBGRAPH1)
+  dummy: ID! @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/inc_nested_defer_produces_nested_defer_nodes.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/inc_nested_defer_produces_nested_defer_nodes.graphql
@@ -1,0 +1,75 @@
+# Composed from subgraphs with hash: 5015fdb8921eb7b529abb9cf852400161530ab6f
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+  @join__type(graph: SUBGRAPH3, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH1)
+  y: Int @join__field(graph: SUBGRAPH2)
+  z: Int @join__field(graph: SUBGRAPH3)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/inc_partial_overlap_explodes_abstract_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/inc_partial_overlap_explodes_abstract_type.graphql
@@ -1,0 +1,99 @@
+# Composed from subgraphs with hash: 218a5dfa95bb684a5dbb8a30d54de357fd69b07d
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A
+  @join__type(graph: SUBGRAPH1)
+{
+  w: Int
+}
+
+type B implements I
+  @join__implements(graph: SUBGRAPH2, interface: "I")
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v: Int @join__field(graph: SUBGRAPH2)
+}
+
+type C implements I
+  @join__implements(graph: SUBGRAPH2, interface: "I")
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v: Int @join__field(graph: SUBGRAPH2)
+}
+
+interface I
+  @join__type(graph: SUBGRAPH2)
+{
+  v: Int
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  u: U @join__field(graph: SUBGRAPH1)
+}
+
+union U
+  @join__type(graph: SUBGRAPH1)
+  @join__unionMember(graph: SUBGRAPH1, member: "A")
+  @join__unionMember(graph: SUBGRAPH1, member: "B")
+  @join__unionMember(graph: SUBGRAPH1, member: "C")
+ = A | B | C

--- a/apollo-federation/tests/query_plan/supergraphs/inc_requires_conflicting_arguments_splits_group.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/inc_requires_conflicting_arguments_splits_group.graphql
@@ -1,0 +1,72 @@
+# Composed from subgraphs with hash: 87ed0a618ec64b945956602e8ee7ca48d8808dff
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  f(arg: Int!): Int @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH2, external: true)
+  a: Int! @join__field(graph: SUBGRAPH2, requires: "f(arg: 1)")
+  b: Int! @join__field(graph: SUBGRAPH2, requires: "f(arg: 2)")
+}


### PR DESCRIPTION
## Summary

Implements `@fromContext` directive support in the incremental planner.

- New `context.rs` module: `parse_context_selection`, context condition handling
- Context anchoring and propagation through fetch groups
- Tests for `@fromContext` field routing and entity boundary cases

Replaces erroneously merged PR #10144.