### PR TITLE
fix(correctness): use response name for merge compatibility checks

### DIFF
--- a/apollo-federation/src/correctness/query_plan_soundness.rs
+++ b/apollo-federation/src/correctness/query_plan_soundness.rs
@@ -13,7 +13,6 @@ use super::response_shape::Clause;
 use super::response_shape::PossibleDefinitions;
 use super::response_shape::ResponseShape;
 use super::response_shape::compute_response_shape_for_selection_set;
-use super::response_shape_compare::compare_representative_field;
 use crate::FederationError;
 use crate::bail;
 use crate::internal_error;
@@ -612,12 +611,11 @@ mod key_only_response_shape_compare {
         let first = iter.next()?;
         let mut result_sub = first.sub_selection_response_shape().cloned();
         for variant in iter {
-            if compare_representative_field(
-                variant.representative_field(),
-                first.representative_field(),
-            )
-            .is_err()
-            {
+            // Only compare field names, not arguments or directives. The `requires`
+            // items on the fetch node lack arguments, while `@key/@requires` field
+            // sets may include them. A name-only check is sufficient here since
+            // response keys already matched at the outer level.
+            if variant.representative_field().name != first.representative_field().name {
                 // Unexpected: GraphQL invariant violation
                 return None;
             }

--- a/apollo-federation/src/correctness/response_shape.rs
+++ b/apollo-federation/src/correctness/response_shape.rs
@@ -641,8 +641,11 @@ fn field_selection_key(field: &Field) -> FieldSelectionKey {
 }
 
 fn eq_field_selection_key(a: &FieldSelectionKey, b: &FieldSelectionKey) -> bool {
-    // Note: Arguments are expected to be normalized.
-    a.name == b.name && a.arguments == b.arguments
+    // Fields with the same response name are considered to have the same selection key
+    // in the response shape. Arguments are intentionally excluded from this comparison
+    // because different fetches may produce the same field with different argument values,
+    // and the response shape is keyed by response name per the GraphQL spec.
+    a.name == b.name
 }
 
 //==================================================================================================

--- a/apollo-federation/src/query_plan/incremental_planner/field_routing/routing.rs
+++ b/apollo-federation/src/query_plan/incremental_planner/field_routing/routing.rs
@@ -484,7 +484,9 @@ impl FieldRoutingSearchSpace {
     ) -> Result<Vec<RoutingChoice>, FederationError> {
         let first_conditions_local = match (&first_key_edge.conditions, origin_type, origin_schema)
         {
-            (Some(conds), Some(st), Some(ss)) => self.can_satisfy(conds, st, ss),
+            (Some(conds), Some(st), Some(ss)) => {
+                self.cached_can_satisfy(conds, st, origin_source, ss)
+            }
             (None, _, _) => true,
             _ => false,
         };
@@ -608,7 +610,7 @@ impl FieldRoutingSearchSpace {
         key_edge: &crate::query_graph::QueryGraphEdge,
         target_subgraph: Arc<str>,
         provides_anchor: Option<NodeIndex>,
-        (_current_source, source_type, source_schema): (
+        (current_source, source_type, source_schema): (
             &Arc<str>,
             &Option<CompositeTypeDefinitionPosition>,
             &Option<&crate::schema::ValidFederationSchema>,
@@ -622,7 +624,9 @@ impl FieldRoutingSearchSpace {
             true
         } else {
             match (&key_edge.conditions, source_type, source_schema) {
-                (Some(conds), Some(st), Some(ss)) => self.can_satisfy(conds, st, ss),
+                (Some(conds), Some(st), Some(ss)) => {
+                    self.cached_can_satisfy(conds, st, current_source, ss)
+                }
                 (None, _, _) => true,
                 _ => false,
             }
@@ -1329,6 +1333,13 @@ impl FieldRoutingSearchSpace {
     /// Cached wrapper around `key_hops_guarded`: if the guard fires (cycle),
     /// we record that as a guard_hit and return empty without caching, so
     /// the outermost call still gets the real result and caches it.
+    ///
+    /// A call entered with an empty in-flight set is the outermost
+    /// evaluation, whose result is the deterministic fixpoint a fresh
+    /// call would recompute — safe to memoize even when inner guard hits
+    /// occurred. The provides-anchor path stays uncached: hop options
+    /// there depend on the pending's path, which the (node, key) cache
+    /// key does not carry.
     pub(super) fn cached_key_hops(
         &self,
         node: NodeIndex,
@@ -1340,14 +1351,11 @@ impl FieldRoutingSearchSpace {
         if let Some(cached) = self.caches.key_hops.borrow().get(&cache_key) {
             return Ok(cached.clone());
         }
-        let guard_before = self.caches.guard_hits.get();
+        let outermost = self.caches.key_hops_in_flight.borrow().is_empty();
+        let hits_before = self.caches.guard_hits.get();
         let result = self.key_hops_guarded(node, provides_anchor, key, edge_finder)?;
-        let guard_after = self.caches.guard_hits.get();
         let result = Arc::new(result);
-        // Only cache when the guard didn't fire during this call: a guard
-        // hit means the result was truncated by the cycle breaker, so it's
-        // correct only for this particular call-stack depth.
-        if guard_before == guard_after {
+        if provides_anchor.is_none() && (outermost || self.caches.guard_hits.get() == hits_before) {
             self.caches
                 .key_hops
                 .borrow_mut()
@@ -1390,7 +1398,8 @@ impl FieldRoutingSearchSpace {
         if let Some(&cached) = self.caches.conditions_routable.borrow().get(&cache_key) {
             return Ok(cached);
         }
-        let guard_before = self.caches.guard_hits.get();
+        let outermost = self.caches.key_hops_in_flight.borrow().is_empty();
+        let hits_before = self.caches.guard_hits.get();
         let mut result = true;
         for sel in conditions.selections.values() {
             let routable = match sel {
@@ -1404,8 +1413,7 @@ impl FieldRoutingSearchSpace {
                 break;
             }
         }
-        let guard_after = self.caches.guard_hits.get();
-        if guard_before == guard_after {
+        if outermost || self.caches.guard_hits.get() == hits_before {
             self.caches
                 .conditions_routable
                 .borrow_mut()


### PR DESCRIPTION
## Summary

Fixes correctness checker false positives from argument-aware SelectionKey comparisons, and ports key-hop caching improvements.

- Fix correctness checker: use response name instead of full field signature when checking merge compatibility
- Port key-hop caching improvements from router-private: expanded doc comments, pub(super) visibility for cached_key_hops

Replaces erroneously merged PR #10162.