### PR TITLE
feat(incremental-planner): add connector routing and commit logic

### DIFF
--- a/apollo-federation/src/query_plan/incremental_planner/fetch_graph/mod.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/fetch_graph/mod.rs
@@ -84,6 +84,9 @@ pub(crate) struct FetchNode {
     pub(crate) context_rewrites: Vec<FetchDataKeyRenamer>,
     /// @fromContext variable definitions added to the subgraph operation.
     pub(crate) context_variables: Vec<(Name, Node<apollo_compiler::ast::Type>)>,
+    /// When set, this fetch is backed by a connector rather than a GraphQL
+    /// subgraph endpoint. Plan builder maps this to `FetchProtocol::Connector`.
+    pub(crate) connector: Option<Arc<crate::connectors::Connector>>,
 }
 
 impl FetchNode {
@@ -95,6 +98,7 @@ impl FetchNode {
             defer_ref: None,
             context_rewrites: Vec::new(),
             context_variables: Vec::new(),
+            connector: None,
         }
     }
 
@@ -366,6 +370,7 @@ impl FetchGraph {
                 defer_ref,
                 context_rewrites: Vec::new(),
                 context_variables: Vec::new(),
+                connector: None,
             },
             Some(root_key),
         )
@@ -386,6 +391,7 @@ impl FetchGraph {
                 defer_ref,
                 context_rewrites: Vec::new(),
                 context_variables: Vec::new(),
+                connector: None,
             },
             None,
         )
@@ -414,6 +420,51 @@ impl FetchGraph {
                     merge_at,
                 },
             ),
+            None,
+        )
+    }
+
+    /// Create a root fetch group backed by a connector.
+    pub(crate) fn add_connector_root_group(
+        &mut self,
+        subgraph: &Arc<str>,
+        root_type: CompositeTypeDefinitionPosition,
+        connector: Arc<crate::connectors::Connector>,
+        defer_ref: Option<String>,
+    ) -> NodeIndex {
+        self.insert_node(
+            FetchNode {
+                subgraph: subgraph.clone(),
+                kind: FetchGroupKind::Root { root_type },
+                selection_builder: SelectionBuilder::default(),
+                defer_ref,
+                context_rewrites: Vec::new(),
+                context_variables: Vec::new(),
+                connector: Some(connector),
+            },
+            None,
+        )
+    }
+
+    /// Create an entity fetch group backed by a connector. Never reused —
+    /// each connector entity resolution is its own node.
+    pub(crate) fn add_connector_entity_group(
+        &mut self,
+        subgraph: &Arc<str>,
+        merge_at: Vec<FetchDataPathElement>,
+        connector: Arc<crate::connectors::Connector>,
+        defer_ref: Option<String>,
+    ) -> NodeIndex {
+        self.insert_node(
+            FetchNode {
+                subgraph: subgraph.clone(),
+                kind: FetchGroupKind::Entity { merge_at },
+                selection_builder: SelectionBuilder::default(),
+                defer_ref,
+                context_rewrites: Vec::new(),
+                context_variables: Vec::new(),
+                connector: Some(connector),
+            },
             None,
         )
     }

