### PR TITLE
Inanna/graph proptest coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
  "percent-encoding",
  "petgraph",
  "pretty_assertions",
+ "proptest",
  "regex",
  "ron",
  "rstest",
@@ -5570,12 +5571,16 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -5693,6 +5698,12 @@ checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -6462,6 +6473,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ruzstd"
@@ -8158,6 +8181,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ insta = { version = "1.38.0", features = [
     "glob",
 ] }
 once_cell = "1.19.0"
+proptest = "1.10.0"
 reqwest = { version = "0.12.0", default-features = false }
 
 schemars = { version = "1.0.0", features = ["url2"] }

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -68,6 +68,7 @@ mime = "0.3.17"
 diff = "0.1.13"
 hex.workspace = true
 insta.workspace = true
+proptest.workspace = true
 sha1.workspace = true
 similar.workspace = true
 tempfile.workspace = true

--- a/apollo-federation/src/operation/contains.rs
+++ b/apollo-federation/src/operation/contains.rs
@@ -353,4 +353,424 @@ mod tests {
             Containment::Equal,
         );
     }
+
+    // =========================================================================================
+    // Selection merge/containment semilattice (proptest-graph-notes.md, "Supporting operation
+    // properties"): a small, schema-aware selection generator plus an independent recursive
+    // model, checking `SelectionSet::containment`/`contains` and `merge_selection_sets` against
+    // the algebraic laws of a join-semilattice (merge = least upper bound of containment).
+    // Directive-free and fragment-spread-free for this first pass, per the notes ("Add
+    // @skip/@include only after the base lattice laws are confirmed").
+    // =========================================================================================
+
+    use std::collections::BTreeMap;
+    use std::hash::Hash;
+    use std::hash::Hasher;
+
+    use proptest::prelude::*;
+    use proptest::proptest;
+
+    use super::SelectionSet;
+    use crate::operation::merging::merge_selection_sets;
+
+    fn selection_lattice_schema() -> ValidFederationSchema {
+        let schema = apollo_compiler::Schema::parse_and_validate(
+            r#"
+            interface Intf {
+                intfField: Int
+            }
+            type HasA implements Intf {
+                a: Boolean
+                intfField: Int
+            }
+            type Nested {
+                a: Int
+                b: Int
+                c: Int
+            }
+            type Query {
+                a: Int
+                b: Int
+                c: Int
+                object: Nested
+                intf: Intf
+            }
+            "#,
+            "schema.graphql",
+        )
+        .unwrap();
+        ValidFederationSchema::new(schema).unwrap()
+    }
+
+    /// A schema-independent, order-independent model of a selection set: no aliases, no
+    /// directives, no fragment spreads (only inline fragments with an explicit type condition).
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum ModelSelection {
+        /// A scalar field with no sub-selection (`a`, `b`, `c`, `intfField`).
+        Leaf,
+        /// A composite field (`object`, `intf`).
+        Field(ModelSelectionSet),
+        /// An inline fragment with a type condition (`... on HasA { ... }`).
+        Fragment(&'static str, ModelSelectionSet),
+    }
+    type ModelSelectionSet = BTreeMap<String, ModelSelection>;
+
+    /// Generate a non-empty subset of `{a, b, c}` under `Nested`.
+    fn lattice_nested_selection_strategy() -> impl Strategy<Value = ModelSelectionSet> {
+        any::<(bool, bool, bool)>().prop_map(|(mut a, b, c)| {
+            a |= !(b || c);
+            let mut set = BTreeMap::new();
+            if a {
+                set.insert("a".to_string(), ModelSelection::Leaf);
+            }
+            if b {
+                set.insert("b".to_string(), ModelSelection::Leaf);
+            }
+            if c {
+                set.insert("c".to_string(), ModelSelection::Leaf);
+            }
+            set
+        })
+    }
+
+    /// Generate a selection under `Intf`: `intfField` directly, an inline fragment on `HasA`
+    /// selecting some of `{a, intfField}`, or both — always non-empty.
+    fn lattice_intf_selection_strategy() -> impl Strategy<Value = ModelSelectionSet> {
+        any::<(bool, bool, bool, bool)>().prop_map(
+            |(mut has_intf_field, has_fragment, mut frag_a, frag_intf_field)| {
+                frag_a |= !(frag_a || frag_intf_field);
+                has_intf_field |= !(has_intf_field || has_fragment);
+                let mut set = BTreeMap::new();
+                if has_intf_field {
+                    set.insert("intfField".to_string(), ModelSelection::Leaf);
+                }
+                if has_fragment {
+                    let mut frag = BTreeMap::new();
+                    if frag_a {
+                        frag.insert("a".to_string(), ModelSelection::Leaf);
+                    }
+                    if frag_intf_field {
+                        frag.insert("intfField".to_string(), ModelSelection::Leaf);
+                    }
+                    set.insert(
+                        "...HasA".to_string(),
+                        ModelSelection::Fragment("HasA", frag),
+                    );
+                }
+                set
+            },
+        )
+    }
+
+    /// Generate a full top-level selection set under `Query`: any non-empty combination of the
+    /// scalar fields `a`/`b`/`c` and the composite fields `object`/`intf`.
+    fn lattice_selection_set_strategy() -> impl Strategy<Value = ModelSelectionSet> {
+        (
+            any::<(bool, bool, bool)>(),
+            prop::option::of(lattice_nested_selection_strategy()),
+            prop::option::of(lattice_intf_selection_strategy()),
+        )
+            .prop_map(|((mut a, b, c), object, intf)| {
+                a |= !(a || b || c || object.is_some() || intf.is_some());
+                let mut set = BTreeMap::new();
+                if a {
+                    set.insert("a".to_string(), ModelSelection::Leaf);
+                }
+                if b {
+                    set.insert("b".to_string(), ModelSelection::Leaf);
+                }
+                if c {
+                    set.insert("c".to_string(), ModelSelection::Leaf);
+                }
+                if let Some(object) = object {
+                    set.insert("object".to_string(), ModelSelection::Field(object));
+                }
+                if let Some(intf) = intf {
+                    set.insert("intf".to_string(), ModelSelection::Field(intf));
+                }
+                set
+            })
+    }
+
+    /// Print a model selection set to GraphQL source text. `seed` deterministically permutes
+    /// entry order at every level, independent of the model's own `BTreeMap` order, so two
+    /// prints of the same model with different seeds exercise insertion-order independence.
+    fn lattice_print(set: &ModelSelectionSet, seed: u64) -> String {
+        let mut entries: Vec<(&String, &ModelSelection)> = set.iter().collect();
+        entries.sort_by_key(|(key, _)| {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            (seed, *key).hash(&mut hasher);
+            hasher.finish()
+        });
+        entries
+            .into_iter()
+            .map(|(key, selection)| match selection {
+                ModelSelection::Leaf => key.clone(),
+                ModelSelection::Field(sub) => format!(
+                    "{key} {{ {} }}",
+                    lattice_print(sub, seed.wrapping_mul(31).wrapping_add(1))
+                ),
+                ModelSelection::Fragment(ty, sub) => format!(
+                    "... on {ty} {{ {} }}",
+                    lattice_print(sub, seed.wrapping_mul(31).wrapping_add(2))
+                ),
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn lattice_parse(
+        schema: &ValidFederationSchema,
+        set: &ModelSelectionSet,
+        seed: u64,
+    ) -> SelectionSet {
+        let source = format!("{{ {} }}", lattice_print(set, seed));
+        Operation::parse(schema.clone(), &source, "lattice.graphql")
+            .expect("generated selection set must be valid")
+            .selection_set
+    }
+
+    /// `container` structurally contains `containee`: every key `containee` has, `container` has
+    /// too, with a recursively-containing selection.
+    fn lattice_contains(container: &ModelSelectionSet, containee: &ModelSelectionSet) -> bool {
+        containee.iter().all(|(key, containee_selection)| {
+            container.get(key).is_some_and(|container_selection| {
+                lattice_selection_contains(container_selection, containee_selection)
+            })
+        })
+    }
+
+    fn lattice_selection_contains(a: &ModelSelection, b: &ModelSelection) -> bool {
+        match (a, b) {
+            (ModelSelection::Leaf, ModelSelection::Leaf) => true,
+            (ModelSelection::Field(a_set), ModelSelection::Field(b_set)) => {
+                lattice_contains(a_set, b_set)
+            }
+            (ModelSelection::Fragment(a_ty, a_set), ModelSelection::Fragment(b_ty, b_set)) => {
+                a_ty == b_ty && lattice_contains(a_set, b_set)
+            }
+            _ => false,
+        }
+    }
+
+    fn lattice_merge(a: &ModelSelectionSet, b: &ModelSelectionSet) -> ModelSelectionSet {
+        let mut result = a.clone();
+        for (key, b_selection) in b {
+            match result.get(key) {
+                None => {
+                    result.insert(key.clone(), b_selection.clone());
+                }
+                Some(a_selection) => {
+                    let merged = lattice_selection_merge(a_selection, b_selection);
+                    result.insert(key.clone(), merged);
+                }
+            }
+        }
+        result
+    }
+
+    fn lattice_selection_merge(a: &ModelSelection, b: &ModelSelection) -> ModelSelection {
+        match (a, b) {
+            (ModelSelection::Field(a_set), ModelSelection::Field(b_set)) => {
+                ModelSelection::Field(lattice_merge(a_set, b_set))
+            }
+            (ModelSelection::Fragment(ty, a_set), ModelSelection::Fragment(_, b_set)) => {
+                ModelSelection::Fragment(ty, lattice_merge(a_set, b_set))
+            }
+            _ => a.clone(),
+        }
+    }
+
+    /// Remove entries from `set` according to `feed` (`true` = keep), recursing into
+    /// composite/fragment sub-selections. Never leaves a composite sub-selection empty (that
+    /// would produce invalid, empty-braces GraphQL) — falls back to the original sub-selection
+    /// instead — so the result is always valid and non-empty, and by construction
+    /// `lattice_contains(set, &result)` holds. Running out of bits defaults to "keep".
+    fn lattice_shrink(
+        set: &ModelSelectionSet,
+        feed: &mut std::vec::IntoIter<bool>,
+    ) -> ModelSelectionSet {
+        let mut result = BTreeMap::new();
+        for (key, selection) in set {
+            if !feed.next().unwrap_or(true) {
+                continue;
+            }
+            let shrunk = match selection {
+                ModelSelection::Leaf => ModelSelection::Leaf,
+                ModelSelection::Field(sub) => {
+                    let shrunk_sub = lattice_shrink(sub, feed);
+                    ModelSelection::Field(if shrunk_sub.is_empty() {
+                        sub.clone()
+                    } else {
+                        shrunk_sub
+                    })
+                }
+                ModelSelection::Fragment(ty, sub) => {
+                    let shrunk_sub = lattice_shrink(sub, feed);
+                    ModelSelection::Fragment(
+                        ty,
+                        if shrunk_sub.is_empty() {
+                            sub.clone()
+                        } else {
+                            shrunk_sub
+                        },
+                    )
+                }
+            };
+            result.insert(key.clone(), shrunk);
+        }
+        if result.is_empty() {
+            set.clone()
+        } else {
+            result
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// `SelectionSet::contains`/`containment` must exactly match the naive structural model,
+        /// for two independently generated selection sets (printed with independent orderings,
+        /// so this also exercises order-independence).
+        #[test]
+        fn selection_set_containment_matches_naive_model(
+            a in lattice_selection_set_strategy(),
+            b in lattice_selection_set_strategy(),
+            seed_a in any::<u64>(),
+            seed_b in any::<u64>(),
+        ) {
+            let schema = selection_lattice_schema();
+            let production_a = lattice_parse(&schema, &a, seed_a);
+            let production_b = lattice_parse(&schema, &b, seed_b);
+
+            prop_assert_eq!(production_a.contains(&production_b), lattice_contains(&a, &b));
+            prop_assert_eq!(production_b.contains(&production_a), lattice_contains(&b, &a));
+
+            let expected_equal = lattice_contains(&a, &b) && lattice_contains(&b, &a);
+            prop_assert_eq!(
+                production_a
+                    .containment(&production_b, ContainmentOptions::default())
+                    .is_equal(),
+                expected_equal
+            );
+        }
+
+        /// Containment is reflexive (including across a re-printed, differently-ordered copy of
+        /// the same selection) and transitive: shrinking a selection twice produces a chain
+        /// `a ⊇ b ⊇ c`, and production containment must agree at every link, including `a ⊇ c`.
+        #[test]
+        fn selection_set_containment_is_reflexive_and_transitive(
+            a in lattice_selection_set_strategy(),
+            seed_a1 in any::<u64>(),
+            seed_a2 in any::<u64>(),
+            seed_b in any::<u64>(),
+            seed_c in any::<u64>(),
+            shrink_bits_1 in prop::collection::vec(any::<bool>(), 24),
+            shrink_bits_2 in prop::collection::vec(any::<bool>(), 24),
+        ) {
+            let schema = selection_lattice_schema();
+            let production_a1 = lattice_parse(&schema, &a, seed_a1);
+            let production_a2 = lattice_parse(&schema, &a, seed_a2);
+            prop_assert!(
+                production_a1
+                    .containment(&production_a2, ContainmentOptions::default())
+                    .is_equal(),
+                "reflexive/order-independent equality failed"
+            );
+
+            let b = lattice_shrink(&a, &mut shrink_bits_1.into_iter());
+            let c = lattice_shrink(&b, &mut shrink_bits_2.into_iter());
+            prop_assert!(lattice_contains(&a, &b));
+            prop_assert!(lattice_contains(&b, &c));
+            prop_assert!(lattice_contains(&a, &c));
+
+            let production_b = lattice_parse(&schema, &b, seed_b);
+            let production_c = lattice_parse(&schema, &c, seed_c);
+            prop_assert!(production_a1.contains(&production_b), "a must contain its shrink b");
+            prop_assert!(production_b.contains(&production_c), "b must contain its shrink c");
+            prop_assert!(
+                production_a1.contains(&production_c),
+                "containment must be transitive: a must contain c"
+            );
+        }
+
+        /// The named broad property: `merge_selection_sets` is the least upper bound of
+        /// containment. Checked against the naive model, plus the standalone algebraic laws
+        /// (contains each operand, commutative, associative, idempotent, upper-bound-for-any-
+        /// superset) directly on production values.
+        #[test]
+        fn selection_merge_is_least_upper_bound_of_containment(
+            a in lattice_selection_set_strategy(),
+            b in lattice_selection_set_strategy(),
+            c in lattice_selection_set_strategy(),
+            seed_a in any::<u64>(),
+            seed_b in any::<u64>(),
+            seed_c in any::<u64>(),
+            seed_merge_model in any::<u64>(),
+        ) {
+            let schema = selection_lattice_schema();
+            let production_a = lattice_parse(&schema, &a, seed_a);
+            let production_b = lattice_parse(&schema, &b, seed_b);
+            let production_c = lattice_parse(&schema, &c, seed_c);
+
+            // Oracle: production merge(a, b) must be semantically equal to the naive model's
+            // union, independently re-parsed.
+            let merge_ab =
+                merge_selection_sets(vec![production_a.clone(), production_b.clone()]).unwrap();
+            let model_merge_ab = lattice_merge(&a, &b);
+            let production_model_merge_ab = lattice_parse(&schema, &model_merge_ab, seed_merge_model);
+            prop_assert!(
+                merge_ab
+                    .containment(&production_model_merge_ab, ContainmentOptions::default())
+                    .is_equal(),
+                "merge(a, b) did not match the naive union model"
+            );
+
+            // Merge contains each operand.
+            prop_assert!(merge_ab.contains(&production_a));
+            prop_assert!(merge_ab.contains(&production_b));
+
+            // Commutative.
+            let merge_ba =
+                merge_selection_sets(vec![production_b.clone(), production_a.clone()]).unwrap();
+            prop_assert!(
+                merge_ab
+                    .containment(&merge_ba, ContainmentOptions::default())
+                    .is_equal(),
+                "merge is not commutative"
+            );
+
+            // Associative.
+            let merge_ab_c =
+                merge_selection_sets(vec![merge_ab.clone(), production_c.clone()]).unwrap();
+            let merge_bc =
+                merge_selection_sets(vec![production_b.clone(), production_c.clone()]).unwrap();
+            let merge_a_bc = merge_selection_sets(vec![production_a.clone(), merge_bc]).unwrap();
+            prop_assert!(
+                merge_ab_c
+                    .containment(&merge_a_bc, ContainmentOptions::default())
+                    .is_equal(),
+                "merge is not associative"
+            );
+
+            // Idempotent.
+            let merge_aa =
+                merge_selection_sets(vec![production_a.clone(), production_a.clone()]).unwrap();
+            prop_assert!(
+                merge_aa
+                    .containment(&production_a, ContainmentOptions::default())
+                    .is_equal(),
+                "merge is not idempotent"
+            );
+
+            // If C contains A and B, it contains merge(A, B). `merge_ab_c` is a real superset of
+            // both a and b (merging in c can only add more), so it must contain their merge too.
+            prop_assert!(merge_ab_c.contains(&production_a));
+            prop_assert!(merge_ab_c.contains(&production_b));
+            prop_assert!(
+                merge_ab_c.contains(&merge_ab),
+                "a superset of a and b must contain their merge"
+            );
+        }
+    }
 }

--- a/apollo-federation/src/operation/contains.rs
+++ b/apollo-federation/src/operation/contains.rs
@@ -392,6 +392,7 @@ mod tests {
                 a: Int
                 b: Int
                 c: Int
+                arg(x: Int): Int
                 object: Nested
                 intf: Intf
             }
@@ -626,6 +627,35 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct KeyedFieldSpec {
+        alias: u8,
+        argument: u8,
+        directive: u8,
+    }
+
+    fn keyed_field_strategy() -> impl Strategy<Value = KeyedFieldSpec> {
+        (0u8..3, 0u8..3, 0u8..3).prop_map(|(alias, argument, directive)| KeyedFieldSpec {
+            alias,
+            argument,
+            directive,
+        })
+    }
+
+    fn keyed_field_text(spec: KeyedFieldSpec) -> String {
+        let alias = match spec.alias {
+            0 => "".to_string(),
+            value => format!("alias_{value}: "),
+        };
+        let directive = match spec.directive {
+            0 => "",
+            1 => " @include(if: true)",
+            2 => " @skip(if: false)",
+            _ => unreachable!("generated in 0..3"),
+        };
+        format!("{alias}arg(x: {}){directive}", spec.argument)
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(256))]
 
@@ -770,6 +800,43 @@ mod tests {
             prop_assert!(
                 merge_ab_c.contains(&merge_ab),
                 "a superset of a and b must contain their merge"
+            );
+        }
+
+
+        /// Selection identity includes response name, arguments, and directives. Generate those
+        /// dimensions independently so containment cannot accidentally collapse distinct
+        /// `SelectionKey`s or become sensitive to insertion order.
+        #[test]
+        fn selection_containment_distinguishes_complete_field_keys(
+            a in keyed_field_strategy(),
+            b in keyed_field_strategy(),
+        ) {
+            let schema = selection_lattice_schema();
+            let a_text = keyed_field_text(a);
+            let b_text = keyed_field_text(b);
+            let a_selection = Operation::parse(
+                schema.clone(),
+                &format!("{{ {a_text} }}"),
+                "key-a.graphql",
+            )
+            .unwrap()
+            .selection_set;
+            let b_selection = Operation::parse(
+                schema,
+                &format!("{{ {b_text} }}"),
+                "key-b.graphql",
+            )
+            .unwrap()
+            .selection_set;
+            prop_assert_eq!(
+                a_selection
+                    .containment(&b_selection, ContainmentOptions::default())
+                    .is_equal(),
+                a == b,
+                "field-key containment collapsed `{}` and `{}`",
+                a_text,
+                b_text,
             );
         }
     }

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -12,6 +12,8 @@ use super::SelectionSet;
 use super::TYPENAME_FIELD;
 use super::runtime_types_intersect;
 use crate::error::FederationError;
+use crate::link::federation_spec_definition::FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::spec_definition::SpecDefinition;
 use crate::schema::ValidFederationSchema;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::OutputTypeDefinitionPosition;
@@ -202,10 +204,16 @@ impl Field {
         if let Some(federation_spec_definition) = schema
             .subgraph_metadata()
             .map(|d| d.federation_spec_definition())
+            // `subgraph_metadata` is populated even for subgraphs that default to Federation 1
+            // (no `@link` at all) or that link an early Federation 2.x spec, neither of which
+            // defines `@fromContext` (added in 2.8). `try_directive_definition` reports that
+            // absence as `None` instead of erroring, unlike `from_context_directive_definition`:
+            // no `@fromContext` directive in this schema's spec means no argument can possibly
+            // have it applied, so there's nothing to check below.
+            && let Some(from_context_directive_definition) = federation_spec_definition
+                .try_directive_definition(schema, &FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)
         {
-            let from_context_directive_definition_name = &federation_spec_definition
-                .from_context_directive_definition(schema)?
-                .name;
+            let from_context_directive_definition_name = &from_context_directive_definition.name;
             // We need to ensure that all arguments with `@fromContext` are provided. If the
             // would-be parent type's field has an argument with `@fromContext` and that argument
             // has no value/data in this field, then we return `None` to indicate the rebase isn't
@@ -496,5 +504,256 @@ impl SelectionSet {
         self.selections
             .values()
             .fallible_all(|selection| selection.can_add_to(parent_type, schema))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // =====================================================================================
+    // Rebase (proptest-graph-notes.md, "Supporting operation properties"): checks
+    // `SelectionSet::can_rebase_on`/`rebase_on` against each other and against algebraic
+    // laws, biased toward the interface/implementing-object boundary the notes call out
+    // ("key collapse happens at those boundaries") — here, rebasing a selection made
+    // against an interface onto one of two disjoint implementing object types, which is
+    // the one case in this schema where a `... on <Type>` fragment condition can fail to
+    // intersect the rebase target.
+    // =====================================================================================
+
+    use apollo_compiler::name;
+    use proptest::prelude::*;
+    use proptest::proptest;
+
+    use super::super::merging::merge_selection_sets;
+    use crate::operation::SelectionSet;
+    use crate::operation::contains::ContainmentOptions;
+    use crate::schema::ValidFederationSchema;
+    use crate::schema::field_set::parse_field_set;
+    use crate::schema::position::CompositeTypeDefinitionPosition;
+
+    fn rebase_test_schema() -> ValidFederationSchema {
+        let schema = apollo_compiler::Schema::parse_and_validate(
+            r#"
+            interface Intf {
+                intfField: Int
+            }
+            type HasA implements Intf {
+                a: Boolean
+                intfField: Int
+            }
+            type HasB implements Intf {
+                b: Boolean
+                intfField: Int
+            }
+            type Query {
+                intf: Intf
+            }
+            "#,
+            "schema.graphql",
+        )
+        .unwrap();
+        ValidFederationSchema::new(schema).unwrap()
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum RebaseTarget {
+        Intf,
+        HasA,
+        HasB,
+    }
+
+    impl RebaseTarget {
+        fn composite_type(self, schema: &ValidFederationSchema) -> CompositeTypeDefinitionPosition {
+            let name = match self {
+                RebaseTarget::Intf => name!("Intf"),
+                RebaseTarget::HasA => name!("HasA"),
+                RebaseTarget::HasB => name!("HasB"),
+            };
+            schema.get_type(&name).unwrap().try_into().unwrap()
+        }
+    }
+
+    fn object_target_strategy() -> impl Strategy<Value = RebaseTarget> {
+        prop_oneof![Just(RebaseTarget::HasA), Just(RebaseTarget::HasB)]
+    }
+
+    /// A selection set under `Intf`: `intfField` directly, an inline fragment on `HasA` or
+    /// `HasB` selecting some of `{own_field, intfField}`, or both — always non-empty. The
+    /// fragment's type condition is independent of whichever target the property later
+    /// rebases onto, so roughly half of generated (selection, target) pairs are expected to
+    /// fail to rebase (mismatched fragment condition) and half to succeed.
+    fn intf_selection_string_strategy() -> impl Strategy<Value = String> {
+        (
+            any::<bool>(),
+            prop::option::of((object_target_strategy(), any::<bool>(), any::<bool>())),
+        )
+            .prop_map(|(mut has_intf_field, fragment)| {
+                let mut parts = Vec::new();
+                if let Some((target, mut frag_own_field, frag_intf_field)) = fragment {
+                    frag_own_field |= !(frag_own_field || frag_intf_field);
+                    let own_field_name = match target {
+                        RebaseTarget::HasA => "a",
+                        RebaseTarget::HasB => "b",
+                        RebaseTarget::Intf => {
+                            unreachable!("object_target_strategy only yields HasA/HasB")
+                        }
+                    };
+                    let type_name = match target {
+                        RebaseTarget::HasA => "HasA",
+                        RebaseTarget::HasB => "HasB",
+                        RebaseTarget::Intf => {
+                            unreachable!("object_target_strategy only yields HasA/HasB")
+                        }
+                    };
+                    let mut inner = Vec::new();
+                    if frag_own_field {
+                        inner.push(own_field_name.to_string());
+                    }
+                    if frag_intf_field {
+                        inner.push("intfField".to_string());
+                    }
+                    parts.push(format!("... on {type_name} {{ {} }}", inner.join(" ")));
+                }
+                has_intf_field |= parts.is_empty();
+                if has_intf_field {
+                    parts.push("intfField".to_string());
+                }
+                parts.join(" ")
+            })
+    }
+
+    fn parse_intf_selection(schema: &ValidFederationSchema, source: &str) -> SelectionSet {
+        parse_field_set(schema, name!("Intf"), source, true)
+            .expect("generated selection set must be valid under Intf")
+    }
+
+    /// Regression for a real bug the property below found on its first run: `can_rebase_on`
+    /// (via `Field::type_if_added_to`) crashed with an internal error, instead of returning a
+    /// plain `bool`, whenever a field actually resolves on the rebase target and the schema's
+    /// federation spec version doesn't define `@fromContext` (added in Federation 2.8) — which
+    /// is every ordinary Federation 1 subgraph (no `@link` to the federation spec at all,
+    /// `rebase_test_schema()`'s exact shape) as well as any Federation 2.0-2.7 subgraph.
+    /// `type_if_added_to` unconditionally called the erroring `from_context_directive_definition`
+    /// instead of the `Option`-returning `try_directive_definition`. Fixed by skipping the
+    /// `@fromContext`-argument check entirely when the directive isn't defined in this schema's
+    /// spec, since no argument could possibly carry it in that case.
+    #[test]
+    fn can_rebase_on_does_not_crash_on_a_federation_1_subgraph() {
+        let schema = rebase_test_schema();
+        let selection_set = parse_intf_selection(&schema, "intfField");
+        let has_a = RebaseTarget::HasA.composite_type(&schema);
+
+        assert!(
+            selection_set.can_rebase_on(&has_a, &schema).is_ok(),
+            "can_rebase_on must not internal-error on a Federation-1-style subgraph"
+        );
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// `can_rebase_on` must agree with whether `rebase_on` succeeds, and a successful
+        /// rebase must validate against the target type/schema.
+        #[test]
+        fn rebase_can_rebase_on_agrees_with_rebase_on_success(
+            selection_str in intf_selection_string_strategy(),
+            target in object_target_strategy(),
+        ) {
+            let schema = rebase_test_schema();
+            let target_type = target.composite_type(&schema);
+            let selection_set = parse_intf_selection(&schema, &selection_str);
+
+            let can_rebase = selection_set.can_rebase_on(&target_type, &schema).unwrap();
+            let rebase_result = selection_set.rebase_on(&target_type, &schema);
+            prop_assert_eq!(
+                can_rebase,
+                rebase_result.is_ok(),
+                "can_rebase_on disagreed with rebase_on's success"
+            );
+
+            if let Ok(rebased) = rebase_result {
+                let rebased_text = format!("{rebased}");
+                let target_name = match target {
+                    RebaseTarget::HasA => name!("HasA"),
+                    RebaseTarget::HasB => name!("HasB"),
+                    RebaseTarget::Intf => unreachable!("object_target_strategy only yields HasA/HasB"),
+                };
+                let reparsed = parse_field_set(&schema, target_name, &rebased_text, true);
+                prop_assert!(
+                    reparsed.is_ok(),
+                    "rebased selection set failed to validate on the target schema: {reparsed:?}"
+                );
+            }
+        }
+
+        /// Rebasing to the exact same schema/type is identity; rebasing an already-rebased
+        /// selection set to the same target again is idempotent.
+        #[test]
+        fn rebase_to_same_type_is_identity_and_double_rebase_is_idempotent(
+            selection_str in intf_selection_string_strategy(),
+            target in prop_oneof![
+                Just(RebaseTarget::Intf),
+                Just(RebaseTarget::HasA),
+                Just(RebaseTarget::HasB),
+            ],
+        ) {
+            let schema = rebase_test_schema();
+            let selection_set = parse_intf_selection(&schema, &selection_str);
+
+            if target == RebaseTarget::Intf {
+                let rebased = selection_set
+                    .rebase_on(&target.composite_type(&schema), &schema)
+                    .unwrap();
+                prop_assert_eq!(rebased, selection_set);
+                return Ok(());
+            }
+
+            let target_type = target.composite_type(&schema);
+            let Ok(once) = selection_set.rebase_on(&target_type, &schema) else {
+                return Ok(());
+            };
+            let twice = once.clone().rebase_on(&target_type, &schema).unwrap();
+            prop_assert_eq!(
+                once,
+                twice,
+                "rebasing an already-rebased set to the same target must be idempotent"
+            );
+        }
+
+        /// Rebase distributes over merge: `rebase(merge(a, b)) == merge(rebase(a), rebase(b))`,
+        /// whenever `a` and `b` individually rebase onto the target.
+        #[test]
+        fn rebase_distributes_over_merge(
+            a_str in intf_selection_string_strategy(),
+            b_str in intf_selection_string_strategy(),
+            target in object_target_strategy(),
+        ) {
+            let schema = rebase_test_schema();
+            let target_type = target.composite_type(&schema);
+            let a = parse_intf_selection(&schema, &a_str);
+            let b = parse_intf_selection(&schema, &b_str);
+
+            let Ok(rebased_a) = a.rebase_on(&target_type, &schema) else {
+                return Ok(());
+            };
+            let Ok(rebased_b) = b.rebase_on(&target_type, &schema) else {
+                return Ok(());
+            };
+
+            let merged = merge_selection_sets(vec![a, b]).unwrap();
+            let merged_rebased = merged.rebase_on(&target_type, &schema);
+            prop_assert!(
+                merged_rebased.is_ok(),
+                "merge(a, b) failed to rebase even though both a and b individually rebase onto the same target"
+            );
+            let merged_then_rebased = merged_rebased.unwrap();
+            let rebased_then_merged = merge_selection_sets(vec![rebased_a, rebased_b]).unwrap();
+
+            prop_assert!(
+                merged_then_rebased
+                    .containment(&rebased_then_merged, ContainmentOptions::default())
+                    .is_equal(),
+                "rebase(merge(a, b)) must equal merge(rebase(a), rebase(b))"
+            );
+        }
     }
 }

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -12,8 +12,6 @@ use super::SelectionSet;
 use super::TYPENAME_FIELD;
 use super::runtime_types_intersect;
 use crate::error::FederationError;
-use crate::link::federation_spec_definition::FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC;
-use crate::link::spec_definition::SpecDefinition;
 use crate::schema::ValidFederationSchema;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::OutputTypeDefinitionPosition;
@@ -204,16 +202,10 @@ impl Field {
         if let Some(federation_spec_definition) = schema
             .subgraph_metadata()
             .map(|d| d.federation_spec_definition())
-            // `subgraph_metadata` is populated even for subgraphs that default to Federation 1
-            // (no `@link` at all) or that link an early Federation 2.x spec, neither of which
-            // defines `@fromContext` (added in 2.8). `try_directive_definition` reports that
-            // absence as `None` instead of erroring, unlike `from_context_directive_definition`:
-            // no `@fromContext` directive in this schema's spec means no argument can possibly
-            // have it applied, so there's nothing to check below.
-            && let Some(from_context_directive_definition) = federation_spec_definition
-                .try_directive_definition(schema, &FEDERATION_FROM_CONTEXT_DIRECTIVE_NAME_IN_SPEC)
         {
-            let from_context_directive_definition_name = &from_context_directive_definition.name;
+            let from_context_directive_definition_name = &federation_spec_definition
+                .from_context_directive_definition(schema)?
+                .name;
             // We need to ensure that all arguments with `@fromContext` are provided. If the
             // would-be parent type's field has an argument with `@fromContext` and that argument
             // has no value/data in this field, then we return `None` to indicate the rebase isn't
@@ -509,15 +501,7 @@ impl SelectionSet {
 
 #[cfg(test)]
 mod tests {
-    // =====================================================================================
-    // Rebase (proptest-graph-notes.md, "Supporting operation properties"): checks
-    // `SelectionSet::can_rebase_on`/`rebase_on` against each other and against algebraic
-    // laws, biased toward the interface/implementing-object boundary the notes call out
-    // ("key collapse happens at those boundaries") — here, rebasing a selection made
-    // against an interface onto one of two disjoint implementing object types, which is
-    // the one case in this schema where a `... on <Type>` fragment condition can fail to
-    // intersect the rebase target.
-    // =====================================================================================
+    // Deterministic regression repros appear before the generated coverage that found them.
 
     use apollo_compiler::name;
     use proptest::prelude::*;
@@ -553,6 +537,61 @@ mod tests {
         .unwrap();
         ValidFederationSchema::new(schema).unwrap()
     }
+
+    /// The generated laws should explore ordinary rebase outcomes rather than all stopping at
+    /// the Federation-1 missing-`@fromContext` defect reproduced below. Build the same semantic
+    /// schema through the normal Federation-2 link-expansion path so the relevant directive
+    /// definitions and subgraph metadata are present.
+    fn rebase_federation_2_test_schema() -> ValidFederationSchema {
+        let expanded = crate::subgraph::typestate::Subgraph::parse(
+            "rebase",
+            "http://rebase",
+            r#"
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.9")
+
+            interface Intf {
+                intfField: Int
+            }
+            type HasA implements Intf {
+                a: Boolean
+                intfField: Int
+            }
+            type HasB implements Intf {
+                b: Boolean
+                intfField: Int
+            }
+            type Query {
+                intf: Intf
+            }
+            "#,
+        )
+        .unwrap()
+        .expand_links()
+        .unwrap();
+        ValidFederationSchema::new_assume_valid(expanded.schema().clone()).unwrap()
+    }
+
+    /// Operation-level repro: a schema whose federation version predates `@fromContext` has no
+    /// contextual arguments to validate. Rebasing an otherwise compatible field through the
+    /// production `SelectionSet::can_rebase_on` API must therefore return `Ok(true)`.
+    #[test]
+    fn can_rebase_on_does_not_crash_on_a_federation_1_subgraph() {
+        let schema = rebase_test_schema();
+        let selection_set = parse_field_set(&schema, name!("Intf"), "intfField", true)
+            .expect("intfField must be valid on Intf");
+        let has_a: CompositeTypeDefinitionPosition =
+            schema.get_type(&name!("HasA")).unwrap().try_into().unwrap();
+
+        let can_rebase = selection_set
+            .can_rebase_on(&has_a, &schema)
+            .expect("can_rebase_on must not internal-error on a Federation-1-style subgraph");
+        assert!(
+            can_rebase,
+            "a field shared by the interface and implementing object must be rebaseable"
+        );
+    }
+
+    // Generated coverage.
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum RebaseTarget {
@@ -623,29 +662,7 @@ mod tests {
 
     fn parse_intf_selection(schema: &ValidFederationSchema, source: &str) -> SelectionSet {
         parse_field_set(schema, name!("Intf"), source, true)
-            .expect("generated selection set must be valid under Intf")
-    }
-
-    /// Regression for a real bug the property below found on its first run: `can_rebase_on`
-    /// (via `Field::type_if_added_to`) crashed with an internal error, instead of returning a
-    /// plain `bool`, whenever a field actually resolves on the rebase target and the schema's
-    /// federation spec version doesn't define `@fromContext` (added in Federation 2.8) — which
-    /// is every ordinary Federation 1 subgraph (no `@link` to the federation spec at all,
-    /// `rebase_test_schema()`'s exact shape) as well as any Federation 2.0-2.7 subgraph.
-    /// `type_if_added_to` unconditionally called the erroring `from_context_directive_definition`
-    /// instead of the `Option`-returning `try_directive_definition`. Fixed by skipping the
-    /// `@fromContext`-argument check entirely when the directive isn't defined in this schema's
-    /// spec, since no argument could possibly carry it in that case.
-    #[test]
-    fn can_rebase_on_does_not_crash_on_a_federation_1_subgraph() {
-        let schema = rebase_test_schema();
-        let selection_set = parse_intf_selection(&schema, "intfField");
-        let has_a = RebaseTarget::HasA.composite_type(&schema);
-
-        assert!(
-            selection_set.can_rebase_on(&has_a, &schema).is_ok(),
-            "can_rebase_on must not internal-error on a Federation-1-style subgraph"
-        );
+            .expect("selection set must be valid under Intf")
     }
 
     proptest! {
@@ -658,7 +675,7 @@ mod tests {
             selection_str in intf_selection_string_strategy(),
             target in object_target_strategy(),
         ) {
-            let schema = rebase_test_schema();
+            let schema = rebase_federation_2_test_schema();
             let target_type = target.composite_type(&schema);
             let selection_set = parse_intf_selection(&schema, &selection_str);
 
@@ -696,7 +713,7 @@ mod tests {
                 Just(RebaseTarget::HasB),
             ],
         ) {
-            let schema = rebase_test_schema();
+            let schema = rebase_federation_2_test_schema();
             let selection_set = parse_intf_selection(&schema, &selection_str);
 
             if target == RebaseTarget::Intf {
@@ -727,7 +744,7 @@ mod tests {
             b_str in intf_selection_string_strategy(),
             target in object_target_strategy(),
         ) {
-            let schema = rebase_test_schema();
+            let schema = rebase_federation_2_test_schema();
             let target_type = target.composite_type(&schema);
             let a = parse_intf_selection(&schema, &a_str);
             let b = parse_intf_selection(&schema, &b_str);

--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -499,4 +499,175 @@ type Query {
             }
         "#);
     }
+
+    // =========================================================================================
+    // `flatten_unnecessary_fragments` is idempotent and semantically equivalent to the input
+    // (proptest-graph-notes.md, "Supporting operation properties"). This schema and shape
+    // deliberately mirror `does_not_duplicate_fragments_regression_router782` above: a real past
+    // bug lived in exactly this "redundant nested fragment duplicated across an abstract-type
+    // wrapper" shape, and the function's own PORT_NOTE flags that a second flattening pass could
+    // in principle find newly-liftable selections a first pass didn't ("this could be worth
+    // investigating"), which is exactly what the idempotence check below probes.
+    // =========================================================================================
+    mod flatten_proptest {
+        use apollo_compiler::Schema;
+        use proptest::prelude::*;
+        use proptest::proptest;
+
+        use super::super::*;
+        use crate::correctness::compare_operations;
+        use crate::operation::Operation;
+
+        const FLATTEN_TEST_SCHEMA: &str = r#"
+            interface Node {
+                id: ID!
+            }
+            interface HasNodes {
+                nodes: [Node!]!
+            }
+            type MySpecialNode implements Node & HasNodes {
+                id: ID!
+                value: String
+                nodes: [Node!]!
+            }
+            type Query {
+                nodes: [Node]
+            }
+        "#;
+
+        fn schema() -> ValidFederationSchema {
+            let schema = Schema::parse_and_validate(FLATTEN_TEST_SCHEMA, "schema.graphql").unwrap();
+            ValidFederationSchema::new(schema).unwrap()
+        }
+
+        /// Mirrors the shape of `does_not_duplicate_fragments_regression_router782`'s query:
+        /// a top-level `__typename`/`... on MySpecialNode` under `Node`, plus an optional
+        /// `... on HasNodes { ... on Node { ... } } }` wrapper — redundant (`HasNodes`/`Node` are
+        /// both satisfied by the same runtime type here) and, when it repeats the same
+        /// `... on MySpecialNode` fragment the top level already has, exactly the duplication
+        /// shape the regression fixed.
+        #[derive(Debug, Clone, Copy)]
+        struct FlattenSpec {
+            top_typename: bool,
+            direct_special_node: bool,
+            nested_wrapper: bool,
+            nested_typename: bool,
+            nested_special_node: bool,
+        }
+
+        fn flatten_spec_strategy() -> impl Strategy<Value = FlattenSpec> {
+            any::<(bool, bool, bool, bool, bool)>().prop_map(
+                |(
+                    top_typename,
+                    direct_special_node,
+                    nested_wrapper,
+                    nested_typename,
+                    nested_special_node,
+                )| FlattenSpec {
+                    top_typename,
+                    direct_special_node,
+                    nested_wrapper,
+                    nested_typename,
+                    nested_special_node,
+                },
+            )
+        }
+
+        fn build_query(spec: FlattenSpec) -> String {
+            let mut parts = Vec::new();
+            if spec.top_typename {
+                parts.push("__typename".to_string());
+            }
+            if spec.direct_special_node {
+                parts.push("... on MySpecialNode { value }".to_string());
+            }
+            if spec.nested_wrapper {
+                let mut inner = Vec::new();
+                if spec.nested_typename {
+                    inner.push("__typename".to_string());
+                }
+                if spec.nested_special_node {
+                    inner.push("... on MySpecialNode { value }".to_string());
+                }
+                if inner.is_empty() {
+                    // A composite selection can't be empty; fall back to a harmless field.
+                    inner.push("__typename".to_string());
+                }
+                parts.push(format!(
+                    "... on HasNodes {{ ... on Node {{ {} }} }}",
+                    inner.join(" ")
+                ));
+            }
+            if parts.is_empty() {
+                parts.push("__typename".to_string());
+            }
+            format!("{{ nodes {{ {} }} }}", parts.join(" "))
+        }
+
+        /// Parse `source` as a fresh document and assert its response shape is semantically
+        /// equal (in both directions) to `reference`'s. Response-shape comparison is
+        /// schema-aware: unlike `SelectionSet::containment`'s structural, type-condition-name
+        /// keyed comparison, it knows that two differently-named conditions can select the exact
+        /// same runtime types. An earlier version of this property used `containment` here and
+        /// immediately found a false-positive "meaning changed" report on
+        /// `{ nodes { ... on HasNodes { ... on Node { ... on MySpecialNode { value } } } } }` ->
+        /// `{ nodes { ... on MySpecialNode { value } } }`: in this schema `MySpecialNode` is the
+        /// only type implementing `HasNodes`, so the two selections are genuinely equivalent, but
+        /// `containment` doesn't reason about runtime-type-set equivalence across differently
+        /// named conditions — the wrong oracle for this property, not a bug in `flatten_...`.
+        fn assert_same_response_shape(
+            schema: &ValidFederationSchema,
+            reference: &str,
+            source: &str,
+        ) {
+            let reference_doc = executable::ExecutableDocument::parse_and_validate(
+                schema.schema(),
+                reference,
+                "reference.graphql",
+            )
+            .unwrap();
+            let source_doc = executable::ExecutableDocument::parse_and_validate(
+                schema.schema(),
+                source,
+                "source.graphql",
+            )
+            .unwrap();
+            compare_operations(schema, &reference_doc, &source_doc).unwrap_or_else(|e| {
+                panic!("`{source}` does not have the same response shape as `{reference}`: {e}")
+            });
+            compare_operations(schema, &source_doc, &reference_doc).unwrap_or_else(|e| {
+                panic!("`{reference}` does not have the same response shape as `{source}`: {e}")
+            });
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(256))]
+
+            #[test]
+            fn flatten_unnecessary_fragments_is_idempotent_and_meaning_preserving(
+                spec in flatten_spec_strategy(),
+            ) {
+                let schema = schema();
+                let query = build_query(spec);
+                let operation = Operation::parse(schema.clone(), &query, "query.graphql").unwrap();
+                let original = &operation.selection_set;
+
+                let flat1 = original
+                    .flatten_unnecessary_fragments(&original.type_position, &schema)
+                    .unwrap();
+                assert_same_response_shape(&schema, &query, &format!("{flat1}"));
+
+                let flat2 = flat1
+                    .flatten_unnecessary_fragments(&flat1.type_position, &schema)
+                    .unwrap();
+                prop_assert_eq!(
+                    &flat1,
+                    &flat2,
+                    "a second flatten_unnecessary_fragments pass changed the result: `{}` -> `{}`",
+                    flat1,
+                    flat2
+                );
+            }
+        }
+    }
 }

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -1976,3 +1976,264 @@ fn fragments_with_non_intersecting_types() {
         }
     "###);
 }
+
+/// Path insertion checks (proptest-graph-notes.md, "Supporting operation properties"):
+/// `SelectionSet::add_at_path` matches a direct recursive wrap-and-merge model over valid paths,
+/// and inserting selections under disjoint top-level fields commutes. Reuses `field_element`,
+/// `ADD_AT_PATH_TEST_SCHEMA`, and `SelectionSet::parse` from the deterministic examples above.
+mod add_at_path_proptest {
+    use std::collections::BTreeMap;
+
+    use apollo_compiler::name;
+    use apollo_compiler::schema::Schema;
+    use proptest::prelude::*;
+    use proptest::proptest;
+
+    use super::ADD_AT_PATH_TEST_SCHEMA;
+    use super::field_element;
+    use crate::operation::SelectionSet;
+    use crate::operation::contains::ContainmentOptions;
+    use crate::schema::ValidFederationSchema;
+    use crate::schema::position::ObjectTypeDefinitionPosition;
+
+    fn schema() -> ValidFederationSchema {
+        let schema = Schema::parse_and_validate(ADD_AT_PATH_TEST_SCHEMA, "schema.graphql").unwrap();
+        ValidFederationSchema::new(schema).unwrap()
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum LeafChoice {
+        D,
+        EArg1,
+        Both,
+    }
+
+    impl LeafChoice {
+        fn field_set_text(self) -> &'static str {
+            match self {
+                LeafChoice::D => "d",
+                LeafChoice::EArg1 => "e(arg: 1)",
+                LeafChoice::Both => "d e(arg: 1)",
+            }
+        }
+
+        /// Model keys for the fields this leaf selects, distinct from their printed text so the
+        /// model doesn't need to embed argument syntax in a map key.
+        fn model_keys(self) -> &'static [&'static str] {
+            match self {
+                LeafChoice::D => &["d"],
+                LeafChoice::EArg1 => &["e_arg1"],
+                LeafChoice::Both => &["d", "e_arg1"],
+            }
+        }
+    }
+
+    fn leaf_choice_strategy() -> impl Strategy<Value = LeafChoice> {
+        prop_oneof![
+            Just(LeafChoice::D),
+            Just(LeafChoice::EArg1),
+            Just(LeafChoice::Both),
+        ]
+    }
+
+    /// One `add_at_path` call: a scalar leaf directly under `Query` (`something`/`scalar`), or a
+    /// composite leaf reached through the two-level chain `a.b.c`.
+    #[derive(Debug, Clone, Copy)]
+    enum Insertion {
+        Something,
+        Scalar,
+        AbcLeaf(LeafChoice),
+    }
+
+    fn insertion_strategy() -> impl Strategy<Value = Insertion> {
+        prop_oneof![
+            Just(Insertion::Something),
+            Just(Insertion::Scalar),
+            leaf_choice_strategy().prop_map(Insertion::AbcLeaf),
+        ]
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum ModelSelection {
+        Leaf,
+        Field(ModelSelectionSet),
+    }
+    type ModelSelectionSet = BTreeMap<String, ModelSelection>;
+
+    fn singleton(key: &str, value: ModelSelection) -> ModelSelectionSet {
+        let mut set = BTreeMap::new();
+        set.insert(key.to_string(), value);
+        set
+    }
+
+    /// Plain recursive union merge, independent of `add_at_path`/`merge_selection_sets`.
+    fn merge(a: &ModelSelectionSet, b: &ModelSelectionSet) -> ModelSelectionSet {
+        let mut result = a.clone();
+        for (key, b_selection) in b {
+            match (result.get(key), b_selection) {
+                (Some(ModelSelection::Field(a_sub)), ModelSelection::Field(b_sub)) => {
+                    result.insert(key.clone(), ModelSelection::Field(merge(a_sub, b_sub)));
+                }
+                _ => {
+                    // No existing entry, or both leaves (same key implies same field, so a leaf
+                    // merged with a leaf is just that leaf again): either way, `b`'s value wins.
+                    result.insert(key.clone(), b_selection.clone());
+                }
+            }
+        }
+        result
+    }
+
+    /// The direct "wrap" half of the model: build the nested selection set this insertion
+    /// contributes, independent of anything already accumulated.
+    fn insertion_model(insertion: Insertion) -> ModelSelectionSet {
+        match insertion {
+            Insertion::Something => singleton("something", ModelSelection::Leaf),
+            Insertion::Scalar => singleton("scalar", ModelSelection::Leaf),
+            Insertion::AbcLeaf(leaf) => {
+                let mut leaf_set = BTreeMap::new();
+                for key in leaf.model_keys() {
+                    leaf_set.insert((*key).to_string(), ModelSelection::Leaf);
+                }
+                singleton(
+                    "a",
+                    ModelSelection::Field(singleton(
+                        "b",
+                        ModelSelection::Field(singleton("c", ModelSelection::Field(leaf_set))),
+                    )),
+                )
+            }
+        }
+    }
+
+    fn leaf_text(model_key: &str) -> &str {
+        match model_key {
+            "e_arg1" => "e(arg: 1)",
+            other => other,
+        }
+    }
+
+    fn print_model(set: &ModelSelectionSet) -> String {
+        set.iter()
+            .map(|(key, selection)| match selection {
+                ModelSelection::Leaf => leaf_text(key).to_string(),
+                ModelSelection::Field(sub) => {
+                    format!("{} {{ {} }}", leaf_text(key), print_model(sub))
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    /// Apply one insertion to a production `SelectionSet` via the real `add_at_path`.
+    fn apply_insertion(
+        schema: &ValidFederationSchema,
+        selection_set: &mut SelectionSet,
+        insertion: Insertion,
+    ) {
+        match insertion {
+            Insertion::Something => {
+                selection_set
+                    .add_at_path(
+                        &[field_element(schema, name!("Query"), name!("something")).into()],
+                        None,
+                    )
+                    .unwrap();
+            }
+            Insertion::Scalar => {
+                selection_set
+                    .add_at_path(
+                        &[field_element(schema, name!("Query"), name!("scalar")).into()],
+                        None,
+                    )
+                    .unwrap();
+            }
+            Insertion::AbcLeaf(leaf) => {
+                let path = [
+                    field_element(schema, name!("Query"), name!("a")).into(),
+                    field_element(schema, name!("A"), name!("b")).into(),
+                    field_element(schema, name!("B"), name!("c")).into(),
+                ];
+                let leaf_set = SelectionSet::parse(
+                    schema.clone(),
+                    ObjectTypeDefinitionPosition::new(name!("C")).into(),
+                    leaf.field_set_text(),
+                )
+                .unwrap();
+                selection_set
+                    .add_at_path(&path, Some(&leaf_set.into()))
+                    .unwrap();
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// After every `add_at_path` call, the accumulated production selection set must match
+        /// an independently-built model: wrap each insertion's own nested shape, union it into
+        /// what's accumulated so far, and compare the printed-and-reparsed result semantically.
+        #[test]
+        fn add_at_path_matches_wrap_and_merge_model(
+            insertions in prop::collection::vec(insertion_strategy(), 0..12),
+        ) {
+            let schema = schema();
+            let mut production = SelectionSet::empty(
+                schema.clone(),
+                ObjectTypeDefinitionPosition::new(name!("Query")).into(),
+            );
+            let mut model = ModelSelectionSet::new();
+            for insertion in insertions {
+                apply_insertion(&schema, &mut production, insertion);
+                model = merge(&model, &insertion_model(insertion));
+            }
+
+            if model.is_empty() {
+                prop_assert!(production.is_empty());
+                return Ok(());
+            }
+
+            let expected_text = format!("{{ {} }}", print_model(&model));
+            let expected = SelectionSet::parse(
+                schema,
+                ObjectTypeDefinitionPosition::new(name!("Query")).into(),
+                &expected_text,
+            )
+            .unwrap();
+            prop_assert!(
+                production
+                    .containment(&expected, ContainmentOptions::default())
+                    .is_equal(),
+                "add_at_path result did not match the wrap-and-merge model; expected `{expected_text}`, got `{production}`"
+            );
+        }
+
+        /// Inserting into disjoint top-level fields commutes: `something` and the `a.b.c` chain
+        /// never interact, so applying them in either order must produce the same selection set.
+        #[test]
+        fn add_at_path_disjoint_insertions_commute(leaf in leaf_choice_strategy()) {
+            let schema = schema();
+
+            let mut something_then_abc = SelectionSet::empty(
+                schema.clone(),
+                ObjectTypeDefinitionPosition::new(name!("Query")).into(),
+            );
+            apply_insertion(&schema, &mut something_then_abc, Insertion::Something);
+            apply_insertion(&schema, &mut something_then_abc, Insertion::AbcLeaf(leaf));
+
+            let mut abc_then_something = SelectionSet::empty(
+                schema.clone(),
+                ObjectTypeDefinitionPosition::new(name!("Query")).into(),
+            );
+            apply_insertion(&schema, &mut abc_then_something, Insertion::AbcLeaf(leaf));
+            apply_insertion(&schema, &mut abc_then_something, Insertion::Something);
+
+            prop_assert!(
+                something_then_abc
+                    .containment(&abc_then_something, ContainmentOptions::default())
+                    .is_equal(),
+                "disjoint insertions must commute"
+            );
+        }
+    }
+}

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -1247,6 +1247,166 @@ mod lazy_map_tests {
     }
 }
 
+/// `lazy_map` copy-on-write law (proptest-graph-notes.md, "Supporting operation properties"):
+/// for a small generated mapping language (keep, delete, replace one, replace many), `lazy_map`'s
+/// result must match a plain last-write-wins reconstruction from the mapper's own outputs,
+/// regardless of whether `lazy_map`'s copy-on-write fast path (nothing changed) is taken.
+mod lazy_map_proptest {
+    use proptest::prelude::*;
+    use proptest::proptest;
+
+    use super::super::*;
+    use super::*;
+    use crate::operation::contains::ContainmentOptions;
+
+    const LAZY_MAP_SCHEMA: &str = r#"
+        type Query {
+            a: Int
+            b: Int
+            c: Int
+            d: Int
+            e: Int
+        }
+    "#;
+    const LAZY_MAP_FIELDS: [&str; 5] = ["a", "b", "c", "d", "e"];
+
+    fn query_type() -> CompositeTypeDefinitionPosition {
+        ObjectTypeDefinitionPosition::new(name!("Query")).into()
+    }
+
+    fn field_selection(schema: &ValidFederationSchema, field_name: &str) -> Selection {
+        SelectionSet::parse(schema.clone(), query_type(), field_name)
+            .unwrap()
+            .selections
+            .values()
+            .next()
+            .unwrap()
+            .clone()
+    }
+
+    #[derive(Debug, Clone)]
+    enum Decision {
+        Keep,
+        Delete,
+        ReplaceOne(&'static str),
+        ReplaceMany(Vec<&'static str>),
+    }
+
+    fn decision_strategy() -> impl Strategy<Value = Decision> {
+        prop_oneof![
+            2 => Just(Decision::Keep),
+            1 => Just(Decision::Delete),
+            2 => prop::sample::select(&LAZY_MAP_FIELDS[..]).prop_map(Decision::ReplaceOne),
+            2 => prop::collection::vec(prop::sample::select(&LAZY_MAP_FIELDS[..]), 0..3)
+                .prop_map(Decision::ReplaceMany),
+        ]
+    }
+
+    /// Insert-or-overwrite-by-key, preserving first-insertion position: mirrors the documented
+    /// `make_selection_set`/`lazy_map` contract ("if the same selection key repeats in a later
+    /// group, the previous group will be ignored and replaced by the new group").
+    fn upsert(
+        expected: &mut Vec<(&'static str, &'static str)>,
+        key: &'static str,
+        text: &'static str,
+    ) {
+        if let Some(existing) = expected.iter_mut().find(|(k, _)| *k == key) {
+            existing.1 = text;
+        } else {
+            expected.push((key, text));
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        #[test]
+        fn lazy_map_matches_eager_last_write_wins_reconstruction(
+            decisions in prop::collection::vec(decision_strategy(), 4),
+        ) {
+            let schema = parse_schema(LAZY_MAP_SCHEMA);
+            let base = SelectionSet::parse(schema.clone(), query_type(), "a b c d").unwrap();
+
+            let mut expected: Vec<(&'static str, &'static str)> = Vec::new();
+            let original_keys = ["a", "b", "c", "d"];
+            for (key, decision) in original_keys.iter().zip(&decisions) {
+                match decision {
+                    Decision::Keep => upsert(&mut expected, key, key),
+                    // `SelectionMapperReturn::None` is documented as "Removed; Skip it." and its
+                    // handling is a literal no-op (`update_new_selection`, mod.rs): a deleted
+                    // position contributes nothing of its own, but — unlike a set-based delete —
+                    // it does NOT retroactively remove an entry some *other* position's
+                    // replacement already inserted under this same key. An earlier version of
+                    // this model called `retain` here (removing by key), which is wrong: it
+                    // failed on `decisions = [Keep, ReplaceOne("c"), Delete, Keep]`, where `b`'s
+                    // replacement inserts key "c" and the original `c` position's own delete must
+                    // not erase it. Confirmed via the doc comment/source before fixing (see
+                    // triage note above `Decision`).
+                    Decision::Delete => {}
+                    Decision::ReplaceOne(replacement) => {
+                        upsert(&mut expected, replacement, replacement);
+                    }
+                    Decision::ReplaceMany(replacements) => {
+                        for r in replacements {
+                            upsert(&mut expected, r, r);
+                        }
+                    }
+                }
+            }
+
+            let mut decisions_iter = decisions.into_iter();
+            let result = base
+                .lazy_map(|sel| {
+                    let decision = decisions_iter
+                        .next()
+                        .expect("one decision per original top-level selection");
+                    Ok(match decision {
+                        Decision::Keep => SelectionMapperReturn::Selection(sel.clone()),
+                        Decision::Delete => SelectionMapperReturn::None,
+                        Decision::ReplaceOne(name) => {
+                            SelectionMapperReturn::Selection(field_selection(&schema, name))
+                        }
+                        Decision::ReplaceMany(names) => SelectionMapperReturn::SelectionList(
+                            names.iter().map(|n| field_selection(&schema, n)).collect(),
+                        ),
+                    })
+                })
+                .unwrap();
+
+            if expected.is_empty() {
+                prop_assert!(result.is_empty());
+                return Ok(());
+            }
+
+            let expected_text = format!(
+                "{{ {} }}",
+                expected.iter().map(|(_, t)| *t).collect::<Vec<_>>().join(" ")
+            );
+            let expected_selection_set = SelectionSet::parse(schema, query_type(), &expected_text).unwrap();
+
+            prop_assert!(
+                result
+                    .containment(&expected_selection_set, ContainmentOptions::default())
+                    .is_equal(),
+                "lazy_map result did not match the eager last-write-wins reconstruction; \
+                 expected `{expected_text}`, got `{result}`"
+            );
+        }
+    }
+
+    /// `lazy_map`'s copy-on-write fast path (every selection maps to itself unchanged) returns
+    /// exactly the original selection set, not just something semantically equal to it.
+    #[test]
+    fn lazy_map_all_keep_is_the_identity() {
+        let schema = parse_schema(LAZY_MAP_SCHEMA);
+        let base = SelectionSet::parse(schema, query_type(), "a b c d").unwrap();
+        let result = base
+            .lazy_map(|sel| Ok(SelectionMapperReturn::Selection(sel.clone())))
+            .unwrap();
+        assert_eq!(result, base);
+    }
+}
+
 fn field_element(schema: &ValidFederationSchema, object: Name, field: Name) -> OpPathElement {
     OpPathElement::Field(Field {
         schema: schema.clone(),

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -2320,3 +2320,2328 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::VecDeque;
+
+    use apollo_compiler::collections::IndexSet;
+    use apollo_compiler::executable;
+    use apollo_compiler::name;
+    use proptest::prelude::*;
+    use proptest::proptest;
+    use proptest::test_runner::TestCaseError;
+
+    use crate::Supergraph;
+    use crate::link::graphql_definition::DeferDirectiveArguments;
+    use crate::operation::DirectiveList;
+    use crate::operation::InlineFragment;
+    use crate::operation::SelectionId;
+    use crate::query_graph::build_federated_query_graph;
+    use crate::query_graph::graph_path::operation::OpGraphPath;
+    use crate::query_graph::graph_path::operation::OpGraphPathContext;
+    use crate::query_graph::graph_path::operation::OpGraphPathTrigger;
+    use crate::query_graph::graph_path::operation::OpPathElement;
+    use crate::query_graph::graph_path::operation::SimultaneousPaths;
+    use crate::query_graph::graph_path::operation::SimultaneousPathsWithLazyIndirectPaths;
+    use crate::query_graph::graph_path::transition::TransitionGraphPath;
+
+    const PATH_GRAPH_FIXTURES: [(&str, &str); 6] = [
+        (
+            "interface-object",
+            include_str!(
+                "../../tests/query_plan/supergraphs/can_use_a_key_on_an_interface_object_type.graphql"
+            ),
+        ),
+        (
+            "key-chain",
+            include_str!(
+                "../../tests/query_plan/supergraphs/handles_case_of_key_chains_in_parallel_requires.graphql"
+            ),
+        ),
+        (
+            "abstract-runtime-types",
+            include_str!(
+                "../../tests/query_plan/supergraphs/field_covariance_and_type_explosion.graphql"
+            ),
+        ),
+        (
+            "subscription",
+            include_str!(
+                "../../tests/query_plan/supergraphs/basic_subscription_query_plan.graphql"
+            ),
+        ),
+        (
+            "from-context",
+            include_str!(
+                "../../tests/query_plan/supergraphs/set_context_test_with_type_conditions_for_union.graphql"
+            ),
+        ),
+        (
+            "progressive-override",
+            include_str!(
+                "../../tests/query_plan/supergraphs/it_handles_progressive_override_on_entity_fields.graphql"
+            ),
+        ),
+    ];
+
+    fn build_path_query_graph(fixture: usize) -> Arc<QueryGraph> {
+        let (_, sdl) = PATH_GRAPH_FIXTURES[fixture % PATH_GRAPH_FIXTURES.len()];
+        let supergraph = Supergraph::new_with_router_specs(sdl).unwrap();
+        let api_schema = supergraph.to_api_schema(Default::default()).unwrap();
+        Arc::new(
+            build_federated_query_graph(supergraph.schema, api_schema, None, Some(true)).unwrap(),
+        )
+    }
+
+    fn path_test_error(message: impl Into<String>) -> TestCaseError {
+        TestCaseError::fail(message.into())
+    }
+
+    struct AlwaysSatisfiedConditionResolver;
+
+    impl ConditionResolver for AlwaysSatisfiedConditionResolver {
+        fn resolve(
+            &mut self,
+            _edge: EdgeIndex,
+            _context: &OpGraphPathContext,
+            _excluded_destinations: &ExcludedDestinations,
+            _excluded_conditions: &ExcludedConditions,
+            _extra_conditions: Option<&SelectionSet>,
+        ) -> Result<ConditionResolution, FederationError> {
+            Ok(ConditionResolution::Satisfied {
+                cost: 1.0,
+                path_tree: None,
+                context_map: None,
+            })
+        }
+    }
+
+    struct DirectLeafConditionResolver {
+        graph: Arc<QueryGraph>,
+    }
+
+    impl DirectLeafConditionResolver {
+        fn is_collectable_at(&self, node: NodeIndex, conditions: &SelectionSet) -> bool {
+            conditions.selections.values().all(|selection| {
+                let Selection::Field(required_field) = selection else {
+                    return false;
+                };
+                if required_field.selection_set.is_some() {
+                    return false;
+                }
+                self.graph.out_edges(node).into_iter().any(|edge| {
+                    edge.weight().conditions.is_none()
+                        && edge.weight().required_contexts.is_empty()
+                        // This resolver is used with an empty override map. Neither guarded
+                        // alternative is enabled without an explicit matching label/value.
+                        && edge.weight().override_condition.is_none()
+                        && matches!(
+                            &edge.weight().transition,
+                            QueryGraphEdgeTransition::FieldCollection {
+                                field_definition_position,
+                                ..
+                            } if field_definition_position.field_name()
+                                == required_field.field.name()
+                        )
+                })
+            })
+        }
+    }
+
+    impl ConditionResolver for DirectLeafConditionResolver {
+        fn resolve(
+            &mut self,
+            edge: EdgeIndex,
+            _context: &OpGraphPathContext,
+            _excluded_destinations: &ExcludedDestinations,
+            _excluded_conditions: &ExcludedConditions,
+            extra_conditions: Option<&SelectionSet>,
+        ) -> Result<ConditionResolution, FederationError> {
+            let (head, _) = self.graph.edge_endpoints(edge)?;
+            let edge_conditions_collectable = self
+                .graph
+                .edge_weight(edge)?
+                .conditions
+                .as_ref()
+                .is_none_or(|conditions| self.is_collectable_at(head, conditions));
+            let extra_conditions_collectable =
+                extra_conditions.is_none_or(|conditions| self.is_collectable_at(head, conditions));
+            Ok(
+                if edge_conditions_collectable && extra_conditions_collectable {
+                    ConditionResolution::Satisfied {
+                        cost: 1.0,
+                        path_tree: None,
+                        context_map: None,
+                    }
+                } else {
+                    ConditionResolution::Unsatisfied { reason: None }
+                },
+            )
+        }
+    }
+
+    /// A normal leaf-condition resolver with a generated set of otherwise-valid edges forced to
+    /// `Unsatisfied`. This lets the optimized search's rejection behavior be compared with an
+    /// independent BFS instead of only exercising the all-satisfied path.
+    struct SelectiveLeafConditionResolver {
+        graph: Arc<QueryGraph>,
+        unsatisfied_edges: IndexSet<EdgeIndex>,
+    }
+
+    impl ConditionResolver for SelectiveLeafConditionResolver {
+        fn resolve(
+            &mut self,
+            edge: EdgeIndex,
+            context: &OpGraphPathContext,
+            excluded_destinations: &ExcludedDestinations,
+            excluded_conditions: &ExcludedConditions,
+            extra_conditions: Option<&SelectionSet>,
+        ) -> Result<ConditionResolution, FederationError> {
+            if self.unsatisfied_edges.contains(&edge) {
+                return Ok(ConditionResolution::Unsatisfied { reason: None });
+            }
+            DirectLeafConditionResolver {
+                graph: self.graph.clone(),
+            }
+            .resolve(
+                edge,
+                context,
+                excluded_destinations,
+                excluded_conditions,
+                extra_conditions,
+            )
+        }
+    }
+
+    /// Plain BFS over the *filtered* adjacency relation. In particular, removing a shortcut can
+    /// increase distances, so a depth limit established on the unfiltered graph is not valid here.
+    fn reference_distances<N: Copy + Eq + Hash>(
+        start: N,
+        neighbors: impl Fn(N) -> Vec<N>,
+    ) -> IndexMap<N, usize> {
+        let mut distances = IndexMap::from_iter([(start, 0)]);
+        let mut pending = VecDeque::from([start]);
+        while let Some(node) = pending.pop_front() {
+            let next_distance = distances[&node] + 1;
+            for next in neighbors(node) {
+                if !distances.contains_key(&next) {
+                    distances.insert(next, next_distance);
+                    pending.push_back(next);
+                }
+            }
+        }
+        distances
+    }
+
+    fn locally_satisfiable_key(graph: &Arc<QueryGraph>, edge: EdgeIndex) -> bool {
+        let weight = &graph.graph[edge];
+        let (head, tail) = graph.graph.edge_endpoints(edge).unwrap();
+        matches!(weight.transition, QueryGraphEdgeTransition::KeyResolution)
+            && weight.required_contexts.is_empty()
+            && weight.override_condition.is_none()
+            && weight.conditions.as_ref().is_none_or(|conditions| {
+                DirectLeafConditionResolver {
+                    graph: graph.clone(),
+                }
+                .is_collectable_at(head, conditions)
+            })
+            && matches!(
+                (&graph.graph[head].type_, &graph.graph[tail].type_),
+                (
+                    QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Object(a)),
+                    QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Object(b)),
+                ) if a.type_name == b.type_name
+            )
+            && graph.graph[head].source != graph.graph[tail].source
+    }
+
+    fn filtered_key_distances(
+        graph: &Arc<QueryGraph>,
+        start: NodeIndex,
+        unsatisfied: &IndexSet<EdgeIndex>,
+        disabled: &IndexSet<Arc<str>>,
+    ) -> IndexMap<NodeIndex, usize> {
+        reference_distances(start, |node| {
+            graph
+                .graph
+                .edges(node)
+                .filter(|edge| locally_satisfiable_key(graph, edge.id()))
+                .filter(|edge| !unsatisfied.contains(&edge.id()))
+                .map(|edge| edge.target())
+                .filter(|tail| graph.graph[*tail].source != graph.graph[start].source)
+                .filter(|tail| !disabled.contains(&graph.graph[*tail].source))
+                .collect()
+        })
+    }
+
+    #[derive(Clone, Debug)]
+    struct KeySearchCase {
+        fixture: usize,
+        start: NodeIndex,
+        unsatisfied_edges: Vec<EdgeIndex>,
+        disabled_subgraphs: Vec<Arc<str>>,
+    }
+
+    fn bounded_key_search_strategy() -> impl Strategy<Value = KeySearchCase> {
+        // Enumerate the finite start palette once per runner. Subset strategies shrink actual
+        // eligible edges and destinations; large random masks with irrelevant bits are avoided.
+        let mut corpora = Vec::new();
+        for fixture in 0..PATH_GRAPH_FIXTURES.len() {
+            let graph = build_path_query_graph(fixture);
+            for start in graph.graph.node_indices() {
+                if !matches!(
+                    graph.graph[start].type_,
+                    QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Object(_))
+                ) {
+                    continue;
+                }
+                let distances = filtered_key_distances(
+                    &graph,
+                    start,
+                    &IndexSet::default(),
+                    &IndexSet::default(),
+                );
+                if !distances.values().any(|depth| *depth == 2)
+                    || distances.values().any(|depth| *depth > 2)
+                {
+                    continue;
+                }
+                let conditional_edges: Vec<_> = graph
+                    .graph
+                    .edge_references()
+                    .filter(|edge| {
+                        distances.contains_key(&edge.source())
+                            && graph.graph[edge.target()].source != graph.graph[start].source
+                            && locally_satisfiable_key(&graph, edge.id())
+                            && edge.weight().conditions.is_some()
+                    })
+                    .map(|edge| edge.id())
+                    .collect();
+                let destinations: Vec<_> = distances
+                    .keys()
+                    .filter(|node| **node != start)
+                    .map(|node| graph.graph[*node].source.clone())
+                    .collect::<IndexSet<_>>()
+                    .into_iter()
+                    .collect();
+                corpora.push((fixture, start, conditional_edges, destinations));
+            }
+        }
+        assert!(
+            !corpora.is_empty(),
+            "fixture palette has no closed two-hop key corpus"
+        );
+        prop::sample::select(corpora).prop_flat_map(|(fixture, start, edges, destinations)| {
+            let edge_count = edges.len();
+            let destination_count = destinations.len();
+            (
+                prop::sample::subsequence(edges, 0..=edge_count),
+                prop::sample::subsequence(destinations, 0..=destination_count),
+            )
+                .prop_map(move |(unsatisfied_edges, disabled_subgraphs)| {
+                    KeySearchCase {
+                        fixture,
+                        start,
+                        unsatisfied_edges,
+                        disabled_subgraphs,
+                    }
+                })
+        })
+    }
+
+    #[test]
+    fn reference_bfs_recomputes_distance_after_a_shortcut_is_removed() {
+        // S -> A -> B -> C plus S -> B: removing the shortcut leaves C reachable at depth 3.
+        let edges = [(0, 1), (1, 2), (2, 3), (0, 2)];
+        let distances = |remove_shortcut| {
+            reference_distances(0, |node| {
+                edges
+                    .iter()
+                    .filter(|&&(from, to)| {
+                        from == node && !(remove_shortcut && (from, to) == (0, 2))
+                    })
+                    .map(|&(_, to)| to)
+                    .collect()
+            })
+        };
+        assert_eq!(distances(false)[&3], 2);
+        assert_eq!(distances(true)[&3], 3);
+    }
+
+    #[test]
+    fn reference_bfs_filters_intermediates_not_just_final_destinations() {
+        // A disabled intermediate cannot be used to reach an otherwise enabled destination.
+        let edges = [(0, 1), (1, 2), (0, 3), (3, 1)];
+        let distances = reference_distances(0, |node| {
+            edges
+                .iter()
+                .filter(|&&(from, to)| from == node && to != 1)
+                .map(|&(_, to)| to)
+                .collect()
+        });
+        assert_eq!(distances, IndexMap::from_iter([(0, 0), (3, 1)]));
+    }
+
+    #[test]
+    fn direct_field_baseline_requires_an_enabled_override() {
+        let graph = build_path_query_graph(5);
+        let guarded: Vec<_> = graph
+            .graph
+            .edge_references()
+            .filter(|edge| {
+                edge.weight().override_condition.is_some()
+                    && edge.weight().conditions.is_none()
+                    && edge.weight().required_contexts.is_empty()
+                    && matches!(
+                        edge.weight().transition,
+                        QueryGraphEdgeTransition::FieldCollection { .. }
+                    )
+            })
+            .collect();
+        assert!(
+            !guarded.is_empty(),
+            "fixture must exercise guarded field edges"
+        );
+        for edge in guarded {
+            let guard = edge.weight().override_condition.as_ref().unwrap();
+            let OpGraphPathTrigger::OpPathElement(OpPathElement::Field(field)) =
+                operation_trigger_for_edge(&graph, edge.id()).unwrap()
+            else {
+                panic!("expected a field trigger")
+            };
+            let mut overrides = OverrideConditions::default();
+            assert_ne!(
+                graph.edge_for_field(edge.source(), &field, &overrides),
+                Some(edge.id())
+            );
+            overrides.insert(guard.label.clone(), !guard.condition);
+            assert_ne!(
+                graph.edge_for_field(edge.source(), &field, &overrides),
+                Some(edge.id())
+            );
+            overrides.insert(guard.label.clone(), guard.condition);
+            assert_eq!(
+                graph.edge_for_field(edge.source(), &field, &overrides),
+                Some(edge.id())
+            );
+        }
+    }
+
+    fn generated_shortest_edge_path(
+        graph: &QueryGraph,
+        start: NodeIndex,
+        target: NodeIndex,
+        order_seed: u16,
+    ) -> Vec<EdgeIndex> {
+        let mut queue = VecDeque::from([start]);
+        let mut predecessor = IndexMap::<NodeIndex, (NodeIndex, EdgeIndex)>::default();
+        let mut visited = IndexSet::from_iter([start]);
+        while let Some(node) = queue.pop_front() {
+            if node == target {
+                break;
+            }
+            let mut edges = graph.out_edges(node);
+            edges.retain(|edge| {
+                !matches!(
+                    &edge.weight().transition,
+                    QueryGraphEdgeTransition::FieldCollection {
+                        field_definition_position,
+                        ..
+                    } if field_definition_position.field_name().as_str().starts_with('_')
+                )
+            });
+            edges.sort_by_key(|edge| edge.id().index());
+            if !edges.is_empty() {
+                let edge_count = edges.len();
+                edges.rotate_left(order_seed as usize % edge_count);
+            }
+            for edge in edges {
+                if visited.insert(edge.target()) {
+                    predecessor.insert(edge.target(), (node, edge.id()));
+                    queue.push_back(edge.target());
+                }
+            }
+        }
+        assert!(
+            visited.contains(&target),
+            "no route to generated context edge"
+        );
+        let mut reversed = Vec::new();
+        let mut cursor = target;
+        while cursor != start {
+            let (previous, edge) = predecessor[&cursor];
+            reversed.push(edge);
+            cursor = previous;
+        }
+        reversed.reverse();
+        reversed
+    }
+
+    fn slow_initial_runtime_types(
+        graph: &QueryGraph,
+        head: NodeIndex,
+    ) -> Result<IndexSet<ObjectTypeDefinitionPosition>, TestCaseError> {
+        let node = &graph.graph[head];
+        let QueryGraphNodeType::SchemaType(position) = &node.type_ else {
+            return Ok(IndexSet::default());
+        };
+        let composite: CompositeTypeDefinitionPosition = position
+            .clone()
+            .try_into()
+            .map_err(|error| path_test_error(format!("non-composite path head: {error}")))?;
+        graph.sources[&node.source]
+            .possible_runtime_types(composite)
+            .map_err(|error| path_test_error(format!("head runtime types: {error}")))
+    }
+
+    /// Direct transition interpreter for the path's cached runtime set. This intentionally does
+    /// not call `QueryGraph::advance_possible_runtime_types`.
+    fn slow_advance_runtime_types(
+        graph: &QueryGraph,
+        current: &IndexSet<ObjectTypeDefinitionPosition>,
+        edge_id: EdgeIndex,
+    ) -> Result<IndexSet<ObjectTypeDefinitionPosition>, TestCaseError> {
+        let edge = &graph.graph[edge_id];
+        let (_, tail_id) = graph.graph.edge_endpoints(edge_id).unwrap();
+        let tail = &graph.graph[tail_id];
+        let QueryGraphNodeType::SchemaType(tail_position) = &tail.type_ else {
+            return Err(path_test_error(format!(
+                "edge {edge_id:?} unexpectedly ends at a federated root"
+            )));
+        };
+        match &edge.transition {
+            QueryGraphEdgeTransition::FieldCollection {
+                source,
+                field_definition_position,
+                ..
+            } => {
+                if CompositeTypeDefinitionPosition::try_from(tail_position.clone()).is_err() {
+                    return Ok(IndexSet::default());
+                }
+                let schema = &graph.sources[source];
+                let mut result = IndexSet::default();
+                for runtime_type in current {
+                    let field_position =
+                        runtime_type.field(field_definition_position.field_name().clone());
+                    let Some(field) = field_position.try_get(schema.schema()) else {
+                        continue;
+                    };
+                    let Ok(output_type) =
+                        schema
+                            .get_type(field.ty.inner_named_type())
+                            .and_then(|position| {
+                                CompositeTypeDefinitionPosition::try_from(position)
+                                    .map_err(FederationError::from)
+                            })
+                    else {
+                        continue;
+                    };
+                    result.extend(
+                        schema
+                            .possible_runtime_types(output_type)
+                            .map_err(|error| {
+                                path_test_error(format!(
+                                    "edge {edge_id:?} field runtime types: {error}"
+                                ))
+                            })?,
+                    );
+                }
+                Ok(result)
+            }
+            QueryGraphEdgeTransition::Downcast {
+                source,
+                to_type_position,
+                ..
+            } => {
+                let allowed = graph.sources[source]
+                    .possible_runtime_types(to_type_position.clone())
+                    .map_err(|error| {
+                        path_test_error(format!("edge {edge_id:?} downcast types: {error}"))
+                    })?;
+                Ok(current
+                    .iter()
+                    .filter(|runtime| allowed.contains(*runtime))
+                    .cloned()
+                    .collect())
+            }
+            QueryGraphEdgeTransition::KeyResolution => {
+                let tail_type: CompositeTypeDefinitionPosition =
+                    tail_position
+                        .clone()
+                        .try_into()
+                        .map_err(|error| path_test_error(format!("key tail: {error}")))?;
+                graph.sources[&tail.source]
+                    .possible_runtime_types(tail_type)
+                    .map_err(|error| path_test_error(format!("key runtime types: {error}")))
+            }
+            QueryGraphEdgeTransition::RootTypeResolution { .. }
+            | QueryGraphEdgeTransition::SubgraphEnteringTransition => {
+                let OutputTypeDefinitionPosition::Object(root) = tail_position else {
+                    return Err(path_test_error(format!(
+                        "root transition {edge_id:?} ends at non-object {tail_position}"
+                    )));
+                };
+                Ok(IndexSet::from_iter([root.clone()]))
+            }
+            QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { .. } => Ok(current.clone()),
+        }
+    }
+
+    fn direct_non_trivial_followups(graph: &QueryGraph, edge_id: EdgeIndex) -> Vec<EdgeIndex> {
+        let previous = &graph.graph[edge_id];
+        let (_, tail) = graph.graph.edge_endpoints(edge_id).unwrap();
+        graph
+            .out_edges(tail)
+            .into_iter()
+            .filter(|followup| match &previous.transition {
+                QueryGraphEdgeTransition::KeyResolution => {
+                    !(matches!(
+                        followup.weight().transition,
+                        QueryGraphEdgeTransition::KeyResolution
+                    ) && previous.conditions == followup.weight().conditions)
+                }
+                QueryGraphEdgeTransition::RootTypeResolution { .. }
+                | QueryGraphEdgeTransition::SubgraphEnteringTransition => !matches!(
+                    followup.weight().transition,
+                    QueryGraphEdgeTransition::RootTypeResolution { .. }
+                ),
+                _ => true,
+            })
+            .map(|edge| edge.id())
+            .collect()
+    }
+
+    /// A small interpreter for the state cached by `GraphPath::add`. It records the inputs to
+    /// every command, so the assertions do not have to guess where an old `@defer` or condition
+    /// cost came from by inspecting the final production path.
+    #[derive(Clone, Debug)]
+    struct TransitionPathModel {
+        head: NodeIndex,
+        tail: NodeIndex,
+        edges: Vec<EdgeIndex>,
+        runtime_types: IndexSet<ObjectTypeDefinitionPosition>,
+        runtime_types_before_last_cast: Option<IndexSet<ObjectTypeDefinitionPosition>>,
+        last_subgraph_entering_edge: Option<(usize, QueryPlanCost)>,
+        defer_on_tail: Option<DeferDirectiveArguments>,
+    }
+
+    impl TransitionPathModel {
+        fn new(graph: &QueryGraph, head: NodeIndex) -> Result<Self, TestCaseError> {
+            Ok(Self {
+                head,
+                tail: head,
+                edges: Vec::new(),
+                runtime_types: slow_initial_runtime_types(graph, head)?,
+                runtime_types_before_last_cast: None,
+                last_subgraph_entering_edge: None,
+                defer_on_tail: None,
+            })
+        }
+
+        fn add(
+            &mut self,
+            graph: &QueryGraph,
+            edge_id: EdgeIndex,
+            condition_cost: QueryPlanCost,
+            defer: Option<DeferDirectiveArguments>,
+        ) -> Result<(), TestCaseError> {
+            let (edge_head, edge_tail) = graph.graph.edge_endpoints(edge_id).unwrap();
+            prop_assert_eq!(
+                edge_head,
+                self.tail,
+                "model command is not a path continuation"
+            );
+            let transition = &graph.graph[edge_id].transition;
+            let replacing_fake_downcast =
+                matches!(transition, QueryGraphEdgeTransition::KeyResolution)
+                    && self.edges.last().is_some_and(|last| {
+                        matches!(
+                            graph.graph[*last].transition,
+                            QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { .. }
+                        )
+                    })
+                    && matches!(
+                        graph.graph[edge_tail].type_,
+                        QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Interface(_))
+                    );
+
+            let prior_runtime_types = self.runtime_types.clone();
+            self.runtime_types = slow_advance_runtime_types(graph, &self.runtime_types, edge_id)?;
+            self.tail = edge_tail;
+
+            if replacing_fake_downcast {
+                // The fake cast is a self-edge and a runtime-type identity operation. Production
+                // normalizes `[fake cast, key]` to `[key]`, while advancing from the same state.
+                self.edges.pop();
+                self.edges.push(edge_id);
+                self.runtime_types_before_last_cast = None;
+                self.defer_on_tail = defer.clone();
+                if defer.is_some() {
+                    self.last_subgraph_entering_edge = None;
+                } else if graph.graph[edge_head].source != graph.graph[edge_tail].source {
+                    self.last_subgraph_entering_edge = Some((self.edges.len() - 1, condition_cost));
+                }
+                return Ok(());
+            }
+
+            let index = self.edges.len();
+            self.edges.push(edge_id);
+            self.runtime_types_before_last_cast =
+                matches!(transition, QueryGraphEdgeTransition::Downcast { .. })
+                    .then_some(prior_runtime_types);
+            self.defer_on_tail = if defer.is_some() {
+                defer.clone()
+            } else if matches!(transition, QueryGraphEdgeTransition::Downcast { .. }) {
+                self.defer_on_tail.clone()
+            } else {
+                None
+            };
+            if defer.is_some() {
+                self.last_subgraph_entering_edge = None;
+            } else if graph.graph[edge_head].source != graph.graph[edge_tail].source {
+                self.last_subgraph_entering_edge = Some((index, condition_cost));
+            }
+            Ok(())
+        }
+    }
+
+    fn audit_transition_path(
+        path: &TransitionGraphPath,
+        model: &TransitionPathModel,
+    ) -> Result<(), TestCaseError> {
+        let graph = &path.graph;
+        prop_assert_eq!(path.head, model.head);
+        prop_assert_eq!(path.tail, model.tail);
+        prop_assert_eq!(&path.edges, &model.edges);
+        prop_assert_eq!(path.edges.len(), path.edge_triggers.len());
+        prop_assert_eq!(path.edges.len(), path.edge_conditions.len());
+        prop_assert_eq!(path.edges.len(), path.matching_context_ids.len());
+        prop_assert_eq!(path.edges.len(), path.arguments_to_context_usages.len());
+        prop_assert!(path.edge_conditions.iter().all(Option::is_none));
+        prop_assert!(path.matching_context_ids.iter().all(Option::is_none));
+        prop_assert!(path.arguments_to_context_usages.iter().all(Option::is_none));
+
+        // Independently fold the retained edge sequence as a second check on the state-machine
+        // model. The only normalization above removes a runtime-type-identity self-edge.
+        let mut tail = model.head;
+        let mut runtime_types = slow_initial_runtime_types(graph, path.head)?;
+        let mut before_last_cast = None;
+
+        for (index, edge_id) in path.edges.iter().copied().enumerate() {
+            let (edge_head, edge_tail) = graph.graph.edge_endpoints(edge_id).unwrap();
+            prop_assert_eq!(edge_head, tail, "edge {} does not continue the path", index);
+            prop_assert_eq!(
+                path.edge_triggers[index].as_ref(),
+                &graph.graph[edge_id].transition,
+                "trigger {} does not describe its edge",
+                index
+            );
+
+            let runtime_before = runtime_types.clone();
+            runtime_types = slow_advance_runtime_types(graph, &runtime_types, edge_id)?;
+            before_last_cast = matches!(
+                graph.graph[edge_id].transition,
+                QueryGraphEdgeTransition::Downcast { .. }
+            )
+            .then_some(runtime_before);
+            tail = edge_tail;
+        }
+
+        prop_assert_eq!(model.tail, tail);
+        prop_assert_eq!(&model.runtime_types, &runtime_types);
+        prop_assert_eq!(
+            model.runtime_types_before_last_cast.as_ref(),
+            before_last_cast.as_ref()
+        );
+        prop_assert_eq!(&*path.runtime_types_of_tail, &runtime_types);
+        prop_assert_eq!(
+            path.runtime_types_before_tail_if_last_is_cast.as_deref(),
+            model.runtime_types_before_last_cast.as_ref()
+        );
+        prop_assert_eq!(&path.defer_on_tail, &model.defer_on_tail);
+        prop_assert_eq!(
+            path.last_subgraph_entering_edge_info
+                .as_ref()
+                .map(|info| (info.index, info.conditions_cost)),
+            model.last_subgraph_entering_edge
+        );
+
+        let expected_next = if path.defer_on_tail.is_some() {
+            graph
+                .out_edges_with_federation_self_edges(path.tail)
+                .into_iter()
+                .map(|edge| edge.id())
+                .collect::<Vec<_>>()
+        } else if let Some(edge) = path.edges.last() {
+            direct_non_trivial_followups(graph, *edge)
+        } else {
+            graph
+                .out_edges(path.tail)
+                .into_iter()
+                .map(|edge| edge.id())
+                .collect::<Vec<_>>()
+        };
+        let actual_next = path
+            .next_edges()
+            .map_err(|error| path_test_error(format!("next_edges failed: {error}")))?
+            .collect::<Vec<_>>();
+        prop_assert_eq!(actual_next, expected_next);
+        Ok(())
+    }
+
+    fn operation_trigger_for_edge(
+        graph: &QueryGraph,
+        edge_id: EdgeIndex,
+    ) -> Result<OpGraphPathTrigger, TestCaseError> {
+        Ok(match &graph.graph[edge_id].transition {
+            QueryGraphEdgeTransition::FieldCollection {
+                source,
+                field_definition_position,
+                ..
+            } => Field::from_position(&graph.sources[source], field_definition_position.clone())
+                .into(),
+            QueryGraphEdgeTransition::Downcast {
+                source,
+                from_type_position,
+                to_type_position,
+                ..
+            } => InlineFragment {
+                schema: graph.sources[source].clone(),
+                parent_type_position: from_type_position.clone(),
+                type_condition_position: Some(to_type_position.clone()),
+                directives: Default::default(),
+                selection_id: SelectionId::new(),
+            }
+            .into(),
+            QueryGraphEdgeTransition::InterfaceObjectFakeDownCast {
+                from_type_position,
+                to_type_name,
+                ..
+            } => {
+                let supergraph_schema = graph
+                    .supergraph_schema()
+                    .map_err(|error| path_test_error(format!("supergraph schema: {error}")))?;
+                InlineFragment {
+                    schema: supergraph_schema.clone(),
+                    parent_type_position: supergraph_schema
+                        .get_type(from_type_position.type_name())
+                        .and_then(|position| {
+                            CompositeTypeDefinitionPosition::try_from(position)
+                                .map_err(FederationError::from)
+                        })
+                        .map_err(|error| {
+                            path_test_error(format!("fake downcast parent: {error}"))
+                        })?,
+                    type_condition_position: Some(
+                        supergraph_schema
+                            .get_type(to_type_name)
+                            .and_then(|position| {
+                                CompositeTypeDefinitionPosition::try_from(position)
+                                    .map_err(FederationError::from)
+                            })
+                            .map_err(|error| {
+                                path_test_error(format!("fake downcast target: {error}"))
+                            })?,
+                    ),
+                    directives: Default::default(),
+                    selection_id: SelectionId::new(),
+                }
+                .into()
+            }
+            QueryGraphEdgeTransition::KeyResolution
+            | QueryGraphEdgeTransition::RootTypeResolution { .. }
+            | QueryGraphEdgeTransition::SubgraphEnteringTransition => {
+                OpGraphPathContext::default().into()
+            }
+        })
+    }
+
+    fn directive_only_trigger(path: &OpGraphPath) -> Option<OpGraphPathTrigger> {
+        let QueryGraphNodeType::SchemaType(position) = &path.graph.graph[path.tail].type_ else {
+            return None;
+        };
+        let supergraph_schema = path.graph.supergraph_schema().ok()?;
+        let parent_type_position = supergraph_schema
+            .get_type(position.type_name())
+            .ok()?
+            .try_into()
+            .ok()?;
+        Some(
+            InlineFragment {
+                schema: supergraph_schema,
+                parent_type_position,
+                type_condition_position: None,
+                directives: DirectiveList::one(executable::Directive {
+                    name: name!("include"),
+                    arguments: vec![(name!("if"), false).into()],
+                }),
+                selection_id: SelectionId::new(),
+            }
+            .into(),
+        )
+    }
+
+    fn type_explosion_key_patterns(
+        graph: &QueryGraph,
+    ) -> Vec<(NodeIndex, EdgeIndex, EdgeIndex, EdgeIndex)> {
+        let mut patterns = Vec::new();
+        for head in graph.graph.node_indices() {
+            for direct_key in graph.out_edges_with_federation_self_edges(head) {
+                if !matches!(
+                    direct_key.weight().transition,
+                    QueryGraphEdgeTransition::KeyResolution
+                ) {
+                    continue;
+                }
+                for downcast in graph.out_edges_with_federation_self_edges(head) {
+                    if !matches!(
+                        downcast.weight().transition,
+                        QueryGraphEdgeTransition::Downcast {
+                            from_type_position: CompositeTypeDefinitionPosition::Interface(_),
+                            ..
+                        }
+                    ) {
+                        continue;
+                    }
+                    for exploded_key in
+                        graph.out_edges_with_federation_self_edges(downcast.target())
+                    {
+                        if matches!(
+                            exploded_key.weight().transition,
+                            QueryGraphEdgeTransition::KeyResolution
+                        ) && exploded_key.target() == direct_key.target()
+                            && exploded_key.weight().conditions == direct_key.weight().conditions
+                        {
+                            patterns.push((
+                                head,
+                                direct_key.id(),
+                                downcast.id(),
+                                exploded_key.id(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        patterns
+    }
+
+    fn type_explosion_fixture_patterns() -> &'static Vec<(
+        Arc<QueryGraph>,
+        Vec<(NodeIndex, EdgeIndex, EdgeIndex, EdgeIndex)>,
+    )> {
+        static CORPUS: LazyLock<
+            Vec<(
+                Arc<QueryGraph>,
+                Vec<(NodeIndex, EdgeIndex, EdgeIndex, EdgeIndex)>,
+            )>,
+        > = LazyLock::new(|| {
+            (0..PATH_GRAPH_FIXTURES.len())
+                .filter_map(|fixture| {
+                    let graph = build_path_query_graph(fixture);
+                    let patterns = type_explosion_key_patterns(&graph);
+                    (!patterns.is_empty()).then_some((graph, patterns))
+                })
+                .collect()
+        });
+        &CORPUS
+    }
+
+    /// Shadow state for operation-driven paths. Unlike `TransitionPathModel`, this includes the
+    /// normalization of adjacent operation type conditions and directive-only `None` steps.
+    #[derive(Clone, Debug)]
+    struct OpPathModel {
+        head: NodeIndex,
+        tail: NodeIndex,
+        edges: Vec<Option<EdgeIndex>>,
+        triggers: Vec<OpGraphPathTrigger>,
+        runtime_types: IndexSet<ObjectTypeDefinitionPosition>,
+        runtime_types_before_last_cast: Option<IndexSet<ObjectTypeDefinitionPosition>>,
+        last_subgraph_entering_edge: Option<(usize, QueryPlanCost)>,
+    }
+
+    impl OpPathModel {
+        fn new(graph: &QueryGraph, head: NodeIndex) -> Result<Self, TestCaseError> {
+            Ok(Self {
+                head,
+                tail: head,
+                edges: Vec::new(),
+                triggers: Vec::new(),
+                runtime_types: slow_initial_runtime_types(graph, head)?,
+                runtime_types_before_last_cast: None,
+                last_subgraph_entering_edge: None,
+            })
+        }
+
+        fn add_none(&mut self, trigger: OpGraphPathTrigger) {
+            self.edges.push(None);
+            self.triggers.push(trigger);
+            self.runtime_types_before_last_cast = None;
+        }
+
+        fn add_edge(
+            &mut self,
+            graph: &QueryGraph,
+            edge_id: EdgeIndex,
+            trigger: OpGraphPathTrigger,
+            condition_cost: QueryPlanCost,
+        ) -> Result<(), TestCaseError> {
+            let (edge_head, edge_tail) = graph.graph.edge_endpoints(edge_id).unwrap();
+            prop_assert_eq!(edge_head, self.tail, "generated edge is not a continuation");
+            let transition = &graph.graph[edge_id].transition;
+
+            // Specification-level adjacent-cast law: A -> B -> C can become A -> C when C's
+            // possible runtime objects are a non-empty subset of B's and the direct cast exists.
+            if matches!(transition, QueryGraphEdgeTransition::Downcast { .. })
+                && self.edges.last().copied().flatten().is_some()
+                && matches!(
+                    self.triggers.last(),
+                    Some(OpGraphPathTrigger::OpPathElement(
+                        OpPathElement::InlineFragment(fragment)
+                    )) if fragment.directives.is_empty()
+                )
+                && let Some(runtime_types_before_last_cast) = &self.runtime_types_before_last_cast
+            {
+                let collapsed_runtime_types =
+                    slow_advance_runtime_types(graph, runtime_types_before_last_cast, edge_id)?;
+                if !collapsed_runtime_types.is_empty()
+                    && collapsed_runtime_types.is_subset(&self.runtime_types)
+                {
+                    let last_edge = self.edges.last().copied().flatten().unwrap();
+                    let (last_edge_head, _) = graph.graph.edge_endpoints(last_edge).unwrap();
+                    let direct_edge = graph.out_edges(last_edge_head).into_iter().find(|edge| {
+                        matches!(
+                            edge.weight().transition,
+                            QueryGraphEdgeTransition::Downcast { .. }
+                        ) && graph.graph[edge.target()].type_ == graph.graph[edge_tail].type_
+                    });
+                    if let Some(direct_edge) = direct_edge {
+                        self.edges.pop();
+                        self.triggers.pop();
+                        self.edges.push(Some(direct_edge.id()));
+                        self.triggers.push(trigger);
+                        self.tail = edge_tail;
+                        self.runtime_types = collapsed_runtime_types;
+                        return Ok(());
+                    }
+                }
+            }
+
+            let replacing_fake_downcast =
+                matches!(transition, QueryGraphEdgeTransition::KeyResolution)
+                    && self.edges.last().copied().flatten().is_some_and(|last| {
+                        matches!(
+                            graph.graph[last].transition,
+                            QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { .. }
+                        )
+                    })
+                    && matches!(
+                        graph.graph[edge_tail].type_,
+                        QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Interface(_))
+                    );
+            let prior_runtime_types = self.runtime_types.clone();
+            self.runtime_types = slow_advance_runtime_types(graph, &self.runtime_types, edge_id)?;
+            self.tail = edge_tail;
+
+            if replacing_fake_downcast {
+                self.edges.pop();
+                self.triggers.pop();
+                self.edges.push(Some(edge_id));
+                self.triggers.push(trigger);
+                self.runtime_types_before_last_cast = None;
+                if graph.graph[edge_head].source != graph.graph[edge_tail].source {
+                    self.last_subgraph_entering_edge = Some((self.edges.len() - 1, condition_cost));
+                }
+                return Ok(());
+            }
+
+            let index = self.edges.len();
+            self.edges.push(Some(edge_id));
+            self.triggers.push(trigger);
+            self.runtime_types_before_last_cast =
+                matches!(transition, QueryGraphEdgeTransition::Downcast { .. })
+                    .then_some(prior_runtime_types);
+            if graph.graph[edge_head].source != graph.graph[edge_tail].source {
+                self.last_subgraph_entering_edge = Some((index, condition_cost));
+            }
+            Ok(())
+        }
+    }
+
+    fn audit_operation_path(path: &OpGraphPath, model: &OpPathModel) -> Result<(), TestCaseError> {
+        let graph = &path.graph;
+        prop_assert_eq!(path.head, model.head);
+        prop_assert_eq!(path.tail, model.tail);
+        prop_assert_eq!(&path.edges, &model.edges);
+        prop_assert_eq!(path.edges.len(), path.edge_triggers.len());
+        prop_assert_eq!(path.edges.len(), path.edge_conditions.len());
+        prop_assert_eq!(path.edges.len(), path.matching_context_ids.len());
+        prop_assert_eq!(path.edges.len(), path.arguments_to_context_usages.len());
+        prop_assert!(path.edge_conditions.iter().all(Option::is_none));
+        prop_assert!(path.matching_context_ids.iter().all(Option::is_none));
+        prop_assert!(path.arguments_to_context_usages.iter().all(Option::is_none));
+        prop_assert_eq!(
+            path.edge_triggers
+                .iter()
+                .map(|trigger| trigger.as_ref())
+                .collect::<Vec<_>>(),
+            model.triggers.iter().collect::<Vec<_>>()
+        );
+
+        let mut tail = model.head;
+        let mut runtime_types = slow_initial_runtime_types(graph, model.head)?;
+        let mut before_last_cast = None;
+        let mut last_entering = None;
+        let mut jump_count = 0;
+        for (index, (edge, trigger)) in path.edges.iter().zip(&path.edge_triggers).enumerate() {
+            let Some(edge_id) = edge else {
+                let OpGraphPathTrigger::OpPathElement(OpPathElement::InlineFragment(fragment)) =
+                    trigger.as_ref()
+                else {
+                    return Err(path_test_error(format!(
+                        "None edge {index} did not retain its inline fragment"
+                    )));
+                };
+                prop_assert!(fragment.type_condition_position.is_none());
+                prop_assert!(!fragment.directives.is_empty());
+                before_last_cast = None;
+                continue;
+            };
+
+            let (edge_head, edge_tail) = graph.graph.edge_endpoints(*edge_id).unwrap();
+            prop_assert_eq!(edge_head, tail, "retained edge {} is disconnected", index);
+            match (&graph.graph[*edge_id].transition, trigger.as_ref()) {
+                (
+                    QueryGraphEdgeTransition::FieldCollection {
+                        field_definition_position,
+                        ..
+                    },
+                    OpGraphPathTrigger::OpPathElement(OpPathElement::Field(field)),
+                ) => prop_assert_eq!(&field.field_position, field_definition_position),
+                (
+                    QueryGraphEdgeTransition::Downcast {
+                        to_type_position, ..
+                    },
+                    OpGraphPathTrigger::OpPathElement(OpPathElement::InlineFragment(fragment)),
+                ) => prop_assert_eq!(
+                    fragment
+                        .type_condition_position
+                        .as_ref()
+                        .map(|position| position.type_name()),
+                    Some(to_type_position.type_name())
+                ),
+                (
+                    QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { to_type_name, .. },
+                    OpGraphPathTrigger::OpPathElement(OpPathElement::InlineFragment(fragment)),
+                ) => prop_assert_eq!(
+                    fragment
+                        .type_condition_position
+                        .as_ref()
+                        .map(|position| position.type_name()),
+                    Some(to_type_name)
+                ),
+                (
+                    QueryGraphEdgeTransition::KeyResolution
+                    | QueryGraphEdgeTransition::RootTypeResolution { .. }
+                    | QueryGraphEdgeTransition::SubgraphEnteringTransition,
+                    OpGraphPathTrigger::Context(_),
+                ) => {}
+                (transition, trigger) => {
+                    return Err(path_test_error(format!(
+                        "trigger {trigger:?} does not represent {transition:?} at {index}"
+                    )));
+                }
+            }
+
+            let runtime_before = runtime_types.clone();
+            runtime_types = slow_advance_runtime_types(graph, &runtime_types, *edge_id)?;
+            before_last_cast = matches!(
+                graph.graph[*edge_id].transition,
+                QueryGraphEdgeTransition::Downcast { .. }
+            )
+            .then_some(runtime_before);
+            if graph.graph[edge_head].source != graph.graph[edge_tail].source {
+                jump_count += 1;
+                last_entering = Some((index, edge_id.index() as QueryPlanCost));
+            }
+            tail = edge_tail;
+        }
+
+        prop_assert_eq!(tail, model.tail);
+        prop_assert_eq!(&runtime_types, &model.runtime_types);
+        prop_assert_eq!(
+            before_last_cast.as_ref(),
+            model.runtime_types_before_last_cast.as_ref()
+        );
+        prop_assert_eq!(&*path.runtime_types_of_tail, &runtime_types);
+        prop_assert_eq!(
+            path.runtime_types_before_tail_if_last_is_cast.as_deref(),
+            before_last_cast.as_ref()
+        );
+        prop_assert!(path.defer_on_tail.is_none());
+        prop_assert_eq!(model.last_subgraph_entering_edge, last_entering);
+        prop_assert_eq!(
+            path.last_subgraph_entering_edge_info
+                .as_ref()
+                .map(|info| (info.index, info.conditions_cost)),
+            last_entering
+        );
+        prop_assert_eq!(
+            path.subgraph_jumps()
+                .map_err(|error| path_test_error(format!("subgraph_jumps: {error}")))?,
+            jump_count
+        );
+
+        let expected_next = match path.edges.last().copied().flatten() {
+            Some(edge_id) => direct_non_trivial_followups(graph, edge_id),
+            None => graph
+                .out_edges(path.tail)
+                .into_iter()
+                .map(|edge| edge.id())
+                .collect(),
+        };
+        let actual_next = path
+            .next_edges()
+            .map_err(|error| path_test_error(format!("next_edges failed: {error}")))?
+            .collect::<Vec<_>>();
+        prop_assert_eq!(actual_next, expected_next);
+        Ok(())
+    }
+
+    fn audit_search_result_path(path: &OpGraphPath) -> Result<(), TestCaseError> {
+        let length = path.edges.len();
+        prop_assert_eq!(path.edge_triggers.len(), length);
+        prop_assert_eq!(path.edge_conditions.len(), length);
+        prop_assert_eq!(path.matching_context_ids.len(), length);
+        prop_assert_eq!(path.arguments_to_context_usages.len(), length);
+
+        let mut tail = path.head;
+        let mut runtime_types = slow_initial_runtime_types(&path.graph, path.head)?;
+        for edge in path.edges.iter().flatten() {
+            let (head, next_tail) = path.graph.graph.edge_endpoints(*edge).unwrap();
+            prop_assert_eq!(head, tail, "search returned a disconnected retained edge");
+            runtime_types = slow_advance_runtime_types(&path.graph, &runtime_types, *edge)?;
+            tail = next_tail;
+        }
+        prop_assert_eq!(path.tail, tail);
+        prop_assert_eq!(path.runtime_types_of_tail.as_ref(), &runtime_types);
+        Ok(())
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        /// Select every step from the path's currently valid next-edge set, append it through
+        /// production, then rebuild every cached attribute from the retained edge sequence.
+        #[test]
+        fn transition_graph_path_attributes_match_full_recomputation(
+            fixture in 0usize..PATH_GRAPH_FIXTURES.len(),
+            start_seed in any::<u16>(),
+            commands in prop::collection::vec((any::<u16>(), any::<bool>()), 0..32),
+        ) {
+            let graph = build_path_query_graph(fixture);
+            let starts: Vec<_> = graph
+                .graph
+                .node_indices()
+                .filter(|node| match &graph.graph[*node].type_ {
+                    QueryGraphNodeType::FederatedRootType(_) => true,
+                    QueryGraphNodeType::SchemaType(position) => {
+                        CompositeTypeDefinitionPosition::try_from(position.clone()).is_ok()
+                    }
+                })
+                .collect();
+            let start = starts[start_seed as usize % starts.len()];
+            let mut path = TransitionGraphPath::new(graph.clone(), start).unwrap();
+            let mut model = TransitionPathModel::new(&graph, start)?;
+            audit_transition_path(&path, &model)?;
+
+            for (edge_seed, add_defer) in commands {
+                let candidates = path.next_edges().unwrap().collect::<Vec<_>>();
+                if candidates.is_empty() {
+                    break;
+                }
+                let edge_id = candidates[edge_seed as usize % candidates.len()];
+                let transition = graph.graph[edge_id].transition.clone();
+                let defer = add_defer.then(|| DeferDirectiveArguments {
+                    label: Some("generated".to_string()),
+                    if_: None,
+                });
+                let condition_cost = edge_id.index() as QueryPlanCost;
+                model.add(&graph, edge_id, condition_cost, defer.clone())?;
+                path = path
+                    .add(
+                        transition,
+                        edge_id,
+                        ConditionResolution::Satisfied {
+                            path_tree: None,
+                            cost: condition_cost,
+                            context_map: None,
+                        },
+                        defer,
+                    )
+                    .unwrap();
+                audit_transition_path(&path, &model)?;
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        /// For an unconditioned field edge that is directly collectable from an object node, the
+        /// full operation-advancement search must retain the simple direct result. This drives the
+        /// same direct/indirect option machinery used by planning and compares it with a literal
+        /// one-edge `OpGraphPath::add` construction.
+        #[test]
+        fn operation_element_advancement_contains_direct_field_baseline(
+            fixture in 0usize..PATH_GRAPH_FIXTURES.len(),
+            candidate_seed in any::<usize>(),
+        ) {
+            let graph = build_path_query_graph(fixture);
+            let candidates = graph
+                .graph
+                .edge_references()
+                .filter(|edge| {
+                    let (head, _) = graph.graph.edge_endpoints(edge.id()).unwrap();
+                    matches!(
+                        graph.graph[head].type_,
+                        QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Object(_))
+                    ) && edge.weight().conditions.is_none()
+                        && edge.weight().required_contexts.is_empty()
+                        && edge.weight().override_condition.is_none()
+                        && matches!(
+                            edge.weight().transition,
+                            QueryGraphEdgeTransition::FieldCollection { .. }
+                        )
+                })
+                .map(|edge| edge.id())
+                .collect::<Vec<_>>();
+            prop_assert!(!candidates.is_empty());
+            let edge = candidates[candidate_seed % candidates.len()];
+            let (head, _) = graph.graph.edge_endpoints(edge).unwrap();
+            let trigger = operation_trigger_for_edge(&graph, edge)?;
+            let operation_element = match &trigger {
+                OpGraphPathTrigger::OpPathElement(operation_element) => operation_element.clone(),
+                _ => return Err(path_test_error("field edge did not produce an operation element")),
+            };
+            let path = OpGraphPath::new(graph.clone(), head).unwrap();
+            let expected = path
+                .add(
+                    trigger,
+                    Some(edge),
+                    ConditionResolution::no_conditions(),
+                    None,
+                )
+                .unwrap();
+            let mut search = SimultaneousPathsWithLazyIndirectPaths::new(
+                SimultaneousPaths::from(path),
+                OpGraphPathContext::default(),
+                ExcludedDestinations::default(),
+                ExcludedConditions::default(),
+            );
+            let mut resolver = AlwaysSatisfiedConditionResolver;
+            let options = search
+                .advance_with_operation_element(
+                    graph.supergraph_schema().unwrap(),
+                    &operation_element,
+                    &mut resolver,
+                    &OverrideConditions::default(),
+                    &|| Ok(()),
+                    &IndexSet::default(),
+                )?
+                .ok_or_else(|| path_test_error("direct field unexpectedly had no options"))?;
+            for option in &options {
+                for candidate in &option.paths.0 {
+                    audit_search_result_path(candidate)?;
+                }
+            }
+
+            prop_assert!(options.iter().any(|option| {
+                option.paths.0.iter().any(|candidate| {
+                    candidate.tail == expected.tail
+                        && candidate.edges == expected.edges
+                        && candidate.edge_triggers == expected.edge_triggers
+                })
+            }), "optimized operation advancement omitted the literal direct field path");
+        }
+
+        /// Progressive override creates paired field edges guarded by opposite values of one
+        /// label. Both the direct lookup and the full operation-advancement path must select the
+        /// edge whose guard matches the generated planner input.
+        #[test]
+        fn operation_element_advancement_respects_progressive_override_conditions(
+            candidate_seed in any::<usize>(),
+            condition in any::<bool>(),
+        ) {
+            let graph = build_path_query_graph(5);
+            let candidates = graph
+                .graph
+                .edge_references()
+                .filter(|edge| {
+                    edge.weight().override_condition.as_ref().is_some_and(|override_| {
+                        override_.condition == condition
+                            && matches!(
+                                edge.weight().transition,
+                                QueryGraphEdgeTransition::FieldCollection { .. }
+                            )
+                    })
+                })
+                .map(|edge| edge.id())
+                .collect::<Vec<_>>();
+            prop_assert!(!candidates.is_empty(), "override fixture lost condition={condition}");
+            let expected_edge = candidates[candidate_seed % candidates.len()];
+            let expected_override = graph.graph[expected_edge]
+                .override_condition
+                .as_ref()
+                .unwrap();
+            let (head, _) = graph.graph.edge_endpoints(expected_edge).unwrap();
+            let trigger = operation_trigger_for_edge(&graph, expected_edge)?;
+            let OpGraphPathTrigger::OpPathElement(OpPathElement::Field(field)) = &trigger else {
+                return Err(path_test_error("override edge did not produce a field"));
+            };
+            let mut overrides = OverrideConditions::default();
+            overrides.insert(expected_override.label.clone(), condition);
+
+            let selected = graph
+                .edge_for_field(head, field, &overrides)
+                .ok_or_else(|| path_test_error("matching override field was not collectable"))?;
+            prop_assert_eq!(
+                graph.graph[selected].override_condition.as_ref(),
+                Some(expected_override),
+            );
+
+            let path = OpGraphPath::new(graph.clone(), head).unwrap();
+            let mut search = SimultaneousPathsWithLazyIndirectPaths::new(
+                SimultaneousPaths::from(path),
+                OpGraphPathContext::default(),
+                ExcludedDestinations::default(),
+                ExcludedConditions::default(),
+            );
+            let mut resolver = AlwaysSatisfiedConditionResolver;
+            let options = search
+                .advance_with_operation_element(
+                    graph.supergraph_schema().unwrap(),
+                    &OpPathElement::Field(field.clone()),
+                    &mut resolver,
+                    &overrides,
+                    &|| Ok(()),
+                    &IndexSet::default(),
+                )?
+                .ok_or_else(|| path_test_error("matching override had no advancement option"))?;
+            prop_assert!(
+                options.iter().any(|option| option.paths.0.iter().any(|candidate| {
+                    candidate.edges.last().copied().flatten() == Some(selected)
+                })),
+                "operation advancement omitted selected override edge {:?}",
+                selected,
+            );
+        }
+
+        /// A one-hop non-collecting transition followed by a field edge is the smallest useful
+        /// indirect-search witness. Generate only cases where that field has no direct edge from
+        /// the starting node, then require the optimized search to find a collecting path after a
+        /// real subgraph jump.
+        #[test]
+        fn operation_element_advancement_finds_one_hop_indirect_field(
+            fixture_seed in 0usize..PATH_GRAPH_FIXTURES.len(),
+            candidate_seed in any::<usize>(),
+        ) {
+            let mut selected = None;
+            for offset in 0..PATH_GRAPH_FIXTURES.len() {
+                let fixture = (fixture_seed + offset) % PATH_GRAPH_FIXTURES.len();
+                let graph = build_path_query_graph(fixture);
+                let mut candidates = Vec::new();
+                for transition in graph.graph.edge_references().filter(|edge| {
+                    !edge.weight().transition.collect_operation_elements()
+                        && edge.weight().required_contexts.is_empty()
+                }) {
+                    let (start, indirect_target) =
+                        graph.graph.edge_endpoints(transition.id()).unwrap();
+                    let (
+                        QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Object(start_type)),
+                        QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Object(target_type)),
+                    ) = (&graph.graph[start].type_, &graph.graph[indirect_target].type_)
+                    else {
+                        continue;
+                    };
+                    if start_type.type_name != target_type.type_name
+                        || graph.graph[start].source == graph.graph[indirect_target].source
+                    {
+                        continue;
+                    }
+                    let conditions_locally_available = transition
+                        .weight()
+                        .conditions
+                        .as_ref()
+                        .is_none_or(|conditions| {
+                            conditions.selections.values().all(|selection| {
+                                let Selection::Field(required_field) = selection
+                                else {
+                                    return false;
+                                };
+                                if required_field.selection_set.is_some() {
+                                    return false;
+                                }
+                                graph.out_edges(start).into_iter().any(|edge| {
+                                    edge.weight().conditions.is_none()
+                                        && edge.weight().required_contexts.is_empty()
+                                        && edge.weight().override_condition.is_none()
+                                        && matches!(
+                                        &edge.weight().transition,
+                                        QueryGraphEdgeTransition::FieldCollection {
+                                            field_definition_position,
+                                            ..
+                                        } if field_definition_position.field_name()
+                                            == required_field.field.name()
+                                        )
+                                })
+                            })
+                        });
+                    if !conditions_locally_available {
+                        continue;
+                    }
+                    for field_edge in graph.out_edges(indirect_target).into_iter().filter(|edge| {
+                        edge.weight().conditions.is_none()
+                            && edge.weight().required_contexts.is_empty()
+                            && edge.weight().override_condition.is_none()
+                            && matches!(
+                                edge.weight().transition,
+                                QueryGraphEdgeTransition::FieldCollection { .. }
+                            )
+                    }) {
+                        let QueryGraphEdgeTransition::FieldCollection {
+                            field_definition_position,
+                            ..
+                        } = &field_edge.weight().transition
+                        else {
+                            unreachable!()
+                        };
+                        let has_direct = graph.out_edges(start).into_iter().any(|edge| {
+                            matches!(
+                                &edge.weight().transition,
+                                QueryGraphEdgeTransition::FieldCollection {
+                                    field_definition_position: direct,
+                                    ..
+                                } if direct.field_name() == field_definition_position.field_name()
+                            )
+                        });
+                        if !has_direct {
+                            candidates.push((start, transition.id(), field_edge.id()));
+                        }
+                    }
+                }
+                if !candidates.is_empty() {
+                    selected = Some((fixture, graph, candidates));
+                    break;
+                }
+            }
+            let Some((fixture, graph, candidates)) = selected else {
+                return Err(path_test_error(
+                    "fixture palette contains no one-hop indirect-only object field",
+                ));
+            };
+            let (start, transition_edge, field_edge) =
+                candidates[candidate_seed % candidates.len()];
+            let trigger = operation_trigger_for_edge(&graph, field_edge)?;
+            let operation_element = match &trigger {
+                OpGraphPathTrigger::OpPathElement(operation_element) => operation_element.clone(),
+                _ => return Err(path_test_error("field edge did not produce an operation element")),
+            };
+            let OpPathElement::Field(requested_field) = &operation_element else {
+                return Err(path_test_error("generated operation element is not a field"));
+            };
+            let requested_field_name = requested_field.name().clone();
+            let path = OpGraphPath::new(graph.clone(), start).unwrap();
+            let direct_witness = path
+                .add(
+                    operation_trigger_for_edge(&graph, transition_edge)?,
+                    Some(transition_edge),
+                    ConditionResolution::Satisfied {
+                        cost: 1.0,
+                        path_tree: None,
+                        context_map: None,
+                    },
+                    None,
+                )
+                .and_then(|path| {
+                    path.add(
+                        trigger.clone(),
+                        Some(field_edge),
+                        ConditionResolution::no_conditions(),
+                        None,
+                    )
+                })?;
+            prop_assert_eq!(
+                direct_witness.edge_triggers.last().unwrap().as_ref(),
+                &OpGraphPathTrigger::OpPathElement(operation_element.clone()),
+            );
+            let mut search = SimultaneousPathsWithLazyIndirectPaths::new(
+                SimultaneousPaths::from(path),
+                OpGraphPathContext::default(),
+                ExcludedDestinations::default(),
+                ExcludedConditions::default(),
+            );
+            let mut resolver = DirectLeafConditionResolver {
+                graph: graph.clone(),
+            };
+            let options = search
+                .advance_with_operation_element(
+                    graph.supergraph_schema().unwrap(),
+                    &operation_element,
+                    &mut resolver,
+                    &OverrideConditions::default(),
+                    &|| Ok(()),
+                    &IndexSet::default(),
+                )?
+                .ok_or_else(|| {
+                    path_test_error(format!(
+                        "literal one-hop candidate had no options: fixture={}, start={}, transition_edge={} ({:?}), field_edge={}, field={}, witness={}",
+                        PATH_GRAPH_FIXTURES[fixture].0,
+                        graph.graph[start],
+                        transition_edge.index(),
+                        graph.graph[transition_edge].transition,
+                        field_edge.index(),
+                        requested_field_name,
+                        direct_witness,
+                    ))
+                })?;
+            for option in &options {
+                for candidate in &option.paths.0 {
+                    audit_search_result_path(candidate)?;
+                }
+            }
+
+            prop_assert!(options.iter().any(|option| {
+                option.paths.0.iter().any(|candidate| {
+                    candidate.subgraph_jumps().is_ok_and(|jumps| jumps >= 1)
+                        && candidate.edge_triggers.last().is_some_and(|trigger| matches!(
+                            trigger.as_ref(),
+                            OpGraphPathTrigger::OpPathElement(OpPathElement::Field(field))
+                                if field.name() == &requested_field_name
+                        ))
+                })
+            }), "optimized operation advancement missed the one-hop indirect field");
+        }
+
+        /// Compare optimized indirect search with the smallest non-trivial bounded-BFS result:
+        /// a destination whose shortest locally-satisfiable non-collecting route has two edges.
+        #[test]
+        fn operation_element_advancement_finds_shortest_two_hop_indirect_field(
+            fixture_seed in 0usize..PATH_GRAPH_FIXTURES.len(),
+            candidate_seed in any::<usize>(),
+        ) {
+            let mut selected = None;
+            for offset in 0..PATH_GRAPH_FIXTURES.len() {
+                let fixture = (fixture_seed + offset) % PATH_GRAPH_FIXTURES.len();
+                let graph = build_path_query_graph(fixture);
+                let resolver_model = DirectLeafConditionResolver { graph: graph.clone() };
+                let locally_valid_transition = |edge: EdgeIndex| {
+                    let weight = &graph.graph[edge];
+                    let (head, tail) = graph.graph.edge_endpoints(edge).unwrap();
+                    !weight.transition.collect_operation_elements()
+                        && weight.required_contexts.is_empty()
+                        && weight.override_condition.is_none()
+                        && weight.conditions.as_ref().is_none_or(|conditions| {
+                            resolver_model.is_collectable_at(head, conditions)
+                        })
+                        && matches!(
+                            (&graph.graph[head].type_, &graph.graph[tail].type_),
+                            (
+                                QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Object(a)),
+                                QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Object(b)),
+                            ) if a.type_name == b.type_name
+                        )
+                        && graph.graph[head].source != graph.graph[tail].source
+                };
+                let mut candidates = Vec::new();
+                for start in graph.graph.node_indices() {
+                    let one_hop = graph
+                        .out_edges(start)
+                        .into_iter()
+                        .map(|edge| edge.id())
+                        .filter(|edge| locally_valid_transition(*edge))
+                        .collect::<Vec<_>>();
+                    let direct_destinations = one_hop
+                        .iter()
+                        .map(|edge| graph.graph.edge_endpoints(*edge).unwrap().1)
+                        .collect::<IndexSet<_>>();
+                    for first_edge in one_hop {
+                        let middle = graph.graph.edge_endpoints(first_edge).unwrap().1;
+                        for second_edge in graph
+                            .out_edges(middle)
+                            .into_iter()
+                            .map(|edge| edge.id())
+                            .filter(|edge| locally_valid_transition(*edge))
+                        {
+                            let destination = graph.graph.edge_endpoints(second_edge).unwrap().1;
+                            if destination == start || direct_destinations.contains(&destination) {
+                                continue;
+                            }
+                            for field_edge in graph.out_edges(destination).into_iter().filter(|edge| {
+                                edge.weight().conditions.is_none()
+                                    && edge.weight().required_contexts.is_empty()
+                                    && edge.weight().override_condition.is_none()
+                                    && matches!(
+                                        edge.weight().transition,
+                                        QueryGraphEdgeTransition::FieldCollection { .. }
+                                    )
+                            }) {
+                                let QueryGraphEdgeTransition::FieldCollection {
+                                    field_definition_position,
+                                    ..
+                                } = &field_edge.weight().transition else {
+                                    unreachable!()
+                                };
+                                let field_name = field_definition_position.field_name();
+                                let exists_at_start = graph.out_edges(start).into_iter().any(|edge| {
+                                    matches!(
+                                        &edge.weight().transition,
+                                        QueryGraphEdgeTransition::FieldCollection {
+                                            field_definition_position: direct,
+                                            ..
+                                        } if direct.field_name() == field_name
+                                    )
+                                });
+                                let is_last_key_field = graph.graph[second_edge]
+                                    .conditions
+                                    .as_ref()
+                                    .is_some_and(|conditions| {
+                                        conditions.selections.values().any(|selection| matches!(
+                                            selection,
+                                            Selection::Field(required) if required.field.name() == field_name
+                                        ))
+                                    });
+                                if !exists_at_start && !is_last_key_field {
+                                    candidates.push((start, first_edge, second_edge, field_edge.id()));
+                                }
+                            }
+                        }
+                    }
+                }
+                if !candidates.is_empty() {
+                    selected = Some((fixture, graph, candidates));
+                    break;
+                }
+            }
+            let Some((fixture, graph, candidates)) = selected else {
+                // This palette is finite and may cease to contain a shortest-two-hop field as
+                // fixtures evolve. Treat that as a test-maintenance failure, not a vacuous pass.
+                return Err(path_test_error("fixture palette contains no valid shortest-two-hop field"));
+            };
+            let (start, first_edge, second_edge, field_edge) =
+                candidates[candidate_seed % candidates.len()];
+            let field_trigger = operation_trigger_for_edge(&graph, field_edge)?;
+            let OpGraphPathTrigger::OpPathElement(operation_element) = &field_trigger else {
+                return Err(path_test_error("field edge did not produce an operation element"));
+            };
+            let OpPathElement::Field(requested_field) = operation_element else {
+                return Err(path_test_error("generated operation element is not a field"));
+            };
+            let requested_name = requested_field.name().clone();
+            let path = OpGraphPath::new(graph.clone(), start).unwrap();
+            let literal_witness = path
+                .add(
+                    operation_trigger_for_edge(&graph, first_edge)?,
+                    Some(first_edge),
+                    ConditionResolution::Satisfied { cost: 1.0, path_tree: None, context_map: None },
+                    None,
+                )?
+                .add(
+                    operation_trigger_for_edge(&graph, second_edge)?,
+                    Some(second_edge),
+                    ConditionResolution::Satisfied { cost: 1.0, path_tree: None, context_map: None },
+                    None,
+                )?
+                .add(
+                    field_trigger.clone(),
+                    Some(field_edge),
+                    ConditionResolution::no_conditions(),
+                    None,
+                )?;
+            let expected_tail = literal_witness.tail;
+            let mut search = SimultaneousPathsWithLazyIndirectPaths::new(
+                SimultaneousPaths::from(path),
+                OpGraphPathContext::default(),
+                ExcludedDestinations::default(),
+                ExcludedConditions::default(),
+            );
+            let mut resolver = DirectLeafConditionResolver { graph: graph.clone() };
+            let options = search
+                .advance_with_operation_element(
+                    graph.supergraph_schema().unwrap(),
+                    operation_element,
+                    &mut resolver,
+                    &OverrideConditions::default(),
+                    &|| Ok(()),
+                    &IndexSet::default(),
+                )?
+                .ok_or_else(|| path_test_error(format!(
+                    "two-hop witness had no options: fixture={}, field={}, witness={}",
+                    PATH_GRAPH_FIXTURES[fixture].0,
+                    requested_name,
+                    literal_witness,
+                )))?;
+            for option in &options {
+                for candidate in &option.paths.0 {
+                    audit_search_result_path(candidate)?;
+                }
+            }
+            prop_assert!(options.iter().any(|option| option.paths.0.iter().any(|candidate| {
+                candidate.tail == expected_tail
+                    && candidate.subgraph_jumps().is_ok_and(|jumps| jumps >= 2)
+                    && candidate.edge_triggers.last().is_some_and(|trigger| matches!(
+                        trigger.as_ref(),
+                        OpGraphPathTrigger::OpPathElement(OpPathElement::Field(field))
+                            if field.name() == &requested_name
+                    ))
+            })), "optimized advancement omitted the shortest two-hop field witness");
+        }
+
+        /// Compare the exact destination/minimum-distance map on a filtered, non-contextual
+        /// key closure. The *filtered* closure must fit within two hops; we establish that bound
+        /// with full BFS instead of assuming edge deletion preserves original distances.
+        #[test]
+        fn bounded_indirect_key_search_matches_exact_bfs_destination_set(
+            case in bounded_key_search_strategy(),
+        ) {
+            let graph = build_path_query_graph(case.fixture);
+            let fixture = case.fixture;
+            let start = case.start;
+            let unsatisfied_edges: IndexSet<_> = case.unsatisfied_edges.into_iter().collect();
+            let disabled_subgraphs: IndexSet<_> = case.disabled_subgraphs.into_iter().collect();
+
+            // Disabled subgraphs are removed from traversal, including intermediates. Removing
+            // shortcuts or intermediates can lengthen routes; do not silently truncate them.
+            let distance = filtered_key_distances(&graph, start, &unsatisfied_edges, &disabled_subgraphs);
+            prop_assume!(distance.values().all(|depth| *depth <= 2));
+            let expected = distance.iter()
+                .filter(|(node, _)| **node != start)
+                .fold(IndexMap::<Arc<str>, usize>::default(), |mut map, (node, depth)| {
+                    map.entry(graph.graph[*node].source.clone())
+                        .and_modify(|old| *old = (*old).min(*depth))
+                        .or_insert(*depth);
+                    map
+                });
+            let path = Arc::new(OpGraphPath::new(graph.clone(), start).unwrap());
+            let mut resolver = SelectiveLeafConditionResolver {
+                graph: graph.clone(),
+                unsatisfied_edges: unsatisfied_edges.clone(),
+            };
+            let actual: IndirectPaths<OpGraphPathTrigger, Option<EdgeIndex>, ()> = path
+                .advance_with_non_collecting_and_type_preserving_transitions(
+                    &OpGraphPathContext::default(),
+                    &mut resolver,
+                    &ExcludedDestinations::default(),
+                    &ExcludedConditions::default(),
+                    &OverrideConditions::default(),
+                    |_, context| OpGraphPathTrigger::Context(context.clone()),
+                    |graph, node, trigger, overrides| {
+                        Ok(graph.edge_for_op_graph_path_trigger(node, trigger, overrides))
+                    },
+                    &disabled_subgraphs,
+                )?;
+            let actual = actual.paths.iter().try_fold(
+                IndexMap::<Arc<str>, usize>::default(),
+                |mut map, path| {
+                    audit_search_result_path(path)?;
+                    // Check every retained edge before aggregation: a minimum-distance map
+                    // alone could hide an extra invalid path to an otherwise valid destination.
+                    for edge in path.edges.iter().flatten() {
+                        prop_assert!(locally_satisfiable_key(&graph, *edge));
+                        prop_assert!(!unsatisfied_edges.contains(edge));
+                        let tail = graph.graph.edge_endpoints(*edge).unwrap().1;
+                        prop_assert!(!disabled_subgraphs.contains(&graph.graph[tail].source));
+                        prop_assert_ne!(&graph.graph[tail].source, &graph.graph[start].source);
+                    }
+                    let source = path.graph.graph[path.tail].source.clone();
+                    let length = path.edges.iter().flatten().count();
+                    map.entry(source)
+                        .and_modify(|old| *old = (*old).min(length))
+                        .or_insert(length);
+                    Ok::<_, TestCaseError>(map)
+                },
+            )?;
+            prop_assert_eq!(
+                actual,
+                expected,
+                "filtered key closure disagreed for fixture {} at {}",
+                PATH_GRAPH_FIXTURES[fixture].0,
+                graph.graph[start],
+            );
+        }
+
+        /// Drive `OpGraphPath` with operation-shaped triggers and directive-only fragments. The
+        /// oracle implements adjacent-cast elimination as a runtime-set law, then audits all path
+        /// caches and bookkeeping by folding the normalized retained edge sequence from scratch.
+        #[test]
+        fn operation_graph_path_normalization_preserves_semantics_and_bookkeeping(
+            fixture in 0usize..PATH_GRAPH_FIXTURES.len(),
+            start_seed in any::<u16>(),
+            commands in prop::collection::vec((any::<u16>(), any::<bool>()), 0..40),
+        ) {
+            let graph = build_path_query_graph(fixture);
+            let starts: Vec<_> = graph
+                .graph
+                .node_indices()
+                .filter(|node| match &graph.graph[*node].type_ {
+                    QueryGraphNodeType::FederatedRootType(_) => true,
+                    QueryGraphNodeType::SchemaType(position) => {
+                        CompositeTypeDefinitionPosition::try_from(position.clone()).is_ok()
+                    }
+                })
+                .collect();
+            let start = starts[start_seed as usize % starts.len()];
+            let mut path = OpGraphPath::new(graph.clone(), start).unwrap();
+            let mut model = OpPathModel::new(&graph, start)?;
+            audit_operation_path(&path, &model)?;
+
+            for (edge_seed, insert_directive_only_fragment) in commands {
+                if insert_directive_only_fragment
+                    && let Some(trigger) = directive_only_trigger(&path)
+                {
+                    model.add_none(trigger.clone());
+                    path = path
+                        .add(
+                            trigger,
+                            None,
+                            ConditionResolution::no_conditions(),
+                            None,
+                        )
+                        .unwrap();
+                    audit_operation_path(&path, &model)?;
+                }
+
+                let candidates = path.next_edges().unwrap().collect::<Vec<_>>();
+                if candidates.is_empty() {
+                    continue;
+                }
+                let edge_id = candidates[edge_seed as usize % candidates.len()];
+                let trigger = operation_trigger_for_edge(&graph, edge_id)?;
+                let condition_cost = edge_id.index() as QueryPlanCost;
+                model.add_edge(&graph, edge_id, trigger.clone(), condition_cost)?;
+                path = path
+                    .add(
+                        trigger,
+                        Some(edge_id),
+                        ConditionResolution::Satisfied {
+                            path_tree: None,
+                            cost: condition_cost,
+                            context_map: None,
+                        },
+                        None,
+                    )
+                    .unwrap();
+                audit_operation_path(&path, &model)?;
+            }
+        }
+    }
+
+    // Generated context-path coverage.
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        /// Exercise context placement only through states the planner can actually reach. Start
+        /// at the federated root, walk to a real `@fromContext` consumer through the fixture's
+        /// context-setting union/object path, and let `can_satisfy_conditions` derive every level
+        /// and payload rather than fabricating a `ContextMapEntry`.
+        #[test]
+        fn reachable_operation_path_context_resolution_keeps_attributes_in_lockstep(
+            route_order_seed in any::<u16>(),
+            directive_counts in prop::collection::vec(0u8..4, 0..12),
+        ) {
+            let graph = build_path_query_graph(4);
+            let consumer_edge = graph
+                .graph
+                .edge_references()
+                .find(|edge| !edge.weight().required_contexts.is_empty())
+                .expect("context fixture must contain a @fromContext field edge")
+                .id();
+            let (consumer_head, _) = graph.graph.edge_endpoints(consumer_edge).unwrap();
+            let federated_root = graph
+                .graph
+                .node_indices()
+                .find(|node| {
+                    graph.graph[*node].source.as_ref() == "_"
+                        && graph.graph[*node].root_kind
+                            == Some(SchemaRootDefinitionKind::Query)
+                })
+                .expect("federated graph must have a synthetic query root");
+            let route = generated_shortest_edge_path(
+                &graph,
+                federated_root,
+                consumer_head,
+                route_order_seed,
+            );
+            let mut path = OpGraphPath::new(graph.clone(), federated_root).unwrap();
+            for (step, edge) in route.into_iter().enumerate() {
+                let directive_count = directive_counts
+                    .get(step % directive_counts.len().max(1))
+                    .copied()
+                    .unwrap_or_default();
+                for _ in 0..directive_count {
+                    let Some(trigger) = directive_only_trigger(&path) else {
+                        // The synthetic federated root is not a schema composite and therefore
+                        // cannot carry an operation fragment. Real schema nodes later in the route
+                        // can, and remain generated below.
+                        break;
+                    };
+                    path = path
+                        .add(
+                            trigger,
+                            None,
+                            ConditionResolution::no_conditions(),
+                            None,
+                        )
+                        .unwrap();
+                }
+                path = path
+                    .add(
+                        operation_trigger_for_edge(&graph, edge)?,
+                        Some(edge),
+                        ConditionResolution::no_conditions(),
+                        None,
+                    )
+                    .unwrap();
+            }
+            prop_assert_eq!(path.tail(), consumer_head);
+
+            let before_len = path.edges.len();
+            let mut resolver = AlwaysSatisfiedConditionResolver;
+            let resolution = path.can_satisfy_conditions(
+                consumer_edge,
+                &mut resolver,
+                &OpGraphPathContext::default(),
+                &ExcludedDestinations::default(),
+                &ExcludedConditions::default(),
+            )?;
+            let ConditionResolution::Satisfied {
+                context_map: Some(context_map),
+                ..
+            } = &resolution
+            else {
+                return Err(path_test_error(format!(
+                    "reachable @fromContext consumer was not satisfied: path={path}; resolution={resolution:?}",
+                )));
+            };
+            let context_map = context_map.clone();
+            prop_assert!(!context_map.is_empty());
+            for entry in context_map.values() {
+                prop_assert!(entry.levels_in_query_path >= 1);
+                prop_assert!(entry.levels_in_query_path <= before_len);
+                prop_assert!(entry.levels_in_data_path >= 1);
+                prop_assert!(entry.levels_in_data_path <= entry.levels_in_query_path);
+            }
+
+            path = path
+                .add(
+                    operation_trigger_for_edge(&graph, consumer_edge)?,
+                    Some(consumer_edge),
+                    resolution,
+                    None,
+                )
+                .unwrap();
+            prop_assert_eq!(path.edges.len(), before_len + 1);
+            prop_assert_eq!(path.edges.len(), path.edge_conditions.len());
+            prop_assert_eq!(path.edges.len(), path.matching_context_ids.len());
+            prop_assert_eq!(path.edges.len(), path.arguments_to_context_usages.len());
+
+            let usages = path.arguments_to_context_usages[before_len]
+                .as_ref()
+                .expect("consumer field must own generated context argument usages");
+            for entry in context_map.values() {
+                let context_step = before_len - entry.levels_in_query_path;
+                prop_assert!(path.matching_context_ids[context_step]
+                    .as_ref()
+                    .is_some_and(|ids| ids.contains(&entry.context_id)));
+                if let Some(condition_tree) = &entry.path_tree {
+                    prop_assert_eq!(
+                        path.edge_conditions[context_step].as_ref(),
+                        Some(condition_tree),
+                    );
+                }
+                let usage = usages
+                    .get(&entry.argument_name)
+                    .expect("derived context argument usage was not attached to consumer");
+                prop_assert_eq!(&usage.context_id, &entry.context_id);
+                prop_assert_eq!(&usage.selection_set, &entry.selection_set);
+                prop_assert_eq!(&usage.subgraph_argument_type, &entry.argument_type);
+                prop_assert_eq!(
+                    &usage.relative_path,
+                    &vec![FetchDataPathElement::Parent; entry.levels_in_data_path],
+                );
+            }
+        }
+
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        /// Build the exact pair recognized by
+        /// `is_equivalent_save_for_type_explosion_to`: one path takes an interface key directly,
+        /// while the other downcasts to a runtime implementation before taking an equivalent key.
+        /// Append the same generated suffix to both paths, then require the asymmetric recognizer
+        /// to agree with that literal construction.
+        #[test]
+        fn operation_path_type_explosion_equivalence_matches_literal_edge_pattern(
+            fixture_seed in any::<usize>(),
+            pattern_seed in any::<usize>(),
+            suffix_seeds in prop::collection::vec(any::<u16>(), 0..16),
+        ) {
+            let candidates = type_explosion_fixture_patterns();
+            prop_assert!(
+                !candidates.is_empty(),
+                "fixture palette no longer contains a direct-key/type-exploded-key pair"
+            );
+            let (graph, patterns) = &candidates[fixture_seed % candidates.len()];
+            let (head, direct_key, downcast, exploded_key) =
+                patterns[pattern_seed % patterns.len()];
+
+            let mut direct = OpGraphPath::new(graph.clone(), head).unwrap();
+            direct = direct
+                .add(
+                    operation_trigger_for_edge(graph, direct_key)?,
+                    Some(direct_key),
+                    ConditionResolution::no_conditions(),
+                    None,
+                )
+                .unwrap();
+            let mut exploded = OpGraphPath::new(graph.clone(), head).unwrap();
+            for edge in [downcast, exploded_key] {
+                exploded = exploded
+                    .add(
+                        operation_trigger_for_edge(graph, edge)?,
+                        Some(edge),
+                        ConditionResolution::no_conditions(),
+                        None,
+                    )
+                    .unwrap();
+            }
+
+            for seed in suffix_seeds {
+                let direct_next = direct.next_edges().unwrap().collect::<Vec<_>>();
+                let exploded_next = exploded.next_edges().unwrap().collect::<Vec<_>>();
+                let common = direct_next
+                    .into_iter()
+                    .filter(|edge| exploded_next.contains(edge))
+                    .collect::<Vec<_>>();
+                if common.is_empty() {
+                    break;
+                }
+                let edge = common[seed as usize % common.len()];
+                let trigger = operation_trigger_for_edge(graph, edge)?;
+                direct = direct
+                    .add(
+                        trigger.clone(),
+                        Some(edge),
+                        ConditionResolution::no_conditions(),
+                        None,
+                    )
+                    .unwrap();
+                exploded = exploded
+                    .add(
+                        trigger,
+                        Some(edge),
+                        ConditionResolution::no_conditions(),
+                        None,
+                    )
+                    .unwrap();
+            }
+
+            prop_assert_eq!(direct.head, exploded.head);
+            prop_assert_eq!(direct.tail, exploded.tail);
+            prop_assert_eq!(direct.edges.len() + 1, exploded.edges.len());
+            prop_assert!(direct
+                .is_equivalent_save_for_type_explosion_to(&exploded)
+                .unwrap());
+            prop_assert!(!exploded
+                .is_equivalent_save_for_type_explosion_to(&direct)
+                .unwrap());
+            prop_assert!(!direct
+                .is_equivalent_save_for_type_explosion_to(&direct)
+                .unwrap());
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        /// `terminate_with_non_requested_typename_field` is a second path-normalization route:
+        /// it removes every trailing cast/directive-only step and then appends `__typename` when
+        /// the retained tail is composite. Derive that prefix directly from the pre-call path and
+        /// verify that every cached vector and runtime attribute describes the rewritten path.
+        #[test]
+        fn typename_termination_truncates_trailing_path_attributes_in_lockstep(
+            fixture in 0usize..PATH_GRAPH_FIXTURES.len(),
+            start_seed in any::<u16>(),
+            commands in prop::collection::vec((any::<u16>(), any::<bool>()), 0..40),
+        ) {
+            let graph = build_path_query_graph(fixture);
+            let starts = graph
+                .graph
+                .node_indices()
+                .filter(|node| match &graph.graph[*node].type_ {
+                    QueryGraphNodeType::FederatedRootType(_) => true,
+                    QueryGraphNodeType::SchemaType(position) => {
+                        CompositeTypeDefinitionPosition::try_from(position.clone()).is_ok()
+                    }
+                })
+                .collect::<Vec<_>>();
+            let start = starts[start_seed as usize % starts.len()];
+            let mut path = OpGraphPath::new(graph.clone(), start).unwrap();
+
+            for (edge_seed, insert_directive_only_fragment) in commands {
+                if insert_directive_only_fragment
+                    && let Some(trigger) = directive_only_trigger(&path)
+                {
+                    path = path
+                        .add(
+                            trigger,
+                            None,
+                            ConditionResolution::no_conditions(),
+                            None,
+                        )
+                        .unwrap();
+                }
+                let candidates = path.next_edges().unwrap().collect::<Vec<_>>();
+                if candidates.is_empty() {
+                    continue;
+                }
+                let edge_id = candidates[edge_seed as usize % candidates.len()];
+                let trigger = operation_trigger_for_edge(&graph, edge_id)?;
+                path = path
+                    .add(
+                        trigger,
+                        Some(edge_id),
+                        ConditionResolution::Satisfied {
+                            path_tree: None,
+                            cost: edge_id.index() as QueryPlanCost,
+                            context_map: None,
+                        },
+                        None,
+                    )
+                    .unwrap();
+            }
+
+            let prefix_len = path
+                .edges
+                .iter()
+                .enumerate()
+                .rev()
+                .find_map(|(index, edge)| {
+                    edge.and_then(|edge| {
+                        (!matches!(
+                            graph.graph[edge].transition,
+                            QueryGraphEdgeTransition::Downcast { .. }
+                        ))
+                        .then_some(index + 1)
+                    })
+                })
+                .unwrap_or(0);
+            let prefix_tail = if prefix_len == 0 {
+                path.head
+            } else {
+                let edge = path.edges[prefix_len - 1]
+                    .expect("the last retained step is a concrete non-cast edge");
+                graph.graph.edge_endpoints(edge).unwrap().1
+            };
+            let prefix_is_composite = match &graph.graph[prefix_tail].type_ {
+                QueryGraphNodeType::SchemaType(position) => {
+                    CompositeTypeDefinitionPosition::try_from(position.clone()).is_ok()
+                }
+                QueryGraphNodeType::FederatedRootType(_) => false,
+            };
+            let expected_len = prefix_len + usize::from(prefix_is_composite);
+            let terminated = path
+                .terminate_with_non_requested_typename_field(&OverrideConditions::default())
+                .map_err(|error| {
+                    path_test_error(format!(
+                        "typename termination failed: {error}; fixture={}; head={:?} {:?}; prefix_tail={:?} {:?}; path={path:?}",
+                        PATH_GRAPH_FIXTURES[fixture].0,
+                        path.head,
+                        graph.graph[path.head],
+                        prefix_tail,
+                        graph.graph[prefix_tail],
+                    ))
+                })?;
+
+            prop_assert_eq!(terminated.edges.len(), expected_len);
+            prop_assert_eq!(terminated.edge_triggers.len(), expected_len);
+            prop_assert_eq!(terminated.edge_conditions.len(), expected_len);
+            prop_assert_eq!(terminated.matching_context_ids.len(), expected_len);
+            prop_assert_eq!(terminated.arguments_to_context_usages.len(), expected_len);
+            prop_assert_eq!(&terminated.edges[..prefix_len], &path.edges[..prefix_len]);
+            prop_assert_eq!(
+                &terminated.edge_triggers[..prefix_len],
+                &path.edge_triggers[..prefix_len]
+            );
+            prop_assert_eq!(
+                &terminated.edge_conditions[..prefix_len],
+                &path.edge_conditions[..prefix_len]
+            );
+            prop_assert_eq!(
+                &terminated.matching_context_ids[..prefix_len],
+                &path.matching_context_ids[..prefix_len]
+            );
+            prop_assert_eq!(
+                &terminated.arguments_to_context_usages[..prefix_len],
+                &path.arguments_to_context_usages[..prefix_len]
+            );
+
+            if prefix_is_composite {
+                let typename_edge = terminated.edges[prefix_len]
+                    .expect("typename termination must append a real field edge");
+                let QueryGraphEdgeTransition::FieldCollection {
+                    field_definition_position,
+                    ..
+                } = &graph.graph[typename_edge].transition
+                else {
+                    return Err(path_test_error("typename termination appended a non-field edge"));
+                };
+                prop_assert_eq!(field_definition_position.field_name().as_str(), "__typename");
+                prop_assert!(terminated.edge_conditions[prefix_len].is_none());
+                prop_assert!(terminated.matching_context_ids[prefix_len].is_none());
+                prop_assert!(terminated.arguments_to_context_usages[prefix_len].is_none());
+            }
+
+            let mut expected_tail = terminated.head;
+            let mut expected_runtime_types = slow_initial_runtime_types(&graph, terminated.head)?;
+            let mut before_last_cast = None;
+            for edge in &terminated.edges {
+                let Some(edge) = edge else {
+                    before_last_cast = None;
+                    continue;
+                };
+                let runtime_before = expected_runtime_types.clone();
+                expected_runtime_types =
+                    slow_advance_runtime_types(&graph, &expected_runtime_types, *edge)?;
+                before_last_cast = matches!(
+                    graph.graph[*edge].transition,
+                    QueryGraphEdgeTransition::Downcast { .. }
+                )
+                .then_some(runtime_before);
+                expected_tail = graph.graph.edge_endpoints(*edge).unwrap().1;
+            }
+            prop_assert_eq!(terminated.tail, expected_tail);
+            prop_assert_eq!(&*terminated.runtime_types_of_tail, &expected_runtime_types);
+            prop_assert_eq!(
+                terminated.runtime_types_before_tail_if_last_is_cast.as_deref(),
+                before_last_cast.as_ref()
+            );
+            prop_assert!(terminated.defer_on_tail.is_none());
+            prop_assert_eq!(
+                terminated
+                    .last_subgraph_entering_edge_info
+                    .as_ref()
+                    .map(|info| (info.index, info.conditions_cost)),
+                path.last_subgraph_entering_edge_info
+                    .as_ref()
+                    .map(|info| (info.index, info.conditions_cost))
+            );
+        }
+    }
+}

--- a/apollo-federation/src/query_graph/graph_path/operation.rs
+++ b/apollo-federation/src/query_graph/graph_path/operation.rs
@@ -2509,15 +2509,79 @@ mod tests {
     use apollo_compiler::Schema;
     use petgraph::stable_graph::EdgeIndex;
     use petgraph::stable_graph::NodeIndex;
+    use proptest::prelude::*;
 
     use crate::operation::Field;
+    use crate::operation::InlineFragment;
+    use crate::operation::SelectionId;
     use crate::query_graph::build_query_graph::build_query_graph;
     use crate::query_graph::condition_resolver::ConditionResolution;
     use crate::query_graph::graph_path::operation::OpGraphPath;
     use crate::query_graph::graph_path::operation::OpGraphPathTrigger;
+    use crate::query_graph::graph_path::operation::OpPath;
     use crate::query_graph::graph_path::operation::OpPathElement;
     use crate::schema::ValidFederationSchema;
     use crate::schema::position::ObjectFieldDefinitionPosition;
+    use crate::schema::position::ObjectTypeDefinitionPosition;
+
+    fn op_path_test_schema() -> ValidFederationSchema {
+        ValidFederationSchema::new(
+            Schema::parse_and_validate(
+                "type Query { t: T } type T { child: T id: ID! }",
+                "op-path-test.graphql",
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn op_path_field(
+        schema: &ValidFederationSchema,
+        type_name: &str,
+        field_name: &str,
+    ) -> Arc<OpPathElement> {
+        Arc::new(OpPathElement::Field(Field::from_position(
+            schema,
+            ObjectFieldDefinitionPosition {
+                type_name: Name::new(type_name).unwrap(),
+                field_name: Name::new(field_name).unwrap(),
+            }
+            .into(),
+        )))
+    }
+
+    fn op_path_fragment(
+        schema: &ValidFederationSchema,
+        type_name: Option<&str>,
+    ) -> Arc<OpPathElement> {
+        Arc::new(OpPathElement::InlineFragment(InlineFragment {
+            schema: schema.clone(),
+            parent_type_position: ObjectTypeDefinitionPosition {
+                type_name: Name::new("T").unwrap(),
+            }
+            .into(),
+            type_condition_position: type_name.map(|type_name| {
+                ObjectTypeDefinitionPosition {
+                    type_name: Name::new(type_name).unwrap(),
+                }
+                .into()
+            }),
+            directives: Default::default(),
+            selection_id: SelectionId::new(),
+        }))
+    }
+
+    fn op_path_element_kind(element: &OpPathElement) -> String {
+        match element {
+            OpPathElement::Field(field) => format!("field:{}", field.name()),
+            OpPathElement::InlineFragment(fragment) => {
+                fragment.type_condition_position.as_ref().map_or_else(
+                    || "fragment:*".to_string(),
+                    |position| format!("fragment:{}", position.type_name()),
+                )
+            }
+        }
+    }
 
     #[test]
     fn path_display() {
@@ -2583,5 +2647,89 @@ mod tests {
             path.to_string(),
             "Query(S1) --[t]--> T(S1) --[id]--> ID(S1)"
         );
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        #[test]
+        fn op_path_filter_on_schema_matches_literal_element_filter(
+            codes in prop::collection::vec(0u8..5, 0..40),
+        ) {
+            let schema = op_path_test_schema();
+            let elements = codes
+                .iter()
+                .map(|code| match code % 5 {
+                    0 => op_path_field(&schema, "Query", "t"),
+                    1 => op_path_field(&schema, "T", "child"),
+                    2 => op_path_field(&schema, "T", "id"),
+                    3 => op_path_fragment(&schema, Some("T")),
+                    _ => op_path_fragment(&schema, Some("Missing")),
+                })
+                .collect::<Vec<_>>();
+            let path = OpPath(elements.clone());
+            let actual = path.filter_on_schema(&schema);
+            let actual_kinds = actual
+                .0
+                .iter()
+                .map(|element| op_path_element_kind(element))
+                .collect::<Vec<_>>();
+            let expected_kinds = elements
+                .iter()
+                .filter(|element| {
+                    !matches!(
+                        element.as_ref(),
+                        OpPathElement::InlineFragment(fragment)
+                            if fragment.type_condition_position.as_ref().is_some_and(
+                                |position| schema.get_type(position.type_name()).is_err()
+                            )
+                    )
+                })
+                .map(|element| op_path_element_kind(element))
+                .collect::<Vec<_>>();
+            prop_assert_eq!(actual_kinds, expected_kinds);
+        }
+
+        #[test]
+        fn concat_op_paths_removes_only_redundant_leading_fragment_run(
+            head_prefix in prop::collection::vec(0u8..3, 0..12),
+            redundant_fragments in 0usize..12,
+            tail_fields in prop::collection::vec(0u8..2, 0..12),
+        ) {
+            let schema = op_path_test_schema();
+            let mut head = head_prefix
+                .into_iter()
+                .map(|code| if code % 2 == 0 {
+                    op_path_field(&schema, "T", "child")
+                } else {
+                    op_path_fragment(&schema, Some("T"))
+                })
+                .collect::<Vec<_>>();
+            // `child` returns T, making an immediately following `... on T` redundant.
+            head.push(op_path_field(&schema, "T", "child"));
+            let mut tail = (0..redundant_fragments)
+                .map(|_| op_path_fragment(&schema, Some("T")))
+                .collect::<Vec<_>>();
+            tail.extend(tail_fields.into_iter().map(|code| {
+                if code == 0 {
+                    op_path_field(&schema, "T", "id")
+                } else {
+                    op_path_field(&schema, "T", "child")
+                }
+            }));
+
+            let actual = super::concat_op_paths(&OpPath(head.clone()), &OpPath(tail.clone()));
+            let expected = head
+                .iter()
+                .chain(tail.iter().skip(redundant_fragments))
+                .map(|element| op_path_element_kind(element))
+                .collect::<Vec<_>>();
+            let actual = actual
+                .0
+                .iter()
+                .map(|element| op_path_element_kind(element))
+                .collect::<Vec<_>>();
+            prop_assert_eq!(actual, expected);
+        }
     }
 }

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -1143,3 +1143,1030 @@ impl QueryGraph {
             .ok_and_any(|field| field.directives.has(&provides_directive_definition.name))?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use petgraph::visit::EdgeRef;
+    use petgraph::visit::IntoNodeReferences;
+    use proptest::prelude::*;
+    use proptest::test_runner::TestCaseError;
+
+    use crate::Supergraph;
+    use crate::query_graph::build_query_graph::FEDERATED_GRAPH_ROOT_SOURCE;
+
+    /// A compile-time corpus chosen by graph feature, not by expected query-plan text. Together
+    /// these exercise key cliques, nested @requires, @provides node duplication, interface
+    /// objects, abstract runtime types, progressive @override, @context/@fromContext, renamed
+    /// roots, and non-query roots. Keeping the SDL embedded makes a failing audit replayable
+    /// without depending on the working directory or enumerating fixture files at runtime.
+    const QUERY_GRAPH_FIXTURES: [(&str, &str); 12] = [
+        (
+            "key-chains",
+            include_str!(
+                "../../tests/query_plan/supergraphs/handles_case_of_key_chains_in_parallel_requires.graphql"
+            ),
+        ),
+        (
+            "nested-provides",
+            include_str!(
+                "../../tests/query_plan/supergraphs/it_works_with_nested_provides.graphql"
+            ),
+        ),
+        (
+            "nested-requires",
+            include_str!(
+                "../../tests/query_plan/supergraphs/handles_multiple_requires_involving_different_nestedness.graphql"
+            ),
+        ),
+        (
+            "interface-object",
+            include_str!(
+                "../../tests/query_plan/supergraphs/can_use_a_key_on_an_interface_object_type.graphql"
+            ),
+        ),
+        (
+            "abstract-runtime-types",
+            include_str!(
+                "../../tests/query_plan/supergraphs/field_covariance_and_type_explosion.graphql"
+            ),
+        ),
+        (
+            "progressive-override",
+            include_str!(
+                "../../tests/query_plan/supergraphs/it_handles_progressive_override_on_entity_fields.graphql"
+            ),
+        ),
+        (
+            "from-context",
+            include_str!(
+                "../../tests/query_plan/supergraphs/set_context_test_with_type_conditions_for_union.graphql"
+            ),
+        ),
+        (
+            "renamed-root",
+            include_str!("../../tests/query_plan/supergraphs/defer_on_renamed_root_type.graphql"),
+        ),
+        (
+            "subscription",
+            include_str!(
+                "../../tests/query_plan/supergraphs/basic_subscription_query_plan.graphql"
+            ),
+        ),
+        (
+            "mutation",
+            include_str!(
+                "../../tests/query_plan/supergraphs/adjacent_mutations_get_merged.graphql"
+            ),
+        ),
+        (
+            "interface-union",
+            include_str!("../../tests/query_plan/supergraphs/interface_union_interaction.graphql"),
+        ),
+        (
+            "nested-external-key",
+            include_str!(
+                "../../tests/query_plan/supergraphs/external_on_nested_key_fields_with_cross_subgraph_requires.graphql"
+            ),
+        ),
+    ];
+
+    fn build_fixture_query_graph(
+        fixture: usize,
+        for_query_planning: bool,
+    ) -> Result<QueryGraph, FederationError> {
+        let (_, sdl) = QUERY_GRAPH_FIXTURES[fixture % QUERY_GRAPH_FIXTURES.len()];
+        let supergraph = Supergraph::new_with_router_specs(sdl)?;
+        let api_schema = supergraph.to_api_schema(Default::default())?;
+        build_federated_query_graph(
+            supergraph.schema,
+            api_schema,
+            None,
+            Some(for_query_planning),
+        )
+    }
+
+    fn audit_error(message: impl Into<String>) -> TestCaseError {
+        TestCaseError::fail(message.into())
+    }
+
+    fn schema_type_name(node: &QueryGraphNode) -> Option<&Name> {
+        match &node.type_ {
+            QueryGraphNodeType::SchemaType(position) => Some(position.type_name()),
+            QueryGraphNodeType::FederatedRootType(_) => None,
+        }
+    }
+
+    fn expected_root_type_name(
+        schema: &ValidFederationSchema,
+        root_kind: SchemaRootDefinitionKind,
+    ) -> Option<&Name> {
+        let definition = &schema.schema().schema_definition;
+        match root_kind {
+            SchemaRootDefinitionKind::Query => definition.query.as_ref().map(|name| &**name),
+            SchemaRootDefinitionKind::Mutation => definition.mutation.as_ref().map(|name| &**name),
+            SchemaRootDefinitionKind::Subscription => {
+                definition.subscription.as_ref().map(|name| &**name)
+            }
+        }
+    }
+
+    /// Recompute the reachability bit using a forward search. This is intentionally the opposite
+    /// direction from the builder's incremental reverse-ancestor marking algorithm and handles
+    /// same-source cycles with an explicit visited set.
+    fn has_cross_source_edge_reachable_from(graph: &QueryGraph, start: NodeIndex) -> bool {
+        let mut visited = IndexSet::default();
+        let mut stack = vec![start];
+        while let Some(node) = stack.pop() {
+            if !visited.insert(node) {
+                continue;
+            }
+            let source = &graph.graph[node].source;
+            for edge in graph.graph.edges_directed(node, Direction::Outgoing) {
+                let target = edge.target();
+                if graph.graph[target].source != *source {
+                    return true;
+                }
+                if !visited.contains(&target) {
+                    stack.push(target);
+                }
+            }
+        }
+        false
+    }
+
+    fn is_trivial_followup(previous: &QueryGraphEdge, followup: &QueryGraphEdge) -> bool {
+        match &previous.transition {
+            QueryGraphEdgeTransition::KeyResolution => {
+                matches!(followup.transition, QueryGraphEdgeTransition::KeyResolution)
+                    && previous.conditions == followup.conditions
+            }
+            QueryGraphEdgeTransition::RootTypeResolution { .. }
+            | QueryGraphEdgeTransition::SubgraphEnteringTransition => matches!(
+                followup.transition,
+                QueryGraphEdgeTransition::RootTypeResolution { .. }
+            ),
+            _ => false,
+        }
+    }
+
+    /// Check the builder premise that makes a pruned two-hop transition semantically redundant:
+    /// the first edge's head must have a direct transition to the second edge's destination.
+    fn has_direct_replacement_for_trivial_followup(
+        graph: &QueryGraph,
+        previous_id: EdgeIndex,
+        followup_id: EdgeIndex,
+    ) -> bool {
+        let (origin, _) = graph.graph.edge_endpoints(previous_id).unwrap();
+        let (_, destination) = graph.graph.edge_endpoints(followup_id).unwrap();
+        let previous = &graph.graph[previous_id];
+        let followup = &graph.graph[followup_id];
+        let destination_node = &graph.graph[destination];
+
+        // Interface-object key edges can produce A(S1) -> I-object(S2) -> I(S1). There is no
+        // literal A -> I key edge because both types are already in S1; staying on concrete A is
+        // the strictly more specific zero-hop replacement. Require a same-source runtime-subset
+        // proof instead of granting that exception by transition name alone.
+        let origin_node = &graph.graph[origin];
+        let zero_hop_is_safe = || {
+            if origin_node.source != destination_node.source {
+                return false;
+            }
+            let Ok(origin_type) =
+                CompositeTypeDefinitionPosition::try_from(origin_node.type_.clone())
+            else {
+                return origin == destination;
+            };
+            let Ok(destination_type) =
+                CompositeTypeDefinitionPosition::try_from(destination_node.type_.clone())
+            else {
+                return origin == destination;
+            };
+            let Some(schema) = graph.sources.get(&origin_node.source) else {
+                return false;
+            };
+            let Ok(origin_runtime) = schema.possible_runtime_types(origin_type) else {
+                return false;
+            };
+            let Ok(destination_runtime) = schema.possible_runtime_types(destination_type) else {
+                return false;
+            };
+            origin_runtime
+                .iter()
+                .all(|runtime| destination_runtime.contains(runtime))
+        };
+        if zero_hop_is_safe() {
+            return true;
+        }
+
+        // The direct replacement may be a self-key/root edge (for A -> B -> A). Normal traversal
+        // deliberately hides those edges because staying in A is the zero-hop alternative, but
+        // the builder still creates the self edge that proves its clique premise.
+        graph
+            .out_edges_with_federation_self_edges(origin)
+            .into_iter()
+            .any(|candidate_ref| {
+                let candidate = candidate_ref.weight();
+                let candidate_destination = &graph.graph[candidate_ref.target()];
+                if candidate_destination.source != destination_node.source
+                    || schema_type_name(candidate_destination) != schema_type_name(destination_node)
+                {
+                    return false;
+                }
+                match (
+                    &previous.transition,
+                    &followup.transition,
+                    &candidate.transition,
+                ) {
+                    (
+                        QueryGraphEdgeTransition::KeyResolution,
+                        QueryGraphEdgeTransition::KeyResolution,
+                        QueryGraphEdgeTransition::KeyResolution,
+                    ) => candidate.conditions == previous.conditions,
+                    (
+                        QueryGraphEdgeTransition::RootTypeResolution { root_kind },
+                        QueryGraphEdgeTransition::RootTypeResolution {
+                            root_kind: followup_kind,
+                        },
+                        QueryGraphEdgeTransition::RootTypeResolution {
+                            root_kind: candidate_kind,
+                        },
+                    ) => root_kind == followup_kind && root_kind == candidate_kind,
+                    (
+                        QueryGraphEdgeTransition::SubgraphEnteringTransition,
+                        QueryGraphEdgeTransition::RootTypeResolution {
+                            root_kind: followup_kind,
+                        },
+                        QueryGraphEdgeTransition::SubgraphEnteringTransition,
+                    ) => candidate_destination.root_kind == Some(*followup_kind),
+                    _ => false,
+                }
+            })
+    }
+
+    fn audit_transition(graph: &QueryGraph, edge_id: EdgeIndex) -> Result<(), TestCaseError> {
+        let (head_id, tail_id) = graph.graph.edge_endpoints(edge_id).unwrap();
+        let head = &graph.graph[head_id];
+        let tail = &graph.graph[tail_id];
+        let edge = &graph.graph[edge_id];
+
+        match &edge.transition {
+            QueryGraphEdgeTransition::FieldCollection {
+                source,
+                field_definition_position,
+                ..
+            } => {
+                prop_assert_eq!(&head.source, source, "field edge {:?} head source", edge_id);
+                prop_assert_eq!(&tail.source, source, "field edge {:?} tail source", edge_id);
+                let schema = graph.sources.get(source).ok_or_else(|| {
+                    audit_error(format!(
+                        "field edge {edge_id:?} has missing source {source}"
+                    ))
+                })?;
+                let field = field_definition_position
+                    .get(schema.schema())
+                    .map_err(|error| audit_error(format!("field edge {edge_id:?}: {error}")))?;
+                let field_parent = field_definition_position.parent();
+                prop_assert_eq!(
+                    schema_type_name(head),
+                    Some(field_parent.type_name()),
+                    "field edge {:?} starts at the wrong type",
+                    edge_id
+                );
+                prop_assert_eq!(
+                    schema_type_name(tail),
+                    Some(field.ty.inner_named_type()),
+                    "field edge {:?} ends at the wrong base output type",
+                    edge_id
+                );
+            }
+            QueryGraphEdgeTransition::Downcast {
+                source,
+                from_type_position,
+                to_type_position,
+            } => {
+                prop_assert_eq!(&head.source, source, "downcast {:?} head source", edge_id);
+                prop_assert_eq!(&tail.source, source, "downcast {:?} tail source", edge_id);
+                prop_assert_eq!(
+                    schema_type_name(head),
+                    Some(from_type_position.type_name()),
+                    "downcast {:?} starts at the wrong type",
+                    edge_id
+                );
+                prop_assert_eq!(
+                    schema_type_name(tail),
+                    Some(to_type_position.type_name()),
+                    "downcast {:?} ends at the wrong type",
+                    edge_id
+                );
+                let schema = graph.sources.get(source).ok_or_else(|| {
+                    audit_error(format!("downcast {edge_id:?} has missing source {source}"))
+                })?;
+                let from_runtime = schema
+                    .possible_runtime_types(from_type_position.clone())
+                    .map_err(|error| audit_error(format!("downcast {edge_id:?}: {error}")))?;
+                let to_runtime = schema
+                    .possible_runtime_types(to_type_position.clone())
+                    .map_err(|error| audit_error(format!("downcast {edge_id:?}: {error}")))?;
+                prop_assert!(
+                    from_runtime.iter().any(|ty| to_runtime.contains(ty)),
+                    "downcast {edge_id:?} has disjoint runtime types"
+                );
+            }
+            QueryGraphEdgeTransition::KeyResolution => {
+                prop_assert!(
+                    edge.conditions.is_some(),
+                    "key edge {edge_id:?} has no key conditions"
+                );
+                if schema_type_name(head) != schema_type_name(tail) {
+                    // The sole legal type-changing key is a concrete implementation entering an
+                    // @interfaceObject. Prove the relationship in the supergraph rather than
+                    // accepting every differently-named key edge.
+                    let supergraph = graph.supergraph_schema.as_ref().ok_or_else(|| {
+                        audit_error(format!("type-changing key {edge_id:?} has no supergraph"))
+                    })?;
+                    let head_name = schema_type_name(head).ok_or_else(|| {
+                        audit_error(format!("key edge {edge_id:?} starts at a federated root"))
+                    })?;
+                    let tail_name = schema_type_name(tail).ok_or_else(|| {
+                        audit_error(format!("key edge {edge_id:?} ends at a federated root"))
+                    })?;
+                    let tail_supergraph_position =
+                        supergraph.get_type(tail_name).map_err(|error| {
+                            audit_error(format!(
+                                "key edge {edge_id:?} has invalid interface-object target: {error}"
+                            ))
+                        })?;
+                    let tail_supergraph_type: CompositeTypeDefinitionPosition =
+                        tail_supergraph_position.try_into().map_err(|error| {
+                            audit_error(format!(
+                                "key edge {edge_id:?} has non-composite interface-object target: {error}"
+                            ))
+                        })?;
+                    let runtime_types = supergraph
+                        .possible_runtime_types(tail_supergraph_type)
+                        .map_err(|error| audit_error(format!("key edge {edge_id:?}: {error}")))?;
+                    prop_assert!(
+                        runtime_types
+                            .iter()
+                            .any(|runtime| &runtime.type_name == head_name),
+                        "type-changing key {:?} does not enter an interface object applicable to {}",
+                        edge_id,
+                        head_name
+                    );
+                }
+            }
+            QueryGraphEdgeTransition::RootTypeResolution { root_kind } => {
+                prop_assert_eq!(head.root_kind, Some(*root_kind));
+                prop_assert_eq!(tail.root_kind, Some(*root_kind));
+            }
+            QueryGraphEdgeTransition::SubgraphEnteringTransition => {
+                let QueryGraphNodeType::FederatedRootType(root_kind) = head.type_ else {
+                    return Err(audit_error(format!(
+                        "entering edge {edge_id:?} does not start at a federated root"
+                    )));
+                };
+                prop_assert_eq!(head.source.as_ref(), FEDERATED_GRAPH_ROOT_SOURCE);
+                prop_assert_eq!(head.root_kind, Some(root_kind));
+                prop_assert_eq!(tail.root_kind, Some(root_kind));
+                prop_assert_ne!(tail.source.as_ref(), FEDERATED_GRAPH_ROOT_SOURCE);
+            }
+            QueryGraphEdgeTransition::InterfaceObjectFakeDownCast {
+                source,
+                from_type_position,
+                to_type_name,
+            } => {
+                prop_assert_eq!(&head.source, source);
+                prop_assert_eq!(&tail.source, source);
+                prop_assert_eq!(schema_type_name(head), Some(from_type_position.type_name()));
+                prop_assert_eq!(
+                    schema_type_name(tail),
+                    Some(from_type_position.type_name()),
+                    "fake downcast {:?} must remain on its interface-object type",
+                    edge_id
+                );
+                let supergraph = graph.supergraph_schema.as_ref().ok_or_else(|| {
+                    audit_error(format!("fake downcast {edge_id:?} has no supergraph"))
+                })?;
+                prop_assert!(
+                    supergraph.schema().types.contains_key(to_type_name),
+                    "fake downcast {edge_id:?} targets absent supergraph type {to_type_name}"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Full structural and cached-attribute audit built only from raw nodes, raw edges, and source
+    /// schemas. It intentionally does not call any production precomputation helper.
+    fn audit_query_graph(graph: &QueryGraph) -> Result<(), TestCaseError> {
+        prop_assert_eq!(graph.current_source.as_ref(), FEDERATED_GRAPH_ROOT_SOURCE);
+        prop_assert!(graph.sources.contains_key(FEDERATED_GRAPH_ROOT_SOURCE));
+
+        let expected_subgraphs: IndexSet<&str> = graph
+            .sources
+            .keys()
+            .filter(|source| source.as_ref() != FEDERATED_GRAPH_ROOT_SOURCE)
+            .map(|source| source.as_ref())
+            .collect();
+        let actual_subgraphs: IndexSet<&str> = graph
+            .subgraphs_by_name
+            .keys()
+            .map(|source| source.as_ref())
+            .collect();
+        prop_assert_eq!(actual_subgraphs, expected_subgraphs);
+
+        for node_id in graph.graph.node_indices() {
+            let node = &graph.graph[node_id];
+            let schema = graph.sources.get(&node.source).ok_or_else(|| {
+                audit_error(format!(
+                    "node {node_id:?} has missing source {}",
+                    node.source
+                ))
+            })?;
+            match &node.type_ {
+                QueryGraphNodeType::SchemaType(position) => {
+                    let actual_position =
+                        schema.get_type(position.type_name()).map_err(|error| {
+                            audit_error(format!("node {node_id:?} type does not exist: {error}"))
+                        })?;
+                    let expected_position: crate::schema::position::TypeDefinitionPosition =
+                        position.clone().into();
+                    prop_assert_eq!(
+                        actual_position,
+                        expected_position,
+                        "node {:?} has the wrong output kind",
+                        node_id
+                    );
+                }
+                QueryGraphNodeType::FederatedRootType(root_kind) => {
+                    prop_assert_eq!(node.source.as_ref(), FEDERATED_GRAPH_ROOT_SOURCE);
+                    prop_assert_eq!(node.root_kind, Some(*root_kind));
+                }
+            }
+            if let Some(root_kind) = node.root_kind {
+                match &node.type_ {
+                    QueryGraphNodeType::FederatedRootType(kind) => {
+                        prop_assert_eq!(*kind, root_kind);
+                    }
+                    QueryGraphNodeType::SchemaType(position) => {
+                        prop_assert_eq!(
+                            Some(position.type_name()),
+                            expected_root_type_name(schema, root_kind),
+                            "node {:?} is indexed as the wrong {} root",
+                            node_id,
+                            root_kind
+                        );
+                    }
+                }
+            }
+            prop_assert_eq!(
+                node.has_reachable_cross_subgraph_edges,
+                has_cross_source_edge_reachable_from(graph, node_id),
+                "node {:?} has stale cross-subgraph reachability",
+                node_id
+            );
+
+            // Validate construction completeness for ordinary (non-@provides-copy) schema
+            // nodes. The rest of this audit reconstructs caches from the raw graph, which is
+            // intentionally unable to notice an edge omitted from that raw graph. Deriving the
+            // required field set from the source schema closes that blind spot for object fields
+            // and for the built-in __typename field on every composite type where the builder is
+            // documented to create it.
+            let QueryGraphNodeType::SchemaType(position) = &node.type_ else {
+                continue;
+            };
+            if node.provide_id.is_some() {
+                // @provides copies deliberately contain only a path-specific subset of fields.
+                continue;
+            }
+            let outgoing_field_positions = graph
+                .graph
+                .edges_directed(node_id, Direction::Outgoing)
+                .filter_map(|edge| match &edge.weight().transition {
+                    QueryGraphEdgeTransition::FieldCollection {
+                        field_definition_position,
+                        is_part_of_provides: false,
+                        ..
+                    } => Some(field_definition_position.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            match position {
+                OutputTypeDefinitionPosition::Object(object) => {
+                    let object_definition = object.get(schema.schema()).map_err(|error| {
+                        audit_error(format!("object node {node_id:?}: {error}"))
+                    })?;
+                    let metadata = schema.subgraph_metadata();
+                    for field_name in object_definition.fields.keys() {
+                        let field_position: FieldDefinitionPosition =
+                            object.field(field_name.clone()).into();
+                        let is_external = metadata
+                            .is_some_and(|metadata| metadata.is_field_external(&field_position));
+                        let count = outgoing_field_positions
+                            .iter()
+                            .filter(|candidate| **candidate == field_position)
+                            .count();
+                        if is_external {
+                            prop_assert_eq!(
+                                count,
+                                0,
+                                "base object node {:?} exposes external field {}",
+                                node_id,
+                                field_position,
+                            );
+                        } else {
+                            prop_assert!(
+                                count >= 1,
+                                "base object node {node_id:?} omitted field edge {field_position}"
+                            );
+                        }
+                    }
+                    let is_interface_object = schema
+                        .is_interface_object_type(object.clone().into())
+                        .map_err(|error| {
+                            audit_error(format!("object node {node_id:?}: {error}"))
+                        })?;
+                    let typename: FieldDefinitionPosition =
+                        object.introspection_typename_field().into();
+                    let typename_count = outgoing_field_positions
+                        .iter()
+                        .filter(|candidate| **candidate == typename)
+                        .count();
+                    if is_interface_object {
+                        prop_assert_eq!(
+                            typename_count,
+                            0,
+                            "@interfaceObject node {:?} must not resolve __typename locally",
+                            node_id,
+                        );
+                    } else {
+                        prop_assert!(
+                            typename_count >= 1,
+                            "object node {node_id:?} omitted its __typename edge"
+                        );
+                    }
+                }
+                OutputTypeDefinitionPosition::Interface(interface) => {
+                    let interface_definition = interface.get(schema.schema()).map_err(|error| {
+                        audit_error(format!("interface node {node_id:?}: {error}"))
+                    })?;
+                    let metadata = schema.subgraph_metadata();
+                    for field_name in interface_definition.fields.keys() {
+                        let field_position: FieldDefinitionPosition =
+                            interface.field(field_name.clone()).into();
+                        let is_external = metadata
+                            .is_some_and(|metadata| metadata.is_field_external(&field_position));
+                        let count = outgoing_field_positions
+                            .iter()
+                            .filter(|candidate| **candidate == field_position)
+                            .count();
+                        if is_external {
+                            prop_assert_eq!(
+                                count,
+                                0,
+                                "base interface node {:?} exposes external field {}",
+                                node_id,
+                                field_position,
+                            );
+                        } else {
+                            prop_assert!(
+                                count >= 1,
+                                "base interface node {node_id:?} omitted field edge {field_position}",
+                            );
+                        }
+                    }
+                    let typename: FieldDefinitionPosition =
+                        interface.introspection_typename_field().into();
+                    prop_assert!(
+                        outgoing_field_positions
+                            .iter()
+                            .any(|candidate| *candidate == typename),
+                        "interface node {node_id:?} omitted its __typename edge"
+                    );
+                }
+                OutputTypeDefinitionPosition::Union(union) => {
+                    let typename: FieldDefinitionPosition =
+                        union.introspection_typename_field().into();
+                    prop_assert!(
+                        outgoing_field_positions
+                            .iter()
+                            .any(|candidate| *candidate == typename),
+                        "union node {node_id:?} omitted its __typename edge"
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        // Root indexes are also checked against the source schemas, rather than reconstructed
+        // solely from whatever root-marked nodes happen to exist in the graph.
+        for (source, schema) in &graph.sources {
+            let definition = &schema.schema().schema_definition;
+            for (kind, expected_name) in [
+                (SchemaRootDefinitionKind::Query, definition.query.as_ref()),
+                (
+                    SchemaRootDefinitionKind::Mutation,
+                    definition.mutation.as_ref(),
+                ),
+                (
+                    SchemaRootDefinitionKind::Subscription,
+                    definition.subscription.as_ref(),
+                ),
+            ] {
+                let Some(expected_name) = expected_name else {
+                    continue;
+                };
+                let indexed = graph
+                    .root_kinds_to_nodes_by_source
+                    .get(source)
+                    .and_then(|roots| roots.get(&kind))
+                    .ok_or_else(|| {
+                        audit_error(format!("source {source} omitted its {kind} root"))
+                    })?;
+                prop_assert_eq!(
+                    schema_type_name(&graph.graph[*indexed]),
+                    Some(&**expected_name),
+                    "source {} indexed the wrong {} root",
+                    source,
+                    kind,
+                );
+            }
+        }
+
+        prop_assert_eq!(
+            graph.types_to_nodes_by_source.len(),
+            graph.sources.len(),
+            "types-to-nodes source set differs"
+        );
+        for source in graph.sources.keys() {
+            let mut expected: IndexMap<NamedType, IndexSet<NodeIndex>> = IndexMap::default();
+            if source.as_ref() == FEDERATED_GRAPH_ROOT_SOURCE {
+                for (node_id, node) in graph.graph.node_references() {
+                    if node.source.as_ref() == FEDERATED_GRAPH_ROOT_SOURCE {
+                        continue;
+                    }
+                    if let QueryGraphNodeType::SchemaType(position) = &node.type_ {
+                        expected
+                            .entry(position.type_name().clone())
+                            .or_default()
+                            .insert(node_id);
+                    }
+                }
+            } else {
+                for (node_id, node) in graph.graph.node_references() {
+                    if node.source == *source {
+                        if let QueryGraphNodeType::SchemaType(position) = &node.type_ {
+                            expected
+                                .entry(position.type_name().clone())
+                                .or_default()
+                                .insert(node_id);
+                        }
+                    }
+                }
+            }
+            let actual = graph
+                .types_to_nodes_by_source
+                .get(source)
+                .ok_or_else(|| audit_error(format!("missing type index for source {source}")))?;
+            prop_assert_eq!(actual, &expected, "type index differs for {}", source);
+        }
+
+        prop_assert_eq!(
+            graph.root_kinds_to_nodes_by_source.len(),
+            graph.sources.len(),
+            "root-index source set differs"
+        );
+        for source in graph.sources.keys() {
+            let expected: IndexMap<SchemaRootDefinitionKind, NodeIndex> = graph
+                .graph
+                .node_references()
+                .filter(|(_, node)| node.source == *source)
+                .filter_map(|(node_id, node)| node.root_kind.map(|kind| (kind, node_id)))
+                .collect();
+            let actual = graph
+                .root_kinds_to_nodes_by_source
+                .get(source)
+                .ok_or_else(|| audit_error(format!("missing root index for source {source}")))?;
+            prop_assert_eq!(actual, &expected, "root index differs for {}", source);
+        }
+
+        prop_assert_eq!(
+            graph.non_trivial_followup_edges.len(),
+            graph.graph.edge_count(),
+            "followup cache does not cover every edge"
+        );
+        for edge_id in graph.graph.edge_indices() {
+            let (_, tail) = graph.graph.edge_endpoints(edge_id).unwrap();
+            let previous = &graph.graph[edge_id];
+            let mut expected = Vec::new();
+            for followup in graph.out_edges(tail) {
+                if is_trivial_followup(previous, followup.weight()) {
+                    let direct_candidates: Vec<_> = graph
+                        .out_edges_with_federation_self_edges(
+                            graph.graph.edge_endpoints(edge_id).unwrap().0,
+                        )
+                        .into_iter()
+                        .map(|candidate| {
+                            (
+                                candidate.id(),
+                                candidate.target(),
+                                candidate.weight().clone(),
+                                graph.graph[candidate.target()].clone(),
+                            )
+                        })
+                        .collect();
+                    prop_assert!(
+                        has_direct_replacement_for_trivial_followup(graph, edge_id, followup.id(),),
+                        "pruned chain {:?} ({:?} -> {:?}) -> {:?} ({:?} -> {:?}) has no direct replacement; origin candidates={:?}",
+                        edge_id,
+                        graph.graph.edge_endpoints(edge_id).unwrap(),
+                        previous,
+                        followup.id(),
+                        graph.graph.edge_endpoints(followup.id()).unwrap(),
+                        followup.weight(),
+                        direct_candidates,
+                    );
+                } else {
+                    expected.push(followup.id());
+                }
+            }
+            let actual = graph
+                .non_trivial_followup_edges
+                .get(&edge_id)
+                .ok_or_else(|| {
+                    audit_error(format!("edge {edge_id:?} absent from followup cache"))
+                })?;
+            prop_assert_eq!(
+                actual,
+                &expected,
+                "followup cache differs for {:?}",
+                edge_id
+            );
+            audit_transition(graph, edge_id)?;
+        }
+
+        let mut used_override_labels = IndexSet::default();
+        let mut override_values_by_label: IndexMap<Arc<str>, IndexSet<bool>> = IndexMap::default();
+        for edge in graph.graph.edge_weights() {
+            if let Some(condition) = &edge.override_condition {
+                prop_assert!(
+                    graph.override_condition_labels.contains(&condition.label),
+                    "override edge label {} is absent from the label index",
+                    condition.label
+                );
+                used_override_labels.insert(condition.label.clone());
+                override_values_by_label
+                    .entry(condition.label.clone())
+                    .or_default()
+                    .insert(condition.condition);
+            }
+        }
+        prop_assert_eq!(
+            &used_override_labels,
+            &graph.override_condition_labels,
+            "override label index contains an unused label"
+        );
+        for (label, values) in override_values_by_label {
+            prop_assert_eq!(
+                values,
+                IndexSet::from_iter([false, true]),
+                "progressive override label {} must guard both the old and new field edges",
+                label,
+            );
+        }
+
+        // Derive the complete @fromContext argument set from directive referencers. Merely
+        // validating entries already present in the graph would miss a builder omission.
+        let mut expected_context_arguments: IndexMap<
+            Arc<str>,
+            IndexSet<ObjectFieldArgumentDefinitionPosition>,
+        > = IndexMap::default();
+        for (source, schema) in graph.subgraphs() {
+            let metadata = schema.subgraph_metadata().ok_or_else(|| {
+                audit_error(format!("subgraph {source} has no federation metadata"))
+            })?;
+            let definition = metadata
+                .federation_spec_definition()
+                .from_context_directive_definition(schema)
+                .map_err(|error| audit_error(format!("subgraph {source}: {error}")))?;
+            let Some(referencers) = schema.referencers().directives.get(&definition.name) else {
+                continue;
+            };
+            if !referencers.object_field_arguments.is_empty() {
+                expected_context_arguments.insert(
+                    source.clone(),
+                    referencers.object_field_arguments.iter().cloned().collect(),
+                );
+            }
+        }
+
+        let mut context_ids = IndexSet::default();
+        for (source, arguments) in &graph.arguments_to_context_ids_by_source {
+            prop_assert!(graph.subgraphs_by_name.contains_key(source));
+            for (argument, context_id) in arguments {
+                prop_assert!(
+                    context_ids.insert(context_id.clone()),
+                    "context id {context_id} is reused for multiple arguments"
+                );
+                argument
+                    .get(graph.sources[source].schema())
+                    .map_err(|error| {
+                        audit_error(format!("context argument {argument} is missing: {error}"))
+                    })?;
+            }
+        }
+        let actual_context_arguments: IndexMap<
+            Arc<str>,
+            IndexSet<ObjectFieldArgumentDefinitionPosition>,
+        > = graph
+            .arguments_to_context_ids_by_source
+            .iter()
+            .map(|(source, arguments)| (source.clone(), arguments.keys().cloned().collect()))
+            .collect();
+        prop_assert_eq!(
+            &actual_context_arguments,
+            &expected_context_arguments,
+            "context-argument index differs from schema @fromContext applications",
+        );
+
+        let mut contexts_attached_to_fields = IndexSet::default();
+        for edge in graph.graph.edge_weights() {
+            let QueryGraphEdgeTransition::FieldCollection {
+                source,
+                field_definition_position: FieldDefinitionPosition::Object(field_position),
+                ..
+            } = &edge.transition
+            else {
+                prop_assert!(
+                    edge.required_contexts.is_empty(),
+                    "non-object-field edge unexpectedly carries @fromContext requirements",
+                );
+                continue;
+            };
+            for context in &edge.required_contexts {
+                prop_assert_eq!(&context.subgraph_name, source);
+                prop_assert_eq!(&context.argument_coordinate.parent(), field_position);
+                let argument_definition = context
+                    .argument_coordinate
+                    .get(graph.sources[source].schema())
+                    .map_err(|error| {
+                        audit_error(format!(
+                            "context argument {} is missing: {error}",
+                            context.argument_coordinate,
+                        ))
+                    })?;
+                prop_assert_eq!(
+                    &context.argument_name,
+                    &context.argument_coordinate.argument_name
+                );
+                prop_assert_eq!(&context.argument_type, &argument_definition.ty);
+                let indexed = graph
+                    .arguments_to_context_ids_by_source
+                    .get(&context.subgraph_name)
+                    .and_then(|arguments| arguments.get(&context.argument_coordinate));
+                prop_assert!(
+                    indexed.is_some(),
+                    "required context argument {} in {} has no context id",
+                    context.argument_coordinate,
+                    context.subgraph_name
+                );
+                contexts_attached_to_fields.insert((
+                    context.subgraph_name.clone(),
+                    context.argument_coordinate.clone(),
+                ));
+            }
+        }
+        for (source, arguments) in &expected_context_arguments {
+            for argument in arguments {
+                prop_assert!(
+                    contexts_attached_to_fields.contains(&(source.clone(), argument.clone())),
+                    "@fromContext argument {} in {} was not attached to its field edge",
+                    argument,
+                    source,
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// This corpus is finite, so enumerate it instead of randomly sampling it. That guarantees
+    /// every fixture/mode pair is audited on every run and avoids spending 128 proptest cases on
+    /// repeated values that cannot shrink.
+    #[test]
+    fn built_federated_query_graph_passes_full_audit() -> Result<(), TestCaseError> {
+        for fixture in 0..QUERY_GRAPH_FIXTURES.len() {
+            // The context-v0.1 fixture is intentionally a query-planning-only feature; building
+            // the composition-validation graph rejects it before QueryGraph construction.
+            let modes: &[bool] = if QUERY_GRAPH_FIXTURES[fixture].0 == "from-context" {
+                &[true]
+            } else {
+                &[false, true]
+            };
+            for &for_query_planning in modes {
+                let graph = build_fixture_query_graph(fixture, for_query_planning).map_err(
+                    |error| {
+                        audit_error(format!(
+                            "failed to build fixture {} (for_query_planning={for_query_planning}): {error}",
+                            QUERY_GRAPH_FIXTURES[fixture].0,
+                        ))
+                    },
+                )?;
+                audit_query_graph(&graph)?;
+                if for_query_planning {
+                    non_local_selections_estimation::audit_precomputed_query_graph_metadata(
+                        &graph,
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// `I` and `U` overlap on `B | C` in Subgraph1, so an inline fragment conditioned on `U`
+    /// can be rebased onto an `I` node. The non-local-selection estimator's cache must represent
+    /// that ordinary GraphQL fragment-applicability relation.
+    #[test]
+    fn non_local_selection_metadata_includes_interface_union_overlap() {
+        let graph = build_fixture_query_graph(10, true).unwrap();
+        let interface_nodes = graph
+            .graph
+            .node_indices()
+            .filter(|node| {
+                graph.graph[*node].source.as_ref() == "Subgraph1"
+                    && schema_type_name(&graph.graph[*node]).is_some_and(|name| name == "I")
+            })
+            .collect::<Vec<_>>();
+        assert!(!interface_nodes.is_empty());
+        for node in interface_nodes {
+            assert!(
+                non_local_selections_estimation::metadata_allows_inline_fragment_rebase(
+                    &graph, "U", node,
+                ),
+                "inline fragment on U must be rebaseable onto Subgraph1.I because both can contain B or C"
+            );
+        }
+    }
+
+    /// Keep the corpus honest: a renamed or simplified fixture must not silently erase one of the
+    /// transition families or metadata features this palette exists to exercise.
+    #[test]
+    fn query_graph_fixture_palette_covers_required_features() {
+        let mut transitions = IndexSet::default();
+        let mut has_provides = false;
+        let mut has_override = false;
+        let mut has_context = false;
+        let mut root_kinds = IndexSet::default();
+
+        for fixture in 0..QUERY_GRAPH_FIXTURES.len() {
+            let graph = build_fixture_query_graph(fixture, true).unwrap();
+            for node in graph.graph.node_weights() {
+                root_kinds.extend(node.root_kind);
+            }
+            for edge in graph.graph.edge_weights() {
+                let name = match edge.transition {
+                    QueryGraphEdgeTransition::FieldCollection {
+                        is_part_of_provides,
+                        ..
+                    } => {
+                        has_provides |= is_part_of_provides;
+                        "field"
+                    }
+                    QueryGraphEdgeTransition::Downcast { .. } => "downcast",
+                    QueryGraphEdgeTransition::KeyResolution => "key",
+                    QueryGraphEdgeTransition::RootTypeResolution { .. } => "root-resolution",
+                    QueryGraphEdgeTransition::SubgraphEnteringTransition => "entering",
+                    QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { .. } => {
+                        "interface-object-fake-downcast"
+                    }
+                };
+                transitions.insert(name);
+                has_override |= edge.override_condition.is_some();
+                has_context |= !edge.required_contexts.is_empty();
+            }
+        }
+
+        assert_eq!(
+            transitions,
+            IndexSet::from_iter([
+                "field",
+                "downcast",
+                "key",
+                "root-resolution",
+                "entering",
+                "interface-object-fake-downcast",
+            ])
+        );
+        assert!(has_provides, "fixture palette lost @provides coverage");
+        assert!(
+            has_override,
+            "fixture palette lost progressive @override coverage"
+        );
+        assert!(has_context, "fixture palette lost @fromContext coverage");
+        assert!(root_kinds.contains(&SchemaRootDefinitionKind::Query));
+        assert!(root_kinds.contains(&SchemaRootDefinitionKind::Mutation));
+        assert!(root_kinds.contains(&SchemaRootDefinitionKind::Subscription));
+    }
+}

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -570,26 +570,50 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     use apollo_compiler::ExecutableDocument;
+    use apollo_compiler::Name;
+    use apollo_compiler::Node;
+    use apollo_compiler::Schema;
+    use apollo_compiler::ast::Type;
+    use apollo_compiler::collections::IndexMap;
+    use apollo_compiler::collections::IndexSet;
     use apollo_compiler::parser::Parser;
+    use petgraph::stable_graph::EdgeIndex;
     use petgraph::stable_graph::NodeIndex;
     use petgraph::visit::EdgeRef;
+    use proptest::prelude::*;
+    use proptest::proptest;
 
+    use crate::Supergraph;
     use crate::error::FederationError;
     use crate::operation::Field;
+    use crate::operation::InlineFragment;
+    use crate::operation::Selection;
+    use crate::operation::SelectionId;
+    use crate::operation::SelectionSet;
     use crate::operation::never_cancel;
     use crate::operation::normalize_operation;
     use crate::query_graph::QueryGraph;
     use crate::query_graph::QueryGraphEdgeTransition;
+    use crate::query_graph::QueryGraphNodeType;
+    use crate::query_graph::build_federated_query_graph;
     use crate::query_graph::build_query_graph::build_query_graph;
     use crate::query_graph::condition_resolver::ConditionResolution;
+    use crate::query_graph::graph_path::ContextUsageEntry;
     use crate::query_graph::graph_path::operation::OpGraphPath;
+    use crate::query_graph::graph_path::operation::OpGraphPathContext;
     use crate::query_graph::graph_path::operation::OpGraphPathTrigger;
     use crate::query_graph::graph_path::operation::OpPathElement;
     use crate::query_graph::path_tree::OpPathTree;
+    use crate::query_graph::path_tree::PathTreeChild;
+    use crate::query_plan::FetchDataPathElement;
     use crate::schema::ValidFederationSchema;
+    use crate::schema::position::CompositeTypeDefinitionPosition;
+    use crate::schema::position::OutputTypeDefinitionPosition;
     use crate::schema::position::SchemaRootDefinitionKind;
 
     // NB: stole from operation.rs
@@ -666,6 +690,1169 @@ mod tests {
             curr_node_idx = edge_ref.target();
         }
         Ok(graph_path)
+    }
+
+    fn path_tree_fixture() -> (Arc<QueryGraph>, NodeIndex) {
+        let schema = Schema::parse_and_validate(
+            r#"
+            interface Node {
+              id: ID!
+              nested: Node
+            }
+
+            type A implements Node {
+              id: ID!
+              nested: Node
+              a: String
+            }
+
+            type B implements Node {
+              id: ID!
+              nested: Node
+              b: Int
+            }
+
+            union SearchResult = A | B
+
+            type Query {
+              node: Node
+              search: SearchResult
+              a: A
+              b: B
+            }
+            "#,
+            "path-tree-proptest.graphql",
+        )
+        .unwrap();
+        let schema = ValidFederationSchema::new(schema).unwrap();
+        let graph =
+            Arc::new(build_query_graph("path-tree".into(), schema, Default::default()).unwrap());
+        let root = graph.root_kinds_to_nodes().unwrap()[&SchemaRootDefinitionKind::Query];
+        (graph, root)
+    }
+
+    fn generated_trigger(
+        graph: &QueryGraph,
+        edge_id: EdgeIndex,
+        variant: u8,
+    ) -> OpGraphPathTrigger {
+        match &graph.graph[edge_id].transition {
+            QueryGraphEdgeTransition::FieldCollection {
+                field_definition_position,
+                ..
+            } => {
+                let mut field = Field::from_position(
+                    graph.schema().unwrap(),
+                    field_definition_position.clone(),
+                );
+                if variant % 3 != 0 {
+                    field.alias = Some(
+                        Name::new(format!("generated_alias_{}", variant % 3).as_str()).unwrap(),
+                    );
+                }
+                field.into()
+            }
+            QueryGraphEdgeTransition::Downcast {
+                from_type_position,
+                to_type_position,
+                ..
+            } => InlineFragment {
+                schema: graph.schema().unwrap().clone(),
+                parent_type_position: from_type_position.clone(),
+                type_condition_position: Some(to_type_position.clone()),
+                directives: Default::default(),
+                selection_id: SelectionId::new(),
+            }
+            .into(),
+            QueryGraphEdgeTransition::KeyResolution
+            | QueryGraphEdgeTransition::RootTypeResolution { .. }
+            | QueryGraphEdgeTransition::SubgraphEnteringTransition
+            | QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { .. } => {
+                OpGraphPathContext::default().into()
+            }
+        }
+    }
+
+    fn generated_graph_path(
+        graph: &Arc<QueryGraph>,
+        root: NodeIndex,
+        commands: &[(u16, u8)],
+    ) -> OpGraphPath {
+        let mut path = OpGraphPath::new(graph.clone(), root).unwrap();
+        let mut tail = root;
+        for &(edge_seed, trigger_variant) in commands {
+            let candidates = graph.out_edges(tail);
+            if candidates.is_empty() {
+                break;
+            }
+            let edge = candidates[edge_seed as usize % candidates.len()];
+            let trigger = generated_trigger(graph, edge.id(), trigger_variant);
+            path = path
+                .add(trigger, Some(edge.id()), trivial_condition(), None)
+                .unwrap();
+            tail = edge.target();
+        }
+        path
+    }
+
+    fn trigger_signature(trigger: &OpGraphPathTrigger) -> String {
+        match trigger {
+            OpGraphPathTrigger::OpPathElement(OpPathElement::Field(field)) => format!(
+                "field:{}:{}",
+                field.field_position,
+                field.alias.as_ref().map(Name::as_str).unwrap_or("")
+            ),
+            OpGraphPathTrigger::OpPathElement(OpPathElement::InlineFragment(fragment)) => format!(
+                "fragment:{}:{}",
+                fragment.parent_type_position,
+                fragment
+                    .type_condition_position
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_default()
+            ),
+            OpGraphPathTrigger::Context(context) => format!("context:{context}"),
+        }
+    }
+
+    type SemanticBranch = Vec<(Option<usize>, String)>;
+
+    fn graph_path_branch(path: &OpGraphPath) -> SemanticBranch {
+        path.iter()
+            .map(|(edge, trigger, _, _, _)| {
+                (edge.map(EdgeIndex::index), trigger_signature(trigger))
+            })
+            .collect()
+    }
+
+    fn maximal_path_branches(paths: &[OpGraphPath]) -> BTreeSet<SemanticBranch> {
+        let branches: BTreeSet<_> = paths.iter().map(graph_path_branch).collect();
+        branches
+            .iter()
+            .filter(|branch| {
+                !branches.iter().any(|other| {
+                    other.len() > branch.len() && other.iter().take(branch.len()).eq(branch.iter())
+                })
+            })
+            .cloned()
+            .collect()
+    }
+
+    fn audit_and_collect_tree_branches(tree: &OpPathTree) -> BTreeSet<SemanticBranch> {
+        fn visit(
+            tree: &OpPathTree,
+            prefix: &mut SemanticBranch,
+            output: &mut BTreeSet<SemanticBranch>,
+        ) {
+            assert!(tree.local_selection_sets.is_empty());
+            let mut unique_children = BTreeSet::new();
+            for child in &tree.childs {
+                let key = (
+                    child.edge.map(EdgeIndex::index),
+                    trigger_signature(&child.trigger),
+                );
+                assert!(
+                    unique_children.insert(key.clone()),
+                    "duplicate child for the same edge and trigger at node {:?}",
+                    tree.node
+                );
+                let expected_target = child
+                    .edge
+                    .map(|edge| tree.graph.edge_endpoints(edge).unwrap().1)
+                    .unwrap_or(tree.node);
+                assert_eq!(child.tree.node, expected_target);
+                assert!(child.conditions.is_none());
+                assert!(child.matching_context_ids.is_none());
+                assert!(child.arguments_to_context_usages.is_none());
+                prefix.push(key);
+                visit(&child.tree, prefix, output);
+                prefix.pop();
+            }
+            if tree.childs.is_empty() {
+                output.insert(prefix.clone());
+            }
+        }
+
+        let mut output = BTreeSet::new();
+        visit(tree, &mut Vec::new(), &mut output);
+        output
+    }
+
+    fn tree_from_paths(
+        graph: Arc<QueryGraph>,
+        root: NodeIndex,
+        paths: &[OpGraphPath],
+    ) -> Arc<OpPathTree> {
+        let inputs = paths.iter().map(|path| (path, None)).collect::<Vec<_>>();
+        Arc::new(OpPathTree::from_op_paths(graph, root, &inputs).unwrap())
+    }
+
+    fn local_selection_for_path(
+        graph: &Arc<QueryGraph>,
+        path: &OpGraphPath,
+        alias_seed: u8,
+    ) -> Arc<SelectionSet> {
+        named_local_selection_for_path(graph, path, &format!("local_{alias_seed}"))
+    }
+
+    fn named_local_selection_for_path(
+        graph: &Arc<QueryGraph>,
+        path: &OpGraphPath,
+        alias: &str,
+    ) -> Arc<SelectionSet> {
+        let QueryGraphNodeType::SchemaType(type_position) =
+            &graph.node_weight(path.tail()).unwrap().type_
+        else {
+            panic!("operation path ended at a federated root")
+        };
+        Arc::new(
+            SelectionSet::parse(
+                graph.schema().unwrap().clone(),
+                type_position.clone().try_into().unwrap(),
+                &format!("{alias}: __typename"),
+            )
+            .unwrap(),
+        )
+    }
+
+    fn generated_graph_path_with_composite_tail(
+        graph: &Arc<QueryGraph>,
+        root: NodeIndex,
+        commands: &[(u16, u8)],
+    ) -> OpGraphPath {
+        let mut path = OpGraphPath::new(graph.clone(), root).unwrap();
+        let mut tail = root;
+        for &(edge_seed, trigger_variant) in commands {
+            let candidates = graph
+                .out_edges(tail)
+                .into_iter()
+                .filter(|edge| {
+                    matches!(
+                        &graph.node_weight(edge.target()).unwrap().type_,
+                        QueryGraphNodeType::SchemaType(type_position)
+                            if CompositeTypeDefinitionPosition::try_from(type_position.clone()).is_ok()
+                    )
+                })
+                .collect::<Vec<_>>();
+            if candidates.is_empty() {
+                break;
+            }
+            let edge = candidates[edge_seed as usize % candidates.len()];
+            let trigger = generated_trigger(graph, edge.id(), trigger_variant);
+            path = path
+                .add(trigger, Some(edge.id()), trivial_condition(), None)
+                .unwrap();
+            tail = edge.target();
+        }
+        path
+    }
+
+    fn tree_from_paths_with_local_selections(
+        graph: Arc<QueryGraph>,
+        root: NodeIndex,
+        paths: &[(OpGraphPath, Arc<SelectionSet>)],
+    ) -> Arc<OpPathTree> {
+        let inputs = paths
+            .iter()
+            .map(|(path, selection)| (path, Some(selection)))
+            .collect::<Vec<_>>();
+        Arc::new(OpPathTree::from_op_paths(graph, root, &inputs).unwrap())
+    }
+
+    fn local_selection_model(
+        paths: &[(OpGraphPath, Arc<SelectionSet>)],
+    ) -> BTreeMap<SemanticBranch, BTreeSet<String>> {
+        let mut model = BTreeMap::<SemanticBranch, BTreeSet<String>>::new();
+        for (path, selection) in paths {
+            model
+                .entry(graph_path_branch(path))
+                .or_default()
+                .extend(flat_local_fields(selection));
+        }
+        model
+    }
+
+    fn audit_and_collect_local_selections(
+        tree: &OpPathTree,
+    ) -> BTreeMap<SemanticBranch, BTreeSet<String>> {
+        fn visit(
+            tree: &OpPathTree,
+            prefix: &mut SemanticBranch,
+            output: &mut BTreeMap<SemanticBranch, BTreeSet<String>>,
+        ) {
+            if !tree.local_selection_sets.is_empty() {
+                let selections = tree
+                    .local_selection_sets
+                    .iter()
+                    .flat_map(|selection| flat_local_fields(selection))
+                    .collect::<BTreeSet<_>>();
+                output.insert(prefix.clone(), selections);
+            }
+            for child in &tree.childs {
+                prefix.push((
+                    child.edge.map(EdgeIndex::index),
+                    trigger_signature(&child.trigger),
+                ));
+                visit(&child.tree, prefix, output);
+                prefix.pop();
+            }
+        }
+
+        let mut output = BTreeMap::new();
+        visit(tree, &mut Vec::new(), &mut output);
+        output
+    }
+
+    /// Preserve DFS order and duplicate semantic paths. Unlike the merge oracle above, this is
+    /// suitable for serial mutation trees, where repeated fields must remain distinct.
+    fn ordered_local_selection_occurrences(
+        tree: &OpPathTree,
+    ) -> Vec<(SemanticBranch, Vec<String>)> {
+        fn visit(
+            tree: &OpPathTree,
+            prefix: &mut SemanticBranch,
+            output: &mut Vec<(SemanticBranch, Vec<String>)>,
+        ) {
+            if !tree.local_selection_sets.is_empty() {
+                output.push((
+                    prefix.clone(),
+                    tree.local_selection_sets
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect(),
+                ));
+            }
+            for child in &tree.childs {
+                prefix.push((
+                    child.edge.map(EdgeIndex::index),
+                    trigger_signature(&child.trigger),
+                ));
+                visit(&child.tree, prefix, output);
+                prefix.pop();
+            }
+        }
+
+        let mut output = Vec::new();
+        visit(tree, &mut Vec::new(), &mut output);
+        output
+    }
+
+    fn decorate_single_child_with_context_payload(
+        tree: &Arc<OpPathTree>,
+        side: &str,
+        context_mask: u8,
+        argument_mask: u8,
+    ) -> Arc<OpPathTree> {
+        let mut decorated = tree.as_ref().clone();
+        assert_eq!(decorated.childs.len(), 1);
+        let context_ids: IndexSet<Name> = (0..4)
+            .filter(|bit| context_mask & (1 << bit) != 0)
+            .map(|bit| {
+                let value = format!("context_{bit}");
+                Name::new(&value).unwrap()
+            })
+            .collect();
+
+        let zero_path = OpGraphPath::new(tree.graph.clone(), tree.node).unwrap();
+        let selection = local_selection_for_path(&tree.graph, &zero_path, argument_mask);
+        let arguments: IndexMap<Name, ContextUsageEntry> = (0..4)
+            .filter(|bit| argument_mask & (1 << bit) != 0)
+            .map(|bit| {
+                let argument = format!("{side}_argument_{bit}");
+                let context_id = format!("{side}_context_{bit}");
+                (
+                    Name::new(&argument).unwrap(),
+                    ContextUsageEntry {
+                        context_id: Name::new(&context_id).unwrap(),
+                        relative_path: vec![FetchDataPathElement::Parent; bit as usize],
+                        selection_set: selection.as_ref().clone(),
+                        subgraph_argument_type: Node::new(Type::Named(
+                            Name::new("String").unwrap(),
+                        )),
+                    },
+                )
+            })
+            .collect();
+        let child = &decorated.childs[0];
+        decorated.childs[0] = Arc::new(PathTreeChild {
+            edge: child.edge,
+            trigger: child.trigger.clone(),
+            conditions: child.conditions.clone(),
+            tree: child.tree.clone(),
+            matching_context_ids: Some(context_ids),
+            arguments_to_context_usages: Some(arguments),
+        });
+        Arc::new(decorated)
+    }
+
+    fn with_single_child_condition(
+        tree: &Arc<OpPathTree>,
+        condition: Arc<OpPathTree>,
+    ) -> Arc<OpPathTree> {
+        let mut decorated = tree.as_ref().clone();
+        assert_eq!(decorated.childs.len(), 1);
+        let child = &decorated.childs[0];
+        decorated.childs[0] = Arc::new(PathTreeChild {
+            edge: child.edge,
+            trigger: child.trigger.clone(),
+            conditions: Some(condition),
+            tree: child.tree.clone(),
+            matching_context_ids: child.matching_context_ids.clone(),
+            arguments_to_context_usages: child.arguments_to_context_usages.clone(),
+        });
+        Arc::new(decorated)
+    }
+
+    /// Minimal fixture used only by the deterministic repros. The generated properties below use
+    /// the richer interface/union fixture in `path_tree_fixture`.
+    fn path_tree_repro_fixture() -> (Arc<QueryGraph>, NodeIndex) {
+        let schema = Schema::parse_and_validate(
+            "type Query { node: Node } type Node { id: ID!, child: Node }",
+            "path-tree-repro.graphql",
+        )
+        .unwrap();
+        let schema = ValidFederationSchema::new(schema).unwrap();
+        let graph =
+            Arc::new(build_query_graph("repro".into(), schema, Default::default()).unwrap());
+        let root = graph.root_kinds_to_nodes().unwrap()[&SchemaRootDefinitionKind::Query];
+        (graph, root)
+    }
+
+    /// Build a tree containing one real path and one trailing local selection at that path's tail.
+    fn path_tree_with_local_selection(
+        graph: &Arc<QueryGraph>,
+        root: NodeIndex,
+        path: &OpGraphPath,
+        selection: &str,
+    ) -> Arc<OpPathTree> {
+        let tail = &graph.graph[path.tail()];
+        let QueryGraphNodeType::SchemaType(type_position) = &tail.type_ else {
+            panic!("local selections require a schema-type path tail")
+        };
+        let schema = graph.schema_by_source(&tail.source).unwrap().clone();
+        let selection = Arc::new(
+            SelectionSet::parse(schema, type_position.clone().try_into().unwrap(), selection)
+                .unwrap(),
+        );
+        Arc::new(
+            OpPathTree::from_op_paths(graph.clone(), root, &[(path, Some(&selection))]).unwrap(),
+        )
+    }
+
+    fn one_edge_path_tree_with_condition(
+        graph: &Arc<QueryGraph>,
+        root: NodeIndex,
+        edge: EdgeIndex,
+        trigger: OpGraphPathTrigger,
+        condition: Arc<OpPathTree>,
+    ) -> Arc<OpPathTree> {
+        let path = OpGraphPath::new(graph.clone(), root)
+            .unwrap()
+            .add(
+                trigger,
+                Some(edge),
+                ConditionResolution::Satisfied {
+                    cost: 1.0,
+                    path_tree: Some(condition),
+                    context_map: None,
+                },
+                None,
+            )
+            .unwrap();
+        Arc::new(OpPathTree::from_op_paths(graph.clone(), root, &[(&path, None)]).unwrap())
+    }
+
+    fn condition_key_repro_fixture() -> (Arc<QueryGraph>, NodeIndex, EdgeIndex) {
+        let supergraph = Supergraph::new_with_router_specs(include_str!(
+            "../../tests/query_plan/supergraphs/can_use_a_key_on_an_interface_object_type.graphql"
+        ))
+        .unwrap();
+        let api_schema = supergraph.to_api_schema(Default::default()).unwrap();
+        let graph = Arc::new(
+            build_federated_query_graph(supergraph.schema, api_schema, None, Some(true)).unwrap(),
+        );
+        let key_edge = graph
+            .graph
+            .edge_references()
+            .find(|edge| {
+                if !matches!(
+                    edge.weight().transition,
+                    QueryGraphEdgeTransition::KeyResolution
+                ) {
+                    return false;
+                }
+                let head = &graph.graph[edge.source()];
+                let tail = &graph.graph[edge.target()];
+                head.source.as_ref() == "S1"
+                    && tail.source.as_ref() == "S2"
+                    && matches!(
+                        &head.type_,
+                        QueryGraphNodeType::SchemaType(
+                            OutputTypeDefinitionPosition::Interface(position)
+                        ) if position.type_name == "I"
+                    )
+            })
+            .expect("fixture must contain the condition-bearing S1.I -> S2.I key")
+            .id();
+        let root = graph.graph.edge_endpoints(key_edge).unwrap().0;
+        assert!(graph.graph[key_edge].conditions.is_some());
+        (graph, root, key_edge)
+    }
+
+    /// The local-payload domain here consists of flat scalar fields. Compare fields, not the
+    /// grouping/order of SelectionSets: preserving two fields in one set is a valid merge too.
+    /// Fail loudly if a future generator adds structure that this small oracle cannot model.
+    fn flat_local_fields(selection: &SelectionSet) -> BTreeSet<String> {
+        selection
+            .selections
+            .values()
+            .map(|selection| {
+                let Selection::Field(field) = selection else {
+                    panic!("extend the local-payload oracle before generating fragments")
+                };
+                assert!(
+                    field.selection_set.is_none(),
+                    "local-payload oracle expects scalar fields"
+                );
+                selection.to_string()
+            })
+            .collect()
+    }
+
+    fn local_selection_texts(tree: &OpPathTree) -> Vec<String> {
+        tree.local_selection_sets
+            .iter()
+            .flat_map(|selection| flat_local_fields(selection))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    #[test]
+    fn local_payload_oracle_accepts_coalesced_fields_but_not_lost_fields() {
+        let (graph, root) = path_tree_repro_fixture();
+        let path = build_graph_path(&graph, SchemaRootDefinitionKind::Query, &["node"]).unwrap();
+        let left = path_tree_with_local_selection(&graph, root, &path, "left: __typename");
+        let right = path_tree_with_local_selection(&graph, root, &path, "right: __typename");
+        let coalesced = path_tree_with_local_selection(
+            &graph,
+            root,
+            &path,
+            "right: __typename left: __typename",
+        );
+        let mut expected = flat_local_fields(&left.childs[0].tree.local_selection_sets[0]);
+        expected.extend(flat_local_fields(
+            &right.childs[0].tree.local_selection_sets[0],
+        ));
+        assert_eq!(
+            flat_local_fields(&coalesced.childs[0].tree.local_selection_sets[0]),
+            expected
+        );
+        assert_ne!(
+            flat_local_fields(&left.childs[0].tree.local_selection_sets[0]),
+            expected
+        );
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Deterministic findings investigated alongside the generated properties below.
+    //
+    // These use the same `OpGraphPath` and `OpPathTree::from_op_paths` constructors as query
+    // planning. They establish loss on structurally valid planner data, but do not claim that
+    // operation normalization currently emits every exact pair of trees used below. The `extend`
+    // case proposes a broader payload-preservation contract separately.
+    // -----------------------------------------------------------------------------------------
+
+    /// `from_op_paths` attaches a fully-local selection at the end of a normal collected field
+    /// path. Merging two trees for that same path must retain both trailing selections.
+    #[test]
+    fn merge_preserves_distinct_trailing_selections_on_the_same_path() {
+        let (graph, root) = path_tree_repro_fixture();
+        let path = build_graph_path(&graph, SchemaRootDefinitionKind::Query, &["node"])
+            .expect("fixture must contain Query.node");
+        let left = path_tree_with_local_selection(&graph, root, &path, "left: __typename");
+        let right = path_tree_with_local_selection(&graph, root, &path, "right: __typename");
+        let merged = left.merge(&right);
+
+        assert_eq!(
+            merged.childs.len(),
+            1,
+            "the shared Query.node path must merge"
+        );
+        assert_eq!(
+            local_selection_texts(&merged.childs[0].tree),
+            vec!["left: __typename", "right: __typename"],
+            "the shared path must retain both trailing selections",
+        );
+    }
+
+    /// One closed path may end with fully-local work where another continues through a child.
+    /// Merging their shared prefix must retain both the local work and the longer path.
+    #[test]
+    fn merge_preserves_leaf_local_selection_when_other_tree_has_children() {
+        let (graph, root) = path_tree_repro_fixture();
+        let leaf_path = build_graph_path(&graph, SchemaRootDefinitionKind::Query, &["node"])
+            .expect("fixture must contain Query.node");
+        let child_path =
+            build_graph_path(&graph, SchemaRootDefinitionKind::Query, &["node", "child"])
+                .expect("fixture must contain Query.node.child");
+        let leaf =
+            path_tree_with_local_selection(&graph, root, &leaf_path, "under_node: __typename");
+        let nonleaf =
+            path_tree_with_local_selection(&graph, root, &child_path, "under_child: __typename");
+        let merged = leaf.merge(&nonleaf);
+
+        assert_eq!(
+            merged.childs.len(),
+            1,
+            "the shared Query.node path must merge"
+        );
+        let node_tree = &merged.childs[0].tree;
+        assert_eq!(
+            local_selection_texts(node_tree),
+            vec!["under_node: __typename"],
+            "merging a leaf into a branch must retain the leaf's local selection",
+        );
+        assert_eq!(node_tree.childs.len(), 1, "the longer path must remain");
+        assert_eq!(
+            local_selection_texts(&node_tree.childs[0].tree),
+            vec!["under_child: __typename"],
+            "the longer path's trailing selection must remain at Query.node.child",
+        );
+    }
+
+    /// The cheap equality predicate controls whether condition trees are merged at all. Trees
+    /// carrying different local work are not equal even when both happen to be leaves.
+    #[test]
+    fn equals_same_root_distinguishes_different_local_selections() {
+        let (graph, root) = path_tree_repro_fixture();
+        let path = build_graph_path(&graph, SchemaRootDefinitionKind::Query, &["node"])
+            .expect("fixture must contain Query.node");
+        let left = path_tree_with_local_selection(&graph, root, &path, "left: __typename");
+        let right = path_tree_with_local_selection(&graph, root, &path, "right: __typename");
+
+        assert_eq!(
+            local_selection_texts(&left.childs[0].tree),
+            vec!["left: __typename"]
+        );
+        assert_eq!(
+            local_selection_texts(&right.childs[0].tree),
+            vec!["right: __typename"]
+        );
+        assert!(
+            !left.equals_same_root(&right),
+            "trees with different trailing local selections must not compare equal",
+        );
+    }
+
+    /// Proposed hardening contract: preserve root-local payload from a leaf argument as well
+    /// as appending children. The documented contract only promises child concatenation, and
+    /// the current mutation-root caller supplies trees with children. This test proposes broader
+    /// semantics; it does not establish a violation of that caller's existing contract.
+    #[test]
+    fn extend_preserves_local_selections_from_a_leaf_tree() {
+        let (graph, root) = path_tree_repro_fixture();
+        let leaf_path = OpGraphPath::new(graph.clone(), root).unwrap();
+        let child_path = build_graph_path(&graph, SchemaRootDefinitionKind::Query, &["node"])
+            .expect("fixture must contain Query.node");
+        let mut tree =
+            path_tree_with_local_selection(&graph, root, &child_path, "under_node: __typename")
+                .as_ref()
+                .clone();
+        let leaf = path_tree_with_local_selection(&graph, root, &leaf_path, "at_root: __typename");
+
+        tree.extend(&leaf);
+        assert_eq!(
+            local_selection_texts(&tree),
+            vec!["at_root: __typename"],
+            "proposed hardening should retain the leaf's local selection",
+        );
+        assert_eq!(tree.childs.len(), 1, "the existing branch must remain");
+        assert_eq!(
+            local_selection_texts(&tree.childs[0].tree),
+            vec!["under_node: __typename"],
+            "the branch's trailing selection must remain at Query.node",
+        );
+    }
+
+    /// Child condition trees are merged through `equals_same_root` and `merge_if_not_equal`.
+    /// Both trees satisfy the real key's required `id`; their distinct additional local work must
+    /// also survive that fast path.
+    #[test]
+    fn merge_preserves_local_selections_from_both_child_condition_trees() {
+        let (graph, root, key_edge) = condition_key_repro_fixture();
+        let condition_path = OpGraphPath::new(graph.clone(), root).unwrap();
+        let left_condition = path_tree_with_local_selection(
+            &graph,
+            root,
+            &condition_path,
+            "id left_condition: __typename",
+        );
+        let right_condition = path_tree_with_local_selection(
+            &graph,
+            root,
+            &condition_path,
+            "id right_condition: __typename",
+        );
+        let left = one_edge_path_tree_with_condition(
+            &graph,
+            root,
+            key_edge,
+            OpGraphPathContext::default().into(),
+            left_condition,
+        );
+        let right = one_edge_path_tree_with_condition(
+            &graph,
+            root,
+            key_edge,
+            OpGraphPathContext::default().into(),
+            right_condition,
+        );
+
+        let merged = left.merge(&right);
+        let condition = merged.childs[0]
+            .conditions
+            .as_ref()
+            .expect("shared child lost its condition tree");
+        assert_eq!(
+            local_selection_texts(condition),
+            vec![
+                "id",
+                "left_condition: __typename",
+                "right_condition: __typename",
+            ],
+            "merging equal-looking condition trees must retain local selections from both",
+        );
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Generated coverage: semantic trie construction, union, equality, and complete payloads.
+    // -----------------------------------------------------------------------------------------
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        /// `from_op_paths` and `merge` are two implementations of trie union. Compare both with
+        /// a flat set-of-maximal-branches model, while varying shared prefixes, aliases, casts,
+        /// duplicates, input order, and merge association.
+        #[test]
+        fn path_tree_conserves_semantic_branches_under_build_and_merge(
+            path_specs in prop::collection::vec(
+                prop::collection::vec((any::<u16>(), any::<u8>()), 1..10),
+                3..25,
+            ),
+        ) {
+            let (graph, root) = path_tree_fixture();
+            let paths = path_specs
+                .iter()
+                .map(|spec| generated_graph_path(&graph, root, spec))
+                .collect::<Vec<_>>();
+            let expected = maximal_path_branches(&paths);
+
+            let tree = tree_from_paths(graph.clone(), root, &paths);
+            prop_assert_eq!(audit_and_collect_tree_branches(&tree), expected.clone());
+
+            let mut reversed = paths.clone();
+            reversed.reverse();
+            let reversed_tree = tree_from_paths(graph.clone(), root, &reversed);
+            prop_assert_eq!(
+                audit_and_collect_tree_branches(&reversed_tree),
+                expected.clone()
+            );
+
+            let first_cut = paths.len() / 3;
+            let second_cut = 2 * paths.len() / 3;
+            let a = tree_from_paths(graph.clone(), root, &paths[..first_cut]);
+            let b = tree_from_paths(graph.clone(), root, &paths[first_cut..second_cut]);
+            let c = tree_from_paths(graph.clone(), root, &paths[second_cut..]);
+
+            let left_associated = a.merge(&b).merge(&c);
+            let right_associated = a.merge(&b.merge(&c));
+            prop_assert_eq!(
+                audit_and_collect_tree_branches(&left_associated),
+                expected.clone()
+            );
+            prop_assert_eq!(
+                audit_and_collect_tree_branches(&right_associated),
+                expected.clone()
+            );
+            prop_assert_eq!(
+                audit_and_collect_tree_branches(&b.merge(&a).merge(&c)),
+                expected
+            );
+            prop_assert!(Arc::ptr_eq(&tree.merge(&tree), &tree));
+        }
+
+        /// Building a tree from all payload-bearing paths and unioning trees built from arbitrary
+        /// partitions must place exactly the same local selections at every semantic trie node.
+        #[test]
+        fn path_tree_merge_matches_rebuild_for_local_selections(
+            path_specs in prop::collection::vec(
+                prop::collection::vec((any::<u16>(), any::<u8>()), 0..8),
+                2..20,
+            ),
+        ) {
+            let (graph, root) = path_tree_fixture();
+            let paths = path_specs
+                .iter()
+                .enumerate()
+                .map(|(index, spec)| {
+                    let path = generated_graph_path_with_composite_tail(&graph, root, spec);
+                    let selection = local_selection_for_path(&graph, &path, index as u8);
+                    (path, selection)
+                })
+                .collect::<Vec<_>>();
+            let expected = local_selection_model(&paths);
+            let rebuilt = tree_from_paths_with_local_selections(graph.clone(), root, &paths);
+            prop_assert_eq!(
+                audit_and_collect_local_selections(&rebuilt),
+                expected.clone(),
+                "from_op_paths misplaced a trailing local selection"
+            );
+
+            let cut = paths.len() / 2;
+            let left = tree_from_paths_with_local_selections(
+                graph.clone(),
+                root,
+                &paths[..cut],
+            );
+            let right = tree_from_paths_with_local_selections(
+                graph,
+                root,
+                &paths[cut..],
+            );
+            prop_assert_eq!(
+                audit_and_collect_local_selections(&left.merge(&right)),
+                expected.clone(),
+                "merge misplaced or discarded a trailing local selection"
+            );
+            prop_assert_eq!(
+                audit_and_collect_local_selections(&right.merge(&left)),
+                expected,
+                "merge was order-dependent for trailing local selections"
+            );
+
+            prop_assert!(
+                !left.equals_same_root(&right),
+                "different generated local-selection payloads compared equal"
+            );
+        }
+
+        /// The production caller uses `extend` to concatenate serial mutation trees, whose paths
+        /// always collect at least one root field. Under that caller-shaped precondition,
+        /// extending partitions must retain the same semantic branches as the source paths.
+        #[test]
+        fn path_tree_extend_conserves_nonempty_mutation_shaped_paths(
+            left_specs in prop::collection::vec(
+                prop::collection::vec((any::<u16>(), any::<u8>()), 1..8),
+                1..10,
+            ),
+            right_specs in prop::collection::vec(
+                prop::collection::vec((any::<u16>(), any::<u8>()), 1..8),
+                1..10,
+            ),
+        ) {
+            let (graph, root) = path_tree_fixture();
+            let paths = left_specs
+                .iter()
+                .chain(&right_specs)
+                .enumerate()
+                .map(|(index, spec)| {
+                    let path = generated_graph_path_with_composite_tail(&graph, root, spec);
+                    let selection = local_selection_for_path(&graph, &path, index as u8);
+                    (path, selection)
+                })
+                .collect::<Vec<_>>();
+            let cut = left_specs.len();
+            let left = tree_from_paths_with_local_selections(graph.clone(), root, &paths[..cut]);
+            let right = tree_from_paths_with_local_selections(graph, root, &paths[cut..]);
+            prop_assert!(!left.childs.is_empty());
+            prop_assert!(!right.childs.is_empty());
+
+            let mut expected = ordered_local_selection_occurrences(&left);
+            expected.extend(ordered_local_selection_occurrences(&right));
+
+            let mut extended = left.as_ref().clone();
+            extended.extend(&right);
+            prop_assert_eq!(
+                ordered_local_selection_occurrences(&extended),
+                expected,
+                "extend misplaced, merged, or reordered work from nonempty serial paths"
+            );
+        }
+
+        /// When two paths share an edge/trigger, context metadata belongs to that semantic edge
+        /// and must be unioned rather than duplicated or dropped. Argument names may be disjoint
+        /// or collide; the latter exercises the map's current right-hand replacement behavior.
+        #[test]
+        fn path_tree_merge_unions_shared_child_context_payloads(
+            edge_seed in any::<u16>(),
+            trigger_seed in any::<u8>(),
+            left_context_mask in any::<u8>(),
+            right_context_mask in any::<u8>(),
+            left_argument_mask in any::<u8>(),
+            right_argument_mask in any::<u8>(),
+            collide_argument_names in any::<bool>(),
+        ) {
+            let (graph, root) = path_tree_fixture();
+            let path = generated_graph_path(&graph, root, &[(edge_seed, trigger_seed)]);
+            let base = tree_from_paths(graph, root, &[path]);
+            prop_assert_eq!(base.childs.len(), 1);
+            let left = decorate_single_child_with_context_payload(
+                &base,
+                if collide_argument_names { "shared" } else { "left" },
+                left_context_mask & 0b1111,
+                left_argument_mask & 0b1111,
+            );
+            let right = decorate_single_child_with_context_payload(
+                &base,
+                if collide_argument_names { "shared" } else { "right" },
+                right_context_mask & 0b1111,
+                right_argument_mask & 0b1111,
+            );
+
+            let mut expected_context_ids = left.childs[0]
+                .matching_context_ids
+                .clone()
+                .unwrap_or_default();
+            expected_context_ids.extend(
+                right.childs[0]
+                    .matching_context_ids
+                    .iter()
+                    .flatten()
+                    .cloned(),
+            );
+            let mut expected_arguments = left.childs[0]
+                .arguments_to_context_usages
+                .clone()
+                .unwrap_or_default();
+            expected_arguments.extend(
+                right.childs[0]
+                    .arguments_to_context_usages
+                    .iter()
+                    .flat_map(|arguments| arguments.iter())
+                    .map(|(name, usage)| (name.clone(), usage.clone())),
+            );
+
+            let merged = left.merge(&right);
+            prop_assert_eq!(merged.childs.len(), 1, "shared branch was duplicated");
+            prop_assert_eq!(
+                merged.childs[0]
+                    .matching_context_ids
+                    .as_ref()
+                    .cloned()
+                    .unwrap_or_default(),
+                expected_context_ids,
+            );
+            prop_assert_eq!(
+                merged.childs[0]
+                    .arguments_to_context_usages
+                    .as_ref()
+                    .cloned()
+                    .unwrap_or_default(),
+                expected_arguments,
+            );
+        }
+
+        /// Condition trees use the same trie-union machinery recursively. Vary the containing
+        /// edge/trigger while forcing distinct trailing selections in the two condition trees.
+        #[test]
+        fn path_tree_merge_unions_shared_child_condition_payloads(
+            edge_seed in any::<u16>(),
+            trigger_seed in any::<u8>(),
+            selection_seed in any::<u8>(),
+            // Root-local condition payload loss already has a deterministic repro. Require a
+            // nonempty condition path here so this broad property covers recursive trie nodes.
+            condition_spec in prop::collection::vec((any::<u16>(), any::<u8>()), 1..7),
+        ) {
+            let (graph, root) = path_tree_fixture();
+            let branch_path = generated_graph_path(&graph, root, &[(edge_seed, trigger_seed)]);
+            let base = tree_from_paths(graph.clone(), root, &[branch_path]);
+            let condition_path =
+                generated_graph_path_with_composite_tail(&graph, root, &condition_spec);
+            let condition_branch = graph_path_branch(&condition_path);
+            let left_alias = selection_seed.wrapping_mul(2);
+            let right_alias = left_alias.wrapping_add(1);
+            let left_condition = tree_from_paths_with_local_selections(
+                graph.clone(),
+                root,
+                &[(
+                    condition_path.clone(),
+                    local_selection_for_path(&graph, &condition_path, left_alias),
+                )],
+            );
+            let right_condition = tree_from_paths_with_local_selections(
+                graph,
+                root,
+                &[(
+                    condition_path.clone(),
+                    local_selection_for_path(&base.graph, &condition_path, right_alias),
+                )],
+            );
+
+            let merged = with_single_child_condition(&base, left_condition)
+                .merge(&with_single_child_condition(&base, right_condition));
+            let actual = audit_and_collect_local_selections(
+                merged.childs[0]
+                    .conditions
+                    .as_ref()
+                    .expect("shared child lost its condition tree"),
+            );
+            let expected = BTreeMap::from([(
+                condition_branch,
+                BTreeSet::from([
+                    format!("local_{left_alias}: __typename"),
+                    format!("local_{right_alias}: __typename"),
+                ]),
+            )]);
+            prop_assert_eq!(actual, expected);
+        }
+
+        /// Exercise the complete shared-edge payload at once. This catches interactions hidden by
+        /// dimension-at-a-time tests: the child trie carries local work, while its incoming edge
+        /// simultaneously carries a condition tree, matching context IDs, and argument usages.
+        #[test]
+        fn path_tree_merge_conserves_combined_recursive_edge_payload(
+            edge_seed in any::<u16>(),
+            trigger_seed in any::<u8>(),
+            selection_seed in any::<u8>(),
+            left_context_mask in 1u8..16,
+            right_context_mask in 1u8..16,
+            left_argument_mask in 1u8..16,
+            right_argument_mask in 1u8..16,
+            condition_spec in prop::collection::vec((any::<u16>(), any::<u8>()), 1..7),
+        ) {
+            let (graph, root) = path_tree_fixture();
+            let branch_path = generated_graph_path_with_composite_tail(
+                &graph,
+                root,
+                &[(edge_seed, trigger_seed)],
+            );
+            let left_alias = selection_seed.wrapping_mul(4);
+            let right_alias = left_alias.wrapping_add(1);
+            let left_base = tree_from_paths_with_local_selections(
+                graph.clone(),
+                root,
+                &[(
+                    branch_path.clone(),
+                    local_selection_for_path(&graph, &branch_path, left_alias),
+                )],
+            );
+            let right_base = tree_from_paths_with_local_selections(
+                graph.clone(),
+                root,
+                &[(
+                    branch_path.clone(),
+                    local_selection_for_path(&graph, &branch_path, right_alias),
+                )],
+            );
+            let condition_path =
+                generated_graph_path_with_composite_tail(&graph, root, &condition_spec);
+            let condition_branch = graph_path_branch(&condition_path);
+            let left_condition_alias = left_alias.wrapping_add(2);
+            let right_condition_alias = left_alias.wrapping_add(3);
+            let left_condition = tree_from_paths_with_local_selections(
+                graph.clone(),
+                root,
+                &[(
+                    condition_path.clone(),
+                    local_selection_for_path(&graph, &condition_path, left_condition_alias),
+                )],
+            );
+            let right_condition = tree_from_paths_with_local_selections(
+                graph,
+                root,
+                &[(
+                    condition_path.clone(),
+                    local_selection_for_path(&left_base.graph, &condition_path, right_condition_alias),
+                )],
+            );
+            let left = with_single_child_condition(
+                &decorate_single_child_with_context_payload(
+                    &left_base,
+                    "left_combined",
+                    left_context_mask & 0b1111,
+                    left_argument_mask & 0b1111,
+                ),
+                left_condition,
+            );
+            let right = with_single_child_condition(
+                &decorate_single_child_with_context_payload(
+                    &right_base,
+                    "right_combined",
+                    right_context_mask & 0b1111,
+                    right_argument_mask & 0b1111,
+                ),
+                right_condition,
+            );
+
+            let mut expected_context_ids = left.childs[0]
+                .matching_context_ids
+                .clone()
+                .unwrap_or_default();
+            expected_context_ids.extend(
+                right.childs[0]
+                    .matching_context_ids
+                    .iter()
+                    .flatten()
+                    .cloned(),
+            );
+            let mut expected_arguments = left.childs[0]
+                .arguments_to_context_usages
+                .clone()
+                .unwrap_or_default();
+            expected_arguments.extend(
+                right.childs[0]
+                    .arguments_to_context_usages
+                    .iter()
+                    .flat_map(|arguments| arguments.iter())
+                    .map(|(name, usage)| (name.clone(), usage.clone())),
+            );
+
+            let merged = left.merge(&right);
+            prop_assert_eq!(merged.childs.len(), 1);
+            prop_assert_eq!(
+                merged.childs[0]
+                    .matching_context_ids
+                    .clone()
+                    .unwrap_or_default(),
+                expected_context_ids,
+            );
+            prop_assert_eq!(
+                merged.childs[0]
+                    .arguments_to_context_usages
+                    .clone()
+                    .unwrap_or_default(),
+                expected_arguments,
+            );
+            prop_assert_eq!(
+                audit_and_collect_local_selections(&merged.childs[0].tree),
+                BTreeMap::from([(
+                    Vec::new(),
+                    BTreeSet::from([
+                        format!("local_{left_alias}: __typename"),
+                        format!("local_{right_alias}: __typename"),
+                    ]),
+                )]),
+                "shared child lost its own local payload",
+            );
+            prop_assert_eq!(
+                audit_and_collect_local_selections(
+                    merged.childs[0]
+                        .conditions
+                        .as_ref()
+                        .expect("shared child lost its condition tree"),
+                ),
+                BTreeMap::from([(
+                    condition_branch,
+                    BTreeSet::from([
+                        format!("local_{left_condition_alias}: __typename"),
+                        format!("local_{right_condition_alias}: __typename"),
+                    ]),
+                )]),
+                "shared child condition lost its local payload",
+            );
+        }
     }
 
     #[test]

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -5854,4 +5854,852 @@ mod tests {
             graph.reduced_defer_edges
         );
     }
+
+    // =========================================================================================
+    // Sentinel 1 (proptest-graph-notes.md, "Graph PR 1"): FetchDependencyGraph mutation and
+    // reduction model.
+    //
+    // `DagCommand` drives a `FetchDependencyGraph` through its own private mutation methods
+    // (`new_node`, `add_parent`, `remove_node`, `retain_nodes`, `reduce`,
+    // `remove_redundant_edges`), while `DagModel` performs the same mutation against a naive,
+    // independently-written in-memory graph (plain BFS/DFS reachability, no Petgraph transitive
+    // reduction). After every command, `audit_dag_matches_model` recomputes every fact the
+    // production graph caches — the edge set, acyclicity, `is_reduced`/`is_optimized`, and the
+    // `reduced_defer_edges` ledger — from the model's own state and compares it to production.
+    //
+    // Node identity is the production `NodeIndex` itself (`StableDiGraph` reuses freed indices,
+    // so a node's `NodeIndex` is not proof of insertion order). A separate monotonic `rank` is
+    // assigned at creation and used only to orient generated edges low-rank -> high-rank, which
+    // guarantees every generated trace stays acyclic without ever needing to reject a command.
+    // =========================================================================================
+
+    use proptest::prelude::*;
+    use proptest::proptest;
+    use proptest::test_runner::TestCaseError;
+
+    /// Only the two subgraphs the shared test fixture (`TEST_SUPERGRAPH_SDL`) defines.
+    const DAG_TEST_SUBGRAPHS: [&str; 2] = ["Subgraph1", "Subgraph2"];
+
+    /// Deliberate adversarial shapes from proptest-graph-notes.md's "Required adversarial
+    /// shapes" list (the topology-relevant subset; the rest — mergeable siblings, nested
+    /// `@requires`, interface/union restrictions, list-of-list paths — need selection/input
+    /// payloads that are out of scope for this topology-only harness). Each shape is applied as
+    /// an atomic unit using freshly-created nodes, so it composes with arbitrary surrounding
+    /// commands regardless of where in the trace it lands.
+    #[derive(Debug, Clone, Copy)]
+    enum DagShape {
+        /// A -> B -> C.
+        Chain,
+        /// A -> B -> C, plus a redundant direct A -> C.
+        Shortcut,
+        /// A -> B, A -> C, B -> D, C -> D: no edge here is individually redundant.
+        Diamond,
+        /// A diamond plus a redundant direct A -> D.
+        DiamondWithShortcut,
+        /// A -> M, B -> M, M -> X, M -> Y: multiple roots into a shared middle, fanning back out.
+        BowTie,
+        /// A bow tie plus a redundant direct A -> X.
+        BowTieWithShortcut,
+        /// A(primary) -> B(primary) -> C(deferred), plus a direct A -> C shortcut that crosses
+        /// the defer boundary and must be reduced-defer-ledgered rather than just dropped.
+        DeferCrossingShortcut,
+        /// Remove an existing live node (if any), then add two fresh nodes and connect them —
+        /// the new nodes are likely to reuse the freed `NodeIndex` slot.
+        StableIndexHole,
+    }
+
+    fn dag_shape_strategy() -> impl Strategy<Value = DagShape> {
+        prop_oneof![
+            Just(DagShape::Chain),
+            Just(DagShape::Shortcut),
+            Just(DagShape::Diamond),
+            Just(DagShape::DiamondWithShortcut),
+            Just(DagShape::BowTie),
+            Just(DagShape::BowTieWithShortcut),
+            Just(DagShape::DeferCrossingShortcut),
+            Just(DagShape::StableIndexHole),
+        ]
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum DagCommand {
+        AddNode {
+            subgraph: u8,
+            defer_group: Option<u8>,
+        },
+        AddParent {
+            parent: u16,
+            child: u16,
+        },
+        RemoveNode {
+            node: u16,
+        },
+        RetainByMask {
+            mask: u32,
+        },
+        Reduce,
+        ReduceFrom {
+            node: u16,
+        },
+        /// Deliberately construct one of the required adversarial shapes above, using freshly
+        /// created nodes (`StableIndexHole` additionally consumes `victim` to pick a node to
+        /// remove first).
+        Shape {
+            shape: DagShape,
+            subgraph_seed: u8,
+            defer_seed: u8,
+            victim: u16,
+        },
+    }
+
+    fn dag_defer_group_strategy() -> impl Strategy<Value = Option<u8>> {
+        prop_oneof![
+            3 => Just(None),
+            7 => (0u8..4).prop_map(Some),
+        ]
+    }
+
+    fn dag_command_strategy() -> impl Strategy<Value = DagCommand> {
+        prop_oneof![
+            2 => (any::<u8>(), dag_defer_group_strategy())
+                .prop_map(|(subgraph, defer_group)| DagCommand::AddNode {
+                    subgraph,
+                    defer_group
+                }),
+            4 => (any::<u16>(), any::<u16>())
+                .prop_map(|(parent, child)| DagCommand::AddParent { parent, child }),
+            1 => any::<u16>().prop_map(|node| DagCommand::RemoveNode { node }),
+            1 => any::<u32>().prop_map(|mask| DagCommand::RetainByMask { mask }),
+            2 => Just(DagCommand::Reduce),
+            1 => any::<u16>().prop_map(|node| DagCommand::ReduceFrom { node }),
+            // Weighted so that, combined with the usual 0..40 trace length, the overwhelming
+            // majority of generated traces contain at least one deliberate adversarial shape —
+            // comfortably above the notes' "at least half" floor — while `AddNode`/`AddParent`
+            // above still generate general, unstructured valid DAGs the rest of the time.
+            6 => (dag_shape_strategy(), any::<u8>(), any::<u8>(), any::<u16>()).prop_map(
+                |(shape, subgraph_seed, defer_seed, victim)| DagCommand::Shape {
+                    shape,
+                    subgraph_seed,
+                    defer_seed,
+                    victim,
+                }
+            ),
+        ]
+    }
+
+    fn dag_command_trace_strategy() -> impl Strategy<Value = Vec<DagCommand>> {
+        prop::collection::vec(dag_command_strategy(), 0..40)
+    }
+
+    /// Naive reference model for `FetchDependencyGraph`'s topology. Deliberately independent of
+    /// every production algorithm: no `dag_transitive_reduction_closure`, no incremental
+    /// bookkeeping, just plain graph traversal recomputed from scratch each time.
+    #[derive(Default)]
+    struct DagModel {
+        live: IndexSet<NodeIndex>,
+        rank: IndexMap<NodeIndex, u64>,
+        defer_group: IndexMap<NodeIndex, Option<u8>>,
+        edges: IndexSet<(NodeIndex, NodeIndex)>,
+        /// Mirrors `FetchDependencyGraph::reduced_defer_edges`. Compared as a multiset: per the
+        /// sprint decision log, internal duplicates are not (yet) known to be a contract
+        /// violation, only the externally-collected dependency set is.
+        ledger: Vec<(NodeIndex, NodeIndex)>,
+        next_rank: u64,
+        is_reduced: bool,
+    }
+
+    impl DagModel {
+        fn sorted_live(&self) -> Vec<NodeIndex> {
+            let mut nodes: Vec<NodeIndex> = self.live.iter().copied().collect();
+            nodes.sort_by_key(|n| n.index());
+            nodes
+        }
+
+        /// Choice-by-modulo selection of a currently-live node (see proptest-graph-notes.md).
+        fn pick(&self, choice: u16) -> Option<NodeIndex> {
+            let sorted = self.sorted_live();
+            if sorted.is_empty() {
+                None
+            } else {
+                Some(sorted[choice as usize % sorted.len()])
+            }
+        }
+
+        fn children(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + '_ {
+            self.edges
+                .iter()
+                .filter(move |&&(source, _)| source == node)
+                .map(|&(_, target)| target)
+        }
+
+        /// Nodes reachable from `start` via a path of length >= 1 (proper descendants).
+        fn descendants(&self, start: NodeIndex) -> IndexSet<NodeIndex> {
+            let mut visited = IndexSet::default();
+            let mut stack: Vec<NodeIndex> = self.children(start).collect();
+            while let Some(node) = stack.pop() {
+                if visited.insert(node) {
+                    stack.extend(self.children(node));
+                }
+            }
+            visited
+        }
+
+        /// Whether `target` remains reachable from `source` using every edge except `excluded`.
+        fn reachable_excluding(
+            &self,
+            source: NodeIndex,
+            target: NodeIndex,
+            excluded: (NodeIndex, NodeIndex),
+        ) -> bool {
+            let mut visited = IndexSet::default();
+            let mut stack = vec![source];
+            while let Some(node) = stack.pop() {
+                for child in self.children(node) {
+                    if (node, child) == excluded {
+                        continue;
+                    }
+                    if child == target {
+                        return true;
+                    }
+                    if visited.insert(child) {
+                        stack.push(child);
+                    }
+                }
+            }
+            false
+        }
+
+        /// Global transitive reduction: an edge is redundant iff its endpoints remain connected
+        /// without it. For a DAG this set is unique, so this is directly comparable to whatever
+        /// edges `dag_transitive_reduction_closure` retains.
+        fn globally_redundant_edges(&self) -> IndexSet<(NodeIndex, NodeIndex)> {
+            self.edges
+                .iter()
+                .copied()
+                .filter(|&(source, target)| {
+                    self.reachable_excluding(source, target, (source, target))
+                })
+                .collect()
+        }
+
+        /// Local reduction restricted to edges leaving `node`, matching
+        /// `FetchDependencyGraph::remove_redundant_edges`: an edge `node -> v` is redundant iff
+        /// `v` is also reachable from `node` via some other direct child (a path of length >= 2).
+        fn locally_redundant_edges_from(
+            &self,
+            node: NodeIndex,
+        ) -> IndexSet<(NodeIndex, NodeIndex)> {
+            let mut reachable_via_other_child = IndexSet::default();
+            for child in self.children(node).collect::<Vec<_>>() {
+                reachable_via_other_child.extend(self.descendants(child));
+            }
+            self.children(node)
+                .filter(|target| reachable_via_other_child.contains(target))
+                .map(|target| (node, target))
+                .collect()
+        }
+
+        /// Mirrors `record_reduced_defer_edges`: only cross-defer-boundary edges are ledgered.
+        fn record_ledger(&mut self, removed: &IndexSet<(NodeIndex, NodeIndex)>) {
+            for &(source, target) in removed {
+                if self.defer_group[&source] != self.defer_group[&target] {
+                    self.ledger.push((source, target));
+                }
+            }
+        }
+
+        /// Mirrors the lockstep cleanup in `remove_node`/`retain_nodes`.
+        fn drop_node(&mut self, node: NodeIndex) {
+            self.live.shift_remove(&node);
+            self.rank.shift_remove(&node);
+            self.defer_group.shift_remove(&node);
+            self.edges.retain(|&(s, t)| s != node && t != node);
+            self.ledger.retain(|&(s, t)| s != node && t != node);
+        }
+    }
+
+    /// Apply one command to both the production graph and the reference model. Every branch
+    /// documents which production `on_modification`/flag behavior it is mirroring.
+    fn apply_dag_command(
+        graph: &mut FetchDependencyGraph,
+        model: &mut DagModel,
+        command: &DagCommand,
+    ) {
+        match *command {
+            DagCommand::AddNode {
+                subgraph,
+                defer_group,
+            } => {
+                let subgraph_name =
+                    DAG_TEST_SUBGRAPHS[subgraph as usize % DAG_TEST_SUBGRAPHS.len()];
+                let defer_ref = defer_group.map(|g| format!("d{g}"));
+                let node = add_test_node(graph, subgraph_name, defer_ref.as_deref());
+                model.live.insert(node);
+                model.rank.insert(node, model.next_rank);
+                model.next_rank += 1;
+                model.defer_group.insert(node, defer_group);
+                // `new_node` unconditionally calls `on_modification`.
+                model.is_reduced = false;
+            }
+            DagCommand::AddParent { parent, child } => {
+                let (Some(a), Some(b)) = (model.pick(parent), model.pick(child)) else {
+                    return;
+                };
+                if a == b {
+                    // A self-relation: production's descendant assert would fire on this, so
+                    // there is no valid interpretation other than skipping (a no-op trace entry).
+                    return;
+                }
+                // Only ever add low-rank -> high-rank edges, so the trace can never build a
+                // cycle even after `StableDiGraph` reuses a freed `NodeIndex`.
+                let (lo, hi) = if model.rank[&a] < model.rank[&b] {
+                    (a, b)
+                } else {
+                    (b, a)
+                };
+                if model.edges.contains(&(lo, hi)) {
+                    // `add_parent` early-returns via `contains_edge` without calling
+                    // `on_modification`.
+                    return;
+                }
+                graph.add_parent(
+                    hi,
+                    ParentRelation {
+                        parent_node_id: lo,
+                        path_in_parent: None,
+                    },
+                );
+                model.edges.insert((lo, hi));
+                model.is_reduced = false;
+            }
+            DagCommand::RemoveNode { node } => {
+                let Some(node) = model.pick(node) else {
+                    return;
+                };
+                graph.remove_node(node);
+                model.drop_node(node);
+                // `remove_node` unconditionally calls `on_modification`.
+                model.is_reduced = false;
+            }
+            DagCommand::RetainByMask { mask } => {
+                let sorted = model.sorted_live();
+                if sorted.is_empty() {
+                    return;
+                }
+                // Bit `i` of `mask` decides whether to keep the `i`-th live node in index order;
+                // beyond the mask's 32 bits, default to keeping (never shift by >= 32).
+                let keep: IndexSet<NodeIndex> = sorted
+                    .iter()
+                    .enumerate()
+                    .filter(|&(i, _)| i >= 32 || (mask >> i) & 1 == 1)
+                    .map(|(_, &n)| n)
+                    .collect();
+                graph.retain_nodes(|n| keep.contains(n));
+                if keep.len() < sorted.len() {
+                    for &node in &sorted {
+                        if !keep.contains(&node) {
+                            model.drop_node(node);
+                        }
+                    }
+                    // `retain_nodes` only calls `on_modification` when the node count dropped.
+                    model.is_reduced = false;
+                }
+            }
+            DagCommand::Reduce => {
+                if model.is_reduced {
+                    graph.reduce(); // exercises the early-return; no state change expected.
+                    return;
+                }
+                let removed = model.globally_redundant_edges();
+                model.record_ledger(&removed);
+                for edge in &removed {
+                    model.edges.shift_remove(edge);
+                }
+                graph.reduce();
+                model.is_reduced = true;
+            }
+            DagCommand::ReduceFrom { node } => {
+                let Some(node) = model.pick(node) else {
+                    return;
+                };
+                let removed = model.locally_redundant_edges_from(node);
+                model.record_ledger(&removed);
+                graph.remove_redundant_edges(node);
+                for edge in &removed {
+                    model.edges.shift_remove(edge);
+                }
+                if !removed.is_empty() {
+                    // `remove_redundant_edges` only calls `on_modification` when it actually
+                    // removed an edge.
+                    model.is_reduced = false;
+                }
+            }
+            DagCommand::Shape {
+                shape,
+                subgraph_seed,
+                defer_seed,
+                victim,
+            } => apply_dag_shape(graph, model, shape, subgraph_seed, defer_seed, victim),
+        }
+    }
+
+    /// Construct one adversarial shape using freshly created nodes, wired together directly by
+    /// their concrete `NodeIndex` values (no modulo addressing needed, since the nodes are all
+    /// created right here).
+    fn apply_dag_shape(
+        graph: &mut FetchDependencyGraph,
+        model: &mut DagModel,
+        shape: DagShape,
+        subgraph_seed: u8,
+        defer_seed: u8,
+        victim: u16,
+    ) {
+        let subgraph_for = |i: u8| -> &'static str {
+            DAG_TEST_SUBGRAPHS[(subgraph_seed.wrapping_add(i) as usize) % DAG_TEST_SUBGRAPHS.len()]
+        };
+        let add = |graph: &mut FetchDependencyGraph,
+                   model: &mut DagModel,
+                   i: u8,
+                   defer_group: Option<u8>|
+         -> NodeIndex {
+            let defer_ref = defer_group.map(|g| format!("d{g}"));
+            let node = add_test_node(graph, subgraph_for(i), defer_ref.as_deref());
+            model.live.insert(node);
+            model.rank.insert(node, model.next_rank);
+            model.next_rank += 1;
+            model.defer_group.insert(node, defer_group);
+            node
+        };
+        let connect = |graph: &mut FetchDependencyGraph,
+                       model: &mut DagModel,
+                       parent: NodeIndex,
+                       child: NodeIndex| {
+            if model.edges.contains(&(parent, child)) {
+                return;
+            }
+            graph.add_parent(
+                child,
+                ParentRelation {
+                    parent_node_id: parent,
+                    path_in_parent: None,
+                },
+            );
+            model.edges.insert((parent, child));
+        };
+
+        match shape {
+            DagShape::Chain => {
+                let a = add(graph, model, 0, None);
+                let b = add(graph, model, 1, None);
+                let c = add(graph, model, 2, None);
+                connect(graph, model, a, b);
+                connect(graph, model, b, c);
+            }
+            DagShape::Shortcut => {
+                let a = add(graph, model, 0, None);
+                let b = add(graph, model, 1, None);
+                let c = add(graph, model, 2, None);
+                connect(graph, model, a, b);
+                connect(graph, model, b, c);
+                connect(graph, model, a, c);
+            }
+            DagShape::Diamond => {
+                let a = add(graph, model, 0, None);
+                let b = add(graph, model, 1, None);
+                let c = add(graph, model, 2, None);
+                let d = add(graph, model, 3, None);
+                connect(graph, model, a, b);
+                connect(graph, model, a, c);
+                connect(graph, model, b, d);
+                connect(graph, model, c, d);
+            }
+            DagShape::DiamondWithShortcut => {
+                let a = add(graph, model, 0, None);
+                let b = add(graph, model, 1, None);
+                let c = add(graph, model, 2, None);
+                let d = add(graph, model, 3, None);
+                connect(graph, model, a, b);
+                connect(graph, model, a, c);
+                connect(graph, model, b, d);
+                connect(graph, model, c, d);
+                connect(graph, model, a, d);
+            }
+            DagShape::BowTie => {
+                let a = add(graph, model, 0, None);
+                let b = add(graph, model, 1, None);
+                let m = add(graph, model, 2, None);
+                let x = add(graph, model, 3, None);
+                let y = add(graph, model, 4, None);
+                connect(graph, model, a, m);
+                connect(graph, model, b, m);
+                connect(graph, model, m, x);
+                connect(graph, model, m, y);
+            }
+            DagShape::BowTieWithShortcut => {
+                let a = add(graph, model, 0, None);
+                let b = add(graph, model, 1, None);
+                let m = add(graph, model, 2, None);
+                let x = add(graph, model, 3, None);
+                let y = add(graph, model, 4, None);
+                connect(graph, model, a, m);
+                connect(graph, model, b, m);
+                connect(graph, model, m, x);
+                connect(graph, model, m, y);
+                connect(graph, model, a, x);
+            }
+            DagShape::DeferCrossingShortcut => {
+                let a = add(graph, model, 0, None);
+                let b = add(graph, model, 1, None);
+                let c = add(graph, model, 2, Some(defer_seed % 4));
+                connect(graph, model, a, b);
+                connect(graph, model, b, c);
+                connect(graph, model, a, c);
+            }
+            DagShape::StableIndexHole => {
+                let Some(victim_node) = model.pick(victim) else {
+                    return;
+                };
+                graph.remove_node(victim_node);
+                model.drop_node(victim_node);
+                let a = add(graph, model, 0, None);
+                let b = add(graph, model, 1, None);
+                connect(graph, model, a, b);
+            }
+        }
+        // Every reachable branch above creates at least one node, which unconditionally calls
+        // `on_modification` in production (the early-return branch of `StableIndexHole`, which
+        // makes no production call at all, returns before reaching this line).
+        model.is_reduced = false;
+    }
+
+    /// Recompute every audited fact from `model`'s own state and compare it to `graph`.
+    fn audit_dag_matches_model(
+        graph: &FetchDependencyGraph,
+        model: &DagModel,
+    ) -> Result<(), TestCaseError> {
+        // 1. Live node sets correspond exactly.
+        let mut production_nodes: Vec<usize> =
+            graph.graph.node_indices().map(|n| n.index()).collect();
+        production_nodes.sort_unstable();
+        let mut model_nodes: Vec<usize> = model.live.iter().map(|n| n.index()).collect();
+        model_nodes.sort_unstable();
+        prop_assert_eq!(production_nodes, model_nodes, "live node sets diverged");
+
+        // 2. The production graph must remain acyclic.
+        prop_assert!(
+            petgraph::algo::toposort(&graph.graph, None).is_ok(),
+            "production graph is not acyclic"
+        );
+
+        // 3. Direct edge endpoints match exactly.
+        let mut production_edges: Vec<(usize, usize)> = graph
+            .graph
+            .edge_references()
+            .map(|e| (e.source().index(), e.target().index()))
+            .collect();
+        production_edges.sort_unstable();
+        let mut model_edges: Vec<(usize, usize)> = model
+            .edges
+            .iter()
+            .map(|&(s, t)| (s.index(), t.index()))
+            .collect();
+        model_edges.sort_unstable();
+        prop_assert_eq!(production_edges, model_edges, "edge sets diverged");
+
+        // 4. `is_reduced`/`is_optimized` match the model's invalidation state. This harness never
+        // calls `reduce_and_optimize`, so `is_optimized` should never become true.
+        prop_assert_eq!(graph.is_reduced, model.is_reduced, "is_reduced diverged");
+        prop_assert!(!graph.is_optimized, "is_optimized unexpectedly set");
+
+        // 5. If reduced, every retained edge must be indispensable.
+        if model.is_reduced {
+            let redundant = model.globally_redundant_edges();
+            prop_assert!(
+                redundant.is_empty(),
+                "reduced graph retains a redundant edge: {redundant:?}"
+            );
+        }
+
+        // 6. `reduced_defer_edges` ledger, compared as a multiset.
+        let mut production_ledger: Vec<(usize, usize)> = graph
+            .reduced_defer_edges
+            .iter()
+            .map(|&(s, t)| (s.index(), t.index()))
+            .collect();
+        production_ledger.sort_unstable();
+        let mut model_ledger: Vec<(usize, usize)> = model
+            .ledger
+            .iter()
+            .map(|&(s, t)| (s.index(), t.index()))
+            .collect();
+        model_ledger.sort_unstable();
+        prop_assert_eq!(
+            production_ledger,
+            model_ledger,
+            "reduced_defer_edges ledger diverged"
+        );
+
+        // 7. Every ledger entry refers to a live node.
+        for &(s, t) in &graph.reduced_defer_edges {
+            prop_assert!(model.live.contains(&s), "ledger source {s:?} is not live");
+            prop_assert!(model.live.contains(&t), "ledger target {t:?} is not live");
+        }
+
+        Ok(())
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// The core sentinel: after every command in a generated trace, the production graph's
+        /// topology, `is_reduced`/`is_optimized` flags, and `reduced_defer_edges` ledger must
+        /// match a naive reference model recomputed from scratch. See "Sentinel 1" in
+        /// proptest-graph-notes.md.
+        #[test]
+        fn fetch_dependency_graph_trace_matches_naive_model(commands in dag_command_trace_strategy()) {
+            let mut graph = make_test_dep_graph();
+            let mut model = DagModel::default();
+            for command in &commands {
+                apply_dag_command(&mut graph, &mut model, command);
+                audit_dag_matches_model(&graph, &model)?;
+            }
+        }
+
+        /// Focused dense-index property: `to_toposorted_adjacency_list`'s rank mapping must round
+        /// trip every edge back to its original `NodeIndex` pair, including across stable-index
+        /// holes left by node removal.
+        #[test]
+        fn toposorted_adjacency_round_trips_edges_with_stable_index_holes(
+            commands in dag_command_trace_strategy()
+        ) {
+            let mut graph = make_test_dep_graph();
+            let mut model = DagModel::default();
+            for command in &commands {
+                apply_dag_command(&mut graph, &mut model, command);
+            }
+
+            let Some((adj, tred_index_of)) = to_toposorted_adjacency_list(&graph.graph) else {
+                // This harness only ever builds a DAG (see the rank-ordering invariant above).
+                return Err(TestCaseError::fail("expected an acyclic graph"));
+            };
+
+            let live_count = tred_index_of.iter().filter(|&&rank| rank != usize::MAX).count();
+            let mut rank_to_node: Vec<Option<NodeIndex>> = vec![None; live_count];
+            for (original_index, &rank) in tred_index_of.iter().enumerate() {
+                if rank != usize::MAX {
+                    rank_to_node[rank] = Some(NodeIndex::new(original_index));
+                }
+            }
+
+            let mut round_tripped: Vec<(usize, usize)> = adj
+                .edge_references()
+                .map(|e| {
+                    let source = rank_to_node[e.source().index()].expect("rank must map back to a node");
+                    let target = rank_to_node[e.target().index()].expect("rank must map back to a node");
+                    (source.index(), target.index())
+                })
+                .collect();
+            round_tripped.sort_unstable();
+
+            let mut actual: Vec<(usize, usize)> = graph
+                .graph
+                .edge_references()
+                .map(|e| (e.source().index(), e.target().index()))
+                .collect();
+            actual.sort_unstable();
+
+            prop_assert_eq!(round_tripped, actual);
+        }
+    }
+
+    /// A -> B -> C: transitive reduction of a plain chain must remove nothing.
+    #[test]
+    fn dag_chain_has_no_redundant_edges() {
+        let mut graph = make_test_dep_graph();
+        let a = add_test_node(&mut graph, "Subgraph1", None);
+        let b = add_test_node(&mut graph, "Subgraph2", None);
+        let c = add_test_node(&mut graph, "Subgraph2", None);
+        add_test_edge(&mut graph, a, b);
+        add_test_edge(&mut graph, b, c);
+
+        graph.reduce();
+
+        let mut edges: Vec<(usize, usize)> = graph
+            .graph
+            .edge_references()
+            .map(|e| (e.source().index(), e.target().index()))
+            .collect();
+        edges.sort_unstable();
+        assert_eq!(edges, vec![(a.index(), b.index()), (b.index(), c.index())]);
+        assert!(graph.reduced_defer_edges.is_empty());
+    }
+
+    /// A -> B -> C plus a direct A -> C shortcut: reduce must remove exactly the shortcut.
+    #[test]
+    fn dag_reduce_removes_shortcut_edge() {
+        let mut graph = make_test_dep_graph();
+        let a = add_test_node(&mut graph, "Subgraph1", None);
+        let b = add_test_node(&mut graph, "Subgraph2", None);
+        let c = add_test_node(&mut graph, "Subgraph2", None);
+        add_test_edge(&mut graph, a, b);
+        add_test_edge(&mut graph, b, c);
+        add_test_edge(&mut graph, a, c);
+
+        graph.reduce();
+
+        let mut edges: Vec<(usize, usize)> = graph
+            .graph
+            .edge_references()
+            .map(|e| (e.source().index(), e.target().index()))
+            .collect();
+        edges.sort_unstable();
+        assert_eq!(edges, vec![(a.index(), b.index()), (b.index(), c.index())]);
+        assert!(graph.is_reduced);
+    }
+
+    /// Diamond (A -> B, A -> C, B -> D, C -> D) plus a redundant direct A -> D shortcut: reduce
+    /// must remove only the shortcut, keeping every diamond edge (none of them are individually
+    /// redundant).
+    #[test]
+    fn dag_reduce_keeps_diamond_removes_shortcut() {
+        let mut graph = make_test_dep_graph();
+        let a = add_test_node(&mut graph, "Subgraph1", None);
+        let b = add_test_node(&mut graph, "Subgraph2", None);
+        let c = add_test_node(&mut graph, "Subgraph2", None);
+        let d = add_test_node(&mut graph, "Subgraph1", None);
+        add_test_edge(&mut graph, a, b);
+        add_test_edge(&mut graph, a, c);
+        add_test_edge(&mut graph, b, d);
+        add_test_edge(&mut graph, c, d);
+        add_test_edge(&mut graph, a, d);
+
+        graph.reduce();
+
+        let mut edges: Vec<(usize, usize)> = graph
+            .graph
+            .edge_references()
+            .map(|e| (e.source().index(), e.target().index()))
+            .collect();
+        edges.sort_unstable();
+        let mut expected = vec![
+            (a.index(), b.index()),
+            (a.index(), c.index()),
+            (b.index(), d.index()),
+            (c.index(), d.index()),
+        ];
+        expected.sort_unstable();
+        assert_eq!(edges, expected);
+    }
+
+    /// Bow tie (A -> M, B -> M, M -> X, M -> Y) plus a redundant direct A -> X shortcut: reduce
+    /// must remove only the shortcut.
+    #[test]
+    fn dag_reduce_keeps_bow_tie_removes_shortcut() {
+        let mut graph = make_test_dep_graph();
+        let a = add_test_node(&mut graph, "Subgraph1", None);
+        let b = add_test_node(&mut graph, "Subgraph1", None);
+        let m = add_test_node(&mut graph, "Subgraph2", None);
+        let x = add_test_node(&mut graph, "Subgraph1", None);
+        let y = add_test_node(&mut graph, "Subgraph1", None);
+        add_test_edge(&mut graph, a, m);
+        add_test_edge(&mut graph, b, m);
+        add_test_edge(&mut graph, m, x);
+        add_test_edge(&mut graph, m, y);
+        add_test_edge(&mut graph, a, x);
+
+        graph.reduce();
+
+        let mut edges: Vec<(usize, usize)> = graph
+            .graph
+            .edge_references()
+            .map(|e| (e.source().index(), e.target().index()))
+            .collect();
+        edges.sort_unstable();
+        let mut expected = vec![
+            (a.index(), m.index()),
+            (b.index(), m.index()),
+            (m.index(), x.index()),
+            (m.index(), y.index()),
+        ];
+        expected.sort_unstable();
+        assert_eq!(edges, expected);
+    }
+
+    /// Removing an interior node and adding a new one exercises a stable-index hole: the new
+    /// node reuses the freed `NodeIndex`, and reduction must still behave correctly across it.
+    #[test]
+    fn dag_reduce_across_stable_index_hole() {
+        let mut graph = make_test_dep_graph();
+        let a = add_test_node(&mut graph, "Subgraph1", None);
+        let b = add_test_node(&mut graph, "Subgraph2", None);
+        let c = add_test_node(&mut graph, "Subgraph2", None);
+        graph.remove_node(b);
+        // Reuses `b`'s freed slot; `d.index() == b.index()` is the point of this test.
+        let d = add_test_node(&mut graph, "Subgraph1", None);
+        assert_eq!(d.index(), b.index());
+
+        add_test_edge(&mut graph, a, d);
+        add_test_edge(&mut graph, d, c);
+        add_test_edge(&mut graph, a, c);
+
+        graph.reduce();
+
+        let mut edges: Vec<(usize, usize)> = graph
+            .graph
+            .edge_references()
+            .map(|e| (e.source().index(), e.target().index()))
+            .collect();
+        edges.sort_unstable();
+        assert_eq!(edges, vec![(a.index(), d.index()), (d.index(), c.index())]);
+    }
+
+    /// A(primary) -> B(primary) -> C(deferred), plus a direct A -> C shortcut crossing the defer
+    /// boundary: `reduce` (not just `remove_redundant_edges`) must ledger the shortcut so
+    /// `collect_reduced_defer_dependencies` can still recover the dependency later.
+    #[test]
+    fn dag_reduce_records_defer_crossing_shortcut_in_ledger() {
+        let mut graph = make_test_dep_graph();
+        let a = add_test_node(&mut graph, "Subgraph1", None);
+        let b = add_test_node(&mut graph, "Subgraph2", None);
+        let c = add_test_node(&mut graph, "Subgraph2", Some("defer1"));
+        add_test_edge(&mut graph, a, b);
+        add_test_edge(&mut graph, b, c);
+        add_test_edge(&mut graph, a, c);
+
+        graph.reduce();
+
+        assert_eq!(graph.reduced_defer_edges, vec![(a, c)]);
+    }
+
+    /// Calling `reduce` a second time on an already-reduced graph must be a complete no-op:
+    /// edges, ledger, and flags are all unchanged.
+    #[test]
+    fn dag_reduce_is_idempotent() {
+        let mut graph = make_test_dep_graph();
+        let a = add_test_node(&mut graph, "Subgraph1", None);
+        let b = add_test_node(&mut graph, "Subgraph2", None);
+        let c = add_test_node(&mut graph, "Subgraph2", Some("defer1"));
+        add_test_edge(&mut graph, a, b);
+        add_test_edge(&mut graph, b, c);
+        add_test_edge(&mut graph, a, c);
+
+        graph.reduce();
+        let edges_after_first: Vec<(usize, usize)> = graph
+            .graph
+            .edge_references()
+            .map(|e| (e.source().index(), e.target().index()))
+            .collect();
+        let ledger_after_first = graph.reduced_defer_edges.clone();
+        assert!(graph.is_reduced);
+
+        graph.reduce();
+        let edges_after_second: Vec<(usize, usize)> = graph
+            .graph
+            .edge_references()
+            .map(|e| (e.source().index(), e.target().index()))
+            .collect();
+        assert_eq!(edges_after_first, edges_after_second);
+        assert_eq!(ledger_after_first, graph.reduced_defer_edges);
+        assert!(graph.is_reduced);
+    }
 }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -6032,6 +6032,13 @@ mod tests {
                 .map(|&(_, target)| target)
         }
 
+        fn parents(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + '_ {
+            self.edges
+                .iter()
+                .filter(move |&&(_, target)| target == node)
+                .map(|&(source, _)| source)
+        }
+
         /// Nodes reachable from `start` via a path of length >= 1 (proper descendants).
         fn descendants(&self, start: NodeIndex) -> IndexSet<NodeIndex> {
             let mut visited = IndexSet::default();
@@ -6701,5 +6708,348 @@ mod tests {
         assert_eq!(edges_after_first, edges_after_second);
         assert_eq!(ledger_after_first, graph.reduced_defer_edges);
         assert!(graph.is_reduced);
+    }
+
+    // =========================================================================================
+    // ProcessingState sub-property (proptest-graph-notes.md, Sentinel 1 / "Graph PR 2").
+    //
+    // `ProcessingState` is a separate exact state machine over the same generated DAG. Two kinds
+    // of property here:
+    //   - `create_state_for_children_of_processed_node` is compared against a naive
+    //     recomputation over the Sentinel-1 `DagModel` graph (an oracle test).
+    //   - `merge_with`/`update_for_processed_nodes` are pure data operations on `ProcessingState`
+    //     itself (no `&FetchDependencyGraph` involved), so their laws are checked directly against
+    //     synthetically generated, internally well-formed states, with no graph needed at all.
+    // =========================================================================================
+
+    /// Snapshot a `ProcessingState` into a normalized, order-independent form for comparison:
+    /// sorted `next` indices, and sorted `(node index, sorted parent indices)` pairs for
+    /// `unhandled`. `path_in_parent` is always `None` in every state this harness builds, so the
+    /// index alone identifies a `ParentRelation`.
+    fn processing_state_snapshot(
+        state: &ProcessingState,
+    ) -> (Vec<usize>, Vec<(usize, Vec<usize>)>) {
+        let mut next: Vec<usize> = state.next.iter().map(|n| n.index()).collect();
+        next.sort_unstable();
+        let mut unhandled: Vec<(usize, Vec<usize>)> = state
+            .unhandled
+            .iter()
+            .map(|u| {
+                let mut parents: Vec<usize> = u
+                    .unhandled_parents
+                    .iter()
+                    .map(|p| p.parent_node_id.index())
+                    .collect();
+                parents.sort_unstable();
+                (u.node.index(), parents)
+            })
+            .collect();
+        unhandled.sort_unstable();
+        (next, unhandled)
+    }
+
+    /// `ProcessingState`/`UnhandledNode` don't derive `Clone` (their production-visible API is
+    /// consuming-by-value), so tests that need the same state twice rebuild it field-by-field.
+    fn clone_processing_state(state: &ProcessingState) -> ProcessingState {
+        ProcessingState {
+            next: state.next.clone(),
+            unhandled: state
+                .unhandled
+                .iter()
+                .map(|u| UnhandledNode {
+                    node: u.node,
+                    unhandled_parents: u.unhandled_parents.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// `create_state_for_children_of_processed_node` must exactly match a naive
+        /// recomputation from the Sentinel-1 `DagModel`: a child is "next" iff `processed_index`
+        /// is its only parent, otherwise "unhandled" with every other parent still outstanding.
+        #[test]
+        fn create_state_for_children_of_processed_node_matches_naive_recomputation(
+            commands in dag_command_trace_strategy(),
+            pick in any::<u16>(),
+        ) {
+            let mut graph = make_test_dep_graph();
+            let mut model = DagModel::default();
+            for command in &commands {
+                apply_dag_command(&mut graph, &mut model, command);
+            }
+            let Some(processed_index) = model.pick(pick) else {
+                return Ok(());
+            };
+            let children: Vec<NodeIndex> = model.children(processed_index).collect();
+
+            let mut expected_next = Vec::new();
+            let mut expected_unhandled: Vec<(usize, Vec<usize>)> = Vec::new();
+            for &child in &children {
+                let parents: Vec<NodeIndex> = model.parents(child).collect();
+                if parents.len() == 1 {
+                    expected_next.push(child.index());
+                } else {
+                    let mut remaining: Vec<usize> = parents
+                        .iter()
+                        .filter(|&&p| p != processed_index)
+                        .map(|p| p.index())
+                        .collect();
+                    remaining.sort_unstable();
+                    expected_unhandled.push((child.index(), remaining));
+                }
+            }
+            expected_next.sort_unstable();
+            expected_unhandled.sort_unstable();
+
+            let actual = graph.create_state_for_children_of_processed_node(processed_index, children);
+            let (actual_next, actual_unhandled) = processing_state_snapshot(&actual);
+            prop_assert_eq!(actual_next.clone(), expected_next);
+            prop_assert_eq!(actual_unhandled.clone(), expected_unhandled);
+
+            // Well-formedness is guaranteed here because a single real call can't produce the
+            // cross-state conflicts that make it inapplicable to the pure-algebra properties
+            // below (see their doc comments).
+            let next_set: IndexSet<usize> = actual_next.iter().copied().collect();
+            prop_assert_eq!(next_set.len(), actual_next.len(), "duplicate `next` entry");
+            let unhandled_nodes: Vec<usize> = actual_unhandled.iter().map(|(n, _)| *n).collect();
+            let unhandled_node_set: IndexSet<usize> = unhandled_nodes.iter().copied().collect();
+            prop_assert_eq!(
+                unhandled_node_set.len(),
+                unhandled_nodes.len(),
+                "duplicate `unhandled` entry"
+            );
+            for node in &unhandled_nodes {
+                prop_assert!(!next_set.contains(node), "node {node} in both next and unhandled");
+            }
+            for (_, parents) in &actual_unhandled {
+                prop_assert!(!parents.is_empty(), "unhandled entry with no remaining parents");
+            }
+        }
+
+        /// `merge_with` is commutative, associative, and idempotent as a *set* operation (vector
+        /// order is incidental).
+        ///
+        /// The three states being merged are NOT independently generated: an earlier version of
+        /// this property did that and found a real associativity failure, which turned out to be
+        /// a generator bug rather than a production one (see the long comment above
+        /// `dag_consistent_sibling_states_strategy` for the full analysis and the discarded
+        /// counterexample). `merge_with`'s only caller (`process_nodes`) always merges states
+        /// that are per-sibling *views of the same underlying parent sets* — each state's opinion
+        /// about a shared descendant differs only in which one already-processed sibling has been
+        /// subtracted from that descendant's true parent set. Three views that disagree about a
+        /// descendant's true parent set (e.g. one claims it's `{0, A}`, another claims `{1, B}`)
+        /// can't arise from real siblings and aren't a precondition `merge_with` is expected to
+        /// tolerate, so the generator below constructs three such internally-consistent views
+        /// from one shared ground truth instead of three unrelated random states.
+        #[test]
+        fn processing_state_merge_with_is_commutative_associative_idempotent(
+            full_parents in dag_shared_full_parent_sets_strategy(),
+        ) {
+            let state_a = || dag_sibling_view(&full_parents, PS_SIBLINGS[0]);
+            let state_b = || dag_sibling_view(&full_parents, PS_SIBLINGS[1]);
+            let state_c = || dag_sibling_view(&full_parents, PS_SIBLINGS[2]);
+
+            let commutative_ab = state_a().merge_with(state_b());
+            let commutative_ba = state_b().merge_with(state_a());
+            prop_assert_eq!(
+                processing_state_snapshot(&commutative_ab),
+                processing_state_snapshot(&commutative_ba),
+                "merge_with is not commutative"
+            );
+
+            let assoc_left = state_a().merge_with(state_b()).merge_with(state_c());
+            let assoc_right = state_a().merge_with(state_b().merge_with(state_c()));
+            prop_assert_eq!(
+                processing_state_snapshot(&assoc_left),
+                processing_state_snapshot(&assoc_right),
+                "merge_with is not associative"
+            );
+
+            let idempotent = state_a().merge_with(state_a());
+            prop_assert_eq!(
+                processing_state_snapshot(&idempotent),
+                processing_state_snapshot(&state_a()),
+                "merge_with(a, a) must equal a"
+            );
+        }
+
+        /// `update_for_processed_nodes` is a pure filter over each `unhandled` entry's remaining
+        /// parents. For disjoint `p1`/`p2`, applying it twice (once per set) must equal applying
+        /// it once to their union; applying it to the empty set is the identity; applying the
+        /// same set twice is idempotent.
+        #[test]
+        fn processing_state_update_for_processed_nodes_matches_sequential_application(
+            state in dag_processing_state_strategy(),
+            p1 in prop::collection::vec(0..PS_PARENT_UNIVERSE, 0..4),
+            p2_raw in prop::collection::vec(0..PS_PARENT_UNIVERSE, 0..4),
+        ) {
+            let p1: Vec<NodeIndex> = {
+                let mut v: Vec<usize> = p1;
+                v.sort_unstable();
+                v.dedup();
+                v.into_iter().map(NodeIndex::new).collect()
+            };
+            // Keep `p2` disjoint from `p1`, per the law's precondition.
+            let p2: Vec<NodeIndex> = {
+                let mut v: Vec<usize> = p2_raw;
+                v.sort_unstable();
+                v.dedup();
+                v.into_iter()
+                    .filter(|n| !p1.contains(&NodeIndex::new(*n)))
+                    .map(NodeIndex::new)
+                    .collect()
+            };
+
+            let identity = clone_processing_state(&state).update_for_processed_nodes(&[]);
+            prop_assert_eq!(
+                processing_state_snapshot(&identity),
+                processing_state_snapshot(&state),
+                "update_for_processed_nodes(&[]) must be the identity"
+            );
+
+            let mut union = p1.clone();
+            union.extend(p2.iter().copied());
+            let union_applied = clone_processing_state(&state).update_for_processed_nodes(&union);
+            let sequential_applied = clone_processing_state(&state)
+                .update_for_processed_nodes(&p1)
+                .update_for_processed_nodes(&p2);
+            prop_assert_eq!(
+                processing_state_snapshot(&union_applied),
+                processing_state_snapshot(&sequential_applied),
+                "update_for_processed_nodes(p1 ++ p2) must equal update(p1).update(p2) for disjoint p1/p2"
+            );
+
+            let applied_once = clone_processing_state(&state).update_for_processed_nodes(&p1);
+            let applied_twice = clone_processing_state(&state)
+                .update_for_processed_nodes(&p1)
+                .update_for_processed_nodes(&p1);
+            prop_assert_eq!(
+                processing_state_snapshot(&applied_once),
+                processing_state_snapshot(&applied_twice),
+                "update_for_processed_nodes(p1) must be idempotent"
+            );
+        }
+    }
+
+    /// Universe sizes for `dag_processing_state_strategy`: small enough to shrink well and to
+    /// make node/parent collisions (needed to exercise `merge_with`'s intersection logic) common.
+    const PS_NODE_UNIVERSE: usize = 6;
+    const PS_PARENT_UNIVERSE: usize = 6;
+
+    /// Generate an internally well-formed `ProcessingState`: no duplicate `next` entry, no
+    /// duplicate `unhandled` node, no node in both, and every `unhandled` entry has at least one
+    /// (deduplicated) parent — the invariant `ProcessingState`'s own doc comment states
+    /// ("we make sure that this never hold node with no edges").
+    fn dag_processing_state_strategy() -> impl Strategy<Value = ProcessingState> {
+        prop::collection::vec(0..PS_NODE_UNIVERSE, 0..PS_NODE_UNIVERSE).prop_flat_map(|raw| {
+            let mut tracked = raw;
+            tracked.sort_unstable();
+            tracked.dedup();
+            let n = tracked.len();
+            (
+                prop::collection::vec(any::<bool>(), n),
+                prop::collection::vec(prop::collection::vec(0..PS_PARENT_UNIVERSE, 1..4), n),
+            )
+                .prop_map(move |(is_next_flags, parent_choices)| {
+                    let mut next = Vec::new();
+                    let mut unhandled = Vec::new();
+                    for (i, &node_idx) in tracked.iter().enumerate() {
+                        let node = NodeIndex::new(node_idx);
+                        if is_next_flags[i] {
+                            next.push(node);
+                        } else {
+                            let mut parents = parent_choices[i].clone();
+                            parents.sort_unstable();
+                            parents.dedup();
+                            let unhandled_parents = parents
+                                .into_iter()
+                                .map(|p| ParentRelation {
+                                    parent_node_id: NodeIndex::new(p),
+                                    path_in_parent: None,
+                                })
+                                .collect();
+                            unhandled.push(UnhandledNode {
+                                node,
+                                unhandled_parents,
+                            });
+                        }
+                    }
+                    ProcessingState { next, unhandled }
+                })
+        })
+    }
+
+    /// Three fixed "already-processed sibling" identifiers, deliberately far outside the
+    /// candidate/background-parent ranges below so they can never collide with an ordinary
+    /// parent by coincidence.
+    const PS_SIBLINGS: [usize; 3] = [1_000, 1_001, 1_002];
+    const PS_CANDIDATE_UNIVERSE: usize = 5;
+    const PS_BACKGROUND_PARENT_UNIVERSE: usize = 4;
+    /// Offset applied to background-parent ids so they can never collide with `PS_SIBLINGS`.
+    const PS_BACKGROUND_OFFSET: usize = 5_000;
+
+    /// Ground truth for `dag_sibling_view`: for each of a small number of candidate nodes, its
+    /// true, complete parent set — a subset of `PS_SIBLINGS` plus zero or more "background"
+    /// parents that no generated sibling view ever accounts for (so some candidates stay
+    /// permanently unhandled no matter which siblings are merged, exactly like a real fetch node
+    /// that also depends on a fetch outside the batch being processed).
+    fn dag_shared_full_parent_sets_strategy() -> impl Strategy<Value = Vec<Vec<usize>>> {
+        prop::collection::vec(
+            (
+                prop::collection::vec(0..PS_SIBLINGS.len(), 0..PS_SIBLINGS.len()),
+                prop::collection::vec(0..PS_BACKGROUND_PARENT_UNIVERSE, 0..3),
+            ),
+            PS_CANDIDATE_UNIVERSE,
+        )
+        .prop_map(|per_candidate| {
+            per_candidate
+                .into_iter()
+                .map(|(sibling_idxs, background)| {
+                    let mut parents: Vec<usize> =
+                        sibling_idxs.into_iter().map(|i| PS_SIBLINGS[i]).collect();
+                    parents.extend(background.into_iter().map(|b| PS_BACKGROUND_OFFSET + b));
+                    parents.sort_unstable();
+                    parents.dedup();
+                    parents
+                })
+                .collect()
+        })
+    }
+
+    /// The `ProcessingState` a single sibling (`excluded_sibling`) would compute via
+    /// `create_state_for_children_of_processed_node`, given the shared ground truth
+    /// `full_parents`: a candidate is in this view at all only if `excluded_sibling` is really
+    /// one of its parents (mirroring "only this sibling's own children are candidates"), and its
+    /// remaining parents are every other true parent.
+    fn dag_sibling_view(full_parents: &[Vec<usize>], excluded_sibling: usize) -> ProcessingState {
+        let mut next = Vec::new();
+        let mut unhandled = Vec::new();
+        for (candidate_idx, parents) in full_parents.iter().enumerate() {
+            if !parents.contains(&excluded_sibling) {
+                continue;
+            }
+            let node = NodeIndex::new(candidate_idx);
+            let remaining: Vec<ParentRelation> = parents
+                .iter()
+                .copied()
+                .filter(|&p| p != excluded_sibling)
+                .map(|p| ParentRelation {
+                    parent_node_id: NodeIndex::new(p),
+                    path_in_parent: None,
+                })
+                .collect();
+            if remaining.is_empty() {
+                next.push(node);
+            } else {
+                unhandled.push(UnhandledNode {
+                    node,
+                    unhandled_parents: remaining,
+                });
+            }
+        }
+        ProcessingState { next, unhandled }
     }
 }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -5877,6 +5877,8 @@ mod tests {
     use proptest::proptest;
     use proptest::test_runner::TestCaseError;
 
+    use crate::schema::field_set::parse_field_set;
+
     /// Only the two subgraphs the shared test fixture (`TEST_SUPERGRAPH_SDL`) defines.
     const DAG_TEST_SUBGRAPHS: [&str; 2] = ["Subgraph1", "Subgraph2"];
 
@@ -7051,5 +7053,193 @@ mod tests {
             }
         }
         ProcessingState { next, unhandled }
+    }
+
+    // =========================================================================================
+    // Defer dependency extension (proptest-graph-notes.md, Sentinel 1 / "Graph PR 2"): real
+    // top-level field tokens, `merge_at = None`, no aliases, no fragments — the first payload
+    // stage the notes describe.
+    //
+    // The rule under test, from `collect_reduced_defer_dependencies`'s own doc comment: a removed
+    // cross-defer edge source -> target must be recovered as a defer dependency iff the source's
+    // selection shares a field (other than `__typename`) with one of the target's `_entities`
+    // input selections. This builds the canonical three-node shape from the notes
+    // (`A(primary) -> B(primary) -> C(deferred)`, plus a redundant `A -> C` shortcut, reduced via
+    // the real `reduce()` — not hand-pushed into the ledger) with real field selections on `A`
+    // and real `_entities` inputs on `C`, and compares the recovered dependency against a direct
+    // field-name-set-intersection oracle.
+    // =========================================================================================
+
+    /// Which of the shared test fixture's three real `T` fields (`id`, `v1`, `v2` — see
+    /// `TEST_SUPERGRAPH_SDL`), plus `__typename`, a selection includes. This is the fixed field
+    /// universe the notes recommend materializing tokens from. `__typename` is kept separate
+    /// because the production rule explicitly excludes it from intersection.
+    #[derive(Debug, Clone, Copy)]
+    struct DagFieldSelection {
+        id: bool,
+        v1: bool,
+        v2: bool,
+        typename: bool,
+    }
+
+    fn dag_field_selection_strategy() -> impl Strategy<Value = DagFieldSelection> {
+        any::<(bool, bool, bool, bool)>().prop_map(|(id, v1, v2, typename)| {
+            // A field set string can't be empty; if every flag came back false, force one real
+            // field on rather than falling back to `__typename` alone, so the "no real overlap"
+            // case is still exercised as often as the "some overlap" case.
+            let id = id || !(v1 || v2 || typename);
+            DagFieldSelection {
+                id,
+                v1,
+                v2,
+                typename,
+            }
+        })
+    }
+
+    fn dag_field_selection_string(selection: DagFieldSelection) -> String {
+        let mut parts = Vec::new();
+        if selection.typename {
+            parts.push("__typename");
+        }
+        if selection.id {
+            parts.push("id");
+        }
+        if selection.v1 {
+            parts.push("v1");
+        }
+        if selection.v2 {
+            parts.push("v2");
+        }
+        parts.join(" ")
+    }
+
+    /// The oracle: field-name-set intersection, `__typename` excluded — independent of
+    /// `has_field_intersection`'s `SelectionMap`/inline-fragment-aware traversal.
+    fn dag_field_selections_intersect(a: DagFieldSelection, b: DagFieldSelection) -> bool {
+        (a.id && b.id) || (a.v1 && b.v1) || (a.v2 && b.v2)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// See the module doc comment above for the full rule and shape being tested.
+        #[test]
+        fn collect_reduced_defer_dependencies_matches_field_intersection(
+            source_selection in dag_field_selection_strategy(),
+            target_selection in dag_field_selection_strategy(),
+            defer_choice in 0u8..4,
+        ) {
+            let mut graph = make_test_dep_graph();
+            // `a` and `c` are both in Subgraph2: per the fixture SDL, `v1`/`v2` are owned only by
+            // Subgraph2 (`id` is the shared key field, present in both), so Subgraph2 is the only
+            // subgraph schema against which all three real `T` fields can be parsed.
+            let a = add_test_node(&mut graph, "Subgraph2", None);
+            let b = add_test_node(&mut graph, "Subgraph1", None);
+            let defer_label = format!("d{defer_choice}");
+            let c = add_test_node(&mut graph, "Subgraph2", Some(defer_label.as_str()));
+
+            // Give `a` a real top-level selection (the source's tokens).
+            let a_subgraph_schema = graph.federated_query_graph.schema_by_source("Subgraph2").unwrap().clone();
+            let source_fields = parse_field_set(
+                &a_subgraph_schema,
+                name!("T"),
+                &dag_field_selection_string(source_selection),
+                true,
+            )
+            .unwrap();
+            Arc::make_mut(graph.graph.node_weight_mut(a).unwrap())
+                .selection_set_mut()
+                .add_selections(&Arc::new(source_fields))
+                .unwrap();
+
+            // Give `c` real `_entities` inputs (the target's tokens). These are built against the
+            // supergraph schema, matching `FetchInputs::add`'s precondition; `SelectionKey` is
+            // schema-independent (response name + directives), so intersection with `a`'s
+            // subgraph-schema-rooted selection still matches by field name.
+            let supergraph_schema = graph.supergraph_schema.clone();
+            let target_fields = parse_field_set(
+                &supergraph_schema,
+                name!("T"),
+                &dag_field_selection_string(target_selection),
+                true,
+            )
+            .unwrap();
+            Arc::make_mut(graph.graph.node_weight_mut(c).unwrap())
+                .add_inputs(&target_fields, iter::empty())
+                .unwrap();
+
+            add_test_edge(&mut graph, a, b);
+            add_test_edge(&mut graph, b, c);
+            add_test_edge(&mut graph, a, c);
+
+            graph.reduce();
+            prop_assert_eq!(
+                graph.reduced_defer_edges.clone(),
+                vec![(a, c)],
+                "the shortcut must be ledgered before the dependency-recovery rule can be exercised"
+            );
+
+            let mut deps = Vec::new();
+            graph.collect_reduced_defer_dependencies(a, &mut deps).unwrap();
+
+            if dag_field_selections_intersect(source_selection, target_selection) {
+                let id = *graph
+                    .graph
+                    .node_weight(a)
+                    .unwrap()
+                    .id
+                    .get()
+                    .expect("a's fetch id must be assigned once a dependency is recorded");
+                prop_assert_eq!(deps, vec![(defer_label, format!("{id}"))]);
+            } else {
+                prop_assert!(
+                    deps.is_empty(),
+                    "recovered a dependency despite no shared field: {deps:?}"
+                );
+            }
+        }
+    }
+
+    /// `__typename` alone must never be enough to recover a dependency, even though it's a valid,
+    /// non-empty selection on both sides (the property above already covers this via generated
+    /// cases, but the exact all-`__typename` combination is worth a deterministic witness).
+    #[test]
+    fn dag_collect_reduced_defer_dependencies_ignores_typename_only_overlap() {
+        let mut graph = make_test_dep_graph();
+        let a = add_test_node(&mut graph, "Subgraph1", None);
+        let b = add_test_node(&mut graph, "Subgraph2", None);
+        let c = add_test_node(&mut graph, "Subgraph2", Some("defer1"));
+
+        let subgraph1_schema = graph
+            .federated_query_graph
+            .schema_by_source("Subgraph1")
+            .unwrap()
+            .clone();
+        let source_fields =
+            parse_field_set(&subgraph1_schema, name!("T"), "__typename", true).unwrap();
+        Arc::make_mut(graph.graph.node_weight_mut(a).unwrap())
+            .selection_set_mut()
+            .add_selections(&Arc::new(source_fields))
+            .unwrap();
+
+        let supergraph_schema = graph.supergraph_schema.clone();
+        let target_fields =
+            parse_field_set(&supergraph_schema, name!("T"), "__typename", true).unwrap();
+        Arc::make_mut(graph.graph.node_weight_mut(c).unwrap())
+            .add_inputs(&target_fields, iter::empty())
+            .unwrap();
+
+        add_test_edge(&mut graph, a, b);
+        add_test_edge(&mut graph, b, c);
+        add_test_edge(&mut graph, a, c);
+        graph.reduce();
+        assert_eq!(graph.reduced_defer_edges, vec![(a, c)]);
+
+        let mut deps = Vec::new();
+        graph
+            .collect_reduced_defer_dependencies(a, &mut deps)
+            .unwrap();
+        assert!(deps.is_empty(), "expected no dependency, got {deps:?}");
     }
 }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -460,6 +460,12 @@ impl ProcessingState {
     // structure as `create_state_for_children_of_processed_node`, because it needs access to the
     // graph.
 
+    /// Merge two sibling views produced from the same underlying dependency graph.
+    ///
+    /// This is not a general-purpose merge for arbitrary independently-constructed states. Its
+    /// caller merges the results of processing nodes from one ready batch, so when both sides
+    /// mention the same descendant, their remaining-parent lists are views of the same true
+    /// parent set with different already-processed siblings removed.
     pub(crate) fn merge_with(self, other: ProcessingState) -> ProcessingState {
         let mut next = self.next;
         for g in other.next {
@@ -5498,6 +5504,9 @@ fn path_for_parent(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::collections::BTreeSet;
+
     use super::*;
 
     #[test]
@@ -5726,10 +5735,38 @@ mod tests {
         )
     }
 
+    fn make_recursive_test_dep_graph() -> FetchDependencyGraph {
+        let sdl = TEST_SUPERGRAPH_SDL.replacen(
+            "  v2: Int @join__field(graph: SUBGRAPH2)",
+            "  v2: Int @join__field(graph: SUBGRAPH2)\n  child: T @join__field(graph: SUBGRAPH2)",
+            1,
+        );
+        let supergraph = Supergraph::new(&sdl).unwrap();
+        let api_schema = supergraph.to_api_schema(Default::default()).unwrap();
+        let federated_query_graph = Arc::new(
+            build_federated_query_graph(supergraph.schema.clone(), api_schema, None, None).unwrap(),
+        );
+        FetchDependencyGraph::new(
+            supergraph.schema.clone(),
+            federated_query_graph,
+            None,
+            Arc::new(FetchIdGenerator::new()),
+        )
+    }
+
     fn add_test_node(
         graph: &mut FetchDependencyGraph,
         subgraph_name: &str,
         defer_ref: Option<&str>,
+    ) -> NodeIndex {
+        add_test_node_at(graph, subgraph_name, defer_ref, None)
+    }
+
+    fn add_test_node_at(
+        graph: &mut FetchDependencyGraph,
+        subgraph_name: &str,
+        defer_ref: Option<&str>,
+        merge_at: Option<Vec<FetchDataPathElement>>,
     ) -> NodeIndex {
         let sg: Arc<str> = Arc::from(subgraph_name);
         let subgraph_schema = graph
@@ -5748,7 +5785,7 @@ mod tests {
                 parent_type,
                 false,
                 SchemaRootDefinitionKind::Query,
-                None,
+                merge_at,
                 defer_ref.map(String::from),
             )
             .unwrap()
@@ -5856,8 +5893,7 @@ mod tests {
     }
 
     // =========================================================================================
-    // Sentinel 1 (proptest-graph-notes.md, "Graph PR 1"): FetchDependencyGraph mutation and
-    // reduction model.
+    // FetchDependencyGraph mutation and reduction model.
     //
     // `DagCommand` drives a `FetchDependencyGraph` through its own private mutation methods
     // (`new_node`, `add_parent`, `remove_node`, `retain_nodes`, `reduce`,
@@ -5868,9 +5904,8 @@ mod tests {
     // `reduced_defer_edges` ledger — from the model's own state and compares it to production.
     //
     // Node identity is the production `NodeIndex` itself (`StableDiGraph` reuses freed indices,
-    // so a node's `NodeIndex` is not proof of insertion order). A separate monotonic `rank` is
-    // assigned at creation and used only to orient generated edges low-rank -> high-rank, which
-    // guarantees every generated trace stays acyclic without ever needing to reject a command.
+    // so a node's `NodeIndex` is not proof of insertion order). Generated parent/child directions
+    // are retained as chosen; only a command that would introduce a cycle becomes a no-op.
     // =========================================================================================
 
     use proptest::prelude::*;
@@ -5882,8 +5917,8 @@ mod tests {
     /// Only the two subgraphs the shared test fixture (`TEST_SUPERGRAPH_SDL`) defines.
     const DAG_TEST_SUBGRAPHS: [&str; 2] = ["Subgraph1", "Subgraph2"];
 
-    /// Deliberate adversarial shapes from proptest-graph-notes.md's "Required adversarial
-    /// shapes" list (the topology-relevant subset; the rest — mergeable siblings, nested
+    /// Deliberate adversarial shapes for reduction and stable-index bookkeeping (the
+    /// topology-relevant subset; mergeable siblings, nested
     /// `@requires`, interface/union restrictions, list-of-list paths — need selection/input
     /// payloads that are out of scope for this topology-only harness). Each shape is applied as
     /// an atomic unit using freshly-created nodes, so it composes with arbitrary surrounding
@@ -5929,6 +5964,9 @@ mod tests {
             subgraph: u8,
             defer_group: Option<u8>,
         },
+        AddRoot {
+            subgraph: u8,
+        },
         AddParent {
             parent: u16,
             child: u16,
@@ -5937,7 +5975,7 @@ mod tests {
             node: u16,
         },
         RetainByMask {
-            mask: u32,
+            mask: [u64; 4],
         },
         Reduce,
         ReduceFrom {
@@ -5951,6 +5989,19 @@ mod tests {
             subgraph_seed: u8,
             defer_seed: u8,
             victim: u16,
+        },
+        /// Build, reduce, and immediately merge a fresh sibling subgraph. Later trace commands
+        /// can then mutate/reduce/remove the survivor and its remapped defer ledger entries.
+        MergeSiblingShape {
+            survivor_selection: u8,
+            merged_selection: u8,
+            defer_seed: u8,
+        },
+        /// Same composition sentinel for the child/target-remap direction.
+        MergeChildShape {
+            survivor_selection: u8,
+            merged_selection: u8,
+            defer_seed: u8,
         },
     }
 
@@ -5968,15 +6019,16 @@ mod tests {
                     subgraph,
                     defer_group
                 }),
+            2 => any::<u8>().prop_map(|subgraph| DagCommand::AddRoot { subgraph }),
             4 => (any::<u16>(), any::<u16>())
                 .prop_map(|(parent, child)| DagCommand::AddParent { parent, child }),
             1 => any::<u16>().prop_map(|node| DagCommand::RemoveNode { node }),
-            1 => any::<u32>().prop_map(|mask| DagCommand::RetainByMask { mask }),
+            1 => any::<[u64; 4]>().prop_map(|mask| DagCommand::RetainByMask { mask }),
             2 => Just(DagCommand::Reduce),
             1 => any::<u16>().prop_map(|node| DagCommand::ReduceFrom { node }),
             // Weighted so that, combined with the usual 0..40 trace length, the overwhelming
-            // majority of generated traces contain at least one deliberate adversarial shape —
-            // comfortably above the notes' "at least half" floor — while `AddNode`/`AddParent`
+            // majority of generated traces contain at least one deliberate adversarial shape,
+            // while `AddNode`/`AddParent`
             // above still generate general, unstructured valid DAGs the rest of the time.
             6 => (dag_shape_strategy(), any::<u8>(), any::<u8>(), any::<u16>()).prop_map(
                 |(shape, subgraph_seed, defer_seed, victim)| DagCommand::Shape {
@@ -5984,6 +6036,24 @@ mod tests {
                     subgraph_seed,
                     defer_seed,
                     victim,
+                }
+            ),
+            2 => (1u8..8, 1u8..8, any::<u8>()).prop_map(
+                |(survivor_selection, merged_selection, defer_seed)| {
+                    DagCommand::MergeSiblingShape {
+                        survivor_selection,
+                        merged_selection,
+                        defer_seed,
+                    }
+                }
+            ),
+            2 => (1u8..8, 1u8..8, any::<u8>()).prop_map(
+                |(survivor_selection, merged_selection, defer_seed)| {
+                    DagCommand::MergeChildShape {
+                        survivor_selection,
+                        merged_selection,
+                        defer_seed,
+                    }
                 }
             ),
         ]
@@ -5999,14 +6069,13 @@ mod tests {
     #[derive(Default)]
     struct DagModel {
         live: IndexSet<NodeIndex>,
-        rank: IndexMap<NodeIndex, u64>,
         defer_group: IndexMap<NodeIndex, Option<u8>>,
         edges: IndexSet<(NodeIndex, NodeIndex)>,
         /// Mirrors `FetchDependencyGraph::reduced_defer_edges`. Compared as a multiset: per the
         /// sprint decision log, internal duplicates are not (yet) known to be a contract
         /// violation, only the externally-collected dependency set is.
         ledger: Vec<(NodeIndex, NodeIndex)>,
-        next_rank: u64,
+        roots: IndexMap<u8, NodeIndex>,
         is_reduced: bool,
     }
 
@@ -6017,7 +6086,7 @@ mod tests {
             nodes
         }
 
-        /// Choice-by-modulo selection of a currently-live node (see proptest-graph-notes.md).
+        /// Choice-by-modulo selection of a currently-live node.
         fn pick(&self, choice: u16) -> Option<NodeIndex> {
             let sorted = self.sorted_live();
             if sorted.is_empty() {
@@ -6025,6 +6094,15 @@ mod tests {
             } else {
                 Some(sorted[choice as usize % sorted.len()])
             }
+        }
+
+        fn pick_non_root(&self, choice: u16) -> Option<NodeIndex> {
+            let nodes: Vec<_> = self
+                .sorted_live()
+                .into_iter()
+                .filter(|node| !self.roots.values().any(|root| root == node))
+                .collect();
+            (!nodes.is_empty()).then(|| nodes[choice as usize % nodes.len()])
         }
 
         fn children(&self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + '_ {
@@ -6051,6 +6129,17 @@ mod tests {
                 }
             }
             visited
+        }
+
+        fn reachability_pairs(&self) -> IndexSet<(NodeIndex, NodeIndex)> {
+            self.sorted_live()
+                .into_iter()
+                .flat_map(|source| {
+                    self.descendants(source)
+                        .into_iter()
+                        .map(move |target| (source, target))
+                })
+                .collect()
         }
 
         /// Whether `target` remains reachable from `source` using every edge except `excluded`.
@@ -6120,10 +6209,47 @@ mod tests {
         /// Mirrors the lockstep cleanup in `remove_node`/`retain_nodes`.
         fn drop_node(&mut self, node: NodeIndex) {
             self.live.shift_remove(&node);
-            self.rank.shift_remove(&node);
             self.defer_group.shift_remove(&node);
             self.edges.retain(|&(s, t)| s != node && t != node);
             self.ledger.retain(|&(s, t)| s != node && t != node);
+        }
+
+        fn reduce(&mut self) {
+            if self.is_reduced {
+                return;
+            }
+            let reachability_before = self.reachability_pairs();
+            let removed = self.globally_redundant_edges();
+            self.record_ledger(&removed);
+            for edge in &removed {
+                self.edges.shift_remove(edge);
+            }
+            assert_eq!(self.reachability_pairs(), reachability_before);
+            self.is_reduced = true;
+        }
+
+        fn merge_into(&mut self, survivor: NodeIndex, merged: NodeIndex, merge_parents: bool) {
+            let old_edges = self.edges.clone();
+            self.edges
+                .retain(|&(source, target)| source != merged && target != merged);
+            for (source, target) in old_edges {
+                if source == merged && target != survivor {
+                    self.edges.insert((survivor, target));
+                }
+                if merge_parents && target == merged && source != survivor {
+                    self.edges.insert((source, survivor));
+                }
+            }
+            for entry in &mut self.ledger {
+                if entry.0 == merged {
+                    entry.0 = survivor;
+                }
+                if entry.1 == merged {
+                    entry.1 = survivor;
+                }
+            }
+            self.drop_node(merged);
+            self.is_reduced = false;
         }
     }
 
@@ -6144,10 +6270,47 @@ mod tests {
                 let defer_ref = defer_group.map(|g| format!("d{g}"));
                 let node = add_test_node(graph, subgraph_name, defer_ref.as_deref());
                 model.live.insert(node);
-                model.rank.insert(node, model.next_rank);
-                model.next_rank += 1;
                 model.defer_group.insert(node, defer_group);
                 // `new_node` unconditionally calls `on_modification`.
+                model.is_reduced = false;
+            }
+            DagCommand::AddRoot { subgraph } => {
+                let subgraph = subgraph as usize % DAG_TEST_SUBGRAPHS.len();
+                let subgraph_name: Arc<str> = Arc::from(DAG_TEST_SUBGRAPHS[subgraph]);
+                let schema = graph
+                    .federated_query_graph
+                    .schema_by_source(&subgraph_name)
+                    .unwrap();
+                let query_type_name = schema
+                    .schema()
+                    .schema_definition
+                    .query
+                    .as_ref()
+                    .unwrap()
+                    .name
+                    .clone();
+                let parent_type = schema
+                    .get_type(&query_type_name)
+                    .unwrap()
+                    .try_into()
+                    .unwrap();
+                let node = graph
+                    .get_or_create_root_node(
+                        &subgraph_name,
+                        SchemaRootDefinitionKind::Query,
+                        parent_type,
+                    )
+                    .unwrap();
+                if let Some(existing) = model.roots.get(&(subgraph as u8)) {
+                    assert_eq!(
+                        node, *existing,
+                        "get_or_create_root_node was not idempotent"
+                    );
+                    return;
+                }
+                model.roots.insert(subgraph as u8, node);
+                model.live.insert(node);
+                model.defer_group.insert(node, None);
                 model.is_reduced = false;
             }
             DagCommand::AddParent { parent, child } => {
@@ -6159,30 +6322,28 @@ mod tests {
                     // there is no valid interpretation other than skipping (a no-op trace entry).
                     return;
                 }
-                // Only ever add low-rank -> high-rank edges, so the trace can never build a
-                // cycle even after `StableDiGraph` reuses a freed `NodeIndex`.
-                let (lo, hi) = if model.rank[&a] < model.rank[&b] {
-                    (a, b)
-                } else {
-                    (b, a)
-                };
-                if model.edges.contains(&(lo, hi)) {
+                // Node creation order is semantically irrelevant. Keep the generated direction
+                // and reject only relations that would actually form a cycle in the model.
+                if model.edges.contains(&(a, b)) || model.descendants(b).contains(&a) {
                     // `add_parent` early-returns via `contains_edge` without calling
-                    // `on_modification`.
+                    // `on_modification`, or its cycle precondition forbids the relation.
                     return;
                 }
                 graph.add_parent(
-                    hi,
+                    b,
                     ParentRelation {
-                        parent_node_id: lo,
+                        parent_node_id: a,
                         path_in_parent: None,
                     },
                 );
-                model.edges.insert((lo, hi));
+                model.edges.insert((a, b));
                 model.is_reduced = false;
             }
             DagCommand::RemoveNode { node } => {
-                let Some(node) = model.pick(node) else {
+                // Production optimization never removes registered roots: `remove_empty_nodes`
+                // explicitly exempts them and merge paths reject top-level nodes. Keep the trace
+                // within that contract while still removing arbitrary non-root nodes.
+                let Some(node) = model.pick_non_root(node) else {
                     return;
                 };
                 graph.remove_node(node);
@@ -6195,12 +6356,16 @@ mod tests {
                 if sorted.is_empty() {
                     return;
                 }
-                // Bit `i` of `mask` decides whether to keep the `i`-th live node in index order;
-                // beyond the mask's 32 bits, default to keeping (never shift by >= 32).
+                // Bit `i` of `mask` decides whether to keep the `i`-th live node in index order.
+                // Four words cover 256 nodes, more than this bounded trace can create.
                 let keep: IndexSet<NodeIndex> = sorted
                     .iter()
                     .enumerate()
-                    .filter(|&(i, _)| i >= 32 || (mask >> i) & 1 == 1)
+                    .filter(|&(i, node)| {
+                        model.roots.values().any(|root| *root == *node)
+                            || i >= mask.len() * u64::BITS as usize
+                            || (mask[i / u64::BITS as usize] >> (i % u64::BITS as usize)) & 1 == 1
+                    })
                     .map(|(_, &n)| n)
                     .collect();
                 graph.retain_nodes(|n| keep.contains(n));
@@ -6219,11 +6384,17 @@ mod tests {
                     graph.reduce(); // exercises the early-return; no state change expected.
                     return;
                 }
+                let reachability_before = model.reachability_pairs();
                 let removed = model.globally_redundant_edges();
                 model.record_ledger(&removed);
                 for edge in &removed {
                     model.edges.shift_remove(edge);
                 }
+                assert_eq!(
+                    model.reachability_pairs(),
+                    reachability_before,
+                    "reference reduction changed reachability"
+                );
                 graph.reduce();
                 model.is_reduced = true;
             }
@@ -6231,12 +6402,18 @@ mod tests {
                 let Some(node) = model.pick(node) else {
                     return;
                 };
+                let reachability_before = model.reachability_pairs();
                 let removed = model.locally_redundant_edges_from(node);
                 model.record_ledger(&removed);
                 graph.remove_redundant_edges(node);
                 for edge in &removed {
                     model.edges.shift_remove(edge);
                 }
+                assert_eq!(
+                    model.reachability_pairs(),
+                    reachability_before,
+                    "reference local reduction changed reachability"
+                );
                 if !removed.is_empty() {
                     // `remove_redundant_edges` only calls `on_modification` when it actually
                     // removed an edge.
@@ -6249,6 +6426,28 @@ mod tests {
                 defer_seed,
                 victim,
             } => apply_dag_shape(graph, model, shape, subgraph_seed, defer_seed, victim),
+            DagCommand::MergeSiblingShape {
+                survivor_selection,
+                merged_selection,
+                defer_seed,
+            } => apply_dag_merge_sibling_shape(
+                graph,
+                model,
+                survivor_selection,
+                merged_selection,
+                defer_seed,
+            ),
+            DagCommand::MergeChildShape {
+                survivor_selection,
+                merged_selection,
+                defer_seed,
+            } => apply_dag_merge_child_shape(
+                graph,
+                model,
+                survivor_selection,
+                merged_selection,
+                defer_seed,
+            ),
         }
     }
 
@@ -6274,8 +6473,6 @@ mod tests {
             let defer_ref = defer_group.map(|g| format!("d{g}"));
             let node = add_test_node(graph, subgraph_for(i), defer_ref.as_deref());
             model.live.insert(node);
-            model.rank.insert(node, model.next_rank);
-            model.next_rank += 1;
             model.defer_group.insert(node, defer_group);
             node
         };
@@ -6365,7 +6562,7 @@ mod tests {
                 connect(graph, model, a, c);
             }
             DagShape::StableIndexHole => {
-                let Some(victim_node) = model.pick(victim) else {
+                let Some(victim_node) = model.pick_non_root(victim) else {
                     return;
                 };
                 graph.remove_node(victim_node);
@@ -6379,6 +6576,255 @@ mod tests {
         // `on_modification` in production (the early-return branch of `StableIndexHole`, which
         // makes no production call at all, returns before reaching this line).
         model.is_reduced = false;
+    }
+
+    fn dag_model_register(model: &mut DagModel, node: NodeIndex, defer_group: Option<u8>) {
+        model.live.insert(node);
+        model.defer_group.insert(node, defer_group);
+        model.is_reduced = false;
+    }
+
+    fn dag_model_connect(
+        graph: &mut FetchDependencyGraph,
+        model: &mut DagModel,
+        parent: NodeIndex,
+        child: NodeIndex,
+    ) {
+        dag_add_parent_with_path(graph, parent, child, OpPath::default());
+        model.edges.insert((parent, child));
+        model.is_reduced = false;
+    }
+
+    fn apply_dag_merge_sibling_shape(
+        graph: &mut FetchDependencyGraph,
+        model: &mut DagModel,
+        survivor_selection: u8,
+        merged_selection: u8,
+        defer_seed: u8,
+    ) {
+        let defer_group = defer_seed % 4;
+        let defer_label = format!("d{defer_group}");
+        let parent = add_test_node(graph, "Subgraph1", None);
+        let survivor = add_merge_test_node(graph, survivor_selection, 0, None);
+        let merged = add_merge_test_node(graph, merged_selection, 0, None);
+        let middle = add_test_node(graph, "Subgraph1", None);
+        let overlap_bit = 1 << merged_selection.trailing_zeros();
+        let deferred = add_merge_test_node(graph, 1, overlap_bit, Some(&defer_label));
+        for node in [parent, survivor, merged, middle] {
+            dag_model_register(model, node, None);
+        }
+        dag_model_register(model, deferred, Some(defer_group));
+
+        dag_model_connect(graph, model, parent, survivor);
+        dag_model_connect(graph, model, parent, merged);
+        dag_model_connect(graph, model, merged, middle);
+        dag_model_connect(graph, model, middle, deferred);
+        dag_model_connect(graph, model, merged, deferred);
+
+        model.reduce();
+        graph.reduce();
+        assert!(model.ledger.contains(&(merged, deferred)));
+        assert!(graph.reduced_defer_edges.contains(&(merged, deferred)));
+        assert!(graph.can_merge_sibling_in(survivor, merged).unwrap());
+        graph.merge_sibling_in(survivor, merged).unwrap();
+        model.merge_into(survivor, merged, false);
+
+        assert_eq!(
+            dag_selection_mask(&graph.graph[survivor].selection_set.selection_set),
+            survivor_selection | merged_selection,
+        );
+    }
+
+    fn apply_dag_merge_child_shape(
+        graph: &mut FetchDependencyGraph,
+        model: &mut DagModel,
+        survivor_selection: u8,
+        merged_selection: u8,
+        defer_seed: u8,
+    ) {
+        let defer_group = defer_seed % 4;
+        let defer_label = format!("d{defer_group}");
+        let source = add_test_node(graph, "Subgraph2", None);
+        dag_add_selection_mask(graph, source, survivor_selection);
+        let survivor = add_merge_test_node(graph, survivor_selection, 0b111, Some(&defer_label));
+        let merged = add_merge_test_node(graph, merged_selection, 0b001, Some(&defer_label));
+        let tail = add_test_node(graph, "Subgraph1", Some(&defer_label));
+        dag_model_register(model, source, None);
+        for node in [survivor, merged, tail] {
+            dag_model_register(model, node, Some(defer_group));
+        }
+
+        dag_model_connect(graph, model, source, survivor);
+        dag_model_connect(graph, model, survivor, merged);
+        dag_model_connect(graph, model, source, merged);
+        dag_model_connect(graph, model, merged, tail);
+
+        model.reduce();
+        graph.reduce();
+        assert!(model.ledger.contains(&(source, merged)));
+        assert!(graph.reduced_defer_edges.contains(&(source, merged)));
+        assert!(graph.can_merge_child_in(survivor, merged).unwrap());
+        graph.merge_child_in(survivor, merged).unwrap();
+        model.merge_into(survivor, merged, false);
+
+        assert_eq!(
+            dag_selection_mask(&graph.graph[survivor].selection_set.selection_set),
+            survivor_selection | merged_selection,
+        );
+    }
+
+    /// Keep the same ledger entries and payloads alive through *multiple* source and target
+    /// merges. This tests primitive contracts, not a claim that planning emits this whole DAG.
+    /// Sources are siblings; deferred targets form a chain. Every source has a reduced shortcut
+    /// to every target. Source merges union inputs; child merges have identical input sets.
+    fn check_repeated_defer_merge_history(
+        source_masks: &[u8],
+        target_masks: &[u8],
+        choices: &[(bool, u8, bool)],
+        reuse_removed_slots: bool,
+    ) -> Result<(), TestCaseError> {
+        let mut graph = make_test_dep_graph();
+        let mut model = DagModel::default();
+        let mut payloads = IndexMap::<NodeIndex, (u8, u8, bool)>::default();
+        let root = add_test_node(&mut graph, "Subgraph1", None);
+        let middle = add_test_node(&mut graph, "Subgraph1", None);
+        for node in [root, middle] {
+            dag_model_register(&mut model, node, None);
+            payloads.insert(node, (0, 0, false));
+        }
+        let mut sources = Vec::new();
+        for &mask in source_masks {
+            let node = add_merge_test_node(&mut graph, mask, 0, None);
+            dag_model_register(&mut model, node, None);
+            payloads.insert(node, (mask, 0, false));
+            dag_model_connect(&mut graph, &mut model, root, node);
+            dag_model_connect(&mut graph, &mut model, node, middle);
+            sources.push(node);
+        }
+        let target_inputs = source_masks.iter().fold(0, |union, mask| union | mask);
+        let mut targets = Vec::new();
+        for (index, &mask) in target_masks.iter().enumerate() {
+            let node = add_merge_test_node(&mut graph, mask, target_inputs, Some("d0"));
+            let preserve = index % 2 == 0;
+            Arc::make_mut(graph.graph.node_weight_mut(node).unwrap()).must_preserve_selection_set =
+                preserve;
+            dag_model_register(&mut model, node, Some(0));
+            payloads.insert(node, (mask, target_inputs, preserve));
+            dag_model_connect(
+                &mut graph,
+                &mut model,
+                targets.last().copied().unwrap_or(middle),
+                node,
+            );
+            for &source in &sources {
+                dag_model_connect(&mut graph, &mut model, source, node);
+            }
+            targets.push(node);
+        }
+        graph.reduce();
+        model.reduce();
+        prop_assert_eq!(model.ledger.len(), source_masks.len() * target_masks.len());
+
+        // Execute enough genuine merges to collapse both groups. Choices select the interleaving
+        // and survivor, not whether a meaningful command happens. The deterministic witness below
+        // guarantees that the same entries are remapped at least twice at *both* endpoints.
+        for step in 0..source_masks.len() + target_masks.len() - 2 {
+            let (prefer_source, choice, reduce_after) = choices[step % choices.len()];
+            let merge_source = sources.len() > 1 && (prefer_source || targets.len() == 1);
+            let (survivor, merged) = if merge_source {
+                let index = choice as usize % sources.len();
+                let survivor = sources[index];
+                let merged = sources[(index + 1) % sources.len()];
+                prop_assert!(graph.can_merge_sibling_in(survivor, merged).unwrap());
+                graph.merge_sibling_in(survivor, merged).unwrap();
+                sources.retain(|node| *node != merged);
+                (survivor, merged)
+            } else {
+                let index = choice as usize % (targets.len() - 1);
+                let survivor = targets[index];
+                let merged = targets.remove(index + 1);
+                prop_assert!(graph.can_merge_child_in(survivor, merged).unwrap());
+                prop_assert_eq!(payloads[&survivor].1, payloads[&merged].1);
+                graph.merge_child_in(survivor, merged).unwrap();
+                (survivor, merged)
+            };
+            model.merge_into(survivor, merged, false);
+            let removed = payloads.shift_remove(&merged).unwrap();
+            let retained = payloads.get_mut(&survivor).unwrap();
+            retained.0 |= removed.0;
+            retained.1 |= removed.1;
+            retained.2 |= removed.2;
+
+            if reuse_removed_slots {
+                // Reuse the just-freed stable slot: a stale ledger endpoint must not silently
+                // attach to this unrelated node when an index becomes live again.
+                let replacement = add_test_node(&mut graph, "Subgraph1", None);
+                prop_assert_eq!(replacement, merged);
+                dag_model_register(&mut model, replacement, None);
+                payloads.insert(replacement, (0, 0, false));
+            }
+            if reduce_after {
+                graph.reduce();
+                model.reduce();
+            }
+            audit_dag_matches_model(&graph, &model)?;
+            for (&node, &(selected, inputs, preserve)) in &payloads {
+                prop_assert_eq!(
+                    dag_selection_mask(&graph.graph[node].selection_set.selection_set),
+                    selected
+                );
+                prop_assert_eq!(dag_input_mask(&graph.graph[node]), inputs);
+                prop_assert_eq!(graph.graph[node].must_preserve_selection_set, preserve);
+
+                let expected_labels: BTreeSet<_> = model
+                    .ledger
+                    .iter()
+                    .filter(|&&(source, target)| {
+                        source == node
+                            && model.defer_group[&source] != model.defer_group[&target]
+                            && selected & payloads[&target].1 != 0
+                    })
+                    .filter_map(|&(_, target)| {
+                        model.defer_group[&target].map(|group| format!("d{group}"))
+                    })
+                    .collect();
+                let mut dependencies = Vec::new();
+                graph
+                    .collect_reduced_defer_dependencies(node, &mut dependencies)
+                    .unwrap();
+                let actual_labels: BTreeSet<_> = dependencies
+                    .iter()
+                    .map(|(label, _)| label.clone())
+                    .collect();
+                prop_assert_eq!(
+                    actual_labels,
+                    expected_labels,
+                    "collected dependencies changed after merge {}",
+                    step
+                );
+                for (_, id) in dependencies {
+                    prop_assert_eq!(id, graph.graph[node].id.get().unwrap().to_string());
+                }
+            }
+        }
+        prop_assert_eq!((sources.len(), targets.len()), (1, 1));
+        Ok(())
+    }
+
+    #[test]
+    fn reduced_defer_dependencies_survive_repeated_remaps_of_both_endpoints() {
+        check_repeated_defer_merge_history(
+            &[FIELD_ID, FIELD_V1, FIELD_V2],
+            &[FIELD_ID, FIELD_V1, FIELD_V2],
+            &[
+                (true, 0, false),
+                (false, 1, true),
+                (true, 0, true),
+                (false, 0, false),
+            ],
+            true,
+        )
+        .unwrap();
     }
 
     /// Recompute every audited fact from `model`'s own state and compare it to `graph`.
@@ -6415,12 +6861,48 @@ mod tests {
         model_edges.sort_unstable();
         prop_assert_eq!(production_edges, model_edges, "edge sets diverged");
 
-        // 4. `is_reduced`/`is_optimized` match the model's invalidation state. This harness never
+        // 4. Reachability agrees pair-by-pair with a fresh model DFS. Keeping this explicit makes
+        // reduction's core semantic contract visible even though exact direct-edge equality is a
+        // stronger structural assertion for this particular model.
+        for source in model.sorted_live() {
+            let model_descendants = model.descendants(source);
+            for target in model.sorted_live() {
+                if source == target {
+                    continue;
+                }
+                prop_assert_eq!(
+                    petgraph::algo::has_path_connecting(&graph.graph, source, target, None),
+                    model_descendants.contains(&target),
+                    "reachability diverged for {} -> {}",
+                    source.index(),
+                    target.index(),
+                );
+            }
+        }
+
+        // 5. The root registry matches the independently tracked set exactly; every entry is live
+        // and belongs to its registration subgraph.
+        let expected_roots: IndexMap<Arc<str>, NodeIndex> = model
+            .roots
+            .iter()
+            .map(|(subgraph, node)| (Arc::from(DAG_TEST_SUBGRAPHS[*subgraph as usize]), *node))
+            .collect();
+        prop_assert_eq!(&graph.root_nodes_by_subgraph, &expected_roots);
+        for (subgraph, node_id) in &graph.root_nodes_by_subgraph {
+            let Some(node) = graph.graph.node_weight(*node_id) else {
+                return Err(TestCaseError::fail(format!(
+                    "root {node_id:?} registered for {subgraph} is not live"
+                )));
+            };
+            prop_assert_eq!(&node.subgraph_name, subgraph);
+        }
+
+        // 6. `is_reduced`/`is_optimized` match the model's invalidation state. This harness never
         // calls `reduce_and_optimize`, so `is_optimized` should never become true.
         prop_assert_eq!(graph.is_reduced, model.is_reduced, "is_reduced diverged");
         prop_assert!(!graph.is_optimized, "is_optimized unexpectedly set");
 
-        // 5. If reduced, every retained edge must be indispensable.
+        // 7. If reduced, every retained edge must be indispensable.
         if model.is_reduced {
             let redundant = model.globally_redundant_edges();
             prop_assert!(
@@ -6429,7 +6911,7 @@ mod tests {
             );
         }
 
-        // 6. `reduced_defer_edges` ledger, compared as a multiset.
+        // 8. `reduced_defer_edges` ledger, compared as a multiset.
         let mut production_ledger: Vec<(usize, usize)> = graph
             .reduced_defer_edges
             .iter()
@@ -6448,7 +6930,7 @@ mod tests {
             "reduced_defer_edges ledger diverged"
         );
 
-        // 7. Every ledger entry refers to a live node.
+        // 9. Every ledger entry refers to a live node.
         for &(s, t) in &graph.reduced_defer_edges {
             prop_assert!(model.live.contains(&s), "ledger source {s:?} is not live");
             prop_assert!(model.live.contains(&t), "ledger target {t:?} is not live");
@@ -6458,12 +6940,11 @@ mod tests {
     }
 
     proptest! {
-        #![proptest_config(ProptestConfig::with_cases(256))]
+        #![proptest_config(ProptestConfig::with_cases(1024))]
 
         /// The core sentinel: after every command in a generated trace, the production graph's
         /// topology, `is_reduced`/`is_optimized` flags, and `reduced_defer_edges` ledger must
-        /// match a naive reference model recomputed from scratch. See "Sentinel 1" in
-        /// proptest-graph-notes.md.
+        /// match a naive reference model recomputed from scratch.
         #[test]
         fn fetch_dependency_graph_trace_matches_naive_model(commands in dag_command_trace_strategy()) {
             let mut graph = make_test_dep_graph();
@@ -6472,6 +6953,16 @@ mod tests {
                 apply_dag_command(&mut graph, &mut model, command);
                 audit_dag_matches_model(&graph, &model)?;
             }
+        }
+
+        #[test]
+        fn repeated_payload_merges_conserve_remapped_defer_dependencies(
+            sources in prop::collection::vec(1u8..8, 3..7),
+            targets in prop::collection::vec(1u8..8, 3..7),
+            choices in prop::collection::vec((any::<bool>(), 0u8..6, any::<bool>()), 1..13),
+            reuse_removed_slots in any::<bool>(),
+        ) {
+            check_repeated_defer_merge_history(&sources, &targets, &choices, reuse_removed_slots)?;
         }
 
         /// Focused dense-index property: `to_toposorted_adjacency_list`'s rank mapping must round
@@ -6713,7 +7204,7 @@ mod tests {
     }
 
     // =========================================================================================
-    // ProcessingState sub-property (proptest-graph-notes.md, Sentinel 1 / "Graph PR 2").
+    // ProcessingState model properties.
     //
     // `ProcessingState` is a separate exact state machine over the same generated DAG. Two kinds
     // of property here:
@@ -6764,6 +7255,38 @@ mod tests {
                 })
                 .collect(),
         }
+    }
+
+    /// Recompute the traversal frontier from graph facts only. A node is ready when all of its
+    /// parents have been processed. A not-yet-ready node is tracked as unhandled only after at
+    /// least one direct parent has been processed; deeper undiscovered nodes do not belong to the
+    /// current frontier yet.
+    fn naive_processing_state_snapshot(
+        model: &DagModel,
+        processed: &IndexSet<NodeIndex>,
+    ) -> (Vec<usize>, Vec<(usize, Vec<usize>)>) {
+        let mut next = Vec::new();
+        let mut unhandled = Vec::new();
+        for node in model.sorted_live() {
+            if processed.contains(&node) {
+                continue;
+            }
+            let parents: Vec<NodeIndex> = model.parents(node).collect();
+            let mut remaining: Vec<usize> = parents
+                .iter()
+                .filter(|parent| !processed.contains(*parent))
+                .map(|parent| parent.index())
+                .collect();
+            if remaining.is_empty() {
+                next.push(node.index());
+            } else if parents.iter().any(|parent| processed.contains(parent)) {
+                remaining.sort_unstable();
+                unhandled.push((node.index(), remaining));
+            }
+        }
+        next.sort_unstable();
+        unhandled.sort_unstable();
+        (next, unhandled)
     }
 
     proptest! {
@@ -6829,6 +7352,81 @@ mod tests {
             for (_, parents) in &actual_unhandled {
                 prop_assert!(!parents.is_empty(), "unhandled entry with no remaining parents");
             }
+        }
+
+        /// Drive `create_state_for_children_of_processed_node`, `merge_with`, and
+        /// `update_for_processed_nodes` together through every ready wave of an arbitrary
+        /// generated DAG. After every wave, compare the complete frontier to a fresh full-graph
+        /// scan rather than to any of the production state transitions.
+        #[test]
+        fn processing_state_full_traversal_matches_naive_frontier_recomputation(
+            commands in dag_command_trace_strategy(),
+            order_seed in any::<u64>(),
+        ) {
+            let mut graph = make_test_dep_graph();
+            let mut model = DagModel::default();
+            for command in &commands {
+                apply_dag_command(&mut graph, &mut model, command);
+            }
+
+            let mut processed = IndexSet::default();
+            let roots: Vec<NodeIndex> = model
+                .sorted_live()
+                .into_iter()
+                .filter(|node| model.parents(*node).next().is_none())
+                .collect();
+            let mut state = ProcessingState::of_ready_nodes(roots);
+            prop_assert_eq!(
+                processing_state_snapshot(&state),
+                naive_processing_state_snapshot(&model, &processed),
+                "initial root frontier diverged"
+            );
+
+            let mut wave = 0usize;
+            while !state.next.is_empty() {
+                let mut batch = state.next.clone();
+                // Exercise arbitrary-looking sibling orders rather than only cyclic rotations of
+                // index order. SplitMix-style mixing is deterministic and shrinks with one seed.
+                batch.sort_by_key(|node| {
+                    let mut key = order_seed
+                        ^ (node.index() as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                        ^ (wave as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+                    key = (key ^ (key >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+                    key = (key ^ (key >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+                    key ^ (key >> 31)
+                });
+
+                let mut next_state = ProcessingState {
+                    next: Vec::new(),
+                    unhandled: state.unhandled,
+                };
+                for node in &batch {
+                    let child_state = graph.create_state_for_children_of_processed_node(
+                        *node,
+                        graph.children_of(*node).collect::<Vec<_>>(),
+                    );
+                    next_state = next_state.merge_with(child_state);
+                }
+                next_state = next_state.update_for_processed_nodes(&batch);
+                processed.extend(batch);
+
+                prop_assert_eq!(
+                    processing_state_snapshot(&next_state),
+                    naive_processing_state_snapshot(&model, &processed),
+                    "frontier diverged after wave {}; processed={:?}",
+                    wave,
+                    processed.iter().map(|node| node.index()).collect::<Vec<_>>()
+                );
+                state = next_state;
+                wave += 1;
+                prop_assert!(
+                    wave <= model.live.len(),
+                    "processing failed to make progress through an acyclic graph"
+                );
+            }
+
+            prop_assert_eq!(processed.len(), model.live.len());
+            prop_assert!(state.unhandled.is_empty());
         }
 
         /// `merge_with` is commutative, associative, and idempotent as a *set* operation (vector
@@ -7001,7 +7599,7 @@ mod tests {
     fn dag_shared_full_parent_sets_strategy() -> impl Strategy<Value = Vec<Vec<usize>>> {
         prop::collection::vec(
             (
-                prop::collection::vec(0..PS_SIBLINGS.len(), 0..PS_SIBLINGS.len()),
+                0u8..(1u8 << PS_SIBLINGS.len()),
                 prop::collection::vec(0..PS_BACKGROUND_PARENT_UNIVERSE, 0..3),
             ),
             PS_CANDIDATE_UNIVERSE,
@@ -7009,9 +7607,14 @@ mod tests {
         .prop_map(|per_candidate| {
             per_candidate
                 .into_iter()
-                .map(|(sibling_idxs, background)| {
-                    let mut parents: Vec<usize> =
-                        sibling_idxs.into_iter().map(|i| PS_SIBLINGS[i]).collect();
+                .map(|(sibling_mask, background)| {
+                    let mut parents: Vec<usize> = PS_SIBLINGS
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(i, sibling)| {
+                            (sibling_mask & (1 << i) != 0).then_some(*sibling)
+                        })
+                        .collect();
                     parents.extend(background.into_iter().map(|b| PS_BACKGROUND_OFFSET + b));
                     parents.sort_unstable();
                     parents.dedup();
@@ -7056,14 +7659,12 @@ mod tests {
     }
 
     // =========================================================================================
-    // Defer dependency extension (proptest-graph-notes.md, Sentinel 1 / "Graph PR 2"): real
-    // top-level field tokens, `merge_at = None`, no aliases, no fragments — the first payload
-    // stage the notes describe.
+    // Defer dependency model using real top-level field selections.
     //
     // The rule under test, from `collect_reduced_defer_dependencies`'s own doc comment: a removed
     // cross-defer edge source -> target must be recovered as a defer dependency iff the source's
     // selection shares a field (other than `__typename`) with one of the target's `_entities`
-    // input selections. This builds the canonical three-node shape from the notes
+    // input selections. This builds the canonical three-node shape
     // (`A(primary) -> B(primary) -> C(deferred)`, plus a redundant `A -> C` shortcut, reduced via
     // the real `reduce()` — not hand-pushed into the ledger) with real field selections on `A`
     // and real `_entities` inputs on `C`, and compares the recovered dependency against a direct
@@ -7072,7 +7673,7 @@ mod tests {
 
     /// Which of the shared test fixture's three real `T` fields (`id`, `v1`, `v2` — see
     /// `TEST_SUPERGRAPH_SDL`), plus `__typename`, a selection includes. This is the fixed field
-    /// universe the notes recommend materializing tokens from. `__typename` is kept separate
+    /// universe used by this model. `__typename` is kept separate
     /// because the production rule explicitly excludes it from intersection.
     #[derive(Debug, Clone, Copy)]
     struct DagFieldSelection {
@@ -7118,6 +7719,45 @@ mod tests {
     /// `has_field_intersection`'s `SelectionMap`/inline-fragment-aware traversal.
     fn dag_field_selections_intersect(a: DagFieldSelection, b: DagFieldSelection) -> bool {
         (a.id && b.id) || (a.v1 && b.v1) || (a.v2 && b.v2)
+    }
+
+    fn dag_defer_structured_selection_text(
+        selection: DagFieldSelection,
+        alias_fields: bool,
+        directive_seed: u8,
+        wrapper_codes: &[u8],
+    ) -> String {
+        let fields = [
+            ("id", selection.id),
+            ("v1", selection.v1),
+            ("v2", selection.v2),
+            ("__typename", selection.typename),
+        ]
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, (field, selected))| {
+            selected.then(|| {
+                let alias = alias_fields
+                    .then(|| format!("alias_{index}: "))
+                    .unwrap_or_default();
+                let directive =
+                    match directive_seed.wrapping_add((index as u8).wrapping_mul(17)) % 3 {
+                        0 => "",
+                        1 => " @include(if: true)",
+                        2 => " @skip(if: false)",
+                        _ => unreachable!("modulo three"),
+                    };
+                format!("{alias}{field}{directive}")
+            })
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+        wrapper_codes
+            .iter()
+            .fold(fields, |inner, code| match code % 2 {
+                0 => format!("... on T {{ {inner} }}"),
+                _ => format!("... @include(if: true) {{ {inner} }}"),
+            })
     }
 
     proptest! {
@@ -7199,6 +7839,84 @@ mod tests {
                 );
             }
         }
+
+        /// Repeat the field-intersection model through identical layers of typed and
+        /// directive-only fragments, aliases, and constant directives. These are the branches
+        /// handled recursively by `has_field_intersection`; using the same structural decoration
+        /// on both sides leaves the independent oracle as ordinary underlying-field overlap.
+        #[test]
+        fn collect_reduced_defer_dependencies_matches_structured_field_intersection(
+            source_selection in dag_field_selection_strategy(),
+            target_selection in dag_field_selection_strategy(),
+            alias_fields in any::<bool>(),
+            directive_seed in any::<u8>(),
+            wrappers in prop::collection::vec(any::<u8>(), 0..4),
+        ) {
+            let mut graph = make_test_dep_graph();
+            let source = add_test_node(&mut graph, "Subgraph2", None);
+            let middle = add_test_node(&mut graph, "Subgraph1", None);
+            let target = add_test_node(&mut graph, "Subgraph2", Some("structured-defer"));
+
+            let source_schema = graph
+                .federated_query_graph
+                .schema_by_source("Subgraph2")
+                .unwrap()
+                .clone();
+            let source_text = dag_defer_structured_selection_text(
+                source_selection,
+                alias_fields,
+                directive_seed,
+                &wrappers,
+            );
+            let source_fields = SelectionSet::parse(
+                source_schema.clone(),
+                source_schema.get_type(&name!("T")).unwrap().try_into().unwrap(),
+                &source_text,
+            )
+            .unwrap();
+            Arc::make_mut(graph.graph.node_weight_mut(source).unwrap())
+                .selection_set_mut()
+                .add_selections(&Arc::new(source_fields))
+                .unwrap();
+
+            let target_text = dag_defer_structured_selection_text(
+                target_selection,
+                alias_fields,
+                directive_seed,
+                &wrappers,
+            );
+            let target_fields = SelectionSet::parse(
+                graph.supergraph_schema.clone(),
+                graph
+                    .supergraph_schema
+                    .get_type(&name!("T"))
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+                &target_text,
+            )
+            .unwrap();
+            Arc::make_mut(graph.graph.node_weight_mut(target).unwrap())
+                .add_inputs(&target_fields, iter::empty())
+                .unwrap();
+
+            add_test_edge(&mut graph, source, middle);
+            add_test_edge(&mut graph, middle, target);
+            add_test_edge(&mut graph, source, target);
+            graph.reduce();
+
+            let mut dependencies = Vec::new();
+            graph
+                .collect_reduced_defer_dependencies(source, &mut dependencies)
+                .unwrap();
+            prop_assert_eq!(
+                !dependencies.is_empty(),
+                dag_field_selections_intersect(source_selection, target_selection),
+                "structured overlap disagreed: source=`{}`, target=`{}`",
+                source_text,
+                target_text,
+            );
+        }
     }
 
     /// `__typename` alone must never be enough to recover a dependency, even though it's a valid,
@@ -7241,5 +7959,2895 @@ mod tests {
             .collect_reduced_defer_dependencies(a, &mut deps)
             .unwrap();
         assert!(deps.is_empty(), "expected no dependency, got {deps:?}");
+    }
+
+    // =========================================================================================
+    // Merge conservation with a real reduced-defer ledger.
+    //
+    // These are deliberately not tests of `remap_reduced_defer_edges` in isolation. Each shape
+    // first runs the production transitive reduction to create a valid ledger entry, then runs a
+    // production merge and audits every externally meaningful fact that can move with the merged
+    // node: selections, inputs, child edges and their paths, reachability, derived-state caches,
+    // and the defer dependency recovered from the remapped ledger.
+    //
+    // The two shapes cover the two independently reachable remap directions:
+    //
+    // * sibling/source remap: B(primary) -> D(deferred) is reduced, then sibling B is merged into
+    //   A, so the ledger must change B -> D into A -> D;
+    // * child/target remap: P(primary) -> B(deferred) is reduced through P -> A -> B, then child B
+    //   is merged into A, so the ledger must change P -> B into P -> A.
+    // =========================================================================================
+
+    const DAG_PAYLOAD_FIELDS: [&str; 3] = ["id", "v1", "v2"];
+    const FIELD_ID: u8 = 0b001;
+    const FIELD_V1: u8 = 0b010;
+    const FIELD_V2: u8 = 0b100;
+
+    fn dag_plain_selection_text(mask: u8) -> String {
+        DAG_PAYLOAD_FIELDS
+            .iter()
+            .enumerate()
+            .filter_map(|(index, field)| (mask & (1 << index) != 0).then_some(*field))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn dag_add_selection_mask(graph: &mut FetchDependencyGraph, node_id: NodeIndex, mask: u8) {
+        if mask == 0 {
+            return;
+        }
+        let node = graph.graph.node_weight(node_id).unwrap();
+        let schema = node.selection_set.selection_set.schema.clone();
+        let type_name = node
+            .selection_set
+            .selection_set
+            .type_position
+            .type_name()
+            .clone();
+        let selection =
+            parse_field_set(&schema, type_name, &dag_plain_selection_text(mask), true).unwrap();
+        Arc::make_mut(graph.graph.node_weight_mut(node_id).unwrap())
+            .selection_set_mut()
+            .add_selections(&Arc::new(selection))
+            .unwrap();
+    }
+
+    fn dag_add_input_mask(graph: &mut FetchDependencyGraph, node_id: NodeIndex, mask: u8) {
+        if mask == 0 {
+            return;
+        }
+        let selection = parse_field_set(
+            &graph.supergraph_schema,
+            name!("T"),
+            &dag_plain_selection_text(mask),
+            true,
+        )
+        .unwrap();
+        Arc::make_mut(graph.graph.node_weight_mut(node_id).unwrap())
+            .add_inputs(&selection, iter::empty())
+            .unwrap();
+    }
+
+    fn add_merge_test_node(
+        graph: &mut FetchDependencyGraph,
+        selection_mask: u8,
+        input_mask: u8,
+        defer_ref: Option<&str>,
+    ) -> NodeIndex {
+        add_merge_test_node_at(
+            graph,
+            selection_mask,
+            input_mask,
+            defer_ref,
+            Some(Vec::new()),
+        )
+    }
+
+    fn add_merge_test_node_at(
+        graph: &mut FetchDependencyGraph,
+        selection_mask: u8,
+        input_mask: u8,
+        defer_ref: Option<&str>,
+        merge_at: Option<Vec<FetchDataPathElement>>,
+    ) -> NodeIndex {
+        let subgraph_name: Arc<str> = Arc::from("Subgraph2");
+        let subgraph_schema = graph
+            .federated_query_graph
+            .schema_by_source(&subgraph_name)
+            .unwrap()
+            .clone();
+        let parent_type = subgraph_schema
+            .get_type(&name!("T"))
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let node_id = graph
+            .new_node(
+                subgraph_name,
+                parent_type,
+                true,
+                SchemaRootDefinitionKind::Query,
+                merge_at,
+                defer_ref.map(String::from),
+            )
+            .unwrap();
+        dag_add_selection_mask(graph, node_id, selection_mask);
+        dag_add_input_mask(graph, node_id, input_mask);
+        node_id
+    }
+
+    fn add_test_root(graph: &mut FetchDependencyGraph, subgraph_name: &str) -> NodeIndex {
+        let source: Arc<str> = Arc::from(subgraph_name);
+        let schema = graph
+            .federated_query_graph
+            .schema_by_source(&source)
+            .unwrap();
+        let query_name = schema
+            .schema()
+            .schema_definition
+            .query
+            .as_ref()
+            .unwrap()
+            .name
+            .clone();
+        let parent_type = schema.get_type(&query_name).unwrap().try_into().unwrap();
+        graph
+            .get_or_create_root_node(&source, SchemaRootDefinitionKind::Query, parent_type)
+            .unwrap()
+    }
+
+    // Small, text-based fixtures shared by the focused repros and generated entity-fetch tests.
+    // These helpers only construct production objects; they contain no property-test oracle.
+    fn add_entity_test_root(graph: &mut FetchDependencyGraph, selected: &str) -> NodeIndex {
+        let root = add_test_root(graph, "Subgraph1");
+        let before = &graph.graph[root].selection_set.selection_set;
+        let selection = SelectionSet::parse(
+            before.schema.clone(),
+            before.type_position.clone(),
+            selected,
+        )
+        .unwrap();
+        Arc::make_mut(graph.graph.node_weight_mut(root).unwrap())
+            .selection_set_mut()
+            .add_selections(&Arc::new(selection))
+            .unwrap();
+        root
+    }
+
+    fn add_entity_test_fetch(
+        graph: &mut FetchDependencyGraph,
+        source: &str,
+        response_name: &str,
+        selected: &str,
+        required: &str,
+    ) -> NodeIndex {
+        let source: Arc<str> = Arc::from(source);
+        let node = graph
+            .new_key_node(
+                &source,
+                vec![FetchDataPathElement::Key(
+                    Name::new(response_name).unwrap(),
+                    None,
+                )],
+                None,
+            )
+            .unwrap();
+        let schema = graph
+            .federated_query_graph
+            .schema_by_source(&source)
+            .unwrap()
+            .clone();
+        let selection = SelectionSet::parse(
+            schema.clone(),
+            schema
+                .get_type(&name!("_Entity"))
+                .unwrap()
+                .try_into()
+                .unwrap(),
+            &format!("... on T {{ {selected} }}"),
+        )
+        .unwrap();
+        let inputs = parse_field_set(&graph.supergraph_schema, name!("T"), required, true).unwrap();
+        // Match normal key-fetch construction, including the type-condition wrapper. A bare T
+        // field set is accepted by add_inputs, but bypasses the optimizer's usual input shape.
+        let inputs = wrap_input_selections(
+            &graph.supergraph_schema,
+            &inputs.type_position.clone(),
+            inputs,
+            &OpGraphPathContext::default(),
+        );
+        let mutable = Arc::make_mut(graph.graph.node_weight_mut(node).unwrap());
+        mutable
+            .selection_set_mut()
+            .add_selections(&Arc::new(selection))
+            .unwrap();
+        mutable.add_inputs(&inputs, iter::empty()).unwrap();
+        node
+    }
+
+    fn entity_test_root_path(graph: &FetchDependencyGraph, response_name: &str) -> OpPath {
+        let schema = graph
+            .federated_query_graph
+            .schema_by_source("Subgraph1")
+            .unwrap();
+        let OpPathElement::Field(mut field) =
+            object_field_element(schema, name!("Query"), name!("t"))
+        else {
+            unreachable!()
+        };
+        if response_name != "t" {
+            field.alias = Some(Name::new(response_name).unwrap());
+        }
+        OpPath(vec![Arc::new(OpPathElement::Field(field))])
+    }
+
+    fn dag_selection_mask(selection_set: &SelectionSet) -> u8 {
+        fn visit(selection_set: &SelectionSet, mask: &mut u8) {
+            for selection in selection_set.selections.values() {
+                match selection {
+                    Selection::Field(field) => {
+                        if let Some(index) = DAG_PAYLOAD_FIELDS
+                            .iter()
+                            .position(|name| *name == field.field.name().as_str())
+                        {
+                            *mask |= 1 << index;
+                        }
+                        if let Some(subselection) = &field.selection_set {
+                            visit(subselection, mask);
+                        }
+                    }
+                    Selection::InlineFragment(fragment) => visit(&fragment.selection_set, mask),
+                }
+            }
+        }
+
+        let mut mask = 0;
+        visit(selection_set, &mut mask);
+        mask
+    }
+
+    fn dag_input_mask(node: &FetchDependencyGraphNode) -> u8 {
+        node.inputs
+            .iter()
+            .flat_map(|inputs| inputs.selection_sets_per_parent_type.values())
+            .fold(0, |mask, selection| mask | dag_selection_mask(selection))
+    }
+
+    // The whole-optimizer domain uses real entity fetches, two subgraphs and two response
+    // locations. Every root actually supplies its representations. Markers track ownership;
+    // the auditor separately compares complete selections so marker survival cannot hide loss.
+    #[derive(Clone, Debug)]
+    struct OptimizerNodeSpec {
+        subgraph: u8,
+        merge_at: u8,
+        selection_mask: u8,
+        input_subset: u8,
+        parent: usize,
+        extra_parent_mask: u16,
+        must_preserve: bool,
+    }
+
+    fn optimizer_dag_strategy() -> impl Strategy<Value = Vec<OptimizerNodeSpec>> {
+        (2usize..9).prop_flat_map(|count| {
+            (0..count)
+                .map(|token| {
+                    (
+                        0u8..2,
+                        0u8..2,
+                        1u8..8,
+                        0u8..8,
+                        0usize..=token,
+                        0u16..(1 << (token + 1)),
+                        any::<bool>(),
+                    )
+                        .prop_map(
+                            |(
+                                subgraph,
+                                merge_at,
+                                selection_mask,
+                                input_subset,
+                                parent,
+                                extra_parent_mask,
+                                must_preserve,
+                            )| {
+                                OptimizerNodeSpec {
+                                    subgraph,
+                                    merge_at,
+                                    selection_mask,
+                                    input_subset,
+                                    parent,
+                                    extra_parent_mask,
+                                    must_preserve,
+                                }
+                            },
+                        )
+                })
+                .collect::<Vec<_>>()
+        })
+    }
+
+    fn optimizer_response_name(location: u8) -> &'static str {
+        match location {
+            0 => "t",
+            1 => "other",
+            _ => panic!("unknown generated response location"),
+        }
+    }
+
+    fn optimizer_merge_at(location: u8) -> Option<Vec<FetchDataPathElement>> {
+        Some(vec![FetchDataPathElement::Key(
+            Name::new(optimizer_response_name(location)).unwrap(),
+            None,
+        )])
+    }
+
+    const OPTIMIZER_ROOT_SELECTION: &str = "t { __typename id } other: t { __typename id }";
+
+    fn make_optimizer_dep_graph() -> FetchDependencyGraph {
+        // Omit per-field restrictions so both keyed subgraphs can collect the three scalar
+        // fields. The focused repros continue using the original, unmodified schema fixture.
+        let sdl = TEST_SUPERGRAPH_SDL
+            .replace("v1: Int @join__field(graph: SUBGRAPH2)", "v1: Int")
+            .replace("v2: Int @join__field(graph: SUBGRAPH2)", "v2: Int");
+        let supergraph = Supergraph::new(&sdl).unwrap();
+        let api_schema = supergraph.to_api_schema(Default::default()).unwrap();
+        let query_graph = Arc::new(
+            build_federated_query_graph(supergraph.schema.clone(), api_schema, None, None).unwrap(),
+        );
+        FetchDependencyGraph::new(
+            supergraph.schema,
+            query_graph,
+            None,
+            Arc::new(FetchIdGenerator::new()),
+        )
+    }
+
+    fn add_optimizer_token_node(
+        graph: &mut FetchDependencyGraph,
+        token: usize,
+        spec: &OptimizerNodeSpec,
+        input_mask: u8,
+    ) -> NodeIndex {
+        let node = add_entity_test_fetch(
+            graph,
+            DAG_TEST_SUBGRAPHS[spec.subgraph as usize],
+            optimizer_response_name(spec.merge_at),
+            &format!(
+                "optimizer_token_{token}: __typename {}",
+                dag_plain_selection_text(spec.selection_mask)
+            ),
+            &format!("__typename {}", dag_plain_selection_text(input_mask)),
+        );
+        Arc::make_mut(graph.graph.node_weight_mut(node).unwrap()).must_preserve_selection_set =
+            spec.must_preserve;
+        node
+    }
+
+    /// Conceptual node 0 is the root; token i is node i + 1. Parent indices and masks are
+    /// generated within their meaningful bounds, so shrinking does not retain irrelevant bits
+    /// or change an arbitrary large integer's modulo interpretation.
+    fn optimizer_conceptual_edges(specs: &[OptimizerNodeSpec]) -> Vec<(usize, usize)> {
+        let mut edges = BTreeSet::new();
+        for (token, spec) in specs.iter().enumerate() {
+            let child = token + 1;
+            assert!(spec.parent < child);
+            edges.insert((spec.parent, child));
+            for parent in 0..child {
+                if spec.extra_parent_mask & (1 << parent) != 0 {
+                    edges.insert((parent, child));
+                }
+            }
+        }
+        edges.into_iter().collect()
+    }
+
+    /// Representation keys are supplied at both root response locations. Other inputs are a
+    /// generated subset of fields selected by strict ancestors at the *same* location.
+    fn optimizer_input_masks(specs: &[OptimizerNodeSpec], edges: &[(usize, usize)]) -> Vec<u8> {
+        let reachable = optimizer_reference_reachability(specs.len(), edges);
+        specs
+            .iter()
+            .enumerate()
+            .map(|(token, spec)| {
+                let available =
+                    specs
+                        .iter()
+                        .enumerate()
+                        .fold(FIELD_ID, |mask, (ancestor, provider)| {
+                            if reachable[ancestor + 1][token + 1]
+                                && provider.merge_at == spec.merge_at
+                            {
+                                mask | provider.selection_mask
+                            } else {
+                                mask
+                            }
+                        });
+                FIELD_ID | (available & spec.input_subset)
+            })
+            .collect()
+    }
+
+    fn build_optimizer_dag(
+        specs: &[OptimizerNodeSpec],
+        reverse_edge_insertion: bool,
+    ) -> (
+        FetchDependencyGraph,
+        NodeIndex,
+        Vec<(usize, usize)>,
+        Vec<u8>,
+    ) {
+        let mut graph = make_optimizer_dep_graph();
+        let root = add_entity_test_root(&mut graph, OPTIMIZER_ROOT_SELECTION);
+        let edges = optimizer_conceptual_edges(specs);
+        let input_masks = optimizer_input_masks(specs, &edges);
+        let nodes: Vec<_> = specs
+            .iter()
+            .enumerate()
+            .map(|(token, spec)| {
+                add_optimizer_token_node(&mut graph, token, spec, input_masks[token])
+            })
+            .collect();
+        let mut insertion_order = edges.clone();
+        if reverse_edge_insertion {
+            insertion_order.reverse();
+        }
+        for (parent, child) in insertion_order {
+            let parent_node = if parent == 0 { root } else { nodes[parent - 1] };
+            let path = if parent == 0 {
+                Some(Arc::new(entity_test_root_path(
+                    &graph,
+                    optimizer_response_name(specs[child - 1].merge_at),
+                )))
+            } else if specs[parent - 1].merge_at == specs[child - 1].merge_at {
+                Some(Arc::new(OpPath::default()))
+            } else {
+                // An ordering constraint between different response locations does not imply
+                // that either fetch contains the other's selection.
+                None
+            };
+            graph.add_parent(
+                nodes[child - 1],
+                ParentRelation {
+                    parent_node_id: parent_node,
+                    path_in_parent: path,
+                },
+            );
+        }
+        (graph, root, edges, input_masks)
+    }
+
+    fn optimizer_reference_reachability(
+        node_count: usize,
+        edges: &[(usize, usize)],
+    ) -> Vec<Vec<bool>> {
+        let mut children = vec![Vec::new(); node_count + 1];
+        for &(parent, child) in edges {
+            children[parent].push(child);
+        }
+        (0..=node_count)
+            .map(|start| {
+                let mut reachable = vec![false; node_count + 1];
+                let mut stack = children[start].clone();
+                while let Some(node) = stack.pop() {
+                    if !reachable[node] {
+                        reachable[node] = true;
+                        stack.extend(children[node].iter().copied());
+                    }
+                }
+                reachable
+            })
+            .collect()
+    }
+
+    fn optimizer_tokens(selection_set: &SelectionSet) -> BTreeSet<usize> {
+        fn visit(selection_set: &SelectionSet, tokens: &mut BTreeSet<usize>) {
+            for selection in selection_set.selections.values() {
+                match selection {
+                    Selection::Field(field) => {
+                        if let Some(token) = field
+                            .field
+                            .response_name()
+                            .as_str()
+                            .strip_prefix("optimizer_token_")
+                            .and_then(|suffix| suffix.parse().ok())
+                        {
+                            assert!(
+                                tokens.insert(token),
+                                "optimizer token was duplicated in a node"
+                            );
+                        }
+                        if let Some(selection_set) = &field.selection_set {
+                            visit(selection_set, tokens);
+                        }
+                    }
+                    Selection::InlineFragment(fragment) => {
+                        visit(&fragment.selection_set, tokens);
+                    }
+                }
+            }
+        }
+
+        let mut tokens = BTreeSet::new();
+        visit(selection_set, &mut tokens);
+        tokens
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct OptimizerSemanticSnapshot {
+        token_groups: Vec<Vec<usize>>,
+        reachability: Vec<(Vec<usize>, Vec<usize>)>,
+    }
+
+    /// Inputs may keep a redundant ... on T wrapper that the test parser removes. Compare
+    /// scalar fields after checking that every wrapper is neutral on T. Do not flatten unknown
+    /// type conditions, aliases, directives or nested response paths into the same field bag.
+    fn optimizer_flat_input_fields(
+        selection: &SelectionSet,
+    ) -> Result<BTreeSet<String>, TestCaseError> {
+        prop_assert_eq!(selection.type_position.type_name().as_str(), "T");
+        let mut fields = BTreeSet::new();
+        for selection in selection.selections.values() {
+            match selection {
+                Selection::Field(field) => {
+                    prop_assert!(field.selection_set.is_none());
+                    prop_assert!(field.field.alias.is_none());
+                    prop_assert!(
+                        field.field.arguments.is_empty() && field.field.directives.is_empty()
+                    );
+                    fields.insert(field.field.name().to_string());
+                }
+                Selection::InlineFragment(fragment) => {
+                    prop_assert!(fragment.inline_fragment.directives.is_empty());
+                    let casted_type = fragment.inline_fragment.casted_type();
+                    prop_assert_eq!(casted_type.type_name().as_str(), "T");
+                    fields.extend(optimizer_flat_input_fields(&fragment.selection_set)?);
+                }
+            }
+        }
+        Ok(fields)
+    }
+
+    fn audit_optimized_dag(
+        graph: &FetchDependencyGraph,
+        root: NodeIndex,
+        specs: &[OptimizerNodeSpec],
+        original_input_masks: &[u8],
+    ) -> Result<OptimizerSemanticSnapshot, TestCaseError> {
+        prop_assert!(graph.is_reduced && graph.is_optimized);
+        audit_optimizer_payloads(graph, root, specs, original_input_masks)
+    }
+
+    /// Check independently of the optimizer's flags, so the same oracle can validate generated
+    /// inputs and can be tested against deliberate corruptions without running an optimizer.
+    fn audit_optimizer_payloads(
+        graph: &FetchDependencyGraph,
+        root: NodeIndex,
+        specs: &[OptimizerNodeSpec],
+        original_input_masks: &[u8],
+    ) -> Result<OptimizerSemanticSnapshot, TestCaseError> {
+        prop_assert_eq!(original_input_masks.len(), specs.len());
+        prop_assert!(
+            petgraph::algo::toposort(&graph.graph, None).is_ok(),
+            "optimizer introduced a cycle"
+        );
+        prop_assert!(graph.reduced_defer_edges.is_empty());
+        prop_assert_eq!(
+            &graph.root_nodes_by_subgraph,
+            &IndexMap::from_iter([(Arc::from("Subgraph1"), root)])
+        );
+        let root_node = graph
+            .graph
+            .node_weight(root)
+            .ok_or_else(|| TestCaseError::fail("optimizer removed the root"))?;
+        let expected_root = SelectionSet::parse(
+            root_node.selection_set.selection_set.schema.clone(),
+            ObjectTypeDefinitionPosition::new(name!("Query")).into(),
+            OPTIMIZER_ROOT_SELECTION,
+        )
+        .unwrap();
+        prop_assert_eq!(
+            root_node.selection_set.selection_set.as_ref(),
+            &expected_root
+        );
+
+        for edge in graph.graph.edge_references() {
+            let Some(path) = &edge.weight().path else {
+                continue;
+            };
+            let fields: Vec<_> = path
+                .0
+                .iter()
+                .filter_map(|element| match element.as_ref() {
+                    OpPathElement::Field(field) => Some(field.response_name().clone()),
+                    OpPathElement::InlineFragment(_) => None,
+                })
+                .collect();
+            if edge.source() == root {
+                let expected_location: Vec<_> = fields
+                    .into_iter()
+                    .map(|name| FetchDataPathElement::Key(name, None))
+                    .collect();
+                prop_assert_eq!(
+                    &graph.graph[edge.target()].merge_at,
+                    &Some(expected_location),
+                    "root-relative path disagrees with child response location"
+                );
+            } else {
+                prop_assert!(
+                    fields.is_empty(),
+                    "flat entity fetches have no nested field path"
+                );
+                prop_assert_eq!(
+                    &graph.graph[edge.source()].merge_at,
+                    &graph.graph[edge.target()].merge_at,
+                    "a known relative path cannot identify two distinct root response locations"
+                );
+            }
+        }
+
+        let mut carriers = vec![Vec::new(); specs.len()];
+        let mut groups = BTreeMap::<Vec<usize>, NodeIndex>::new();
+        for node in graph.graph.node_indices() {
+            let tokens = optimizer_tokens(&graph.graph[node].selection_set.selection_set)
+                .into_iter()
+                .collect::<Vec<_>>();
+            if tokens.is_empty() {
+                prop_assert_eq!(node, root, "unaccounted non-root fetch");
+                continue;
+            }
+            for &token in &tokens {
+                if token >= specs.len() {
+                    return Err(TestCaseError::fail(format!(
+                        "unknown optimizer token {token} in node {node:?}"
+                    )));
+                }
+                carriers[token].push(node);
+            }
+
+            let first = &specs[tokens[0]];
+            prop_assert!(
+                tokens
+                    .iter()
+                    .all(|&token| specs[token].merge_at == first.merge_at
+                        && specs[token].subgraph == first.subgraph),
+                "optimizer merged tokens from different subgraph/merge locations: {tokens:?}"
+            );
+            prop_assert_eq!(
+                &graph.graph[node].merge_at,
+                &optimizer_merge_at(first.merge_at),
+                "wrong actual response location for tokens {:?}",
+                tokens
+            );
+            prop_assert_eq!(
+                graph.graph[node].subgraph_name.as_ref(),
+                DAG_TEST_SUBGRAPHS[first.subgraph as usize]
+            );
+
+            // Reconstruct the expected field set literally from the specs, without calling a
+            // production merge or flattening fields across paths/type conditions. This checks
+            // ordinary fields as well as markers, including their placement under ... on T.
+            let selected = tokens
+                .iter()
+                .fold(0, |mask, token| mask | specs[*token].selection_mask);
+            let markers = tokens
+                .iter()
+                .map(|token| format!("optimizer_token_{token}: __typename"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let schema = graph
+                .federated_query_graph
+                .schema_by_source(DAG_TEST_SUBGRAPHS[first.subgraph as usize])
+                .unwrap()
+                .clone();
+            let expected_selection = SelectionSet::parse(
+                schema.clone(),
+                schema
+                    .get_type(&name!("_Entity"))
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+                &format!(
+                    "... on T {{ {markers} {} }}",
+                    dag_plain_selection_text(selected)
+                ),
+            )
+            .unwrap();
+            prop_assert_eq!(
+                graph.graph[node].selection_set.selection_set.as_ref(),
+                &expected_selection,
+                "selected work changed for token group {:?}",
+                tokens
+            );
+            let expected_inputs = tokens
+                .iter()
+                .fold(0, |mask, token| mask | original_input_masks[*token]);
+            prop_assert_eq!(
+                dag_input_mask(&graph.graph[node]),
+                expected_inputs,
+                "optimizer lost input payload for token group {:?}",
+                tokens,
+            );
+            let expected_input_selection = SelectionSet::parse(
+                graph.supergraph_schema.clone(),
+                ObjectTypeDefinitionPosition::new(name!("T")).into(),
+                &format!(
+                    "... on T {{ __typename {} }}",
+                    dag_plain_selection_text(expected_inputs)
+                ),
+            )
+            .unwrap();
+            let inputs = graph.graph[node]
+                .inputs
+                .as_ref()
+                .ok_or_else(|| TestCaseError::fail("entity fetch lost representation inputs"))?;
+            prop_assert_eq!(inputs.selection_sets_per_parent_type.len(), 1);
+            prop_assert_eq!(
+                optimizer_flat_input_fields(
+                    inputs
+                        .selection_sets_per_parent_type
+                        .values()
+                        .next()
+                        .unwrap()
+                )?,
+                optimizer_flat_input_fields(&expected_input_selection)?,
+                "representation changed for token group {:?}",
+                tokens
+            );
+            prop_assert_eq!(
+                graph.graph[node].must_preserve_selection_set,
+                tokens.iter().any(|token| specs[*token].must_preserve),
+                "optimizer lost must-preserve state for token group {:?}",
+                tokens,
+            );
+            prop_assert!(groups.insert(tokens, node).is_none());
+        }
+
+        for (token, token_carriers) in carriers.iter().enumerate() {
+            prop_assert_eq!(
+                token_carriers.len(),
+                1,
+                "selection provenance token {} had carriers {:?}",
+                token,
+                token_carriers,
+            );
+            prop_assert!(petgraph::algo::has_path_connecting(
+                &graph.graph,
+                root,
+                token_carriers[0],
+                None,
+            ));
+        }
+
+        let token_groups = groups.keys().cloned().collect::<Vec<_>>();
+        let mut reachability = Vec::new();
+        for (source_tokens, source) in &groups {
+            for (target_tokens, target) in &groups {
+                if source != target
+                    && petgraph::algo::has_path_connecting(&graph.graph, *source, *target, None)
+                {
+                    reachability.push((source_tokens.clone(), target_tokens.clone()));
+                }
+            }
+        }
+        reachability.sort();
+
+        Ok(OptimizerSemanticSnapshot {
+            token_groups,
+            reachability,
+        })
+    }
+
+    fn audit_generated_optimizer_input_availability(
+        specs: &[OptimizerNodeSpec],
+        edges: &[(usize, usize)],
+        input_masks: &[u8],
+    ) -> Result<(), TestCaseError> {
+        const ROOT_INPUT_MASK: u8 = 0b001;
+        let reachability = optimizer_reference_reachability(specs.len(), edges);
+        for token in 0..specs.len() {
+            let available = (0..specs.len()).fold(ROOT_INPUT_MASK, |mask, ancestor| {
+                if reachability[ancestor + 1][token + 1]
+                    && specs[ancestor].merge_at == specs[token].merge_at
+                {
+                    mask | specs[ancestor].selection_mask
+                } else {
+                    mask
+                }
+            });
+            prop_assert_eq!(
+                input_masks[token] & !available,
+                0,
+                "generated token {} required unavailable input",
+                token,
+            );
+        }
+        Ok(())
+    }
+
+    /// Fields available at a response location, not a global bag of all field names. This
+    /// deliberately handles just the generated flat T selections at t / other: t.
+    fn optimizer_fields_at(
+        node: &FetchDependencyGraphNode,
+        location: &[FetchDataPathElement],
+    ) -> u8 {
+        if node.merge_at.as_deref() == Some(location) {
+            return dag_selection_mask(&node.selection_set.selection_set);
+        }
+        if node.merge_at.is_some() {
+            return 0;
+        }
+        let [FetchDataPathElement::Key(response_name, None)] = location else {
+            return 0;
+        };
+        node.selection_set
+            .selection_set
+            .selections
+            .values()
+            .fold(0, |mask, selection| {
+                let Selection::Field(field) = selection else {
+                    return mask;
+                };
+                if field.field.response_name() == response_name {
+                    mask | field
+                        .selection_set
+                        .as_ref()
+                        .map_or(0, |selection| dag_selection_mask(selection))
+                } else {
+                    mask
+                }
+            })
+    }
+
+    /// Slow reverse DFS from raw edges; no optimizer reachability cache, marker assumption, or
+    /// implicit root supply. Only strict ancestors can make a representation field available.
+    fn optimizer_strict_ancestors(
+        graph: &FetchDependencyGraph,
+        node: NodeIndex,
+    ) -> BTreeSet<NodeIndex> {
+        let mut ancestors = BTreeSet::new();
+        let mut pending: Vec<_> = graph
+            .graph
+            .edges_directed(node, petgraph::Direction::Incoming)
+            .map(|edge| edge.source())
+            .collect();
+        while let Some(parent) = pending.pop() {
+            if ancestors.insert(parent) {
+                pending.extend(
+                    graph
+                        .graph
+                        .edges_directed(parent, petgraph::Direction::Incoming)
+                        .map(|edge| edge.source()),
+                );
+            }
+        }
+        ancestors
+    }
+
+    fn audit_optimized_input_availability(
+        graph: &FetchDependencyGraph,
+    ) -> Result<(), TestCaseError> {
+        for node in graph.graph.node_indices() {
+            let Some(location) = &graph.graph[node].merge_at else {
+                continue;
+            };
+            let ancestors = optimizer_strict_ancestors(graph, node);
+            prop_assert!(!ancestors.contains(&node), "cyclic input dependency");
+            let available = ancestors.iter().fold(0, |mask, ancestor| {
+                mask | optimizer_fields_at(&graph.graph[*ancestor], location)
+            });
+            let required = dag_input_mask(&graph.graph[node]);
+            prop_assert_eq!(
+                required & !available,
+                0,
+                "fetch {:?} at {:?} requires unavailable fields: required {:03b}, available {:03b}",
+                node,
+                location,
+                required,
+                available
+            );
+        }
+        Ok(())
+    }
+
+    fn optimizer_auditor_fixture() -> (
+        FetchDependencyGraph,
+        NodeIndex,
+        Vec<OptimizerNodeSpec>,
+        Vec<u8>,
+    ) {
+        let specs = vec![
+            OptimizerNodeSpec {
+                subgraph: 0,
+                merge_at: 0,
+                selection_mask: FIELD_V1,
+                input_subset: 0,
+                parent: 0,
+                extra_parent_mask: 0,
+                must_preserve: false,
+            },
+            OptimizerNodeSpec {
+                subgraph: 1,
+                merge_at: 1,
+                selection_mask: FIELD_V2,
+                input_subset: 0,
+                parent: 0,
+                extra_parent_mask: 0,
+                must_preserve: true,
+            },
+        ];
+        let (graph, root, _, inputs) = build_optimizer_dag(&specs, false);
+        audit_optimizer_payloads(&graph, root, &specs, &inputs).unwrap();
+        audit_optimized_input_availability(&graph).unwrap();
+        (graph, root, specs, inputs)
+    }
+
+    #[test]
+    fn optimizer_payload_auditor_rejects_lost_field_even_when_marker_survives() {
+        let (mut graph, root, specs, inputs) = optimizer_auditor_fixture();
+        let victim = graph
+            .graph
+            .node_indices()
+            .find(|node| {
+                optimizer_tokens(&graph.graph[*node].selection_set.selection_set).contains(&0)
+            })
+            .unwrap();
+        let before = graph.graph[victim].selection_set.selection_set.clone();
+        let removed = SelectionSet::parse(
+            before.schema.clone(),
+            before.type_position.clone(),
+            "... on T { v1 }",
+        )
+        .unwrap();
+        Arc::make_mut(graph.graph.node_weight_mut(victim).unwrap())
+            .selection_set_mut()
+            .selection_set = Arc::new(before.minus(&removed).unwrap());
+        assert_eq!(
+            optimizer_tokens(&graph.graph[victim].selection_set.selection_set),
+            BTreeSet::from([0])
+        );
+        assert_eq!(
+            dag_selection_mask(&graph.graph[victim].selection_set.selection_set),
+            0
+        );
+        let error = audit_optimizer_payloads(&graph, root, &specs, &inputs).unwrap_err();
+        assert!(
+            error.to_string().contains("selected work changed"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn optimizer_payload_auditor_rejects_corrupt_location_inputs_flags_and_paths() {
+        // Check each corruption independently on an initially accepted fixture. None relies on
+        // production optimization failing first or on flags set by the implementation.
+        for corruption in [
+            "location",
+            "inputs",
+            "must_preserve",
+            "source",
+            "relative_path",
+        ] {
+            let (mut graph, root, specs, inputs) = optimizer_auditor_fixture();
+            let victim = graph
+                .graph
+                .node_indices()
+                .find(|node| {
+                    optimizer_tokens(&graph.graph[*node].selection_set.selection_set).contains(&0)
+                })
+                .unwrap();
+            match corruption {
+                "location" => {
+                    Arc::make_mut(graph.graph.node_weight_mut(victim).unwrap()).merge_at =
+                        optimizer_merge_at(1)
+                }
+                "inputs" => dag_add_input_mask(&mut graph, victim, FIELD_V2),
+                "must_preserve" => {
+                    Arc::make_mut(graph.graph.node_weight_mut(victim).unwrap())
+                        .must_preserve_selection_set = true
+                }
+                "source" => {
+                    Arc::make_mut(graph.graph.node_weight_mut(victim).unwrap()).subgraph_name =
+                        Arc::from("Subgraph2")
+                }
+                "relative_path" => {
+                    let edge = graph.graph.find_edge(root, victim).unwrap();
+                    Arc::make_mut(graph.graph.edge_weight_mut(edge).unwrap()).path =
+                        Some(Arc::new(OpPath::default()));
+                }
+                _ => unreachable!(),
+            }
+            assert!(
+                audit_optimizer_payloads(&graph, root, &specs, &inputs).is_err(),
+                "auditor accepted corrupt {corruption}"
+            );
+        }
+    }
+
+    #[test]
+    fn optimizer_availability_auditor_rejects_lost_ordering_even_when_consumer_stays_reachable() {
+        let mut graph = make_test_dep_graph();
+        let root = add_entity_test_root(&mut graph, "t { __typename id }");
+        let provider = add_entity_test_fetch(&mut graph, "Subgraph2", "t", "v2", "__typename id");
+        let consumer =
+            add_entity_test_fetch(&mut graph, "Subgraph2", "t", "v1", "__typename id v2");
+        let root_path = entity_test_root_path(&graph, "t");
+        dag_add_parent_with_path(&mut graph, root, provider, root_path.clone());
+        dag_add_parent_with_path(&mut graph, root, consumer, root_path);
+        dag_add_parent_with_path(&mut graph, provider, consumer, OpPath::default());
+        audit_optimized_input_availability(&graph).unwrap();
+
+        let edge = graph.graph.find_edge(provider, consumer).unwrap();
+        graph.graph.remove_edge(edge); // Intentional corruption of the oracle's input.
+        assert!(petgraph::algo::has_path_connecting(
+            &graph.graph,
+            root,
+            consumer,
+            None
+        ));
+        assert!(audit_optimized_input_availability(&graph).is_err());
+    }
+
+    #[test]
+    fn optimizer_availability_auditor_does_not_borrow_fields_from_another_response_location() {
+        let mut graph = make_test_dep_graph();
+        let root = add_entity_test_root(&mut graph, OPTIMIZER_ROOT_SELECTION);
+        let provider =
+            add_entity_test_fetch(&mut graph, "Subgraph2", "other", "v2", "__typename id");
+        let consumer =
+            add_entity_test_fetch(&mut graph, "Subgraph2", "t", "v1", "__typename id v2");
+        let path = entity_test_root_path(&graph, "other");
+        dag_add_parent_with_path(&mut graph, root, provider, path);
+        graph.add_parent(
+            consumer,
+            ParentRelation {
+                parent_node_id: provider,
+                path_in_parent: None,
+            },
+        );
+        // The graph is connected, and v2 exists on an ancestor, but at other rather than t.
+        assert!(audit_optimized_input_availability(&graph).is_err());
+    }
+
+    fn dag_test_fragment_path(graph: &FetchDependencyGraph, nested: bool) -> OpPath {
+        if !nested {
+            return OpPath::default();
+        }
+        let schema = graph
+            .federated_query_graph
+            .schema_by_source("Subgraph2")
+            .unwrap();
+        OpPath(vec![Arc::new(inline_fragment_element(
+            schema,
+            name!("T"),
+            Some(name!("T")),
+        ))])
+    }
+
+    fn dag_recursive_child_path(graph: &FetchDependencyGraph, depth: usize) -> OpPath {
+        let schema = graph
+            .federated_query_graph
+            .schema_by_source("Subgraph2")
+            .unwrap();
+        let field_position: FieldDefinitionPosition = schema
+            .get_type(&name!("T"))
+            .unwrap()
+            .try_into()
+            .map(|position: ObjectTypeDefinitionPosition| position.field(name!("child")).into())
+            .unwrap();
+        OpPath(
+            (0..depth)
+                .map(|_| {
+                    Arc::new(OpPathElement::Field(Field::from_position(
+                        schema,
+                        field_position.clone(),
+                    )))
+                })
+                .collect(),
+        )
+    }
+
+    fn dag_selection_nested_at_child_path(mask: u8, depth: usize) -> String {
+        let mut nested = dag_plain_selection_text(mask);
+        for _ in 0..depth {
+            nested = format!("child {{ {nested} }}");
+        }
+        nested
+    }
+
+    fn dag_merge_at_child_path(depth: usize, index_mask: u8) -> Vec<FetchDataPathElement> {
+        let mut path = Vec::new();
+        for level in 0..depth {
+            path.push(FetchDataPathElement::Key(name!("child"), None));
+            if index_mask & (1 << level) != 0 {
+                path.push(FetchDataPathElement::AnyIndex(None));
+            }
+        }
+        path
+    }
+
+    fn dag_add_parent_with_path(
+        graph: &mut FetchDependencyGraph,
+        parent: NodeIndex,
+        child: NodeIndex,
+        path: OpPath,
+    ) {
+        graph.add_parent(
+            child,
+            ParentRelation {
+                parent_node_id: parent,
+                path_in_parent: Some(Arc::new(path)),
+            },
+        );
+    }
+
+    fn dag_assert_ledger_is_live(graph: &FetchDependencyGraph) -> Result<(), TestCaseError> {
+        for &(source, target) in &graph.reduced_defer_edges {
+            prop_assert!(
+                graph.graph.node_weight(source).is_some(),
+                "ledger source {source:?} was removed"
+            );
+            prop_assert!(
+                graph.graph.node_weight(target).is_some(),
+                "ledger target {target:?} was removed"
+            );
+        }
+        Ok(())
+    }
+
+    fn child_merge_candidate(
+        child_defer: Option<&str>,
+    ) -> (FetchDependencyGraph, NodeIndex, NodeIndex) {
+        let mut graph = make_test_dep_graph();
+        let parent = add_merge_test_node(&mut graph, 0b001, 0b001, None);
+        let child = add_merge_test_node(&mut graph, 0b010, 0b001, child_defer);
+        dag_add_parent_with_path(&mut graph, parent, child, OpPath::default());
+        (graph, parent, child)
+    }
+
+    /// Exhaust every independent rejection gate in `can_merge_child_in`. This is deliberately a
+    /// finite table rather than random sampling: if a future refactor drops one case, every run
+    /// still proves that the optimizer refuses the unsafe shape.
+    #[test]
+    fn can_merge_child_in_rejects_every_unsafe_relation() {
+        let (graph, parent, child) = child_merge_candidate(None);
+        assert!(graph.can_merge_child_in(parent, child).unwrap());
+
+        let mut graph = make_test_dep_graph();
+        let parent = add_merge_test_node(&mut graph, 1, 1, None);
+        let child = add_merge_test_node(&mut graph, 2, 1, None);
+        add_test_edge(&mut graph, parent, child);
+        assert!(
+            !graph.can_merge_child_in(parent, child).unwrap(),
+            "missing path"
+        );
+
+        let (graph, parent, child) = child_merge_candidate(Some("deferred"));
+        assert!(
+            !graph.can_merge_child_in(parent, child).unwrap(),
+            "different defer"
+        );
+
+        let mut graph = make_test_dep_graph();
+        let parent = add_merge_test_node(&mut graph, 1, 1, None);
+        let child = add_test_node(&mut graph, "Subgraph1", None);
+        dag_add_parent_with_path(&mut graph, parent, child, OpPath::default());
+        assert!(
+            !graph.can_merge_child_in(parent, child).unwrap(),
+            "different subgraph"
+        );
+
+        let (mut graph, parent, child) = child_merge_candidate(None);
+        let independent_parent = add_test_node(&mut graph, "Subgraph1", None);
+        dag_add_parent_with_path(&mut graph, independent_parent, child, OpPath::default());
+        assert!(
+            !graph.can_merge_child_in(parent, child).unwrap(),
+            "an independent parent dependency would be lost"
+        );
+
+        let (mut graph, parent, child) = child_merge_candidate(None);
+        let ancestor = add_test_node(&mut graph, "Subgraph1", None);
+        dag_add_parent_with_path(&mut graph, ancestor, parent, OpPath::default());
+        dag_add_parent_with_path(&mut graph, ancestor, child, OpPath::default());
+        assert!(
+            graph.can_merge_child_in(parent, child).unwrap(),
+            "an already-transitive extra parent is safe"
+        );
+    }
+
+    fn sibling_merge_candidate_with(
+        right_defer: Option<&str>,
+        right_merge_at: Option<Vec<FetchDataPathElement>>,
+    ) -> (FetchDependencyGraph, NodeIndex, NodeIndex, NodeIndex) {
+        let mut graph = make_test_dep_graph();
+        let common_parent = add_test_node(&mut graph, "Subgraph1", None);
+        let left = add_merge_test_node(&mut graph, 1, 1, None);
+        let right = add_merge_test_node_at(&mut graph, 2, 1, right_defer, right_merge_at);
+        dag_add_parent_with_path(&mut graph, common_parent, left, OpPath::default());
+        dag_add_parent_with_path(&mut graph, common_parent, right, OpPath::default());
+        (graph, common_parent, left, right)
+    }
+
+    fn sibling_merge_candidate() -> (FetchDependencyGraph, NodeIndex, NodeIndex, NodeIndex) {
+        sibling_merge_candidate_with(None, Some(Vec::new()))
+    }
+
+    #[test]
+    fn can_merge_sibling_in_rejects_every_mismatched_identity() {
+        let (graph, _, left, right) = sibling_merge_candidate();
+        assert!(graph.can_merge_sibling_in(left, right).unwrap());
+
+        let (mut graph, _, left, right) = sibling_merge_candidate();
+        let extra_parent = add_test_node(&mut graph, "Subgraph1", None);
+        dag_add_parent_with_path(&mut graph, extra_parent, right, OpPath::default());
+        assert!(
+            !graph.can_merge_sibling_in(left, right).unwrap(),
+            "multiple parents"
+        );
+
+        let (graph, _, left, right) = sibling_merge_candidate_with(
+            None,
+            Some(vec![FetchDataPathElement::Key(name!("other"), None)]),
+        );
+        assert!(
+            !graph.can_merge_sibling_in(left, right).unwrap(),
+            "different merge_at"
+        );
+
+        let (graph, _, left, right) =
+            sibling_merge_candidate_with(Some("deferred"), Some(Vec::new()));
+        assert!(
+            !graph.can_merge_sibling_in(left, right).unwrap(),
+            "different defer"
+        );
+
+        let (mut graph, common_parent, left, _) = sibling_merge_candidate();
+        let other_subgraph = add_test_node(&mut graph, "Subgraph1", None);
+        dag_add_parent_with_path(&mut graph, common_parent, other_subgraph, OpPath::default());
+        assert!(
+            !graph.can_merge_sibling_in(left, other_subgraph).unwrap(),
+            "different subgraph"
+        );
+
+        let (mut graph, _, left, right) = sibling_merge_candidate();
+        dag_add_input_mask(&mut graph, right, 0b010);
+        assert!(
+            graph.can_merge_sibling_in(left, right).unwrap(),
+            "different input payloads are intentionally unioned during merge"
+        );
+    }
+
+    fn grandchild_merge_candidate() -> (FetchDependencyGraph, NodeIndex, NodeIndex, NodeIndex) {
+        let mut graph = make_test_dep_graph();
+        let grandparent = add_merge_test_node(&mut graph, 1, 0b111, None);
+        let parent = add_merge_test_node(&mut graph, 2, 0b001, None);
+        let grandchild = add_merge_test_node(&mut graph, 4, 0b001, None);
+        dag_add_parent_with_path(&mut graph, grandparent, parent, OpPath::default());
+        dag_add_parent_with_path(&mut graph, parent, grandchild, OpPath::default());
+        (graph, grandparent, parent, grandchild)
+    }
+
+    #[test]
+    fn can_merge_grandchild_in_rejects_every_unsafe_relation() {
+        let (graph, grandparent, parent, grandchild) = grandchild_merge_candidate();
+        assert!(
+            graph
+                .can_merge_grand_child_in(grandparent, parent, grandchild)
+                .unwrap()
+        );
+
+        let (mut graph, grandparent, parent, grandchild) = grandchild_merge_candidate();
+        let extra_parent = add_test_node(&mut graph, "Subgraph1", None);
+        dag_add_parent_with_path(&mut graph, extra_parent, grandchild, OpPath::default());
+        assert!(
+            !graph
+                .can_merge_grand_child_in(grandparent, parent, grandchild)
+                .unwrap(),
+            "multiple parents"
+        );
+
+        let (mut graph, grandparent, parent, grandchild) = grandchild_merge_candidate();
+        Arc::make_mut(graph.graph.node_weight_mut(grandchild).unwrap()).merge_at =
+            Some(vec![FetchDataPathElement::Key(name!("other"), None)]);
+        assert!(
+            !graph
+                .can_merge_grand_child_in(grandparent, parent, grandchild)
+                .unwrap(),
+            "different merge_at"
+        );
+
+        let (mut graph, grandparent, parent, grandchild) = grandchild_merge_candidate();
+        dag_add_input_mask(&mut graph, grandchild, 0b010);
+        assert!(
+            !graph
+                .can_merge_grand_child_in(grandparent, parent, grandchild)
+                .unwrap(),
+            "grandchild inputs not contained by its parent"
+        );
+
+        let (mut graph, grandparent, parent, grandchild) = grandchild_merge_candidate();
+        Arc::make_mut(graph.graph.node_weight_mut(grandchild).unwrap()).defer_ref =
+            Some("deferred".to_string());
+        assert!(
+            !graph
+                .can_merge_grand_child_in(grandparent, parent, grandchild)
+                .unwrap(),
+            "different defer"
+        );
+    }
+
+    /// A redundant edge is safe to remove only while another ordering path supplies the same
+    /// still-required input. All entity fetches below act on the same object at response path t.
+    #[test]
+    fn reduce_and_optimize_preserves_an_input_dependency_through_a_late_merge() {
+        let mut graph = make_test_dep_graph();
+        let root = add_entity_test_root(&mut graph, "t { __typename id }");
+        let earlier = add_entity_test_fetch(&mut graph, "Subgraph2", "t", "id v1", "__typename id");
+        let provider =
+            add_entity_test_fetch(&mut graph, "Subgraph2", "t", "id v2", "__typename id v1");
+        let later = add_entity_test_fetch(&mut graph, "Subgraph2", "t", "id v1", "__typename id");
+        let consumer =
+            add_entity_test_fetch(&mut graph, "Subgraph2", "t", "v1", "__typename id v2");
+        let root_path = entity_test_root_path(&graph, "t");
+        dag_add_parent_with_path(&mut graph, root, earlier, root_path);
+        // Root supplies id; earlier supplies v1; provider supplies v2.
+        // R -> earlier -> provider -> later -> consumer, plus provider -> consumer.
+        for (parent, child) in [
+            (earlier, provider),
+            (provider, later),
+            (later, consumer),
+            (provider, consumer),
+        ] {
+            dag_add_parent_with_path(&mut graph, parent, child, OpPath::default());
+        }
+        graph.reduce();
+        assert!(
+            !graph.is_parent_of(provider, consumer),
+            "the shortcut should be redundant"
+        );
+        assert!(petgraph::algo::has_path_connecting(
+            &graph.graph,
+            provider,
+            consumer,
+            None
+        ));
+
+        graph.reduce_and_optimize().unwrap();
+
+        // Inspect the current work, rather than demanding that particular NodeIndices survive
+        // a future valid rewrite. Whichever fetch still requires v2 must have a provider.
+        let v2_inputs = parse_field_set(&graph.supergraph_schema, name!("T"), "v2", true).unwrap();
+        let consumers: Vec<_> = graph.graph.node_indices().filter(|node| {
+            graph.graph[*node].inputs.as_ref().is_some_and(|inputs| {
+                inputs.selection_sets_per_parent_type.values().any(|selection| {
+                    selection.contains(&v2_inputs) || selection.selections.values().any(|part| {
+                        matches!(part, Selection::InlineFragment(fragment) if fragment.selection_set.contains(&v2_inputs))
+                    })
+                })
+            })
+        }).collect();
+        assert!(
+            !consumers.is_empty(),
+            "fixture must retain the v2-consuming work"
+        );
+        for consumer in consumers {
+            let selection = &graph.graph[consumer].selection_set.selection_set;
+            let v2_output = SelectionSet::parse(
+                selection.schema.clone(),
+                selection.type_position.clone(),
+                "... on T { v2 }",
+            )
+            .unwrap();
+            let providers: Vec<_> = graph
+                .graph
+                .node_indices()
+                .filter(|node| {
+                    graph.graph[*node].merge_at == graph.graph[consumer].merge_at
+                        && graph.graph[*node]
+                            .selection_set
+                            .selection_set
+                            .contains(&v2_output)
+                })
+                .collect();
+            assert!(
+                !providers.is_empty(),
+                "the v2 output must remain in the graph"
+            );
+            assert!(
+                providers.into_iter().any(|provider| {
+                    provider != consumer
+                        && petgraph::algo::has_path_connecting(
+                            &graph.graph,
+                            provider,
+                            consumer,
+                            None,
+                        )
+                }),
+                "a fetch still requiring v2 has lost its provider ordering"
+            );
+        }
+    }
+
+    /// Merging one bucket changes the ancestry used by the next. Use real subgraph buckets,
+    /// key-fetch constructors and root-supplied inputs at t; no invented response locations.
+    #[test]
+    fn reduce_and_optimize_does_not_use_stale_topology_across_merge_buckets() {
+        let mut graph = make_test_dep_graph();
+        let root = add_entity_test_root(&mut graph, "t { __typename id }");
+        let p = add_entity_test_fetch(
+            &mut graph,
+            "Subgraph1",
+            "t",
+            "p: __typename",
+            "__typename id",
+        );
+        let u = add_entity_test_fetch(
+            &mut graph,
+            "Subgraph2",
+            "t",
+            "u: __typename",
+            "__typename id",
+        );
+        let d = add_entity_test_fetch(
+            &mut graph,
+            "Subgraph1",
+            "t",
+            "d: __typename",
+            "__typename id",
+        );
+        let v = add_entity_test_fetch(
+            &mut graph,
+            "Subgraph2",
+            "t",
+            "v: __typename",
+            "__typename id",
+        );
+        let root_path = entity_test_root_path(&graph, "t");
+        dag_add_parent_with_path(&mut graph, root, p, root_path.clone());
+        dag_add_parent_with_path(&mut graph, root, u, root_path);
+        for (parent, child) in [(u, d), (u, v), (p, v)] {
+            dag_add_parent_with_path(&mut graph, parent, child, OpPath::default());
+        }
+        assert!(petgraph::algo::toposort(&graph.graph, None).is_ok());
+        assert_eq!(graph.graph[p].inputs, graph.graph[d].inputs);
+        assert_eq!(graph.graph[u].inputs, graph.graph[v].inputs);
+        assert!(!petgraph::algo::has_path_connecting(
+            &graph.graph,
+            p,
+            u,
+            None
+        ));
+        assert!(!petgraph::algo::has_path_connecting(
+            &graph.graph,
+            u,
+            p,
+            None
+        ));
+
+        // U/V merging transfers P's dependency to U, creating P -> U -> D. The P/D bucket
+        // must not reuse a pre-merge order that now attempts to create a cycle.
+        graph.reduce_and_optimize().unwrap();
+        assert!(petgraph::algo::toposort(&graph.graph, None).is_ok());
+    }
+
+    /// Optimization proposal, not a promised global normal form. Demonstrate the intermediate
+    /// opportunity separately so the final assertions can accept a correct additional merge.
+    #[test]
+    fn reduce_and_optimize_consumes_siblings_created_by_the_late_merge_phase() {
+        let mut graph = make_optimizer_dep_graph();
+        let root = add_entity_test_root(&mut graph, "t { __typename id }");
+        let first = add_entity_test_fetch(&mut graph, "Subgraph1", "t", "v1", "__typename id");
+        let second = add_entity_test_fetch(&mut graph, "Subgraph1", "t", "v2", "__typename id");
+        let left = add_entity_test_fetch(
+            &mut graph,
+            "Subgraph2",
+            "t",
+            "left: __typename",
+            "__typename id",
+        );
+        let right = add_entity_test_fetch(
+            &mut graph,
+            "Subgraph2",
+            "t",
+            "right: __typename",
+            "__typename id v1",
+        );
+        let root_path = entity_test_root_path(&graph, "t");
+        dag_add_parent_with_path(&mut graph, root, first, root_path);
+        for (parent, child) in [(first, second), (first, left), (second, right)] {
+            dag_add_parent_with_path(&mut graph, parent, child, OpPath::default());
+        }
+
+        // A separate phase snapshot establishes why the optimization is possible. Do not
+        // require these two NodeIndices to survive the complete optimizer below.
+        let mut phase_snapshot = graph.clone();
+        phase_snapshot.reduce();
+        phase_snapshot
+            .merge_child_fetches_for_same_subgraph_and_path()
+            .unwrap();
+        phase_snapshot
+            .merge_fetches_to_same_subgraph_and_same_inputs()
+            .unwrap();
+        assert!(phase_snapshot.can_merge_sibling_in(left, right).unwrap());
+
+        graph.reduce_and_optimize().unwrap();
+        let children: Vec<_> = graph
+            .graph
+            .node_indices()
+            .filter(|node| graph.graph[*node].subgraph_name.as_ref() == "Subgraph2")
+            .collect();
+        assert_eq!(
+            children.len(),
+            1,
+            "proposed optimization should combine the new siblings"
+        );
+        let actual = &graph.graph[children[0]].selection_set.selection_set;
+        let expected = SelectionSet::parse(
+            actual.schema.clone(),
+            actual.type_position.clone(),
+            "... on T { left: __typename right: __typename }",
+        )
+        .unwrap();
+        assert_eq!(
+            actual.as_ref(),
+            &expected,
+            "combining siblings must preserve both outputs"
+        );
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        /// `merge_child_in` delegates path placement to the operation selection machinery. Keep
+        /// the oracle deliberately simple: recursively wrap the merged payload in `child { ... }`
+        /// and compare the complete resulting selection tree, without flattening field names.
+        #[test]
+        fn merge_child_places_selection_at_the_exact_recursive_path(
+            survivor_selection in 1u8..8,
+            merged_selection in 1u8..8,
+            depth in 1usize..5,
+            relocated_child_depth in 0usize..4,
+        ) {
+            let mut graph = make_recursive_test_dep_graph();
+            let survivor = add_merge_test_node(
+                &mut graph,
+                survivor_selection,
+                0,
+                None,
+            );
+            let merged = add_merge_test_node(&mut graph, merged_selection, 0, None);
+            let path = dag_recursive_child_path(&graph, depth);
+            dag_add_parent_with_path(&mut graph, survivor, merged, path.clone());
+            let relocated_child = add_test_node(&mut graph, "Subgraph1", None);
+            let relocated_child_path =
+                dag_recursive_child_path(&graph, relocated_child_depth);
+            dag_add_parent_with_path(
+                &mut graph,
+                merged,
+                relocated_child,
+                relocated_child_path.clone(),
+            );
+
+            prop_assert!(graph.can_merge_child_in(survivor, merged).unwrap());
+            graph.merge_child_in(survivor, merged).unwrap();
+
+            let actual = &graph.graph[survivor].selection_set.selection_set;
+            let expected_text = format!(
+                "{} {}",
+                dag_plain_selection_text(survivor_selection),
+                dag_selection_nested_at_child_path(merged_selection, depth),
+            );
+            let expected = SelectionSet::parse(
+                actual.schema.clone(),
+                actual.type_position.clone(),
+                &expected_text,
+            )
+            .unwrap();
+            prop_assert_eq!(
+                actual.as_ref(),
+                &expected,
+                "merged selection was not placed at path depth {}: {}",
+                depth,
+                expected_text,
+            );
+
+            let expected_relocated_path = Arc::new(OpPath(
+                path.0
+                    .iter()
+                    .chain(&relocated_child_path.0)
+                    .cloned()
+                    .collect(),
+            ));
+            prop_assert_eq!(
+                graph
+                    .parent_relation(relocated_child, survivor)
+                    .and_then(|relation| relation.path_in_parent),
+                Some(expected_relocated_path),
+                "relocated child path was not prefixed by the merge path",
+            );
+        }
+
+        /// Grandchild merging composes two independently stored parent-relative paths. Compare it
+        /// with literal path concatenation and recursive selection wrapping, including an outgoing
+        /// edge that must be relocated from the removed grandchild.
+        #[test]
+        fn merge_grandchild_places_payload_at_concatenated_recursive_path(
+            survivor_selection in 1u8..8,
+            grandchild_selection in 1u8..8,
+            first_depth in 1usize..4,
+            second_depth in 1usize..4,
+            outgoing_depth in 0usize..3,
+        ) {
+            let mut graph = make_recursive_test_dep_graph();
+            let survivor = add_merge_test_node(
+                &mut graph,
+                survivor_selection,
+                0b111,
+                None,
+            );
+            let middle = add_merge_test_node(&mut graph, 1, 0b111, None);
+            let grandchild = add_merge_test_node(
+                &mut graph,
+                grandchild_selection,
+                0b001,
+                None,
+            );
+            let first_path = dag_recursive_child_path(&graph, first_depth);
+            let second_path = dag_recursive_child_path(&graph, second_depth);
+            dag_add_parent_with_path(&mut graph, survivor, middle, first_path.clone());
+            dag_add_parent_with_path(&mut graph, middle, grandchild, second_path.clone());
+
+            let outgoing = add_test_node(&mut graph, "Subgraph1", None);
+            let outgoing_path = dag_recursive_child_path(&graph, outgoing_depth);
+            dag_add_parent_with_path(
+                &mut graph,
+                grandchild,
+                outgoing,
+                outgoing_path.clone(),
+            );
+
+            prop_assert!(
+                graph
+                    .can_merge_grand_child_in(survivor, middle, grandchild)
+                    .unwrap()
+            );
+            graph
+                .merge_grand_child_in(survivor, grandchild)
+                .unwrap();
+
+            let merged_depth = first_depth + second_depth;
+            let actual = &graph.graph[survivor].selection_set.selection_set;
+            let expected_text = format!(
+                "{} {}",
+                dag_plain_selection_text(survivor_selection),
+                dag_selection_nested_at_child_path(grandchild_selection, merged_depth),
+            );
+            let expected = SelectionSet::parse(
+                actual.schema.clone(),
+                actual.type_position.clone(),
+                &expected_text,
+            )
+            .unwrap();
+            prop_assert_eq!(
+                actual.as_ref(),
+                &expected,
+                "grandchild payload was not placed at concatenated depth {}",
+                merged_depth,
+            );
+
+            let expected_outgoing_path = Arc::new(OpPath(
+                first_path
+                    .0
+                    .iter()
+                    .chain(&second_path.0)
+                    .chain(&outgoing_path.0)
+                    .cloned()
+                    .collect(),
+            ));
+            prop_assert_eq!(
+                graph
+                    .parent_relation(outgoing, survivor)
+                    .and_then(|relation| relation.path_in_parent),
+                Some(expected_outgoing_path),
+                "grandchild outgoing path did not receive both merge prefixes",
+            );
+        }
+
+        /// Reduced-defer recovery compares the source selection at the target node's `merge_at`
+        /// depth. Model that alignment as "remove the exact shared prefix, then descend once per
+        /// remaining field key"; list-index elements deliberately consume no selection depth.
+        #[test]
+        fn collect_reduced_defer_dependencies_aligns_nested_merge_at_paths(
+            source_selection in 1u8..8,
+            target_inputs in 1u8..8,
+            shared_depth in 0usize..3,
+            suffix_depth in 0usize..4,
+            source_has_merge_at in any::<bool>(),
+            shared_index_mask in any::<u8>(),
+            suffix_index_mask in any::<u8>(),
+        ) {
+            let mut graph = make_recursive_test_dep_graph();
+            let shared_path = dag_merge_at_child_path(shared_depth, shared_index_mask);
+            let suffix_path = dag_merge_at_child_path(suffix_depth, suffix_index_mask);
+            let child_path = shared_path
+                .iter()
+                .chain(&suffix_path)
+                .cloned()
+                .collect::<Vec<_>>();
+
+            let source = add_merge_test_node_at(
+                &mut graph,
+                0,
+                0,
+                None,
+                if source_has_merge_at {
+                    Some(shared_path.clone())
+                } else {
+                    None
+                },
+            );
+            let middle = add_test_node(&mut graph, "Subgraph1", None);
+            let target = add_merge_test_node_at(
+                &mut graph,
+                1,
+                target_inputs,
+                Some("nested-defer"),
+                Some(child_path),
+            );
+
+            let source_schema = graph.graph[source].selection_set.selection_set.schema.clone();
+            let source_type = graph.graph[source]
+                .selection_set
+                .selection_set
+                .type_position
+                .clone();
+            let selection_depth = if source_has_merge_at {
+                suffix_depth
+            } else {
+                shared_depth + suffix_depth
+            };
+            let source_text = dag_selection_nested_at_child_path(
+                source_selection,
+                selection_depth,
+            );
+            let nested_selection = SelectionSet::parse(source_schema, source_type, &source_text)
+                .unwrap();
+            Arc::make_mut(graph.graph.node_weight_mut(source).unwrap())
+                .selection_set_mut()
+                .add_selections(&Arc::new(nested_selection))
+                .unwrap();
+
+            add_test_edge(&mut graph, source, middle);
+            add_test_edge(&mut graph, middle, target);
+            add_test_edge(&mut graph, source, target);
+            graph.reduce();
+            prop_assert_eq!(graph.reduced_defer_edges.clone(), vec![(source, target)]);
+
+            let mut dependencies = Vec::new();
+            graph
+                .collect_reduced_defer_dependencies(source, &mut dependencies)
+                .unwrap();
+            let expected_overlap = source_selection & target_inputs != 0;
+            prop_assert_eq!(
+                !dependencies.is_empty(),
+                expected_overlap,
+                "merge_at alignment disagreed at shared depth {}, suffix depth {}: {}",
+                shared_depth,
+                suffix_depth,
+                source_text,
+            );
+        }
+
+        /// Check actual constructed inputs against the semantic specs, without running the
+        /// optimizer. This continues searching the generator's validity domain even when a
+        /// separate optimizer property stops at a known production failure.
+        #[test]
+        fn generated_optimizer_dags_have_complete_payloads_and_location_valid_inputs(
+            specs in optimizer_dag_strategy(),
+        ) {
+            for reverse in [false, true] {
+                let (graph, root, edges, inputs) = build_optimizer_dag(&specs, reverse);
+                audit_generated_optimizer_input_availability(&specs, &edges, &inputs)?;
+                audit_optimizer_payloads(&graph, root, &specs, &inputs)?;
+                audit_optimized_input_availability(&graph)?;
+            }
+        }
+
+        /// A single equal-input bucket has no cross-bucket ancestry feedback. Keep this domain
+        /// separate so known late-phase failures cannot stop all whole-optimizer exploration.
+        /// Its DAG topology is still arbitrary: multi-parent nodes, shortcuts and diamonds.
+        #[test]
+        fn whole_optimizer_conserves_single_bucket_dags(
+            mut specs in optimizer_dag_strategy(),
+        ) {
+            for spec in &mut specs {
+                spec.subgraph = 1;
+                spec.merge_at = 0;
+                spec.input_subset = 0;
+            }
+            for reverse in [false, true] {
+                let (mut graph, root, _, inputs) = build_optimizer_dag(&specs, reverse);
+                graph.reduce_and_optimize().unwrap();
+                let snapshot = audit_optimized_dag(&graph, root, &specs, &inputs)?;
+                audit_optimized_input_availability(&graph)?;
+                prop_assert_eq!(snapshot.token_groups, vec![(0..specs.len()).collect::<Vec<_>>()]);
+            }
+        }
+
+        /// Do not let provenance aliases make every fetch artificially useful. These sibling
+        /// leaves span empty selections, outputs already supplied by inputs, genuine new work,
+        /// and preserved nonempty selections. Empty nodes have no dependents, matching the
+        /// documented remove_empty_nodes precondition.
+        #[test]
+        fn whole_optimizer_removes_only_redundant_sibling_work(
+            selections in prop::collection::vec((0u8..8, any::<bool>()), 1..9),
+            reverse in any::<bool>(),
+        ) {
+            let mut graph = make_test_dep_graph();
+            let root = add_entity_test_root(&mut graph, "t { __typename id }");
+            let root_path = entity_test_root_path(&graph, "t");
+            let mut children = Vec::new();
+            let mut expected_new_fields = 0;
+            let mut expected_preserved_fields = 0;
+            for &(mask, preserve) in &selections {
+                let node = if mask == 0 {
+                    graph.new_key_node(&Arc::from("Subgraph2"),
+                        vec![FetchDataPathElement::Key(name!("t"), None)], None).unwrap()
+                } else {
+                    add_entity_test_fetch(&mut graph, "Subgraph2", "t",
+                        &dag_plain_selection_text(mask), "__typename id")
+                };
+                // must_preserve prevents removal of nonempty selections as "useless"; it is
+                // not a requirement to preserve an empty temporary fetch.
+                let preserve = preserve && mask != 0;
+                Arc::make_mut(graph.graph.node_weight_mut(node).unwrap()).must_preserve_selection_set = preserve;
+                expected_new_fields |= mask & !FIELD_ID;
+                if preserve { expected_preserved_fields |= mask; }
+                children.push(node);
+            }
+            if reverse { children.reverse(); }
+            for child in children { dag_add_parent_with_path(&mut graph, root, child, root_path.clone()); }
+            graph.reduce_and_optimize().unwrap();
+            let remaining: Vec<_> = graph.graph.node_indices().filter(|node| *node != root).collect();
+            let needs_fetch = expected_new_fields != 0 || expected_preserved_fields != 0;
+            prop_assert_eq!(remaining.len(), usize::from(needs_fetch));
+            if let Some(&node) = remaining.first() {
+                let selected = dag_selection_mask(&graph.graph[node].selection_set.selection_set);
+                prop_assert_eq!(selected & !FIELD_ID, expected_new_fields);
+                prop_assert_eq!(selected & expected_preserved_fields, expected_preserved_fields);
+                prop_assert_eq!(graph.graph[node].must_preserve_selection_set, expected_preserved_fields != 0);
+                prop_assert_eq!(&graph.graph[node].merge_at, &optimizer_merge_at(0));
+            }
+            audit_optimized_input_availability(&graph)?;
+        }
+
+        /// Run the complete optimizer over a connected generated DAG, not a preselected merge
+        /// shape. Audit complete payloads in both edge orders. Do not require the same merge
+        /// partition: different valid optimization choices are not necessarily wrong results.
+        /// Required-field availability has its own property below.
+        #[test]
+        fn whole_optimizer_conserves_generated_payloads_independent_of_edge_order(
+            specs in optimizer_dag_strategy(),
+        ) {
+            let (mut forward, forward_root, original_edges, original_input_masks) =
+                build_optimizer_dag(&specs, false);
+            forward.reduce_and_optimize().map_err(|error| {
+                TestCaseError::fail(format!("forward optimizer pass failed: {error}"))
+            })?;
+            audit_optimized_dag(
+                &forward,
+                forward_root,
+                &specs,
+                &original_input_masks,
+            )?;
+
+            let (
+                mut reversed,
+                reversed_root,
+                reversed_original_edges,
+                reversed_input_masks,
+            ) =
+                build_optimizer_dag(&specs, true);
+            prop_assert_eq!(&reversed_original_edges, &original_edges);
+            prop_assert_eq!(&reversed_input_masks, &original_input_masks);
+            reversed.reduce_and_optimize().map_err(|error| {
+                TestCaseError::fail(format!("reversed optimizer pass failed: {error}"))
+            })?;
+            audit_optimized_dag(
+                &reversed,
+                reversed_root,
+                &specs,
+                &original_input_masks,
+            )?;
+
+        }
+
+        /// Independently validate that every generated input is available, run the complete
+        /// optimizer, then recompute availability from the resulting dependency graph. This is
+        /// the data-flow law that catches a reduced provider edge being lost when an intermediate
+        /// equal-input fetch is subsequently hoisted.
+        #[test]
+        fn whole_optimizer_preserves_generated_input_availability(
+            specs in optimizer_dag_strategy(),
+        ) {
+            let (mut graph, root, original_edges, original_input_masks) =
+                build_optimizer_dag(&specs, false);
+            audit_generated_optimizer_input_availability(
+                &specs,
+                &original_edges,
+                &original_input_masks,
+            )?;
+            graph.reduce_and_optimize().map_err(|error| {
+                TestCaseError::fail(format!("optimizer pass failed: {error}"))
+            })?;
+            audit_optimized_dag(
+                &graph,
+                root,
+                &specs,
+                &original_input_masks,
+            )?;
+            audit_optimized_input_availability(&graph)?;
+        }
+
+        /// Proposed optimization goal, not a documented global-normal-form guarantee: a second
+        /// pass should find no further merge. Keep this separate from conservation laws so a
+        /// missed optimization is not reported as lost work or an incorrect query result.
+        #[test]
+        fn whole_optimizer_reaches_a_semantic_fixed_point(
+            specs in optimizer_dag_strategy(),
+        ) {
+            let (mut graph, root, _original_edges, original_input_masks) =
+                build_optimizer_dag(&specs, false);
+            graph.reduce_and_optimize().map_err(|error| {
+                TestCaseError::fail(format!("first optimizer pass failed: {error}"))
+            })?;
+            let first = audit_optimized_dag(
+                &graph,
+                root,
+                &specs,
+                &original_input_masks,
+            )?;
+
+            // Re-open the guard so this tests the optimizer's actual phase sequence instead of
+            // the `is_optimized` early return.
+            graph.on_modification();
+            graph.reduce_and_optimize().map_err(|error| {
+                TestCaseError::fail(format!("second optimizer pass failed: {error}"))
+            })?;
+            let second = audit_optimized_dag(
+                &graph,
+                root,
+                &specs,
+                &original_input_masks,
+            )?;
+            prop_assert_eq!(
+                second,
+                first,
+                "a second complete optimizer pass changed the semantic fetch quotient",
+            );
+        }
+
+        /// Exercise the public optimization sequence rather than its merge primitives in
+        /// isolation. Re-opening the optimization guard must produce an identical normal form.
+        #[test]
+        fn reduce_and_optimize_is_idempotent_and_conserves_sibling_payload(
+            left_selection in 1u8..8,
+            right_selection in 1u8..8,
+            left_first in any::<bool>(),
+        ) {
+            let mut graph = make_test_dep_graph();
+            let root = add_test_root(&mut graph, "Subgraph1");
+            let left = add_merge_test_node(&mut graph, left_selection, 0, None);
+            let right = add_merge_test_node(&mut graph, right_selection, 0, None);
+            let ordered = if left_first { [left, right] } else { [right, left] };
+            for child in ordered {
+                dag_add_parent_with_path(&mut graph, root, child, OpPath::default());
+            }
+
+            graph.reduce_and_optimize().unwrap();
+            let children = graph.children_of(root).collect::<Vec<_>>();
+            prop_assert_eq!(children.len(), 1, "mergeable root siblings survived optimization");
+            let survivor = children[0];
+            prop_assert_eq!(
+                dag_selection_mask(&graph.graph[survivor].selection_set.selection_set),
+                left_selection | right_selection,
+                "full optimization lost sibling selection payload",
+            );
+            let first_nodes = graph
+                .graph
+                .node_indices()
+                .map(|node| {
+                    (
+                        node,
+                        graph.graph[node].subgraph_name.clone(),
+                        dag_selection_mask(&graph.graph[node].selection_set.selection_set),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let first_edges = graph
+                .graph
+                .edge_references()
+                .map(|edge| (edge.source(), edge.target(), edge.weight().path.clone()))
+                .collect::<Vec<_>>();
+            let first_ledger = graph.reduced_defer_edges.clone();
+
+            graph.on_modification();
+            graph.reduce_and_optimize().unwrap();
+            let second_nodes = graph
+                .graph
+                .node_indices()
+                .map(|node| {
+                    (
+                        node,
+                        graph.graph[node].subgraph_name.clone(),
+                        dag_selection_mask(&graph.graph[node].selection_set.selection_set),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let second_edges = graph
+                .graph
+                .edge_references()
+                .map(|edge| (edge.source(), edge.target(), edge.weight().path.clone()))
+                .collect::<Vec<_>>();
+            prop_assert_eq!(second_nodes, first_nodes);
+            prop_assert_eq!(second_edges, first_edges);
+            prop_assert_eq!(graph.reduced_defer_edges.clone(), first_ledger);
+            prop_assert!(graph.is_reduced && graph.is_optimized);
+
+            let mut reordered = make_test_dep_graph();
+            let reordered_root = add_test_root(&mut reordered, "Subgraph1");
+            let reordered_left =
+                add_merge_test_node(&mut reordered, left_selection, 0, None);
+            let reordered_right =
+                add_merge_test_node(&mut reordered, right_selection, 0, None);
+            let reversed = if left_first {
+                [reordered_right, reordered_left]
+            } else {
+                [reordered_left, reordered_right]
+            };
+            for child in reversed {
+                dag_add_parent_with_path(
+                    &mut reordered,
+                    reordered_root,
+                    child,
+                    OpPath::default(),
+                );
+            }
+            reordered.reduce_and_optimize().unwrap();
+
+            let canonical = |candidate: &FetchDependencyGraph| {
+                let mut nodes = candidate
+                    .graph
+                    .node_indices()
+                    .map(|node| {
+                        (
+                            candidate.graph[node].subgraph_name.to_string(),
+                            dag_selection_mask(
+                                &candidate.graph[node].selection_set.selection_set,
+                            ),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                nodes.sort();
+                let mut edges = candidate
+                    .graph
+                    .edge_references()
+                    .map(|edge| {
+                        (
+                            candidate.graph[edge.source()].subgraph_name.to_string(),
+                            dag_selection_mask(
+                                &candidate.graph[edge.source()].selection_set.selection_set,
+                            ),
+                            candidate.graph[edge.target()].subgraph_name.to_string(),
+                            dag_selection_mask(
+                                &candidate.graph[edge.target()].selection_set.selection_set,
+                            ),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                edges.sort();
+                (nodes, edges)
+            };
+            prop_assert_eq!(
+                canonical(&reordered),
+                canonical(&graph),
+                "optimized semantics depended on sibling edge insertion order",
+            );
+        }
+
+        /// Exercise the later equal-input optimization rather than the earlier sibling merge.
+        /// The two merge candidates begin under different parents, and each has a distinct child;
+        /// after `reduce_and_optimize` the single survivor must retain the union of both sides'
+        /// incoming dependencies, outgoing dependencies, selections, and inputs.
+        #[test]
+        fn reduce_and_optimize_conserves_all_dependencies_of_equal_input_fetches(
+            left_selection in 1u8..8,
+            right_selection in 1u8..8,
+            reverse_parent_order in any::<bool>(),
+        ) {
+            let mut graph = make_test_dep_graph();
+            let root = add_test_root(&mut graph, "Subgraph1");
+            let left_parent = add_test_node_at(
+                &mut graph,
+                "Subgraph1",
+                None,
+                Some(vec![FetchDataPathElement::Key(name!("left"), None)]),
+            );
+            let right_parent = add_test_node_at(
+                &mut graph,
+                "Subgraph1",
+                None,
+                Some(vec![FetchDataPathElement::Key(name!("right"), None)]),
+            );
+            dag_add_selection_mask(&mut graph, left_parent, 0b001);
+            dag_add_selection_mask(&mut graph, right_parent, 0b001);
+
+            let left = add_merge_test_node(&mut graph, left_selection, 0b001, None);
+            let right = add_merge_test_node(&mut graph, right_selection, 0b001, None);
+            let left_child = add_test_node(&mut graph, "Subgraph1", None);
+            let right_child = add_test_node(&mut graph, "Subgraph1", None);
+            dag_add_selection_mask(&mut graph, left_child, 0b001);
+            dag_add_selection_mask(&mut graph, right_child, 0b001);
+
+            let parents = if reverse_parent_order {
+                [right_parent, left_parent]
+            } else {
+                [left_parent, right_parent]
+            };
+            for parent in parents {
+                dag_add_parent_with_path(&mut graph, root, parent, OpPath::default());
+            }
+            // Unknown parent-relative paths deliberately prevent the child-merge pass from
+            // consuming either equal-input candidate before the all-dependencies pass sees it.
+            add_test_edge(&mut graph, left_parent, left);
+            add_test_edge(&mut graph, right_parent, right);
+            add_test_edge(&mut graph, left, left_child);
+            add_test_edge(&mut graph, right, right_child);
+
+            graph.reduce_and_optimize().unwrap();
+
+            let survivors = [left, right]
+                .into_iter()
+                .filter(|node| graph.graph.node_weight(*node).is_some())
+                .collect::<Vec<_>>();
+            prop_assert_eq!(survivors.len(), 1, "equal-input fetches were not merged");
+            let survivor = survivors[0];
+            prop_assert_eq!(
+                dag_selection_mask(&graph.graph[survivor].selection_set.selection_set),
+                left_selection | right_selection,
+            );
+            prop_assert_eq!(dag_input_mask(&graph.graph[survivor]), 0b001);
+            for parent in [left_parent, right_parent] {
+                prop_assert!(graph.is_parent_of(parent, survivor));
+            }
+            for child in [left_child, right_child] {
+                prop_assert!(graph.is_parent_of(survivor, child));
+            }
+            prop_assert!(graph.is_reduced && graph.is_optimized);
+        }
+
+        /// A sibling merge must transfer both payloads and outgoing dependencies from the merged
+        /// sibling. The defer ledger is produced by the real B -> M -> D / B -> D reduction, so
+        /// successful dependency recovery proves the remap still points at the node that now owns
+        /// B's selected fields.
+        #[test]
+        fn merge_sibling_conserves_payload_topology_and_defer_source(
+            a_selection in 1u8..8,
+            b_selection in 1u8..8,
+            a_inputs in 0u8..8,
+            b_inputs in 0u8..8,
+            deferred_input_seed in any::<u8>(),
+            nested_child_path in any::<bool>(),
+            preserve_a in any::<bool>(),
+            preserve_b in any::<bool>(),
+        ) {
+            let mut graph = make_test_dep_graph();
+            let root = add_test_node(&mut graph, "Subgraph1", None);
+            let a = add_merge_test_node(&mut graph, a_selection, a_inputs, None);
+            let b = add_merge_test_node(&mut graph, b_selection, b_inputs, None);
+            let middle = add_test_node(&mut graph, "Subgraph1", None);
+
+            // Force at least one target input to be provided specifically by B. The remaining
+            // bits stay generated so both exact and partial overlaps are exercised.
+            let overlap_bit = 1 << b_selection.trailing_zeros();
+            let deferred_inputs = (deferred_input_seed & 0b111) | overlap_bit;
+            let deferred = add_merge_test_node(&mut graph, 1, deferred_inputs, Some("defer"));
+
+            Arc::make_mut(graph.graph.node_weight_mut(a).unwrap())
+                .must_preserve_selection_set = preserve_a;
+            Arc::make_mut(graph.graph.node_weight_mut(b).unwrap())
+                .must_preserve_selection_set = preserve_b;
+
+            dag_add_parent_with_path(&mut graph, root, a, OpPath::default());
+            dag_add_parent_with_path(&mut graph, root, b, OpPath::default());
+            let child_path = dag_test_fragment_path(&graph, nested_child_path);
+            dag_add_parent_with_path(&mut graph, b, middle, child_path.clone());
+            dag_add_parent_with_path(&mut graph, middle, deferred, OpPath::default());
+            dag_add_parent_with_path(&mut graph, b, deferred, OpPath::default());
+
+            graph.reduce();
+            prop_assert_eq!(graph.reduced_defer_edges.clone(), vec![(b, deferred)]);
+            prop_assert!(graph.can_merge_sibling_in(a, b).unwrap());
+
+            // Warm the survivor's derived state before the payload mutation.
+            {
+                let node = Arc::make_mut(graph.graph.node_weight_mut(a).unwrap());
+                let _ = node.selection_set.conditions().unwrap();
+                let _ = node.cost();
+            }
+
+            graph.merge_sibling_in(a, b).unwrap();
+
+            prop_assert!(graph.graph.node_weight(b).is_none());
+            let survivor = graph.graph.node_weight(a).unwrap();
+            prop_assert_eq!(
+                dag_selection_mask(&survivor.selection_set.selection_set),
+                a_selection | b_selection,
+                "sibling selections were not unioned"
+            );
+            prop_assert_eq!(
+                dag_input_mask(survivor),
+                a_inputs | b_inputs,
+                "sibling inputs were not unioned"
+            );
+            prop_assert_eq!(
+                survivor.must_preserve_selection_set,
+                preserve_a || preserve_b,
+            );
+            prop_assert_eq!(
+                graph.parent_relation(middle, a).unwrap().path_in_parent,
+                Some(Arc::new(child_path)),
+                "the merged sibling's child path changed"
+            );
+            prop_assert!(graph.is_parent_of(middle, deferred));
+            prop_assert!(petgraph::algo::has_path_connecting(
+                &graph.graph,
+                root,
+                deferred,
+                None,
+            ));
+            prop_assert_eq!(graph.reduced_defer_edges.clone(), vec![(a, deferred)]);
+            dag_assert_ledger_is_live(&graph)?;
+            prop_assert!(!graph.is_reduced, "a merge must invalidate reduction state");
+
+            let survivor = Arc::make_mut(graph.graph.node_weight_mut(a).unwrap());
+            prop_assert_eq!(
+                survivor.cost(),
+                survivor.selection_set.selection_set.cost(1.0),
+                "the survivor retained a stale cached cost"
+            );
+            prop_assert_eq!(
+                survivor.selection_set.conditions().unwrap(),
+                &survivor.selection_set.selection_set.conditions().unwrap(),
+                "the survivor retained stale cached conditions"
+            );
+
+            let mut dependencies = Vec::new();
+            graph.collect_reduced_defer_dependencies(a, &mut dependencies).unwrap();
+            let id = graph.graph[a].id.get().unwrap();
+            prop_assert_eq!(dependencies, vec![("defer".to_string(), id.to_string())]);
+        }
+
+        /// A child merge exercises the opposite ledger endpoint. Here P -> B is genuinely
+        /// transitively redundant through P -> A -> B. After B is folded into A, the ledger and
+        /// B's outgoing edge must both target A without losing B's selection payload.
+        #[test]
+        fn merge_child_conserves_payload_topology_and_defer_target(
+            a_selection in 1u8..8,
+            b_selection in 1u8..8,
+            a_inputs in 1u8..8,
+            b_input_seed in any::<u8>(),
+            source_selection_seed in any::<u8>(),
+            nested_merge_path in any::<bool>(),
+            preserve_a in any::<bool>(),
+            preserve_b in any::<bool>(),
+        ) {
+            let mut graph = make_test_dep_graph();
+            let overlap_bit = 1 << a_inputs.trailing_zeros();
+            let source_selection = (source_selection_seed & 0b111) | overlap_bit;
+            let source = add_test_node(&mut graph, "Subgraph2", None);
+            dag_add_selection_mask(&mut graph, source, source_selection);
+
+            let b_inputs = b_input_seed & a_inputs;
+            let a = add_merge_test_node(
+                &mut graph,
+                a_selection,
+                a_inputs,
+                Some("defer"),
+            );
+            let b = add_merge_test_node(
+                &mut graph,
+                b_selection,
+                b_inputs,
+                Some("defer"),
+            );
+            let tail = add_test_node(&mut graph, "Subgraph1", Some("defer"));
+
+            Arc::make_mut(graph.graph.node_weight_mut(a).unwrap())
+                .must_preserve_selection_set = preserve_a;
+            Arc::make_mut(graph.graph.node_weight_mut(b).unwrap())
+                .must_preserve_selection_set = preserve_b;
+
+            dag_add_parent_with_path(&mut graph, source, a, OpPath::default());
+            let merge_path = dag_test_fragment_path(&graph, nested_merge_path);
+            dag_add_parent_with_path(&mut graph, a, b, merge_path.clone());
+            dag_add_parent_with_path(&mut graph, source, b, OpPath::default());
+            dag_add_parent_with_path(&mut graph, b, tail, OpPath::default());
+
+            graph.reduce();
+            prop_assert_eq!(graph.reduced_defer_edges.clone(), vec![(source, b)]);
+            prop_assert!(graph.can_merge_child_in(a, b).unwrap());
+
+            {
+                let node = Arc::make_mut(graph.graph.node_weight_mut(a).unwrap());
+                let _ = node.selection_set.conditions().unwrap();
+                let _ = node.cost();
+            }
+
+            graph.merge_child_in(a, b).unwrap();
+
+            prop_assert!(graph.graph.node_weight(b).is_none());
+            let survivor = graph.graph.node_weight(a).unwrap();
+            prop_assert_eq!(
+                dag_selection_mask(&survivor.selection_set.selection_set),
+                a_selection | b_selection,
+                "child selections were not unioned"
+            );
+            prop_assert_eq!(
+                dag_input_mask(survivor),
+                a_inputs,
+                "a child merge must not copy inputs already supplied by the parent"
+            );
+            prop_assert_eq!(
+                survivor.must_preserve_selection_set,
+                preserve_a || preserve_b,
+            );
+            prop_assert_eq!(
+                graph.parent_relation(tail, a).unwrap().path_in_parent,
+                Some(Arc::new(merge_path)),
+                "the child merge path was not prefixed onto its relocated edge"
+            );
+            prop_assert!(petgraph::algo::has_path_connecting(
+                &graph.graph,
+                source,
+                tail,
+                None,
+            ));
+            prop_assert_eq!(graph.reduced_defer_edges.clone(), vec![(source, a)]);
+            dag_assert_ledger_is_live(&graph)?;
+            prop_assert!(!graph.is_reduced, "a merge must invalidate reduction state");
+
+            let survivor = Arc::make_mut(graph.graph.node_weight_mut(a).unwrap());
+            prop_assert_eq!(
+                survivor.cost(),
+                survivor.selection_set.selection_set.cost(1.0),
+                "the survivor retained a stale cached cost"
+            );
+            prop_assert_eq!(
+                survivor.selection_set.conditions().unwrap(),
+                &survivor.selection_set.selection_set.conditions().unwrap(),
+                "the survivor retained stale cached conditions"
+            );
+
+            let mut dependencies = Vec::new();
+            graph
+                .collect_reduced_defer_dependencies(source, &mut dependencies)
+                .unwrap();
+            let id = graph.graph[source].id.get().unwrap();
+            prop_assert_eq!(dependencies, vec![("defer".to_string(), id.to_string())]);
+        }
+    }
+
+    // Deterministic derived-state invalidation repro.
+
+    fn add_node_with_selection_and_matching_inputs(
+        graph: &mut FetchDependencyGraph,
+        selected_text: &str,
+        input_text: &str,
+    ) -> NodeIndex {
+        let node_id = add_test_node(graph, "Subgraph2", None);
+        let subgraph_schema = graph
+            .federated_query_graph
+            .schema_by_source("Subgraph2")
+            .unwrap()
+            .clone();
+        let selected = SelectionSet::parse(
+            subgraph_schema.clone(),
+            subgraph_schema
+                .get_type(&name!("T"))
+                .unwrap()
+                .try_into()
+                .unwrap(),
+            selected_text,
+        )
+        .unwrap();
+        let inputs = SelectionSet::parse(
+            graph.supergraph_schema.clone(),
+            graph
+                .supergraph_schema
+                .get_type(&name!("T"))
+                .unwrap()
+                .try_into()
+                .unwrap(),
+            input_text,
+        )
+        .unwrap();
+        let node = Arc::make_mut(graph.graph.node_weight_mut(node_id).unwrap());
+        node.selection_set_mut()
+            .add_selections(&Arc::new(selected))
+            .unwrap();
+        node.add_inputs(&inputs, iter::empty()).unwrap();
+        node_id
+    }
+
+    /// Hardening invariant: the production mutator must invalidate every derived value even if a
+    /// future caller reads conditions before removing inputs. The current planner caller mutates a
+    /// fresh copied node, so this warm-before-mutate ordering is not known to be reachable today.
+    #[test]
+    fn remove_inputs_from_selection_invalidates_warmed_conditions_regression() {
+        let mut graph = make_test_dep_graph();
+        let node_id = add_node_with_selection_and_matching_inputs(&mut graph, "id", "id");
+
+        let node = graph.graph.node_weight(node_id).unwrap();
+        assert_eq!(
+            node.selection_set.conditions().unwrap(),
+            &Conditions::always(),
+            "a non-empty unconditional selection must initially execute",
+        );
+
+        graph.remove_inputs_from_selection(node_id).unwrap();
+
+        let node = graph.graph.node_weight(node_id).unwrap();
+        assert!(node.selection_set.selection_set.is_empty());
+        assert_eq!(
+            node.selection_set.conditions().unwrap(),
+            &Conditions::never(),
+            "conditions must be recomputed from the now-empty selection",
+        );
+    }
+
+    // =========================================================================================
+    // Generated cache-invalidation coverage. The production type deliberately memoizes both
+    // selection conditions and cost, so mutation tests read those values before mutation. The
+    // generator assigns every field one of the meaningful constant @skip/@include forms and
+    // removes a non-empty subset through the node's real `_entities` inputs.
+    // =========================================================================================
+
+    const DAG_CACHE_FIELDS: [&str; 3] = ["id", "v1", "v2"];
+
+    fn dag_cache_directive(seed: u8) -> &'static str {
+        match seed % 5 {
+            0 => "",
+            1 => " @include(if: true)",
+            2 => " @include(if: false)",
+            3 => " @skip(if: true)",
+            4 => " @skip(if: false)",
+            _ => unreachable!("modulo five"),
+        }
+    }
+
+    fn dag_cache_selection_text(mask: u8, mut directive_seed: u8) -> String {
+        DAG_CACHE_FIELDS
+            .iter()
+            .enumerate()
+            .filter_map(|(index, field)| {
+                let directive = dag_cache_directive(directive_seed);
+                directive_seed /= 5;
+                (mask & (1 << index) != 0).then(|| format!("{field}{directive}"))
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        #[test]
+        fn remove_inputs_from_selection_invalidates_all_derived_selection_state(
+            selected_mask in 1u8..8,
+            removed_seed in any::<u8>(),
+            directive_seed in 0u8..125,
+        ) {
+            let mut graph = make_test_dep_graph();
+
+            // Always remove at least one selected field. Choice-by-modulo keeps every generated
+            // case valid and shrinkable without `prop_assume`/`prop_filter` rejection.
+            let mut removed_mask = removed_seed & selected_mask;
+            if removed_mask == 0 {
+                removed_mask = 1 << selected_mask.trailing_zeros();
+            }
+
+            let selected_text = dag_cache_selection_text(selected_mask, directive_seed);
+            let removed_text = dag_cache_selection_text(removed_mask, directive_seed);
+            let node_id = add_node_with_selection_and_matching_inputs(
+                &mut graph,
+                &selected_text,
+                &removed_text,
+            );
+
+            {
+                let node = Arc::make_mut(graph.graph.node_weight_mut(node_id).unwrap());
+                // Warm both caches before mutation; otherwise this property would be vacuous.
+                let cached_conditions = node.selection_set.conditions().unwrap().clone();
+                let direct_conditions = node.selection_set.selection_set.conditions().unwrap();
+                prop_assert_eq!(cached_conditions, direct_conditions);
+                let cached_cost = node.cost();
+                let direct_cost = node.selection_set.selection_set.cost(1.0);
+                prop_assert_eq!(cached_cost, direct_cost);
+            }
+
+            graph.remove_inputs_from_selection(node_id).unwrap();
+
+            let node = Arc::make_mut(graph.graph.node_weight_mut(node_id).unwrap());
+            let direct_conditions = node.selection_set.selection_set.conditions().unwrap();
+            let cached_conditions = node.selection_set.conditions().unwrap().clone();
+            prop_assert_eq!(
+                cached_conditions,
+                direct_conditions,
+                "stale conditions after removing `{}` from `{}`",
+                removed_text,
+                selected_text,
+            );
+            let direct_cost = node.selection_set.selection_set.cost(1.0);
+            let cached_cost = node.cost();
+            prop_assert_eq!(
+                cached_cost,
+                direct_cost,
+                "stale cost after removing `{}` from `{}`",
+                removed_text,
+                selected_text,
+            );
+        }
+    }
+
+    // =========================================================================================
+    // FetchDependencyGraphNodePath as a cached state machine.
+    //
+    // The production type updates five parallel representations on every field/fragment append
+    // and preserves four of them while resetting `path_in_node` for a new key fetch. This trace
+    // generator only emits schema-valid next steps and audits after every command against a small
+    // direct interpreter. The schema deliberately includes aliases, an abstract type with three
+    // implementations, recursive composite fields, and nested lists.
+    // =========================================================================================
+
+    const FETCH_PATH_SCHEMA: &str = r#"
+        schema { query: Query }
+
+        type Query {
+            id: ID!
+            one: Node
+            list: [Node]
+            many: [[Node]]
+        }
+
+        interface Node {
+            id: ID!
+            next: Node
+            list: [Node]
+            matrix: [[Node]]
+        }
+
+        type A implements Node {
+            id: ID!
+            next: Node
+            list: [Node]
+            matrix: [[Node]]
+        }
+
+        type B implements Node {
+            id: ID!
+            next: Node
+            list: [Node]
+            matrix: [[Node]]
+        }
+
+        type C implements Node {
+            id: ID!
+            next: Node
+            list: [Node]
+            matrix: [[Node]]
+        }
+    "#;
+
+    #[derive(Debug, Clone, Copy)]
+    enum FetchPathCommand {
+        /// `shape % 4`: scalar leaf, composite, list of composite, nested list of composite.
+        Field {
+            shape: u8,
+            alias: u8,
+        },
+        Fragment {
+            conditioned: bool,
+            target: u8,
+        },
+        ResetForKey {
+            retain_full_path: bool,
+        },
+    }
+
+    fn fetch_path_command_strategy() -> impl Strategy<Value = FetchPathCommand> {
+        prop_oneof![
+            6 => (any::<u8>(), any::<u8>())
+                .prop_map(|(shape, alias)| FetchPathCommand::Field {
+                    shape,
+                    alias,
+                }),
+            4 => (any::<bool>(), any::<u8>())
+                .prop_map(|(conditioned, target)| FetchPathCommand::Fragment {
+                    conditioned,
+                    target,
+                }),
+            2 => any::<bool>().prop_map(|retain_full_path| FetchPathCommand::ResetForKey {
+                retain_full_path,
+            }),
+        ]
+    }
+
+    fn make_fetch_path_schema() -> ValidFederationSchema {
+        let schema = apollo_compiler::Schema::parse_and_validate(
+            FETCH_PATH_SCHEMA,
+            "fetch_path_schema.graphql",
+        )
+        .unwrap();
+        ValidFederationSchema::new(schema).unwrap()
+    }
+
+    fn fetch_path_runtime_types() -> IndexSet<Name> {
+        [name!("A"), name!("B"), name!("C")].into_iter().collect()
+    }
+
+    fn fetch_path_alias(seed: u8) -> Option<Name> {
+        match seed % 4 {
+            0 => None,
+            1 => Some(name!("first")),
+            2 => Some(name!("second")),
+            3 => Some(name!("third")),
+            _ => unreachable!("modulo four"),
+        }
+    }
+
+    fn fetch_path_field_element(
+        schema: &ValidFederationSchema,
+        declared_type: &Name,
+        shape: u8,
+        alias_seed: u8,
+    ) -> Arc<OpPathElement> {
+        let field_name = match (declared_type == &name!("Query"), shape % 4) {
+            (_, 0) => name!("id"),
+            (true, 1) => name!("one"),
+            (false, 1) => name!("next"),
+            (_, 2) => name!("list"),
+            (true, 3) => name!("many"),
+            (false, 3) => name!("matrix"),
+            _ => unreachable!("modulo four"),
+        };
+        let field_position: FieldDefinitionPosition = match schema.get_type(declared_type).unwrap()
+        {
+            TypeDefinitionPosition::Object(position) => position.field(field_name).into(),
+            TypeDefinitionPosition::Interface(position) => position.field(field_name).into(),
+            other => panic!("generated path reached non-field-bearing type {other}"),
+        };
+        Arc::new(OpPathElement::Field(Field {
+            schema: schema.clone(),
+            field_position,
+            alias: fetch_path_alias(alias_seed),
+            arguments: Default::default(),
+            directives: Default::default(),
+            sibling_typename: None,
+        }))
+    }
+
+    fn fetch_path_fragment_element(
+        schema: &ValidFederationSchema,
+        declared_type: &Name,
+        possible_types: &IndexSet<Name>,
+        conditioned: bool,
+        target_seed: u8,
+    ) -> Arc<OpPathElement> {
+        let target = conditioned.then(|| {
+            let candidates: Vec<_> = possible_types.iter().cloned().collect();
+            candidates[target_seed as usize % candidates.len()].clone()
+        });
+        Arc::new(inline_fragment_element(
+            schema,
+            declared_type.clone(),
+            target,
+        ))
+    }
+
+    #[derive(Debug)]
+    struct FetchPathModel {
+        full_path: Vec<Arc<OpPathElement>>,
+        path_in_node: Vec<Arc<OpPathElement>>,
+        response_path: Vec<FetchDataPathElement>,
+        possible_types: IndexSet<Name>,
+        possible_types_after_last_field: IndexSet<Name>,
+        declared_type: Name,
+    }
+
+    impl FetchPathModel {
+        fn new(type_conditioned_fetching_enabled: bool) -> Self {
+            let possible_types = if type_conditioned_fetching_enabled {
+                IndexSet::from_iter([name!("Query")])
+            } else {
+                IndexSet::default()
+            };
+            Self {
+                full_path: Vec::new(),
+                path_in_node: Vec::new(),
+                response_path: Vec::new(),
+                possible_types_after_last_field: possible_types.clone(),
+                possible_types,
+                declared_type: name!("Query"),
+            }
+        }
+
+        fn add_field(
+            &mut self,
+            element: Arc<OpPathElement>,
+            shape: u8,
+            type_conditioned_fetching_enabled: bool,
+        ) {
+            let OpPathElement::Field(field) = element.as_ref() else {
+                unreachable!("field command constructed a fragment")
+            };
+
+            if self.possible_types_after_last_field.len() != self.possible_types.len() {
+                let conditions: Vec<Name> = self.possible_types.iter().cloned().collect();
+                match self.response_path.last_mut() {
+                    Some(FetchDataPathElement::Key(_, stored))
+                    | Some(FetchDataPathElement::AnyIndex(stored)) => {
+                        *stored = Some(conditions);
+                    }
+                    _ => {}
+                }
+            }
+
+            self.response_path.push(FetchDataPathElement::Key(
+                field.response_name().clone(),
+                None,
+            ));
+            for _ in 0..match shape % 4 {
+                2 => 1,
+                3 => 2,
+                _ => 0,
+            } {
+                self.response_path
+                    .push(FetchDataPathElement::AnyIndex(None));
+            }
+
+            let is_composite = shape % 4 != 0;
+            self.possible_types = if type_conditioned_fetching_enabled && is_composite {
+                fetch_path_runtime_types()
+            } else {
+                IndexSet::default()
+            };
+            self.possible_types_after_last_field = self.possible_types.clone();
+            self.declared_type = if is_composite {
+                name!("Node")
+            } else {
+                name!("ID")
+            };
+            self.full_path.push(element.clone());
+            self.path_in_node.push(element);
+        }
+
+        fn add_fragment(
+            &mut self,
+            element: Arc<OpPathElement>,
+            type_conditioned_fetching_enabled: bool,
+        ) {
+            let OpPathElement::InlineFragment(fragment) = element.as_ref() else {
+                unreachable!("fragment command constructed a field")
+            };
+            if let Some(target) = &fragment.type_condition_position {
+                self.declared_type = target.type_name().clone();
+                if type_conditioned_fetching_enabled {
+                    self.possible_types
+                        .retain(|possible| possible == target.type_name());
+                }
+            }
+            self.full_path.push(element.clone());
+            self.path_in_node.push(element);
+        }
+    }
+
+    fn audit_fetch_path(
+        production: &FetchDependencyGraphNodePath,
+        model: &FetchPathModel,
+    ) -> Result<(), TestCaseError> {
+        prop_assert_eq!(
+            production.full_path.0.as_slice(),
+            model.full_path.as_slice()
+        );
+        prop_assert_eq!(
+            production.path_in_node.0.as_slice(),
+            model.path_in_node.as_slice()
+        );
+        prop_assert_eq!(&production.response_path, &model.response_path);
+        prop_assert_eq!(&production.possible_types, &model.possible_types);
+        prop_assert_eq!(
+            &production.possible_types_after_last_field,
+            &model.possible_types_after_last_field
+        );
+        Ok(())
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        #[test]
+        fn fetch_node_path_trace_matches_schema_interpreter(
+            commands in prop::collection::vec(fetch_path_command_strategy(), 1..40),
+            type_conditioned_fetching_enabled in any::<bool>(),
+        ) {
+            let schema = make_fetch_path_schema();
+            let root_type = schema
+                .get_type(&name!("Query"))
+                .unwrap()
+                .try_into()
+                .unwrap();
+            let mut production = FetchDependencyGraphNodePath::new(
+                schema.clone(),
+                type_conditioned_fetching_enabled,
+                root_type,
+            )
+            .unwrap();
+            let mut model = FetchPathModel::new(type_conditioned_fetching_enabled);
+            audit_fetch_path(&production, &model)?;
+
+            for command in commands {
+                match command {
+                    FetchPathCommand::Field { shape, alias } => {
+                        let element = fetch_path_field_element(
+                            &schema,
+                            &model.declared_type,
+                            shape,
+                            alias,
+                        );
+                        production = production.add(element.clone()).unwrap();
+                        model.add_field(
+                            element,
+                            shape,
+                            type_conditioned_fetching_enabled,
+                        );
+                        audit_fetch_path(&production, &model)?;
+                        if shape % 4 == 0 {
+                            // Scalar fields terminate an operation path. Reaching this branch is
+                            // the point of generating them; later commands cannot validly extend it.
+                            break;
+                        }
+                    }
+                    FetchPathCommand::Fragment { conditioned, target } => {
+                        // The Query root has only one runtime object and a same-type fragment is
+                        // valid; after the first field, target selection is always from the
+                        // current non-empty runtime set, so no generated cast is disjoint.
+                        let choices = if model.possible_types.is_empty() {
+                            IndexSet::from_iter([model.declared_type.clone()])
+                        } else {
+                            model.possible_types.clone()
+                        };
+                        let element = fetch_path_fragment_element(
+                            &schema,
+                            &model.declared_type,
+                            &choices,
+                            conditioned,
+                            target,
+                        );
+                        production = production.add(element.clone()).unwrap();
+                        model.add_fragment(element, type_conditioned_fetching_enabled);
+                    }
+                    FetchPathCommand::ResetForKey { retain_full_path } => {
+                        let context = if retain_full_path {
+                            production.full_path.clone()
+                        } else {
+                            Arc::new(OpPath::default())
+                        };
+                        production = production.for_new_key_fetch(context.clone());
+                        model.path_in_node = context.0.clone();
+                    }
+                }
+                audit_fetch_path(&production, &model)?;
+            }
+        }
     }
 }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
@@ -471,3 +471,77 @@ fn flat_wrap_nodes(
         NodeKind::Sequence => PlanNode::Sequence(SequenceNode { nodes }),
     })
 }
+
+#[cfg(test)]
+mod proptests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    fn marker(id: u8) -> PlanNode {
+        let variable = format!("marker_{id}");
+        PlanNode::Condition(Box::new(ConditionNode {
+            condition_variable: Name::new(&variable).unwrap(),
+            if_clause: None,
+            else_clause: None,
+        }))
+    }
+
+    fn same_kind(kind: NodeKind, nodes: Vec<PlanNode>) -> PlanNode {
+        match kind {
+            NodeKind::Parallel => PlanNode::Parallel(ParallelNode { nodes }),
+            NodeKind::Sequence => PlanNode::Sequence(SequenceNode { nodes }),
+        }
+    }
+
+    fn literal_flat_wrap(kind: NodeKind, nodes: Vec<Option<PlanNode>>) -> Option<PlanNode> {
+        let present = nodes.into_iter().flatten().collect::<Vec<_>>();
+        match present.as_slice() {
+            [] => None,
+            [only] => Some(only.clone()),
+            _ => Some(same_kind(
+                kind,
+                present
+                    .into_iter()
+                    .flat_map(|node| match (kind, node) {
+                        (NodeKind::Parallel, PlanNode::Parallel(inner)) => inner.nodes,
+                        (NodeKind::Sequence, PlanNode::Sequence(inner)) => inner.nodes,
+                        (_, node) => vec![node],
+                    })
+                    .collect(),
+            )),
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        /// The processor's sequence/parallel constructor is a normalization boundary: absent
+        /// branches disappear, zero/one children are unwrapped, and immediate same-kind children
+        /// are flattened only when an actual wrapper is needed.
+        #[test]
+        fn flat_wrap_nodes_matches_literal_normal_form(
+            parallel in any::<bool>(),
+            specs in prop::collection::vec(
+                prop::option::of((any::<bool>(), prop::collection::vec(any::<u8>(), 1..5))),
+                0..24,
+            ),
+        ) {
+            let kind = if parallel { NodeKind::Parallel } else { NodeKind::Sequence };
+            let nodes = specs
+                .into_iter()
+                .map(|spec| spec.map(|(nested, ids)| {
+                    if nested {
+                        same_kind(kind, ids.into_iter().map(marker).collect())
+                    } else {
+                        marker(ids[0])
+                    }
+                }))
+                .collect::<Vec<_>>();
+            prop_assert_eq!(
+                flat_wrap_nodes(kind, nodes.clone()),
+                literal_flat_wrap(kind, nodes),
+            );
+        }
+    }
+}

--- a/apollo-federation/src/query_plan/generate.rs
+++ b/apollo-federation/src/query_plan/generate.rs
@@ -363,4 +363,152 @@ mod tests {
             ],
         );
     }
+
+    // =========================================================================================
+    // "Supporting exact property" (proptest-graph-notes.md): the pruned search must always find
+    // the same minimum cost as an exhaustive Cartesian-product search, for a monotone builder
+    // (element weights are non-negative, so a plan's cost never decreases as elements are
+    // added — the precondition the branch-and-bound pruning above relies on). Deliberately not
+    // tested against a non-monotone builder: the notes are explicit that current pruning assumes
+    // monotone partial costs, and testing that precondition's absence isn't this property's job.
+    // =========================================================================================
+
+    use proptest::prelude::*;
+    use proptest::proptest;
+
+    /// `Plan`/`Element` instantiated as plain integer weights (mirrors `TestPlanBuilder` above,
+    /// but tracks weights directly rather than string lengths, so the reference oracle below is
+    /// exact integer arithmetic rather than a derived string-length cost).
+    struct RecordingPlanBuilder {
+        target_len: usize,
+    }
+
+    impl PlanBuilder<Vec<i64>, i64> for RecordingPlanBuilder {
+        fn add_to_plan(&mut self, plan: &Vec<i64>, elem: i64) -> Result<Vec<i64>, FederationError> {
+            let mut new_plan = plan.clone();
+            new_plan.push(elem);
+            Ok(new_plan)
+        }
+
+        fn compute_plan_cost(
+            &mut self,
+            plan: &mut Vec<i64>,
+        ) -> Result<QueryPlanCost, FederationError> {
+            Ok(plan.iter().sum::<i64>() as QueryPlanCost)
+        }
+
+        fn on_plan_generated(
+            &self,
+            plan: &Vec<i64>,
+            _cost: QueryPlanCost,
+            _prev_cost: Option<QueryPlanCost>,
+        ) {
+            assert_eq!(
+                plan.len(),
+                self.target_len,
+                "on_plan_generated must only ever be called with a complete plan"
+            );
+        }
+    }
+
+    /// Exhaustive reference: enumerate the full Cartesian product recursively and take the
+    /// minimum sum. No stack, no pruning, no branch-and-bound — just direct recursion.
+    fn exhaustive_min_cost(initial_weight: i64, choices: &[Vec<i64>]) -> i64 {
+        fn recurse(remaining: &[Vec<i64>], acc: i64) -> i64 {
+            match remaining.split_first() {
+                None => acc,
+                Some((first, rest)) => first
+                    .iter()
+                    .map(|&weight| recurse(rest, acc + weight))
+                    .min()
+                    .expect("each choice group is non-empty by construction"),
+            }
+        }
+        recurse(choices, initial_weight)
+    }
+
+    fn run_pruned_search(
+        initial_weight: i64,
+        choice_weights: &[Vec<i64>],
+    ) -> (Vec<i64>, QueryPlanCost) {
+        let initial = vec![initial_weight];
+        let to_add: Vec<Choices<i64>> = choice_weights
+            .iter()
+            .map(|choices| choices.iter().map(|&w| Some(w)).collect())
+            .collect();
+        let target_len = initial.len() + to_add.len();
+        let mut builder = RecordingPlanBuilder { target_len };
+        generate_all_plans_and_find_best::<Vec<i64>, i64>(initial, to_add, &mut builder).unwrap()
+    }
+
+    fn choice_weights_strategy() -> impl Strategy<Value = Vec<Vec<i64>>> {
+        prop::collection::vec(prop::collection::vec(0i64..1000, 1..5), 0..6)
+    }
+
+    proptest! {
+        // Narrow and cheap (the doc's own assessment): this code is comparatively
+        // self-contained, so a high case count is affordable.
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        #[test]
+        fn pruned_plan_search_matches_exhaustive_monotone_search(
+            initial_weight in 0i64..1000,
+            choice_weights in choice_weights_strategy(),
+        ) {
+            let exhaustive_min = exhaustive_min_cost(initial_weight, &choice_weights);
+            let target_len = 1 + choice_weights.len();
+
+            let (best_plan, best_cost) = run_pruned_search(initial_weight, &choice_weights);
+
+            // Optimized returned cost equals the exhaustive minimum.
+            prop_assert_eq!(best_cost, exhaustive_min as QueryPlanCost);
+            // The returned plan is one of the minimum-cost plans: its own weights really sum to
+            // that cost, and every element is actually one of the offered choices at that
+            // position (not, say, a stray element from a different branch).
+            prop_assert_eq!(best_plan.len(), target_len);
+            prop_assert_eq!(best_plan.iter().sum::<i64>(), exhaustive_min);
+            prop_assert_eq!(best_plan[0], initial_weight);
+            for (i, choices) in choice_weights.iter().enumerate() {
+                prop_assert!(
+                    choices.contains(&best_plan[i + 1]),
+                    "returned plan picked a weight not among the offered choices at position {i}"
+                );
+            }
+
+            // Empty `to_add` returns the initial plan and its cost unchanged.
+            if choice_weights.is_empty() {
+                prop_assert_eq!(&best_plan, &vec![initial_weight]);
+                prop_assert_eq!(best_cost, initial_weight as QueryPlanCost);
+            }
+
+            // Choice-vector permutation preserves the minimum cost (reordering independent
+            // choice groups can't change which combination is cheapest, only where its elements
+            // land in the plan).
+            if !choice_weights.is_empty() {
+                let mut permuted = choice_weights.clone();
+                permuted.reverse();
+                let permuted_exhaustive_min = exhaustive_min_cost(initial_weight, &permuted);
+                prop_assert_eq!(permuted_exhaustive_min, exhaustive_min);
+                let (_, permuted_best_cost) = run_pruned_search(initial_weight, &permuted);
+                prop_assert_eq!(permuted_best_cost, exhaustive_min as QueryPlanCost);
+            }
+
+            // Dominated-choice addition cannot improve the minimum cost: appending a new group
+            // whose cheapest option is `0` (as good as any option can be) and whose other option
+            // is astronomically expensive (so it can never win) must leave the minimum exactly
+            // where it was, plus that group's forced `0` contribution.
+            let mut with_dominated = choice_weights.clone();
+            with_dominated.push(vec![0, 1_000_000_000]);
+            let dominated_exhaustive_min = exhaustive_min_cost(initial_weight, &with_dominated);
+            prop_assert_eq!(dominated_exhaustive_min, exhaustive_min);
+            let (dominated_best_plan, dominated_best_cost) =
+                run_pruned_search(initial_weight, &with_dominated);
+            prop_assert_eq!(dominated_best_cost, exhaustive_min as QueryPlanCost);
+            prop_assert_eq!(
+                *dominated_best_plan.last().unwrap(),
+                0,
+                "the dominated (astronomically expensive) option must never be selected"
+            );
+        }
+    }
 }

--- a/apollo-federation/src/query_plan/mod.rs
+++ b/apollo-federation/src/query_plan/mod.rs
@@ -261,3 +261,310 @@ impl PlanNode {
         }
     }
 }
+
+#[cfg(test)]
+mod proptests {
+    use std::cell::Cell;
+
+    use proptest::prelude::*;
+    use proptest::proptest;
+
+    use super::*;
+
+    fn plan_name_strategy() -> impl Strategy<Value = Name> {
+        prop::sample::select(vec!["a", "b", "node", "items", "TypeA", "TypeB", "ctx"])
+            .prop_map(|value| Name::new(value).unwrap())
+    }
+
+    fn conditions_strategy() -> impl Strategy<Value = Option<Conditions>> {
+        prop::option::of(prop::collection::vec(plan_name_strategy(), 0..4))
+    }
+
+    fn fetch_data_path_strategy() -> impl Strategy<Value = Vec<FetchDataPathElement>> {
+        prop::collection::vec(
+            prop_oneof![
+                (plan_name_strategy(), conditions_strategy())
+                    .prop_map(|(name, conditions)| FetchDataPathElement::Key(name, conditions)),
+                conditions_strategy().prop_map(FetchDataPathElement::AnyIndex),
+                plan_name_strategy().prop_map(FetchDataPathElement::TypenameEquals),
+                Just(FetchDataPathElement::Parent),
+            ],
+            0..7,
+        )
+    }
+
+    fn query_path_strategy() -> impl Strategy<Value = Vec<QueryPathElement>> {
+        prop::collection::vec(
+            prop_oneof![
+                plan_name_strategy()
+                    .prop_map(|response_key| QueryPathElement::Field { response_key }),
+                plan_name_strategy().prop_map(|type_condition| {
+                    QueryPathElement::InlineFragment { type_condition }
+                }),
+            ],
+            0..6,
+        )
+    }
+
+    fn json_value_strategy() -> BoxedStrategy<serde_json_bytes::Value> {
+        prop_oneof![
+            Just(serde_json_bytes::Value::Null),
+            any::<bool>().prop_map(serde_json_bytes::Value::Bool),
+            any::<i64>().prop_map(|value| serde_json_bytes::Value::from(value)),
+            "[a-zA-Z0-9 _-]{0,16}".prop_map(|value| serde_json_bytes::Value::String(value.into())),
+        ]
+        .prop_recursive(3, 32, 4, |inner| {
+            prop_oneof![
+                prop::collection::vec(inner.clone(), 0..4).prop_map(serde_json_bytes::Value::Array),
+                prop::collection::btree_map("[a-z]{1,8}", inner, 0..4).prop_map(|entries| {
+                    serde_json_bytes::Value::Object(
+                        entries
+                            .into_iter()
+                            .map(|(key, value)| (key.into(), value))
+                            .collect(),
+                    )
+                }),
+            ]
+        })
+        .boxed()
+    }
+
+    fn rewrite_strategy() -> impl Strategy<Value = Arc<FetchDataRewrite>> {
+        prop_oneof![
+            (fetch_data_path_strategy(), json_value_strategy()).prop_map(|(path, value)| {
+                Arc::new(FetchDataRewrite::ValueSetter(FetchDataValueSetter {
+                    path,
+                    set_value_to: value,
+                }))
+            }),
+            (fetch_data_path_strategy(), plan_name_strategy()).prop_map(|(path, rename_key_to)| {
+                Arc::new(FetchDataRewrite::KeyRenamer(FetchDataKeyRenamer {
+                    path,
+                    rename_key_to,
+                }))
+            }),
+        ]
+    }
+
+    fn requires_selection_strategy() -> BoxedStrategy<requires_selection::Selection> {
+        (prop::option::of(plan_name_strategy()), plan_name_strategy())
+            .prop_map(|(alias, name)| {
+                requires_selection::Selection::Field(requires_selection::Field {
+                    alias,
+                    name,
+                    selections: Vec::new(),
+                })
+            })
+            .prop_recursive(3, 32, 4, |inner| {
+                prop_oneof![
+                    (
+                        prop::option::of(plan_name_strategy()),
+                        plan_name_strategy(),
+                        prop::collection::vec(inner.clone(), 0..4),
+                    )
+                        .prop_map(|(alias, name, selections)| {
+                            requires_selection::Selection::Field(requires_selection::Field {
+                                alias,
+                                name,
+                                selections,
+                            })
+                        }),
+                    (
+                        prop::option::of(plan_name_strategy()),
+                        prop::collection::vec(inner, 0..4),
+                    )
+                        .prop_map(|(type_condition, selections)| {
+                            requires_selection::Selection::InlineFragment(
+                                requires_selection::InlineFragment {
+                                    type_condition,
+                                    selections,
+                                },
+                            )
+                        }),
+                ]
+            })
+            .boxed()
+    }
+
+    fn fetch_node_strategy() -> BoxedStrategy<FetchNode> {
+        (
+            prop::sample::select(vec!["accounts", "products", "reviews"]),
+            prop::option::of(any::<u64>()),
+            prop::collection::vec(plan_name_strategy(), 0..4),
+            prop::collection::vec(requires_selection_strategy(), 0..4),
+            prop::option::of(plan_name_strategy()),
+            prop::sample::select(vec![
+                executable::OperationType::Query,
+                executable::OperationType::Mutation,
+                executable::OperationType::Subscription,
+            ]),
+            prop::collection::vec(rewrite_strategy(), 0..4),
+            prop::collection::vec(rewrite_strategy(), 0..4),
+            prop::collection::vec(rewrite_strategy(), 0..4),
+        )
+            .prop_map(
+                |(
+                    subgraph_name,
+                    id,
+                    variable_usages,
+                    requires,
+                    operation_name,
+                    operation_kind,
+                    input_rewrites,
+                    output_rewrites,
+                    context_rewrites,
+                )| FetchNode {
+                    subgraph_name: Arc::from(subgraph_name),
+                    id,
+                    variable_usages,
+                    requires,
+                    operation_document: serializable_document::SerializableDocument::from_string(
+                        "query Generated { __typename }",
+                    ),
+                    operation_name,
+                    operation_kind,
+                    input_rewrites: Arc::new(input_rewrites),
+                    output_rewrites,
+                    context_rewrites,
+                },
+            )
+            .boxed()
+    }
+
+    fn plan_node_strategy() -> BoxedStrategy<PlanNode> {
+        fetch_node_strategy()
+            .prop_map(|fetch| PlanNode::Fetch(Box::new(fetch)))
+            .prop_recursive(4, 64, 4, |inner| {
+                let optional_node =
+                    || prop::option::of(inner.clone()).prop_map(|node| node.map(Box::new));
+                prop_oneof![
+                    prop::collection::vec(inner.clone(), 0..4)
+                        .prop_map(|nodes| PlanNode::Sequence(SequenceNode { nodes })),
+                    prop::collection::vec(inner.clone(), 0..4)
+                        .prop_map(|nodes| PlanNode::Parallel(ParallelNode { nodes })),
+                    (fetch_data_path_strategy(), inner.clone()).prop_map(|(path, node)| {
+                        PlanNode::Flatten(FlattenNode {
+                            path,
+                            node: Box::new(node),
+                        })
+                    }),
+                    (plan_name_strategy(), optional_node(), optional_node()).prop_map(
+                        |(condition_variable, if_clause, else_clause)| {
+                            PlanNode::Condition(Box::new(ConditionNode {
+                                condition_variable,
+                                if_clause,
+                                else_clause,
+                            }))
+                        }
+                    ),
+                    (
+                        prop::option::of(Just(".{ __typename }".to_string())),
+                        optional_node(),
+                        prop::collection::vec(
+                            (
+                                prop::collection::vec(any::<u16>(), 0..4),
+                                prop::option::of(Just("generated-label".to_string())),
+                                query_path_strategy(),
+                                prop::option::of(Just(".{ __typename }".to_string())),
+                                optional_node(),
+                            ),
+                            0..4,
+                        ),
+                    )
+                        .prop_map(
+                            |(primary_selection, primary_node, deferred)| {
+                                PlanNode::Defer(DeferNode {
+                                    primary: PrimaryDeferBlock {
+                                        sub_selection: primary_selection,
+                                        node: primary_node,
+                                    },
+                                    deferred: deferred
+                                        .into_iter()
+                                        .map(|(depends, label, query_path, sub_selection, node)| {
+                                            DeferredDeferBlock {
+                                                depends: depends
+                                                    .into_iter()
+                                                    .map(|id| DeferredDependency {
+                                                        id: id.to_string(),
+                                                    })
+                                                    .collect(),
+                                                label,
+                                                query_path,
+                                                sub_selection,
+                                                node,
+                                            }
+                                        })
+                                        .collect(),
+                                })
+                            }
+                        ),
+                ]
+            })
+            .boxed()
+    }
+
+    fn top_level_plan_node_strategy() -> BoxedStrategy<TopLevelPlanNode> {
+        let plan = plan_node_strategy();
+        prop_oneof![
+            plan.clone().prop_map(|node| match node {
+                PlanNode::Fetch(fetch) => TopLevelPlanNode::Fetch(fetch),
+                PlanNode::Sequence(sequence) => TopLevelPlanNode::Sequence(sequence),
+                PlanNode::Parallel(parallel) => TopLevelPlanNode::Parallel(parallel),
+                PlanNode::Flatten(flatten) => TopLevelPlanNode::Flatten(flatten),
+                PlanNode::Defer(defer) => TopLevelPlanNode::Defer(defer),
+                PlanNode::Condition(condition) => TopLevelPlanNode::Condition(condition),
+            }),
+            (fetch_node_strategy(), prop::option::of(plan)).prop_map(|(primary, rest)| {
+                TopLevelPlanNode::Subscription(SubscriptionNode {
+                    primary: Box::new(primary),
+                    rest: rest.map(Box::new),
+                })
+            }),
+        ]
+        .boxed()
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        /// The serialized plan AST is a public boundary consumed by the router. Generate every
+        /// node/path/rewrite family recursively and require serialization to be stable after a
+        /// deserialize-reserialize cycle. Statistics' documented NaN/null normalization is checked
+        /// separately because IEEE NaN is intentionally not equal to itself.
+        #[test]
+        fn query_plan_json_round_trip_is_stable(
+            node in prop::option::of(top_level_plan_node_strategy()),
+            evaluated_plan_count in 0usize..10_000,
+            evaluated_plan_paths in 0usize..10_000,
+            best_plan_cost in prop_oneof![Just(f64::NAN), -1.0e9f64..1.0e9f64],
+        ) {
+            let plan = QueryPlan {
+                node,
+                statistics: QueryPlanningStatistics {
+                    evaluated_plan_count: Cell::new(evaluated_plan_count),
+                    evaluated_plan_paths: Cell::new(evaluated_plan_paths),
+                    best_plan_cost,
+                },
+            };
+            let serialized = serde_json::to_vec(&plan).unwrap();
+            let round_trip: QueryPlan = serde_json::from_slice(&serialized).unwrap();
+            let reserialized = serde_json::to_vec(&round_trip).unwrap();
+
+            prop_assert_eq!(reserialized, serialized, "query-plan JSON was not stable");
+            prop_assert_eq!(&round_trip.node, &plan.node);
+            prop_assert_eq!(
+                round_trip.statistics.evaluated_plan_count.get(),
+                evaluated_plan_count,
+            );
+            prop_assert_eq!(
+                round_trip.statistics.evaluated_plan_paths.get(),
+                evaluated_plan_paths,
+            );
+            if best_plan_cost.is_nan() {
+                prop_assert!(round_trip.statistics.best_plan_cost.is_nan());
+            } else {
+                prop_assert_eq!(round_trip.statistics.best_plan_cost, best_plan_cost);
+            }
+        }
+    }
+}

--- a/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal/non_local_selections_estimation.rs
@@ -926,6 +926,460 @@ pub(crate) fn precompute_non_local_selection_metadata(
     Ok(metadata)
 }
 
+/// Reconstruct every query-graph attribute used by non-local-selection estimation from raw
+/// nodes, raw edges, and schema runtime-type intersections. This intentionally lives beside the
+/// private metadata representation, while the property that drives it lives with the broader
+/// `QueryGraph` fixture auditor.
+#[cfg(test)]
+pub(crate) fn audit_precomputed_query_graph_metadata(
+    graph: &QueryGraph,
+) -> Result<(), proptest::test_runner::TestCaseError> {
+    use crate::query_graph::QueryGraphNodeType;
+
+    let metadata = graph.non_local_selection_metadata();
+
+    let mut expected_fields = Vec::new();
+    for edge in graph.graph().edge_references() {
+        let QueryGraphEdgeTransition::FieldCollection {
+            field_definition_position,
+            ..
+        } = &edge.weight().transition
+        else {
+            continue;
+        };
+        if CompositeTypeDefinitionPosition::try_from(
+            graph.node_weight(edge.target()).unwrap().type_.clone(),
+        )
+        .is_err()
+        {
+            continue;
+        }
+        expected_fields.push((
+            field_definition_position.field_name().to_string(),
+            edge.source().index(),
+            edge.target().index(),
+            edge.weight()
+                .override_condition
+                .as_ref()
+                .map(|condition| (condition.label.to_string(), condition.condition)),
+        ));
+    }
+    expected_fields.sort();
+    let mut actual_fields = metadata
+        .fields_to_endpoints
+        .iter()
+        .flat_map(|(field_name, endpoints)| {
+            endpoints.iter().map(|(source, target)| match target {
+                FieldTarget::NonOverride(target) => {
+                    (field_name.to_string(), source.index(), target.index(), None)
+                }
+                FieldTarget::Override(target, condition) => (
+                    field_name.to_string(),
+                    source.index(),
+                    target.index(),
+                    Some((condition.label.to_string(), condition.condition)),
+                ),
+            })
+        })
+        .collect::<Vec<_>>();
+    actual_fields.sort();
+    proptest::prop_assert_eq!(
+        actual_fields,
+        expected_fields,
+        "field endpoint metadata differs from raw field edges"
+    );
+
+    let mut expected_inline_fragments = Vec::new();
+    for edge in graph.graph().edge_references() {
+        let type_name = match &edge.weight().transition {
+            QueryGraphEdgeTransition::Downcast {
+                to_type_position, ..
+            } => Some(to_type_position.type_name()),
+            QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { to_type_name, .. } => {
+                Some(to_type_name)
+            }
+            _ => None,
+        };
+        if let Some(type_name) = type_name {
+            expected_inline_fragments.push((
+                type_name.to_string(),
+                edge.source().index(),
+                edge.target().index(),
+            ));
+        }
+    }
+    for (node, weight) in graph.graph().node_references() {
+        if let Ok(position) = CompositeTypeDefinitionPosition::try_from(weight.type_.clone()) {
+            expected_inline_fragments.push((
+                position.type_name().to_string(),
+                node.index(),
+                node.index(),
+            ));
+        }
+    }
+    expected_inline_fragments.sort();
+    expected_inline_fragments.dedup();
+    let mut actual_inline_fragments = metadata
+        .inline_fragments_to_endpoints
+        .iter()
+        .flat_map(|(type_name, endpoints)| {
+            endpoints
+                .iter()
+                .map(|(source, target)| (type_name.to_string(), source.index(), target.index()))
+        })
+        .collect::<Vec<_>>();
+    actual_inline_fragments.sort();
+    proptest::prop_assert_eq!(
+        actual_inline_fragments,
+        expected_inline_fragments,
+        "inline-fragment endpoint metadata differs from casts plus synthetic self-casts"
+    );
+
+    // Normalize the enum into `(source, kind, type name, optional target)`: kind 0 is an ordinary
+    // object downcast and kind 1 is an interface-object fake downcast.
+    let mut expected_object_downcasts = Vec::new();
+    for edge in graph.graph().edge_references() {
+        match &edge.weight().transition {
+            QueryGraphEdgeTransition::Downcast {
+                to_type_position, ..
+            } if to_type_position.is_object_type() => expected_object_downcasts.push((
+                edge.source().index(),
+                0_u8,
+                to_type_position.type_name().to_string(),
+                Some(edge.target().index()),
+            )),
+            QueryGraphEdgeTransition::InterfaceObjectFakeDownCast { to_type_name, .. } => {
+                expected_object_downcasts.push((
+                    edge.source().index(),
+                    1_u8,
+                    to_type_name.to_string(),
+                    None,
+                ));
+            }
+            _ => {}
+        }
+    }
+    for (node, weight) in graph.graph().node_references() {
+        let QueryGraphNodeType::SchemaType(position) = &weight.type_ else {
+            continue;
+        };
+        if matches!(
+            position,
+            crate::schema::position::OutputTypeDefinitionPosition::Object(_)
+        ) && !graph
+            .schema_by_source(&weight.source)
+            .unwrap()
+            .is_interface_object_type(position.clone().into())
+            .unwrap()
+        {
+            expected_object_downcasts.push((
+                node.index(),
+                0_u8,
+                position.type_name().to_string(),
+                Some(node.index()),
+            ));
+        }
+    }
+    expected_object_downcasts.sort();
+    expected_object_downcasts.dedup();
+    let mut actual_object_downcasts = metadata
+        .nodes_to_object_type_downcasts
+        .iter()
+        .flat_map(|(source, downcasts)| match downcasts {
+            ObjectTypeDowncasts::NonInterfaceObject(downcasts) => downcasts
+                .iter()
+                .map(|(type_name, target)| {
+                    (
+                        source.index(),
+                        0_u8,
+                        type_name.to_string(),
+                        Some(target.index()),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            ObjectTypeDowncasts::InterfaceObject(downcasts) => downcasts
+                .iter()
+                .map(|type_name| (source.index(), 1_u8, type_name.to_string(), None))
+                .collect::<Vec<_>>(),
+        })
+        .collect::<Vec<_>>();
+    actual_object_downcasts.sort();
+    proptest::prop_assert_eq!(
+        actual_object_downcasts,
+        expected_object_downcasts,
+        "object-runtime downcast metadata differs from raw casts plus object self-casts"
+    );
+
+    let mut same_type_options: IndexMap<Name, IndexSet<NodeIndex>> = Default::default();
+    let mut raw_interface_options: IndexMap<NodeIndex, IndexSet<Name>> = Default::default();
+    for edge in graph.graph().edge_references() {
+        if !matches!(
+            edge.weight().transition,
+            QueryGraphEdgeTransition::KeyResolution
+                | QueryGraphEdgeTransition::RootTypeResolution { .. }
+        ) {
+            continue;
+        }
+        let head: CompositeTypeDefinitionPosition = graph
+            .node_weight(edge.source())
+            .unwrap()
+            .type_
+            .clone()
+            .try_into()
+            .unwrap();
+        let tail: CompositeTypeDefinitionPosition = graph
+            .node_weight(edge.target())
+            .unwrap()
+            .type_
+            .clone()
+            .try_into()
+            .unwrap();
+        if head.type_name() == tail.type_name() {
+            same_type_options
+                .entry(tail.type_name().clone())
+                .or_default()
+                .insert(edge.target());
+        } else {
+            raw_interface_options
+                .entry(edge.source())
+                .or_default()
+                .insert(tail.type_name().clone());
+        }
+    }
+    let mut complete_interface_options: IndexMap<Name, IndexSet<Name>> = Default::default();
+    let mut remaining_interface_options = IndexMap::default();
+    for (node, options) in raw_interface_options {
+        let node_type: CompositeTypeDefinitionPosition = graph
+            .node_weight(node)
+            .unwrap()
+            .type_
+            .clone()
+            .try_into()
+            .unwrap();
+        if same_type_options
+            .get(node_type.type_name())
+            .is_some_and(|nodes| nodes.contains(&node))
+        {
+            complete_interface_options
+                .entry(node_type.type_name().clone())
+                .or_default()
+                .extend(options);
+        } else {
+            remaining_interface_options.insert(node, options);
+        }
+    }
+    for (node, options) in &mut remaining_interface_options {
+        let node_type: CompositeTypeDefinitionPosition = graph
+            .node_weight(*node)
+            .unwrap()
+            .type_
+            .clone()
+            .try_into()
+            .unwrap();
+        if let Some(complete) = complete_interface_options.get(node_type.type_name()) {
+            options.retain(|option| !complete.contains(option));
+        }
+    }
+    remaining_interface_options.retain(|_, options| !options.is_empty());
+
+    let mut expected_same_type = same_type_options
+        .iter()
+        .flat_map(|(type_name, nodes)| {
+            nodes
+                .iter()
+                .map(|node| (type_name.to_string(), node.index()))
+        })
+        .collect::<Vec<_>>();
+    expected_same_type.sort();
+    let mut actual_same_type = metadata
+        .types_to_indirect_options
+        .iter()
+        .flat_map(|(type_name, options)| {
+            options
+                .same_type_options
+                .iter()
+                .map(|node| (type_name.to_string(), node.index()))
+        })
+        .collect::<Vec<_>>();
+    actual_same_type.sort();
+    proptest::prop_assert_eq!(actual_same_type, expected_same_type);
+
+    let mut expected_complete_interfaces = complete_interface_options
+        .iter()
+        .flat_map(|(type_name, options)| {
+            options
+                .iter()
+                .map(|option| (type_name.to_string(), option.to_string()))
+        })
+        .collect::<Vec<_>>();
+    expected_complete_interfaces.sort();
+    let mut actual_complete_interfaces = metadata
+        .types_to_indirect_options
+        .iter()
+        .flat_map(|(type_name, options)| {
+            options
+                .interface_object_options
+                .iter()
+                .map(|option| (type_name.to_string(), option.to_string()))
+        })
+        .collect::<Vec<_>>();
+    actual_complete_interfaces.sort();
+    proptest::prop_assert_eq!(actual_complete_interfaces, expected_complete_interfaces);
+
+    let mut expected_remaining_interfaces = remaining_interface_options
+        .iter()
+        .flat_map(|(node, options)| {
+            options
+                .iter()
+                .map(|option| (node.index(), option.to_string()))
+        })
+        .collect::<Vec<_>>();
+    expected_remaining_interfaces.sort();
+    let mut actual_remaining_interfaces = metadata
+        .remaining_nodes_to_interface_object_options
+        .iter()
+        .flat_map(|(node, options)| {
+            options
+                .iter()
+                .map(|option| (node.index(), option.to_string()))
+        })
+        .collect::<Vec<_>>();
+    actual_remaining_interfaces.sort();
+    proptest::prop_assert_eq!(actual_remaining_interfaces, expected_remaining_interfaces);
+
+    let mut expected_rebaseable_fields = Vec::new();
+    let mut expected_rebaseable_fragments = Vec::new();
+    for (parent_node, parent_weight) in graph.graph().node_references() {
+        let QueryGraphNodeType::SchemaType(parent_position) = &parent_weight.type_ else {
+            continue;
+        };
+        let Ok(parent_composite) =
+            CompositeTypeDefinitionPosition::try_from(parent_position.clone())
+        else {
+            continue;
+        };
+        let schema = graph.schema_by_source(&parent_weight.source).unwrap();
+        let Some(subgraph_metadata) = schema.subgraph_metadata() else {
+            continue;
+        };
+        let from_context_name = &subgraph_metadata
+            .federation_spec_definition()
+            .from_context_directive_definition(schema)
+            .unwrap()
+            .name;
+        match schema.schema().types.get(parent_composite.type_name()) {
+            Some(ExtendedType::Object(type_)) => {
+                for (field_name, field) in &type_.fields {
+                    if !field
+                        .arguments
+                        .iter()
+                        .any(|argument| argument.directives.has(from_context_name))
+                    {
+                        expected_rebaseable_fields
+                            .push((field_name.to_string(), parent_node.index()));
+                    }
+                }
+                expected_rebaseable_fields.push((
+                    INTROSPECTION_TYPENAME_FIELD_NAME.to_string(),
+                    parent_node.index(),
+                ));
+            }
+            Some(ExtendedType::Interface(type_)) => {
+                for (field_name, field) in &type_.fields {
+                    if !field
+                        .arguments
+                        .iter()
+                        .any(|argument| argument.directives.has(from_context_name))
+                    {
+                        expected_rebaseable_fields
+                            .push((field_name.to_string(), parent_node.index()));
+                    }
+                }
+                expected_rebaseable_fields.push((
+                    INTROSPECTION_TYPENAME_FIELD_NAME.to_string(),
+                    parent_node.index(),
+                ));
+            }
+            Some(ExtendedType::Union(_)) => expected_rebaseable_fields.push((
+                INTROSPECTION_TYPENAME_FIELD_NAME.to_string(),
+                parent_node.index(),
+            )),
+            _ => {}
+        }
+
+        let parent_runtime_types = schema.possible_runtime_types(parent_composite).unwrap();
+        for candidate_weight in graph.graph().node_weights() {
+            if candidate_weight.source != parent_weight.source {
+                continue;
+            }
+            let Ok(candidate) =
+                CompositeTypeDefinitionPosition::try_from(candidate_weight.type_.clone())
+            else {
+                continue;
+            };
+            let candidate_runtime_types = schema.possible_runtime_types(candidate.clone()).unwrap();
+            if parent_runtime_types
+                .iter()
+                .any(|runtime| candidate_runtime_types.contains(runtime))
+            {
+                expected_rebaseable_fragments
+                    .push((candidate.type_name().to_string(), parent_node.index()));
+            }
+        }
+    }
+    expected_rebaseable_fields.sort();
+    expected_rebaseable_fields.dedup();
+    let mut actual_rebaseable_fields = metadata
+        .fields_to_rebaseable_parent_nodes
+        .iter()
+        .flat_map(|(field_name, nodes)| {
+            nodes
+                .iter()
+                .map(|node| (field_name.to_string(), node.index()))
+        })
+        .collect::<Vec<_>>();
+    actual_rebaseable_fields.sort();
+    proptest::prop_assert_eq!(
+        actual_rebaseable_fields,
+        expected_rebaseable_fields,
+        "field-rebase metadata differs from subgraph field availability"
+    );
+
+    expected_rebaseable_fragments.sort();
+    expected_rebaseable_fragments.dedup();
+    let mut actual_rebaseable_fragments = metadata
+        .inline_fragments_to_rebaseable_parent_nodes
+        .iter()
+        .flat_map(|(type_name, nodes)| {
+            nodes
+                .iter()
+                .map(|node| (type_name.to_string(), node.index()))
+        })
+        .collect::<Vec<_>>();
+    actual_rebaseable_fragments.sort();
+    proptest::prop_assert_eq!(
+        actual_rebaseable_fragments,
+        expected_rebaseable_fragments,
+        "inline-fragment rebase metadata differs from runtime-type intersection"
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn metadata_allows_inline_fragment_rebase(
+    graph: &QueryGraph,
+    type_condition: &str,
+    parent_node: NodeIndex,
+) -> bool {
+    graph
+        .non_local_selection_metadata()
+        .inline_fragments_to_rebaseable_parent_nodes
+        .iter()
+        .find(|(name, _)| name.as_str() == type_condition)
+        .is_some_and(|(_, nodes)| nodes.contains(&parent_node))
+}
+
 /// During query graph creation, we pre-compute metadata that helps us greatly speed up the
 /// estimation process during request execution. The expected time and memory consumed for
 /// pre-computation is (in the worst case) expected to be on the order of the number of nodes

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
@@ -40,6 +40,53 @@ const SUBGRAPH2: &str = r#"
   }
 "#;
 
+const SUBGRAPH1_WITH_INTERSECTING_INTERFACE: &str = r#"
+  type Query {
+    iFromS1: I
+  }
+
+  interface I @key(fields: "id") {
+    id: ID!
+    x: Int
+  }
+
+  interface J {
+    z: Int
+  }
+
+  type A implements I & J @key(fields: "id") {
+    id: ID!
+    x: Int
+    z: Int
+  }
+
+  type B implements I @key(fields: "id") {
+    id: ID!
+    x: Int
+  }
+"#;
+
+/// This is a normal planner workflow: composition establishes that `I` and `J` overlap through
+/// `A`, the operation is validated against that API schema, and planning starts from the
+/// `@interfaceObject` representation of `I` in S2.
+#[test]
+fn preserves_empty_object_for_intersecting_interface_from_an_interface_object() {
+    let planner = planner!(
+        S1: SUBGRAPH1_WITH_INTERSECTING_INTERFACE,
+        S2: SUBGRAPH2,
+    );
+    let document = apollo_compiler::ExecutableDocument::parse_and_validate(
+        planner.api_schema().schema(),
+        "{ iFromS2 { ... on J { z } } }",
+        "operation.graphql",
+    )
+    .unwrap();
+
+    planner
+        .build_query_plan(&document, None, Default::default())
+        .expect("the validated operation must be plannable");
+}
+
 #[test]
 fn can_use_a_key_on_an_interface_object_type() {
     let planner = planner!(

--- a/apollo-federation/tests/query_plan/supergraphs/preserves_empty_object_for_intersecting_interface_from_an_interface_object.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/preserves_empty_object_for_intersecting_interface_from_an_interface_object.graphql
@@ -1,0 +1,98 @@
+# Composed from subgraphs with hash: a51edff232bbc18dbb28521b7d70bd113ee9c070
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A implements I & J
+  @join__implements(graph: S1, interface: "I")
+  @join__implements(graph: S1, interface: "J")
+  @join__type(graph: S1, key: "id")
+{
+  id: ID!
+  x: Int
+  z: Int
+  y: Int @join__field
+}
+
+type B implements I
+  @join__implements(graph: S1, interface: "I")
+  @join__type(graph: S1, key: "id")
+{
+  id: ID!
+  x: Int
+  y: Int @join__field
+}
+
+interface I
+  @join__type(graph: S1, key: "id")
+  @join__type(graph: S2, key: "id", isInterfaceObject: true)
+{
+  id: ID!
+  x: Int @join__field(graph: S1)
+  y: Int @join__field(graph: S2)
+}
+
+interface J
+  @join__type(graph: S1)
+{
+  z: Int
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  S1 @join__graph(name: "S1", url: "none")
+  S2 @join__graph(name: "S2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: S1)
+  @join__type(graph: S2)
+{
+  iFromS1: I @join__field(graph: S1)
+  iFromS2: I @join__field(graph: S2)
+}


### PR DESCRIPTION
## Why

Query planning relies on graph-shaped structures with cached state, optimized traversal, merging,
and transitive reduction. Bugs in these structures often require unusual combinations of federation
features, graph topology, or mutation order, making them particularly suitable for property-based
testing.

This PR introduces broad model-based proptest coverage around `QueryGraph`, `OpGraphPath`,
`PathTree`, `FetchDependencyGraph`, operation paths, and the serialized `QueryPlan` AST.

The work is intentionally divided into two review layers:

1. A large generated-search layer explores difficult state spaces using independent models,
   state-machine traces, exhaustive fixture audits, and metamorphic comparisons.
2. Eleven ordinary deterministic tests demonstrate the nine concrete contract violations or
   hardening gaps found by that search.

The deterministic tests are the main review interface for the findings. A reviewer does not need
to trust proptest, random seeds, shrinking, or the generated infrastructure to verify any reported
defect.

The findings are explicitly tiered by reachability:

- **Planner-level:** reproduced from subgraph SDL and a validated GraphQL operation through
  `QueryPlanner::build_query_plan`.
- **Production-object:** reproduced through production operation/path constructors, without a
  complete planner operation known to emit the exact state.
- **Hardening-only:** a real derived-state or data-conservation invariant whose failing call order
  is not known to occur in today's planner.

The focused tests intentionally fail until the production behavior or proposed hardening contract
is addressed. Production fixes are deliberately not included here.

## Findings

There are nine distinct findings represented by eleven focused repro tests.

### 1. Rebasing can fail on Federation versions without `@fromContext`

**Tier: production-object / operation API.** This directly exercises the operation method called
by query planning, although this PR does not include a complete planner operation for the case.

The repro:

1. Creates a normal Federation-1-style schema.
2. Selects `intfField` from an interface.
3. Rebases that selection onto an implementing object that also defines `intfField`.
4. Calls `SelectionSet::can_rebase_on`.
5. Expects the operation to return `Ok(true)`.

Instead, the rebase path attempts to obtain the federation specification's `@fromContext`
directive definition and returns:

```text
Internal {
    message: "Unexpectedly could not find federation spec's \"@fromContext\" directive definition"
}
```

Federation 1 and Federation 2.0–2.7 do not define `@fromContext`. Its absence means there are no
contextual arguments to validate; it should not make an otherwise compatible field impossible to
rebase.

Focused repro:
[`can_rebase_on_does_not_crash_on_a_federation_1_subgraph`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/operation/rebase.rs#L578)

Broad discovery property:
[`rebase_can_rebase_on_agrees_with_rebase_on_success`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/operation/rebase.rs#L674)

Potential production effect: a valid customer schema or operation can encounter an internal
query-planning error solely because its federation specification predates `@fromContext`.

### 2. Stale fetch-selection conditions

**Tier: hardening-only.** The mutator and stale cache are real, but its sole current planner caller
uses a fresh copied node. The warm-before-mutate ordering below is not known to be reachable today.

The repro:

1. Creates an unconditional `id` selection.
2. Adds that selection as the node's inputs.
3. Reads `conditions()` to warm the cache.
4. Removes inputs from the selection.
5. Confirms the underlying selection is empty.
6. Expects cached conditions to change from `always` to `never`.

The cached value remains based on the pre-mutation selection.

Focused repro:
[`remove_inputs_from_selection_invalidates_warmed_conditions_regression`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L9656)

Broad discovery property:
[`remove_inputs_from_selection_invalidates_all_derived_selection_state`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L9715)

Hardening value: a future caller that reads conditions before this mutation would observe state
that no longer describes the fetch node's actual selection.

### 3. Typename termination fails after entering an interface object

**Tier: planner-level.** This is reproduced through the normal planner entry point.

The repro:

1. Defines interfaces `I` and `J` that overlap through object `A`.
2. Defines `I` as an `@interfaceObject` in S2.
3. Composes those subgraphs through the existing `planner!` fixture infrastructure.
4. Parses and validates `{ iFromS2 { ... on J { z } } }` against the API schema.
5. Calls `QueryPlanner::build_query_plan`.

The fragment is valid because `I` and `J` overlap. While preserving the empty-object result for
the branch, typename termination requires a local `__typename` edge on the interface-object
subgraph and returns:

```text
Internal {
    message: "Unexpectedly missing edge for __typename field"
}
```

Focused repro:
[`preserves_empty_object_for_intersecting_interface_from_an_interface_object`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs#L73)

Broad discovery property:
[`typename_termination_truncates_trailing_path_attributes_in_lockstep`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_graph/graph_path.rs#L4364)

Potential production effect: an operation traversing a valid interface-object key path can fail
during query planning.

### 4. `PathTree::merge` discards leaf-local selections

**Tier: production-object.** These use ordinary collected field paths and
`OpPathTree::from_op_paths`, but this PR does not claim operation normalization currently emits the
exact two-tree pairs.

#### Same collected path

The repro:

1. Creates two trees for the ordinary collected path `Query.node`.
2. Gives each path tail a different fully-local selection.
3. Merges the trees.
4. Expects both selections to remain at `Query.node`.

Only the left selection remains.

Focused repro:
[`merge_preserves_distinct_trailing_selections_on_the_same_path`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_graph/path_tree.rs#L1220)

#### Leaf merged with a branch

The repro:

1. Creates a path ending with local work at `Query.node`.
2. Creates another path continuing through `Query.node.child` with its own local work.
3. Merges their shared `Query.node` prefix.
4. Expects both the local work and longer child path to remain.

The leaf's local selection disappears.

Focused repro:
[`merge_preserves_leaf_local_selection_when_other_tree_has_children`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_graph/path_tree.rs#L1243)

Broad discovery property:
[`path_tree_merge_matches_rebuild_for_local_selections`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_graph/path_tree.rs#L1438)

Potential effect if the caller emits this shape: merging planner paths can discard fully-local work.

### 5. `PathTree::equals_same_root` ignores different local work

**Tier: production-object hardening.** The direct comparison uses normal path-tree constructors.
The consequence test uses a real condition-bearing key edge, while explicitly supplying two
successful condition resolutions; an operation producing those distinct condition trees has not
been demonstrated.

The equality predicate is used as a fast path before merging condition trees.

The first repro:

1. Creates two trees for the same `Query.node` path.
2. Gives their path tails different local selections.
3. Calls `equals_same_root`.
4. Expects the trees to compare unequal.

They compare equal even though they represent different work.

Focused equality repro:
[`equals_same_root_distinguishes_different_local_selections`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_graph/path_tree.rs#L1278)

The second repro demonstrates the structural consequence on a real key edge:

1. Locates the real condition-bearing S1.I → S2.I key edge from an existing interface-object
   fixture.
2. Builds both parent paths through `OpGraphPath::add`.
3. Gives their child edges distinct condition trees that both include the required `id`.
4. Merges the parent trees.
5. Expects the merged child condition to contain both selections.

Because the condition trees compare equal, their merge is skipped and the right-hand selection
disappears.

Focused consequence repro:
[`merge_preserves_local_selections_from_both_child_condition_trees`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_graph/path_tree.rs#L1332)

Broad discovery properties:

- [`path_tree_merge_unions_shared_child_condition_payloads`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_graph/path_tree.rs#L1609)
- [`path_tree_merge_conserves_combined_recursive_edge_payload`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_graph/path_tree.rs#L1664)

The combined property forces the shared edge to carry nonempty child-local selections,
condition-local selections, context IDs, and argument-to-context usage maps. Shrinking therefore
cannot erase the realistic surrounding payload and reduce the test to an empty synthetic case.

Potential effect if distinct condition payloads reach this fast path: condition work can be
silently omitted because structurally similar paths are treated as semantically equal.

### 6. `PathTree::extend` discards a leaf's local selections

**Tier: hardening-only.** The sole production caller concatenates serial mutation-root trees with
children. That normal use case is covered by `adjacent_mutations_get_merged`, and the caller-shaped
proptest below passes. The failing empty-child case broadens safety for a valid tree shape not known
to reach that caller today.

The repro:

1. Creates a non-leaf tree with a child and a local selection.
2. Creates a payload-bearing leaf at the same root.
3. Extends the non-leaf tree with that leaf.
4. Expects both local selections to remain.

The leaf's local selection is absent after `extend`.

Focused repro:
[`extend_preserves_local_selections_from_a_leaf_tree`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_graph/path_tree.rs#L1303)

Caller-shaped property:
[`path_tree_extend_conserves_nonempty_mutation_shaped_paths`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_graph/path_tree.rs#L1494)

Hardening value: `extend` will conserve root-local payload if a future caller supplies an
empty-child tree.

### 7. A late fetch merge can discard a required-field dependency

**Tier: production-object / graph optimizer.** This uses normal fetch-node construction,
dependency insertion, transitive reduction, and the complete `reduce_and_optimize` entry point.
This PR does not claim that a complete planner operation currently emits the exact graph.

The repro:

1. Creates a fetch that provides `v2` and a later fetch whose representation requires `v2`.
2. Connects them both directly and through an intermediate fetch.
3. Runs transitive reduction, which correctly removes only the direct shortcut while retaining
   provider-to-consumer reachability through the intermediate fetch.
4. Lets the late equal-input phase merge that intermediate fetch into an earlier equivalent
   fetch.
5. Confirms the provider still selects `v2` and the consumer still requires `v2`.
6. Expects the provider to remain an ancestor of the consumer.

The merge relocates the consumer but drops the only remaining path from the `v2` provider. The
optimized graph can therefore schedule a fetch before the field required by its representation is
available.

Focused repro:
[`reduce_and_optimize_preserves_an_input_dependency_through_a_late_merge`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L8626)

Broad discovery property:
[`whole_optimizer_preserves_generated_input_availability`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L9138)

Potential effect if the planner emits this shape: an optimized query plan can omit the ordering
dependency that makes a required representation field available.

### 8. Merging multiple fetch groups can panic using stale topology

**Tier: production-object / graph optimizer.** The repro constructs an ordinary acyclic fetch DAG
whose nodes have nonempty selections and valid equal-input merge groups, then calls the complete
optimizer. A planner operation producing this exact arrangement has not yet been demonstrated.

The repro:

1. Creates two independent equal-input merge groups, `(P, D)` and `(U, V)`.
2. Connects them in an acyclic DAG and verifies topological sorting succeeds.
3. Verifies each intended pair has equal inputs and `P` and `U` are initially unrelated.
4. Calls `reduce_and_optimize`.

The first merge changes ancestry in the other group. The second merge still follows the
topological ordering captured before that mutation and tries to introduce a cycle, producing:

```text
Node NodeIndex(3) is a descendant of NodeIndex(2): adding it as parent would create a cycle
```

Focused repro:
[`reduce_and_optimize_does_not_use_stale_topology_across_merge_buckets`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L8705)

Broad discovery property:
[`whole_optimizer_conserves_generated_payloads_independent_of_edge_order`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L9092)

Potential effect if the planner emits this shape: query planning panics while optimizing an
otherwise acyclic dependency graph.

### 9. The optimizer can declare a graph complete with mergeable siblings remaining

**Tier: production-object / optimization hardening.** This exercises the complete optimizer with
ordinary fetch nodes. It demonstrates an incomplete optimization rather than a wrong query result,
and no complete planner operation is included for the exact shape.

The repro:

1. Creates two parent/child fetches eligible for the late equal-input merge phase.
2. Gives each parent a child fetch at the same response location.
3. Makes the child inputs different so the late equal-input phase cannot merge them directly.
4. Calls `reduce_and_optimize`.
5. Confirms the parent fetches merged and both children were relocated under the survivor.
6. Uses the production `can_merge_sibling_in` predicate to confirm the relocated children are now
   mergeable.
7. Expects a graph marked optimized to contain only one of them.

Both children remain. The late phase created work for the earlier sibling phase, but the optimizer
sets `is_optimized` without revisiting it.

Focused repro:
[`reduce_and_optimize_consumes_siblings_created_by_the_late_merge_phase`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L8776)

Broad fixed-point property:
[`whole_optimizer_reaches_a_semantic_fixed_point`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L9165)

Potential effect if the planner emits this shape: an avoidable extra fetch survives optimization,
increasing plan size and execution work.

## Generated coverage

The generated layer is intentionally broad. The findings above do not require reviewers to
establish the correctness of every generator, but the surrounding properties provide regression
protection over a substantially larger state space.

### `FetchDependencyGraph`

- Stateful add, remove, retain, reduce, and merge traces.
- Arbitrary acyclic directions and stable-index holes.
- Chain, shortcut, diamond, bow-tie, and defer-crossing shapes.
- Naive DFS reachability and transitive-reduction comparison.
- Root-index and reduced-defer-ledger liveness.
- Sibling and child selection/input payload conservation.
- Source- and target-side defer-ledger remapping.
- Nested child, grandchild, and `merge_at` paths.
- Finite rejection-gate matrices for child, sibling, and grandchild merges.
- Full `reduce_and_optimize` idempotence and equal-input all-dependencies merging.
- Invariance under reversed sibling-edge insertion order.
- Connected generated DAGs with 2–8 payload-bearing fetches through the complete optimizer.
- Unique selection-provenance tokens and exact selection/input/`must_preserve` conservation.
- Independently recomputed required-field availability after arbitrary merges and reductions.
- Semantic fixed-point comparison after reopening the optimization guard.
- Arbitrary `ProcessingState` traversal and merge algebra.
- Flat and structured defer-selection intersection, including aliases, neutral directives, typed
  fragments, wrappers, and `__typename`-only overlap.
- Warmed selection-condition and cost caches.
- Schema-interpreted `FetchDependencyGraphNodePath` traces.

Core state-machine property:
[`fetch_dependency_graph_trace_matches_naive_model`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L6792)

Whole optimization property:
[`whole_optimizer_conserves_generated_payloads_independent_of_edge_order`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L9092)

Focused sibling optimization property:
[`reduce_and_optimize_is_idempotent_and_conserves_sibling_payload`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L9202)

All-dependencies optimization property:
[`reduce_and_optimize_conserves_all_dependencies_of_equal_input_fetches`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_plan/fetch_dependency_graph.rs#L9332)

### `QueryGraph` and graph paths

- Schema-derived completeness for object/interface field edges, `__typename`, and root indexes.
- Reconstruction of node, type, root, context, and non-local-selection indexes.
- Cross-subgraph reachability and transition endpoint/type laws.
- Productive-followup caches and paired true/false progressive-override edges.
- Complete `@fromContext` argument indexing and attachment to the correct field edges.
- Valid transition and operation path state machines.
- Runtime types recomputed independently from raw edges.
- Adjacent-cast and interface-object fake-downcast/key normalization.
- Direct, one-hop, and shortest two-hop field advancement.
- Exact bounded key-search comparison against raw-edge BFS after generated unsatisfied-edge and
  disabled-destination filtering.
- Full operation advancement under both values of progressive-override labels.
- Connectivity and parallel-metadata audits for every returned search path.
- Reachable `@context`/`@fromContext` placement.
- Type-explosion equivalence and typename termination.

Exact bounded search property:
[`bounded_indirect_key_search_matches_exact_bfs_destination_set`](https://github.com/apollographql/router/blob/inanna/graph-proptest-coverage/apollo-federation/src/query_graph/graph_path.rs#L3869)

Its domain is deliberately limited to key closures exhausted within two hops. Within that domain,
the oracle independently removes generated unsatisfied conditional edges and disabled terminal
subgraphs before comparing the exact destination/distance map. Progressive-override selection is
covered separately through full operation-element advancement. It does not claim equivalence for
unbounded or contextual traversal.

### `PathTree`

- Trie construction against a maximal-semantic-branch model.
- Construction-order invariance, associativity, commutativity, and pointer idempotence.
- Local-selection placement against rebuilding from source paths.
- Child condition trees.
- Context-ID and argument-usage union.
- Combined recursive edge payloads.

### Operation paths and `QueryPlan`

- Rebase feasibility versus actual rebase success.
- Modern-Federation rebase identity, idempotence, and distribution over selection merge.
- Complete field-key containment across independently generated aliases, arguments, and
  directives.
- `OpPath` schema filtering and concatenation.
- Recursive QueryPlan JSON round trips.
- Every top-level and nested plan-node family.
- Subscriptions, recursive `requires`, both rewrite families, arbitrary recursive JSON rewrite
  payloads, and defer dependencies.
- Finite and NaN planning statistics.
- Sequence/parallel constructor normalization.

## Failure triage

Not every initially red property was treated as a production finding.

Apparent failures caused by invalid GraphQL names, unreachable fabricated context depths,
schema-incompatible generated paths, an overpermissive condition resolver, or an oracle applied
outside a production cache's intended scope were investigated and corrected in the tests.

Only failures that survived source inspection and could be expressed as a deterministic test are
included above. The tier labels distinguish a normal planner failure from structurally valid
production objects and deliberately broader hardening invariants.

## Validation

The complete test target compiles:

```bash
cargo test -p apollo-federation --lib --no-run
cargo test -p apollo-federation --test main --no-run
```

Formatting and whitespace validation passes:

```bash
git diff --check
```

Green generated properties were exercised at their configured 256, 512, or 1,024 cases. Each
focused finding was run independently with:

```bash
cargo test -p apollo-federation --lib TEST_NAME -- --nocapture
cargo test -p apollo-federation --test main \
  preserves_empty_object_for_intersecting_interface_from_an_interface_object -- --nocapture
```

The complete suite is expected to remain red while the focused findings are intentionally left
unfixed.

## Scope

This PR establishes subsystem-level contracts and focused repros. It includes a normal
query-planner operation where one is demonstrable, but does not claim end-to-end reachability for
every primitive hardening case. It does not include speculative fixes to core planner code.
