### PR TITLE
feat(incremental-planner): add FetchProtocol enum and plan cost estimation

### DIFF
--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -79,6 +79,7 @@ impl FetchNode {
     fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
         let Self {
             subgraph_name,
+            protocol: _,
             id,
             variable_usages: _,
             requires,

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3007,6 +3007,7 @@ impl FetchDependencyGraphNode {
         }
         let node = super::PlanNode::Fetch(Box::new(super::FetchNode {
             subgraph_name: self.subgraph_name.clone(),
+            protocol: Default::default(),
             id: self.id.get().copied(),
             variable_usages,
             requires: input_nodes

--- a/apollo-federation/src/query_plan/incremental_planner/fetch_graph/plan_builder.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/fetch_graph/plan_builder.rs
@@ -540,6 +540,7 @@ impl FetchGraph {
         // 7. Construct FetchNode.
         let fetch_node = PlanNode::Fetch(Box::new(crate::query_plan::FetchNode {
             subgraph_name: node.subgraph.clone(),
+            protocol: Default::default(),
             id: None,
             variable_usages,
             requires,

--- a/apollo-federation/src/query_plan/mod.rs
+++ b/apollo-federation/src/query_plan/mod.rs
@@ -40,6 +40,47 @@ pub enum TopLevelPlanNode {
     Condition(Box<ConditionNode>),
 }
 
+#[allow(dead_code)]
+impl QueryPlan {
+    pub fn cost(&self) -> QueryPlanCost {
+        match &self.node {
+            None => 0.0,
+            Some(top) => top.cost(),
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl TopLevelPlanNode {
+    pub fn cost(&self) -> QueryPlanCost {
+        match self {
+            Self::Fetch(_) => plan_node_cost_at_depth(self.as_plan_node_ref(), 0),
+            Self::Sequence(_) => plan_node_cost_at_depth(self.as_plan_node_ref(), 0),
+            Self::Parallel(_) => plan_node_cost_at_depth(self.as_plan_node_ref(), 0),
+            Self::Flatten(_) => plan_node_cost_at_depth(self.as_plan_node_ref(), 0),
+            Self::Defer(_) => plan_node_cost_at_depth(self.as_plan_node_ref(), 0),
+            Self::Condition(_) => plan_node_cost_at_depth(self.as_plan_node_ref(), 0),
+            Self::Subscription(s) => {
+                let primary_cost = 1000.0;
+                let rest = s.rest.as_ref().map_or(0.0, |n| n.cost_at_depth(1));
+                primary_cost + rest
+            }
+        }
+    }
+
+    fn as_plan_node_ref(&self) -> PlanNodeRef<'_> {
+        match self {
+            Self::Fetch(_) => PlanNodeRef::Fetch,
+            Self::Sequence(s) => PlanNodeRef::Sequence(&s.nodes),
+            Self::Parallel(p) => PlanNodeRef::Parallel(&p.nodes),
+            Self::Flatten(f) => PlanNodeRef::Flatten(&f.node),
+            Self::Defer(d) => PlanNodeRef::Defer(&d.primary),
+            Self::Condition(c) => PlanNodeRef::Condition(c),
+            Self::Subscription(_) => unreachable!("handled above"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SubscriptionNode {
     pub primary: Box<FetchNode>,
@@ -59,9 +100,32 @@ pub enum PlanNode {
     Condition(Box<ConditionNode>),
 }
 
+/// How a fetch communicates with its data source. Extensible for future
+/// non-GraphQL protocols (gRPC, SQL, etc.).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub enum FetchProtocol {
+    /// Standard GraphQL subgraph fetch.
+    #[default]
+    GraphQL,
+    /// Connector-based fetch (REST, etc.). The coordinate string identifies
+    /// the connector (e.g., "subgraph:Type.field[0]") for execution-layer
+    /// lookup.
+    Connector { coordinate: String },
+}
+
+impl FetchProtocol {
+    pub fn is_graphql(&self) -> bool {
+        matches!(self, FetchProtocol::GraphQL)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FetchNode {
     pub subgraph_name: Arc<str>,
+    /// Protocol used to execute this fetch. Defaults to GraphQL.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "FetchProtocol::is_graphql")]
+    pub protocol: FetchProtocol,
     /// Optional identifier for the fetch for defer support. All fetches of a given plan will be
     /// guaranteed to have a unique `id`.
     pub id: Option<u64>,
@@ -249,6 +313,7 @@ pub enum QueryPathElement {
     InlineFragment { type_condition: Name },
 }
 
+#[allow(dead_code)]
 impl PlanNode {
     /// Returns the kind of plan node this is as a human-readable string. Exact output not guaranteed.
     fn node_kind(&self) -> &'static str {
@@ -260,5 +325,63 @@ impl PlanNode {
             Self::Defer(_) => "Defer",
             Self::Condition(_) => "Condition",
         }
+    }
+
+    pub fn cost(&self) -> QueryPlanCost {
+        self.cost_at_depth(0)
+    }
+
+    fn cost_at_depth(&self, depth: usize) -> QueryPlanCost {
+        plan_node_cost_at_depth(self.as_ref(), depth)
+    }
+
+    fn as_ref(&self) -> PlanNodeRef<'_> {
+        match self {
+            Self::Fetch(_) => PlanNodeRef::Fetch,
+            Self::Sequence(s) => PlanNodeRef::Sequence(&s.nodes),
+            Self::Parallel(p) => PlanNodeRef::Parallel(&p.nodes),
+            Self::Flatten(f) => PlanNodeRef::Flatten(&f.node),
+            Self::Defer(d) => PlanNodeRef::Defer(&d.primary),
+            Self::Condition(c) => PlanNodeRef::Condition(c),
+        }
+    }
+}
+
+#[allow(dead_code)]
+enum PlanNodeRef<'a> {
+    Fetch,
+    Sequence(&'a [PlanNode]),
+    Parallel(&'a [PlanNode]),
+    Flatten(&'a PlanNode),
+    Defer(&'a PrimaryDeferBlock),
+    Condition(&'a ConditionNode),
+}
+
+#[allow(dead_code)]
+fn plan_node_cost_at_depth(node: PlanNodeRef<'_>, depth: usize) -> QueryPlanCost {
+    const FETCH_COST: QueryPlanCost = 1000.0;
+    const PIPELINING_COST: QueryPlanCost = 100.0;
+
+    match node {
+        PlanNodeRef::Fetch => FETCH_COST * (1.0f64).max(depth as f64 * PIPELINING_COST),
+        PlanNodeRef::Parallel(nodes) => nodes.iter().map(|n| n.cost_at_depth(depth)).sum(),
+        PlanNodeRef::Sequence(nodes) => nodes
+            .iter()
+            .enumerate()
+            .map(|(i, n)| n.cost_at_depth(depth + i))
+            .sum(),
+        PlanNodeRef::Flatten(inner) => inner.cost_at_depth(depth),
+        PlanNodeRef::Condition(c) => {
+            let if_cost = c.if_clause.as_ref().map_or(0.0, |n| n.cost_at_depth(depth));
+            let else_cost = c
+                .else_clause
+                .as_ref()
+                .map_or(0.0, |n| n.cost_at_depth(depth));
+            if_cost.max(else_cost)
+        }
+        PlanNodeRef::Defer(primary) => primary
+            .node
+            .as_ref()
+            .map_or(0.0, |n| n.cost_at_depth(depth)),
     }
 }

--- a/apollo-federation/src/query_plan/mod.rs
+++ b/apollo-federation/src/query_plan/mod.rs
@@ -108,7 +108,7 @@ pub enum FetchProtocol {
     #[default]
     GraphQL,
     /// Connector-based fetch (REST, etc.). The coordinate string identifies
-    /// the connector (e.g., "subgraph:Type.field[0]") for execution-layer
+    /// the connector (e.g., `subgraph:Type.field[0]`) for execution-layer
     /// lookup.
     Connector { coordinate: String },
 }

--- a/apollo-router/src/query_planner/convert.rs
+++ b/apollo-router/src/query_planner/convert.rs
@@ -60,6 +60,7 @@ impl From<&'_ Box<next::FetchNode>> for plan::PlanNode {
     fn from(value: &'_ Box<next::FetchNode>) -> Self {
         let next::FetchNode {
             subgraph_name,
+            protocol: _,
             id,
             variable_usages,
             requires,
@@ -140,6 +141,7 @@ impl From<&'_ next::FetchNode> for subscription::SubscriptionNode {
     fn from(value: &'_ next::FetchNode) -> Self {
         let next::FetchNode {
             subgraph_name,
+            protocol: _,
             id: _,
             variable_usages,
             requires: _,


### PR DESCRIPTION
## Summary

Introduces `FetchProtocol` (GraphQL | Connector) on `FetchNode` to distinguish connector-backed fetches from standard subgraph fetches.

- `FetchProtocol` enum threaded through the fetch graph and plan builder
- Query plan cost calculation accounts for fetch protocol differences
- Rustdoc link fixes for new types

Replaces erroneously merged PR #10154.