--- a/apollo-federation/src/query_plan/incremental_planner/fetch_graph/plan_builder.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/fetch_graph/plan_builder.rs
@@ -540,7 +540,12 @@ impl FetchGraph {
         // 7. Construct FetchNode.
         let fetch_node = PlanNode::Fetch(Box::new(crate::query_plan::FetchNode {
             subgraph_name: node.subgraph.clone(),
-            protocol: Default::default(),
+            protocol: match &node.connector {
+                Some(c) => crate::query_plan::FetchProtocol::Connector {
+                    coordinate: c.id.coordinate(),
+                },
+                None => Default::default(),
+            },
             id: None,
             variable_usages,
             requires,

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/commit.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/commit.rs
@@ -106,6 +106,20 @@ impl FieldRoutingSearchSpace {
             };
         }
 
+        if let RoutingTarget::Connector {
+            ref connector,
+            ref source_subgraph,
+        } = choice.target
+        {
+            return self.commit_connector_choice(
+                state,
+                pending,
+                connector,
+                source_subgraph,
+                choice,
+            );
+        }
+
         let qg = self.qg();
         let (_, target_qg_node) = qg.edge_endpoints(choice.edge_index())?;
 
@@ -1134,7 +1148,7 @@ impl FieldRoutingSearchSpace {
                 .cached_query_graph
                 .edge_for_inline_fragment(n, &frag_sel.inline_fragment)
             {
-                Some(edge) => Ok(self.cached_query_graph.query_graph.edge_endpoints(edge)?.1),
+                Some(edge) => Ok(self.qg().edge_endpoints(edge)?.1),
                 None => Ok(n),
             }
         };
@@ -1272,4 +1286,29 @@ fn remaining_after_split(sel: &Selection, split: &[Selection]) -> Option<Selecti
         }
         _ => None,
     }
+}
+
+/// The response path elements a field contributes: its response key, plus
+/// an index wildcard per level of list nesting.
+pub(super) fn field_response_elements(
+    field: &Field,
+) -> Result<Vec<FetchDataPathElement>, FederationError> {
+    let mut elements = vec![FetchDataPathElement::Key(
+        field.response_name().clone(),
+        Default::default(),
+    )];
+    let mut ty = &field.field_position.get(field.schema.schema())?.ty;
+    loop {
+        match ty {
+            apollo_compiler::ast::Type::Named(_) | apollo_compiler::ast::Type::NonNullNamed(_) => {
+                break;
+            }
+            apollo_compiler::ast::Type::List(inner)
+            | apollo_compiler::ast::Type::NonNullList(inner) => {
+                elements.push(FetchDataPathElement::AnyIndex(Default::default()));
+                ty = inner;
+            }
+        }
+    }
+    Ok(elements)
 }

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/connect.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/connect.rs
@@ -1,0 +1,439 @@
+//! Connector commit logic for the BULB planner: creating connector fetch
+//! groups, partitioning sub-selections against the connector's output
+//! shape, and re-routing selections the connector does not provide.
+
+use std::sync::Arc;
+
+use apollo_compiler::Name;
+use petgraph::graph::NodeIndex;
+use shape::Shape;
+use shape::ShapeCase;
+use tracing::trace;
+
+use super::super::fetch_graph::InputContribution;
+use super::super::shared_path::SharedPath;
+use super::FieldRoutingSearchSpace;
+use super::commit::field_response_elements;
+use super::routing::HopKind;
+use super::routing::RoutingChoice;
+use super::state::PendingSelection;
+use super::state::PlanState;
+use crate::connectors::Connector;
+use crate::error::FederationError;
+use crate::operation::FieldSelection;
+use crate::operation::InlineFragmentSelection;
+use crate::operation::Selection;
+use crate::operation::SelectionMap;
+use crate::operation::SelectionSet;
+use crate::operation::TYPENAME_FIELD;
+use crate::query_graph::QueryGraphNodeType;
+use crate::query_graph::graph_path::operation::OpPathElement;
+use crate::query_plan::FetchDataPathElement;
+use crate::schema::position::CompositeTypeDefinitionPosition;
+
+/// A selection the connector's output shape does not provide, pulled out to
+/// be routed independently (typically through an entity-resolver connector).
+struct DeferredConnectorSelection {
+    selection: Selection,
+    /// The type containing the deferred selection.
+    parent_type: Name,
+    /// Query graph node for `parent_type` in the connector's subgraph.
+    anchor_node: NodeIndex,
+    /// Op path (within the connector's fetch group) to the selection's parent.
+    op_path: SharedPath<Arc<OpPathElement>>,
+    /// Response path (within the connector's fetch group) to the parent.
+    response_path: SharedPath<FetchDataPathElement>,
+}
+
+/// Strip array wrappers off a shape: a selection set on a list-typed field
+/// is checked against the element shape.
+fn unwrap_list_shape(shape: &Shape) -> &Shape {
+    let mut shape = shape;
+    while let ShapeCase::Array { tail, .. } = shape.case() {
+        shape = tail;
+    }
+    shape
+}
+
+#[allow(dead_code)]
+impl FieldRoutingSearchSpace {
+    /// Commit a routing choice that targets a connector. Connector fields
+    /// are opaque to the planner — the connector resolves the field and its
+    /// whole sub-selection tree, so the subtree is bulk-inserted rather than
+    /// pushed onto the pending stack. Root-level fields get a connector root
+    /// group; entity-resolver connectors (key hops) get a connector entity
+    /// group depending on the parent.
+    pub(super) fn commit_connector_choice(
+        &self,
+        state: &mut PlanState,
+        pending: &PendingSelection,
+        connector: &Arc<Connector>,
+        source_subgraph: &Arc<str>,
+        choice: &RoutingChoice,
+    ) -> Result<(), FederationError> {
+        trace!(
+            source_subgraph = %source_subgraph,
+            coordinate = %connector.id.coordinate(),
+            "committing connector choice",
+        );
+        let current_node_data = self
+            .cached_query_graph
+            .query_graph
+            .node_weight(pending.query_graph_node)?;
+
+        let Selection::Field(field_sel) = &pending.selection else {
+            // Connectors resolve fields, not inline fragments.
+            return Ok(());
+        };
+        let field_op_element = Arc::new(OpPathElement::Field(field_sel.field.clone()));
+        let child_defer_ref = pending.defer_ref.clone();
+        let defer_for_children = child_defer_ref.clone();
+
+        let (fetch_node, child_op_path, response_base) =
+            if matches!(choice.hop_kind, HopKind::KeyHop) {
+                // Entity-resolver connector: key fields ride the parent fetch;
+                // the connector group merges at the pending's response path.
+                let source = self.node_source(pending.query_graph_node)?;
+                let key_locally_resolvable = match &choice.key_conditions {
+                    Some(key_conditions) => self.can_resolve_in_place(
+                        pending.query_graph_node,
+                        key_conditions,
+                        &source,
+                    )?,
+                    None => true,
+                };
+                let local_key = key_locally_resolvable
+                    .then_some(choice.key_conditions.as_ref())
+                    .flatten();
+                self.append_entity_inputs(
+                    state,
+                    pending.fetch_node,
+                    &pending.op_path,
+                    local_key,
+                    &source,
+                );
+
+                let merge_at = self.pending_merge_at(state, pending);
+
+                let new_group = state.graph.add_connector_entity_group(
+                    source_subgraph,
+                    merge_at,
+                    connector.clone(),
+                    child_defer_ref,
+                );
+                let inputs = choice
+                    .key_conditions
+                    .iter()
+                    .map(|key_conditions| InputContribution {
+                        source_type_name: source.type_pos.type_name().clone(),
+                        conditions: key_conditions.clone(),
+                        rewrite_info: None,
+                        condition_alias_rewrites: Vec::new(),
+                    })
+                    .collect();
+                state
+                    .graph
+                    .add_dependency(pending.fetch_node, new_group, inputs);
+
+                if !key_locally_resolvable && let Some(key_conditions) = &choice.key_conditions {
+                    self.push_condition_pendings(state, pending, key_conditions, new_group)?;
+                }
+
+                let entity_base_path = self.entity_root_path(source.type_pos.type_name())?;
+                (
+                    new_group,
+                    entity_base_path.pushed(field_op_element),
+                    SharedPath::new(),
+                )
+            } else if matches!(
+                current_node_data.type_,
+                QueryGraphNodeType::FederatedRootType(_)
+            ) {
+                // Root-level connector field: a fresh root group per connector.
+                let root_kind = match &current_node_data.type_ {
+                    QueryGraphNodeType::FederatedRootType(kind) => *kind,
+                    _ => unreachable!(),
+                };
+                let root_type_name = self
+                    .supergraph_schema
+                    .schema()
+                    .root_operation(root_kind.into())
+                    .ok_or_else(|| {
+                        FederationError::internal(format!("no root type for {root_kind:?}"))
+                    })?;
+                let root_type: CompositeTypeDefinitionPosition = self
+                    .supergraph_schema
+                    .get_type(root_type_name)?
+                    .try_into()?;
+                let node = state.graph.add_connector_root_group(
+                    source_subgraph,
+                    root_type,
+                    connector.clone(),
+                    child_defer_ref,
+                );
+                (
+                    node,
+                    pending.op_path.pushed(field_op_element),
+                    pending.path_in_fetch.clone(),
+                )
+            } else {
+                // Non-root direct connector (no key): a child group merging
+                // at the pending's response path.
+                let source = self.node_source(pending.query_graph_node)?;
+                let merge_at = self.pending_merge_at(state, pending);
+
+                let new_group = state.graph.add_connector_entity_group(
+                    source_subgraph,
+                    merge_at,
+                    connector.clone(),
+                    child_defer_ref,
+                );
+                state
+                    .graph
+                    .add_dependency(pending.fetch_node, new_group, Vec::new());
+                let entity_base_path = self.entity_root_path(source.type_pos.type_name())?;
+                (
+                    new_group,
+                    entity_base_path.pushed(field_op_element),
+                    SharedPath::new(),
+                )
+            };
+
+        // Response path within the connector's fetch group to the field's
+        // sub-selections.
+        let mut child_response_path = response_base;
+        for element in field_response_elements(&field_sel.field)? {
+            child_response_path = child_response_path.pushed(element);
+        }
+
+        // Insert the portion of the tree the connector's output shape
+        // provides. Fields outside the shape go back on the pending stack,
+        // anchored at the connector's landing type.
+        let sub_selections = pending.selection.selection_set();
+        if let Some(sub_ss) = sub_selections.filter(|ss| !ss.is_empty()) {
+            let restored = sub_ss.add_back_typename_in_attachments()?;
+            let landing_type = field_sel
+                .field
+                .field_position
+                .get(field_sel.field.schema.schema())?
+                .ty
+                .inner_named_type()
+                .clone();
+            let mut deferred = Vec::new();
+            let kept = match self
+                .connector_index
+                .output_shape(&connector.id.coordinate())
+            {
+                Some(shape) if matches!(shape.case(), ShapeCase::Object { .. }) => self
+                    .partition_connector_selections(
+                        &restored,
+                        shape,
+                        &landing_type,
+                        source_subgraph,
+                        &child_op_path,
+                        &child_response_path,
+                        &mut deferred,
+                    )?,
+                // Non-object output shape (scalar / opaque): the connector
+                // resolves the whole subtree.
+                _ => Some(restored),
+            };
+            if let Some(kept) = kept {
+                state
+                    .graph
+                    .append_selection(fetch_node, &child_op_path, Some(&Arc::new(kept)));
+            }
+            for deferred_selection in deferred {
+                trace!(
+                    coordinate = %connector.id.coordinate(),
+                    parent_type = %deferred_selection.parent_type,
+                    "re-routing selection the connector's output shape does not provide",
+                );
+                let parent_types = match self
+                    .supergraph_schema
+                    .get_type(&deferred_selection.parent_type)
+                    .ok()
+                    .and_then(|ty| CompositeTypeDefinitionPosition::try_from(ty).ok())
+                {
+                    Some(type_pos) => pending.parent_types.pushed(type_pos),
+                    None => pending.parent_types.clone(),
+                };
+                state.push_pending(
+                    pending
+                        .fork(deferred_selection.selection)
+                        .at(deferred_selection.anchor_node, fetch_node)
+                        .with_op_path(deferred_selection.op_path)
+                        .with_response_path(deferred_selection.response_path)
+                        .with_defer(defer_for_children.clone())
+                        .with_parent_types(parent_types),
+                );
+            }
+        } else {
+            state
+                .graph
+                .append_selection(fetch_node, &child_op_path, None);
+        }
+
+        if let Some(dependent) = pending.ordering_dependent() {
+            state.graph.add_ordering_dependency(fetch_node, dependent)?;
+        }
+
+        Ok(())
+    }
+
+    /// Partition `sub_ss` against a connector's output `shape`: provided
+    /// selections are kept; unprovided ones are collected into `deferred`,
+    /// anchored at their parent type's node in the connector's subgraph.
+    ///
+    /// Returns `None` when nothing is kept.
+    #[allow(clippy::too_many_arguments)]
+    fn partition_connector_selections(
+        &self,
+        sub_ss: &SelectionSet,
+        shape: &Shape,
+        parent_type: &Name,
+        source_subgraph: &Arc<str>,
+        op_path: &SharedPath<Arc<OpPathElement>>,
+        response_path: &SharedPath<FetchDataPathElement>,
+        deferred: &mut Vec<DeferredConnectorSelection>,
+    ) -> Result<Option<SelectionSet>, FederationError> {
+        let ShapeCase::Object { fields, .. } = shape.case() else {
+            return Ok(Some(sub_ss.clone()));
+        };
+        let mut kept = SelectionMap::new();
+        for selection in sub_ss.selections.values() {
+            match selection {
+                Selection::Field(field_sel) => {
+                    let field_name = field_sel.field.name();
+                    if *field_name == TYPENAME_FIELD {
+                        kept.insert(selection.clone());
+                        continue;
+                    }
+                    let Some(child_shape) = fields.get(field_name.as_str()) else {
+                        match self.connector_landing_node(source_subgraph, parent_type) {
+                            Some(anchor_node) => deferred.push(DeferredConnectorSelection {
+                                selection: selection.clone(),
+                                parent_type: parent_type.clone(),
+                                anchor_node,
+                                op_path: op_path.clone(),
+                                response_path: response_path.clone(),
+                            }),
+                            None => {
+                                kept.insert(selection.clone());
+                            }
+                        }
+                        continue;
+                    };
+                    match &field_sel.selection_set {
+                        Some(child_ss) if !child_ss.is_empty() => {
+                            let child_shape = unwrap_list_shape(child_shape);
+                            if !matches!(child_shape.case(), ShapeCase::Object { .. }) {
+                                kept.insert(selection.clone());
+                                continue;
+                            }
+                            let field_def = field_sel
+                                .field
+                                .field_position
+                                .get(field_sel.field.schema.schema())?;
+                            let child_type = field_def.ty.inner_named_type().clone();
+                            let child_op = op_path
+                                .pushed(Arc::new(OpPathElement::Field(field_sel.field.clone())));
+                            let mut child_response = response_path.clone();
+                            for element in field_response_elements(&field_sel.field)? {
+                                child_response = child_response.pushed(element);
+                            }
+                            let child_kept = self.partition_connector_selections(
+                                child_ss,
+                                child_shape,
+                                &child_type,
+                                source_subgraph,
+                                &child_op,
+                                &child_response,
+                                deferred,
+                            )?;
+                            match child_kept {
+                                Some(child_kept) if !child_kept.is_empty() => {
+                                    kept.insert(Selection::Field(Arc::new(FieldSelection {
+                                        field: field_sel.field.clone(),
+                                        selection_set: Some(child_kept),
+                                    })));
+                                }
+                                _ => {}
+                            }
+                        }
+                        _ => {
+                            kept.insert(selection.clone());
+                        }
+                    }
+                }
+                Selection::InlineFragment(fragment_sel) => {
+                    let fragment_type = fragment_sel
+                        .inline_fragment
+                        .type_condition_position
+                        .as_ref()
+                        .map(|t| t.type_name().clone())
+                        .unwrap_or_else(|| parent_type.clone());
+                    let child_op = op_path.pushed(Arc::new(OpPathElement::InlineFragment(
+                        fragment_sel.inline_fragment.clone(),
+                    )));
+                    let child_kept = self.partition_connector_selections(
+                        &fragment_sel.selection_set,
+                        shape,
+                        &fragment_type,
+                        source_subgraph,
+                        &child_op,
+                        response_path,
+                        deferred,
+                    )?;
+                    if let Some(child_kept) = child_kept
+                        && !child_kept.is_empty()
+                    {
+                        kept.insert(Selection::InlineFragment(Arc::new(
+                            InlineFragmentSelection {
+                                inline_fragment: fragment_sel.inline_fragment.clone(),
+                                selection_set: child_kept,
+                            },
+                        )));
+                    }
+                }
+            }
+        }
+        if kept.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(SelectionSet {
+                schema: sub_ss.schema.clone(),
+                type_position: sub_ss.type_position.clone(),
+                selections: Arc::new(kept),
+            }))
+        }
+    }
+
+    /// The canonical query graph node for `type_name` within `source`,
+    /// preferring one that is neither a `@provides` copy nor a root.
+    fn connector_landing_node(&self, source: &str, type_name: &Name) -> Option<NodeIndex> {
+        let qg = self.qg();
+        let all_nodes = qg.nodes_for_type(type_name).ok()?;
+        let source_nodes: Vec<NodeIndex> = all_nodes
+            .iter()
+            .copied()
+            .filter(|node| {
+                qg.node_weight(*node)
+                    .map(|w| w.source.as_ref() == source)
+                    .unwrap_or(false)
+            })
+            .collect();
+        if source_nodes.is_empty() {
+            return None;
+        }
+        source_nodes
+            .iter()
+            .copied()
+            .find(|node| {
+                qg.node_weight(*node)
+                    .map(|weight| weight.provide_id.is_none() && weight.root_kind.is_none())
+                    .unwrap_or(false)
+            })
+            .or_else(|| source_nodes.first().copied())
+    }
+}

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/mod.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/mod.rs
@@ -15,6 +15,7 @@
 pub(super) mod cached_query_graph;
 mod commit;
 mod conditions;
+mod connect;
 mod context;
 mod requires;
 mod routing;
@@ -188,6 +189,7 @@ pub(super) struct NodeSource {
 pub(crate) struct FieldRoutingSearchSpace {
     pub(crate) cached_query_graph: CachedQueryGraph,
     pub(crate) supergraph_schema: ValidFederationSchema,
+    pub(super) connector_index: Arc<crate::connectors::index::ConnectorIndex>,
     pub(super) caches: PlannerCaches,
     pub(super) disabled_subgraphs: apollo_compiler::collections::IndexSet<Arc<str>>,
 }

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/routing.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/routing.rs
@@ -1033,6 +1033,11 @@ impl FieldRoutingSearchSpace {
             }
         }
 
+        // Connector-backed subgraphs have no GraphQL endpoint; drop their
+        // edges before enumerating key hops so they don't crowd out real
+        // alternatives.
+        self.drop_connector_subgraph_edges(&mut options);
+
         trace!(
             type_condition = %type_cond.type_name(),
             "searching key hops for fragment downcast",
@@ -1048,6 +1053,10 @@ impl FieldRoutingSearchSpace {
             },
         )?;
         options.extend(hops.iter().cloned());
+
+        // Key hops into connector-backed subgraphs are equally unexecutable.
+        self.drop_connector_subgraph_edges(&mut options);
+
         Ok(options)
     }
 

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/routing.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/routing.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use apollo_compiler::Name;
 use petgraph::graph::EdgeIndex;
 use petgraph::graph::NodeIndex;
 use tracing::trace;
@@ -7,6 +8,8 @@ use tracing::trace;
 use super::FieldRoutingSearchSpace;
 use super::RoutingSiteKey;
 use super::state::PendingSelection;
+use crate::connectors::Connector;
+use crate::connectors::EntityResolver;
 use crate::error::FederationError;
 use crate::operation::FieldSelection;
 use crate::operation::InlineFragmentSelection;
@@ -26,6 +29,12 @@ pub(crate) enum RoutingTarget {
     SubgraphEdge {
         edge_index: EdgeIndex,
         target_subgraph: Arc<str>,
+    },
+    /// Connector resolution (no query graph edge); the connector resolves
+    /// the field and its entire sub-selection tree.
+    Connector {
+        connector: Arc<Connector>,
+        source_subgraph: Arc<str>,
     },
     /// Per-concrete-type explosion at an abstract position: field on an
     /// abstract type with no direct FieldCollection edge decomposes into
@@ -169,12 +178,43 @@ impl RoutingChoice {
         }
     }
 
-    /// Target subgraph name.
+    /// A connector route; a key hop when `key_conditions` is given.
+    pub(super) fn connector(
+        connector: Arc<Connector>,
+        source_subgraph: Arc<str>,
+        key_conditions: Option<Arc<SelectionSet>>,
+    ) -> Self {
+        let hop_kind = if key_conditions.is_some() {
+            HopKind::KeyHop
+        } else {
+            HopKind::Direct
+        };
+        Self {
+            target: RoutingTarget::Connector {
+                connector,
+                source_subgraph,
+            },
+            hop_kind,
+            key_conditions,
+            conditions_locally_satisfiable: true,
+            conditions_provided: false,
+            requires_resolvable_in_place: true,
+            self_entity_reentry: false,
+            conditions_unroutable: false,
+            intermediate_key_hops: Vec::new(),
+        }
+    }
+
+    /// Target subgraph name (the connector's source subgraph for connector
+    /// routes).
     pub(crate) fn target_subgraph(&self) -> &Arc<str> {
         match &self.target {
             RoutingTarget::SubgraphEdge {
                 target_subgraph, ..
             } => target_subgraph,
+            RoutingTarget::Connector {
+                source_subgraph, ..
+            } => source_subgraph,
             RoutingTarget::TypeExplosion => {
                 static LABEL: std::sync::LazyLock<Arc<str>> =
                     std::sync::LazyLock::new(|| Arc::from("<type-explosion>"));
@@ -192,9 +232,21 @@ impl RoutingChoice {
     pub(crate) fn edge_index(&self) -> EdgeIndex {
         match &self.target {
             RoutingTarget::SubgraphEdge { edge_index, .. } => *edge_index,
-            RoutingTarget::TypeExplosion | RoutingTarget::RestructureFragment => {
+            RoutingTarget::Connector { .. }
+            | RoutingTarget::TypeExplosion
+            | RoutingTarget::RestructureFragment => {
                 panic!("edge_index() called on a non-edge routing choice")
             }
+        }
+    }
+
+    /// Query graph edge index, if this is a subgraph edge route.
+    pub(crate) fn edge_index_opt(&self) -> Option<EdgeIndex> {
+        match &self.target {
+            RoutingTarget::SubgraphEdge { edge_index, .. } => Some(*edge_index),
+            RoutingTarget::Connector { .. }
+            | RoutingTarget::TypeExplosion
+            | RoutingTarget::RestructureFragment => None,
         }
     }
 }
@@ -204,9 +256,13 @@ impl RoutingChoice {
 enum RoutingPreference {
     Provides,
     DirectLocal,
+    /// A connector resolving the field directly (no key hop).
+    DirectConnector,
     /// Same-subgraph entity re-entry for in-place-unresolvable @requires.
     SelfRequiresHop,
     LocallySatisfiableKeyHop,
+    /// A connector reached through entity resolution.
+    ConnectorEntityResolver,
     RemoteKeyHop,
     /// A 2+ hop key chain. Costs multiple entity fetches, so it ranks
     /// below single remote hops.
@@ -695,7 +751,7 @@ impl FieldRoutingSearchSpace {
         let key = (
             pending.query_graph_node,
             super::SelectionArcKey::new(&pending.selection),
-            None::<super::ArcKey<std::collections::HashSet<apollo_compiler::Name>>>,
+            None::<super::ArcKey<std::collections::HashSet<Name>>>,
         );
         let unfiltered = if let Some(cached) = self.caches.routing_options.borrow().get(&key) {
             cached.clone()
@@ -763,23 +819,39 @@ impl FieldRoutingSearchSpace {
             }
         }
 
-        // Rank root options by locally-resolvable sub-selection count.
+        // Connectors on root fields (Query/Mutation).
+        let current_node_data = self
+            .cached_query_graph
+            .query_graph
+            .node_weight(pending.query_graph_node)?;
+        if let QueryGraphNodeType::FederatedRootType(root_kind) = &current_node_data.type_
+            && let Some(root_type_name) = self
+                .supergraph_schema
+                .schema()
+                .root_operation((*root_kind).into())
+        {
+            self.push_connector_options(
+                &mut options,
+                root_type_name,
+                field_selection.field.name(),
+                true,
+            );
+        }
+
+        // Rank root options by locally-resolvable sub-selection count,
+        // preferring subgraphs that satisfy more children in one fetch.
         if options.len() > 1
             && let Some(sub_ss) = field_selection.selection_set.as_ref()
         {
             options.sort_by(|a, b| {
-                let count_a = self
-                    .cached_query_graph
-                    .query_graph
-                    .edge_endpoints(a.edge_index())
-                    .ok()
+                let count_a = a
+                    .edge_index_opt()
+                    .and_then(|ei| self.qg().edge_endpoints(ei).ok())
                     .map(|(_, target)| self.count_local_sub_selections(target, sub_ss))
                     .unwrap_or(0);
-                let count_b = self
-                    .cached_query_graph
-                    .query_graph
-                    .edge_endpoints(b.edge_index())
-                    .ok()
+                let count_b = b
+                    .edge_index_opt()
+                    .and_then(|ei| self.qg().edge_endpoints(ei).ok())
                     .map(|(_, target)| self.count_local_sub_selections(target, sub_ss))
                     .unwrap_or(0);
                 count_b.cmp(&count_a)
@@ -835,6 +907,34 @@ impl FieldRoutingSearchSpace {
             }
         }
 
+        // Connectors resolving this field on this type. A connector route
+        // covers the field's entire sub-selection tree, so when one exists
+        // there is no dead end to recover from and key hops are unnecessary.
+        let current_node_data = self
+            .cached_query_graph
+            .query_graph
+            .node_weight(pending.query_graph_node)?;
+        if let Ok(type_pos) =
+            CompositeTypeDefinitionPosition::try_from(current_node_data.type_.clone())
+        {
+            self.push_connector_options(
+                &mut options,
+                type_pos.type_name(),
+                field_selection.field.name(),
+                false,
+            );
+        }
+        if options
+            .iter()
+            .any(|opt| matches!(opt.target, RoutingTarget::Connector { .. }))
+        {
+            return Ok(options);
+        }
+
+        // No direct connector: drop unexecutable connector-subgraph edges
+        // before deciding whether key hops are needed.
+        self.drop_connector_subgraph_edges(&mut options);
+
         let key = RoutingSiteKey::Field(field_selection.field.name().clone());
         let hops = self.cached_key_hops(
             pending.query_graph_node,
@@ -846,6 +946,21 @@ impl FieldRoutingSearchSpace {
             },
         )?;
         options.extend(hops.iter().cloned());
+
+        // Key hops into connector-backed subgraphs are equally unexecutable;
+        // entity-resolver connector hops replace them.
+        self.drop_connector_subgraph_edges(&mut options);
+
+        // Entity-resolver connector hops.
+        if let Ok(type_pos) =
+            CompositeTypeDefinitionPosition::try_from(current_node_data.type_.clone())
+        {
+            self.push_entity_resolver_options(
+                &mut options,
+                type_pos.type_name(),
+                field_selection.field.name(),
+            );
+        }
 
         if !options.is_empty()
             && self.abstract_type_has_cross_subgraph_keys(pending.query_graph_node)?
@@ -1004,34 +1119,159 @@ impl FieldRoutingSearchSpace {
         Ok(false)
     }
 
+    /// Append connector options for `(type_name, field_name)`, superseding
+    /// subgraph-edge options from the same source subgraph: the resolver for
+    /// a @connect field IS the connector — there is no separate GraphQL
+    /// endpoint for it.
+    fn push_connector_options(
+        &self,
+        options: &mut Vec<RoutingChoice>,
+        type_name: &Name,
+        field_name: &Name,
+        at_root: bool,
+    ) {
+        let Some(connectors) = self.connector_index.by_field(type_name, field_name) else {
+            return;
+        };
+        for connector in connectors {
+            let source_subgraph: Arc<str> = Arc::from(connector.id.subgraph_name.as_str());
+            // A non-root connector commits an entity-style group, which
+            // materializes as an `_entities` fetch; a subgraph with no
+            // entity definitions cannot host one.
+            if !at_root && !self.subgraph_hosts_entity_fetches(&source_subgraph) {
+                continue;
+            }
+            options.retain(|opt| match &opt.target {
+                RoutingTarget::SubgraphEdge {
+                    target_subgraph, ..
+                } => target_subgraph != &source_subgraph,
+                _ => true,
+            });
+            let key_conditions = match &connector.entity_resolver {
+                Some(
+                    EntityResolver::Implicit
+                    | EntityResolver::TypeSingle
+                    | EntityResolver::TypeBatch,
+                ) => self
+                    .connector_index
+                    .key_conditions(&connector.id.coordinate())
+                    .cloned(),
+                _ => None,
+            };
+            options.push(RoutingChoice::connector(
+                connector.clone(),
+                source_subgraph,
+                key_conditions,
+            ));
+        }
+    }
+
+    /// Whether `subgraph`'s extracted schema defines the `_Entity` union:
+    /// entity-style fetch groups materialize as `_entities` operations,
+    /// which only build against a subgraph with at least one resolvable @key.
+    fn subgraph_hosts_entity_fetches(&self, subgraph: &str) -> bool {
+        self.cached_query_graph
+            .query_graph
+            .schema_by_source(subgraph)
+            .ok()
+            .and_then(|schema| schema.entity_type().ok().flatten())
+            .is_some()
+    }
+
+    /// Append entity-resolver connector hops for a field no connector serves
+    /// directly: connectors resolving the whole entity whose `selection`
+    /// returns the field.
+    fn push_entity_resolver_options(
+        &self,
+        options: &mut Vec<RoutingChoice>,
+        type_name: &Name,
+        field_name: &Name,
+    ) {
+        let Some(resolvers) = self.connector_index.entity_resolvers(type_name) else {
+            return;
+        };
+        for connector in resolvers {
+            let coordinate = connector.id.coordinate();
+            if !self
+                .connector_index
+                .resolver_provides(&coordinate, field_name.as_str())
+            {
+                continue;
+            }
+            if !self.subgraph_hosts_entity_fetches(connector.id.subgraph_name.as_str()) {
+                continue;
+            }
+            if options.iter().any(|opt| {
+                matches!(&opt.target, RoutingTarget::Connector { connector: c, .. }
+                    if c.id.coordinate() == coordinate)
+            }) {
+                continue;
+            }
+            let Some(key_conditions) = self.connector_index.key_conditions(&coordinate) else {
+                continue;
+            };
+            options.push(RoutingChoice::connector(
+                connector.clone(),
+                Arc::from(connector.id.subgraph_name.as_str()),
+                Some(key_conditions.clone()),
+            ));
+        }
+    }
+
+    /// Drop subgraph-edge options landing in a connector-backed subgraph:
+    /// no GraphQL endpoint exists behind its service name.
+    fn drop_connector_subgraph_edges(&self, options: &mut Vec<RoutingChoice>) {
+        options.retain(|opt| match &opt.target {
+            RoutingTarget::SubgraphEdge {
+                target_subgraph, ..
+            } => {
+                !self.connector_index.is_connector_subgraph(target_subgraph)
+                    || !self.subgraph_hosts_entity_fetches(target_subgraph)
+            }
+            _ => true,
+        });
+    }
+
     /// Order options best-first: @provides beats a direct local edge beats a
     /// key hop whose conditions are locally satisfiable beats a remote hop.
     pub(super) fn rank_options(&self, options: &mut [RoutingChoice]) {
         options.sort_by_key(|opt| {
-            let edge_index = match &opt.target {
-                RoutingTarget::SubgraphEdge { edge_index, .. } => *edge_index,
-                RoutingTarget::TypeExplosion => return (RoutingPreference::TypeExplosion, 0),
+            let preference = match &opt.target {
+                RoutingTarget::TypeExplosion => {
+                    return (RoutingPreference::TypeExplosion, 0);
+                }
                 RoutingTarget::RestructureFragment => {
                     return (RoutingPreference::RestructureFragment, 0);
                 }
-            };
-            let preference = if let Ok(edge) = self.qg().edge_weight(edge_index) {
-                match &edge.transition {
-                    QueryGraphEdgeTransition::FieldCollection {
-                        is_part_of_provides: true,
-                        ..
-                    } => RoutingPreference::Provides,
-                    _ if opt.hop_kind == HopKind::Direct => RoutingPreference::DirectLocal,
-                    _ if opt.self_entity_reentry => RoutingPreference::SelfRequiresHop,
-                    _ if opt.conditions_unroutable => RoutingPreference::CircularKeyHop,
-                    _ if !opt.intermediate_key_hops.is_empty() => RoutingPreference::ChainedKeyHop,
-                    _ if opt.conditions_locally_satisfiable => {
-                        RoutingPreference::LocallySatisfiableKeyHop
+                RoutingTarget::Connector { .. } => {
+                    if opt.hop_kind == HopKind::KeyHop {
+                        RoutingPreference::ConnectorEntityResolver
+                    } else {
+                        RoutingPreference::DirectConnector
                     }
-                    _ => RoutingPreference::RemoteKeyHop,
                 }
-            } else {
-                RoutingPreference::RemoteKeyHop
+                RoutingTarget::SubgraphEdge { edge_index, .. } => {
+                    if let Ok(edge) = self.qg().edge_weight(*edge_index) {
+                        match &edge.transition {
+                            QueryGraphEdgeTransition::FieldCollection {
+                                is_part_of_provides: true,
+                                ..
+                            } => RoutingPreference::Provides,
+                            _ if opt.hop_kind == HopKind::Direct => RoutingPreference::DirectLocal,
+                            _ if opt.self_entity_reentry => RoutingPreference::SelfRequiresHop,
+                            _ if opt.conditions_unroutable => RoutingPreference::CircularKeyHop,
+                            _ if !opt.intermediate_key_hops.is_empty() => {
+                                RoutingPreference::ChainedKeyHop
+                            }
+                            _ if opt.conditions_locally_satisfiable => {
+                                RoutingPreference::LocallySatisfiableKeyHop
+                            }
+                            _ => RoutingPreference::RemoteKeyHop,
+                        }
+                    } else {
+                        RoutingPreference::RemoteKeyHop
+                    }
+                }
             };
             let key_size = opt
                 .key_conditions
@@ -1243,10 +1483,15 @@ impl FieldRoutingSearchSpace {
             return Ok(true);
         };
         for hop in hops {
+            // Connector hops have no query-graph edge; the connector
+            // resolves its whole subtree, so treat it as reaching.
+            let Some(edge_index) = hop.edge_index_opt() else {
+                return Ok(true);
+            };
             let (_, target) = self
                 .cached_query_graph
                 .query_graph
-                .edge_endpoints(hop.edge_index())?;
+                .edge_endpoints(edge_index)?;
             if self.conditions_routable(target, sub_ss)? {
                 return Ok(true);
             }
@@ -1309,7 +1554,7 @@ impl FieldRoutingSearchSpace {
                     {
                         None => return Ok(false),
                         Some(edge_idx) => {
-                            let edge = self.cached_query_graph.query_graph.edge_weight(edge_idx)?;
+                            let edge = self.qg().edge_weight(edge_idx)?;
                             if !edge.required_contexts.is_empty() {
                                 return Ok(false);
                             }

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/tests.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/tests.rs
@@ -2454,3 +2454,161 @@ fn bulb_plan_from_concrete_subgraph_root_head() {
         "Plan from subgraph root head should fetch both fields: {plan_str}"
     );
 }
+
+const CONNECTOR_ROOT_FIELD_SCHEMA: &str = include_str!("../fixtures/connector_root_field.graphql");
+
+#[test]
+fn connector_root_field_produces_fetch_with_connector_protocol() {
+    let plan_str = plan_query_with_router_specs(
+        CONNECTOR_ROOT_FIELD_SCHEMA,
+        "{ products { id name price } }",
+    );
+    insta::assert_snapshot!(plan_str, @r#"
+    QueryPlan {
+      Fetch(service: "connectors") {
+        {
+          products {
+            id
+            name
+            price
+          }
+        }
+      },
+    }
+    "#);
+}
+
+const CONNECTOR_MIXED_SCHEMA: &str = include_str!("../fixtures/connector_mixed.graphql");
+
+#[test]
+fn mixed_connector_and_subgraph_produces_correct_plan() {
+    let plan_str = plan_query_with_router_specs(
+        CONNECTOR_MIXED_SCHEMA,
+        "{ users { id name } topProducts { id title } }",
+    );
+    assert!(
+        plan_str.contains("connectors"),
+        "Plan should target 'connectors' subgraph: {plan_str}"
+    );
+    assert!(
+        plan_str.contains("graphql"),
+        "Plan should target 'graphql' subgraph: {plan_str}"
+    );
+    assert!(
+        plan_str.contains("users"),
+        "Plan should fetch 'users': {plan_str}"
+    );
+    assert!(
+        plan_str.contains("topProducts"),
+        "Plan should fetch 'topProducts': {plan_str}"
+    );
+}
+
+/// Ad-hoc corpus repro driver: set CORPUS_SCHEMA and CORPUS_OP to file
+/// paths, get the BULB plan and correctness verdict printed.
+#[test_log::test]
+fn corpus_repro_debug() {
+    let Ok(schema_path) = std::env::var("CORPUS_SCHEMA") else {
+        return;
+    };
+    let op_path = std::env::var("CORPUS_OP").unwrap();
+    let schema_str = std::fs::read_to_string(schema_path).unwrap();
+    let op_str = std::fs::read_to_string(op_path).unwrap();
+    let defaults = IncrementalPlannerConfig::default();
+    let config = QueryPlannerConfig {
+        incremental_planner: IncrementalPlannerConfig {
+            enabled: true,
+            fuel: std::env::var("BULB_FUEL")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(defaults.fuel),
+            beam_width: std::env::var("BULB_BEAM")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(defaults.beam_width),
+            ..defaults
+        },
+        ..Default::default()
+    };
+    let supergraph = Supergraph::new_with_router_specs(&schema_str).unwrap();
+    let planner = QueryPlanner::new(&supergraph, config).unwrap();
+    let api_schema = planner.api_schema();
+    let op = apollo_compiler::ExecutableDocument::parse_and_validate(
+        api_schema.schema(),
+        &op_str,
+        "op.graphql",
+    )
+    .unwrap();
+    let plan = planner
+        .build_query_plan(&op, None, Default::default())
+        .unwrap();
+    println!("PLAN:\n{plan}");
+    let subgraphs_by_name = supergraph
+        .extract_subgraphs()
+        .unwrap()
+        .into_iter()
+        .map(|(name, subgraph)| (name, subgraph.schema))
+        .collect();
+    let result = crate::correctness::check_plan(
+        api_schema,
+        planner.supergraph_schema(),
+        &subgraphs_by_name,
+        &op,
+        &plan,
+    );
+    println!("CHECK: {:?}", result.err().map(|e| e.to_string()));
+}
+
+/// Ad-hoc corpus timing driver: CORPUS_SCHEMA + CORPUS_OPS_DIR, plans every
+/// operation (no correctness check) and prints ones slower than
+/// CORPUS_SLOW_MS (default 1000).
+#[test]
+fn corpus_timing_debug() {
+    let Ok(schema_path) = std::env::var("CORPUS_SCHEMA") else {
+        return;
+    };
+    let Ok(ops_dir) = std::env::var("CORPUS_OPS_DIR") else {
+        return;
+    };
+    let slow_ms: u128 = std::env::var("CORPUS_SLOW_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1000);
+    let schema_str = std::fs::read_to_string(schema_path).unwrap();
+    let config = QueryPlannerConfig {
+        incremental_planner: IncrementalPlannerConfig {
+            enabled: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let supergraph = Supergraph::new_with_router_specs(&schema_str).unwrap();
+    let planner = QueryPlanner::new(&supergraph, config).unwrap();
+    let api_schema = planner.api_schema();
+    let mut entries: Vec<_> = std::fs::read_dir(&ops_dir)
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "graphql"))
+        .collect();
+    entries.sort();
+    for (i, path) in entries.iter().enumerate() {
+        let op_str = std::fs::read_to_string(path).unwrap();
+        let Ok(op) = apollo_compiler::ExecutableDocument::parse_and_validate(
+            api_schema.schema(),
+            &op_str,
+            "op.graphql",
+        ) else {
+            continue;
+        };
+        let started = std::time::Instant::now();
+        let _ = planner.build_query_plan(&op, None, Default::default());
+        let ms = started.elapsed().as_millis();
+        if ms >= slow_ms {
+            println!("SLOW {ms}ms {}", path.display());
+        }
+        if i % 2000 == 0 {
+            println!("progress {i}/{}", entries.len());
+        }
+    }
+    println!("timing done");
+}

--- a/apollo-federation/src/query_plan/incremental_planner/fixtures/connector_mixed.graphql
+++ b/apollo-federation/src/query_plan/incremental_planner/fixtures/connector_mixed.graphql
@@ -1,0 +1,74 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "api", http: {baseURL: "http://api.example.com"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+  GRAPHQL @join__graph(name: "graphql", url: "https://graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: CONNECTORS)
+  @join__type(graph: GRAPHQL)
+{
+  users: [User] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "api", http: {GET: "/users"}, selection: "id name"})
+  topProducts: [Product] @join__field(graph: GRAPHQL)
+}
+
+type User
+  @join__type(graph: CONNECTORS, key: "id")
+  @join__type(graph: GRAPHQL, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: CONNECTORS)
+  email: String @join__field(graph: GRAPHQL)
+}
+
+type Product
+  @join__type(graph: GRAPHQL)
+{
+  id: ID!
+  title: String
+}

--- a/apollo-federation/src/query_plan/incremental_planner/fixtures/connector_root_field.graphql
+++ b/apollo-federation/src/query_plan/incremental_planner/fixtures/connector_root_field.graphql
@@ -1,0 +1,63 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "api", http: {baseURL: "http://api.example.com"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: CONNECTORS)
+{
+  products: [Product] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "api", http: {GET: "/products"}, selection: "id name price"})
+}
+
+type Product
+  @join__type(graph: CONNECTORS, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: CONNECTORS)
+  price: Float @join__field(graph: CONNECTORS)
+}

--- a/apollo-federation/src/query_plan/incremental_planner/mod.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/mod.rs
@@ -103,6 +103,7 @@ pub(crate) fn build_bulb_plan(
             parameters.override_conditions.clone(),
         ),
         supergraph_schema: supergraph_schema.clone(),
+        connector_index: parameters.connector_index.clone(),
         caches: field_routing::PlannerCaches::new(),
         disabled_subgraphs: parameters.disabled_subgraphs.clone(),
     };

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/incremental_planner.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/incremental_planner.rs
@@ -1,4 +1,5 @@
 use apollo_compiler::Name;
+use apollo_federation::Supergraph;
 use apollo_federation::query_plan::FetchDataPathElement;
 use apollo_federation::query_plan::FetchDataRewrite;
 use apollo_federation::query_plan::PlanNode;

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/incremental_planner.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/incremental_planner.rs
@@ -9,7 +9,6 @@ use apollo_federation::query_plan::query_planner::QueryPlanIncrementalDeliveryCo
 use apollo_federation::query_plan::query_planner::QueryPlanOptions;
 use apollo_federation::query_plan::query_planner::QueryPlanner;
 use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
-use apollo_federation::Supergraph;
 
 fn incremental_config() -> QueryPlannerConfig {
     QueryPlannerConfig {


### PR DESCRIPTION
## Summary

Extends the BULB field-routing planner to handle Apollo Connectors.

- New `connect.rs` module: `commit_connector_choice` creates connector-backed fetch nodes
- `RoutingTarget::Connector` variant and connector ranking preferences
- Connector entity resolver and direct connector routing
- Connector subgraph edge filtering in fragment options
- Tests for connector field routing scenarios

Replaces erroneously merged PR #10155.