### PR TITLE
fix(defer): round-trip `SubSelectionKey` labels containing `|`

### DIFF
--- a/.changesets/fix_defer_label_unique_per_document.md
+++ b/.changesets/fix_defer_label_unique_per_document.md
@@ -4,4 +4,19 @@ The duplicate `@defer(label:)` check from the [GHSA-gr6h-4wpf-xp52](https://gith
 
 Label uniqueness is now validated on the document, before fragment expansion, still rejecting the operations behind the original security advisory. Operations that reuse a labeled `@defer` via fragment spreads plan and execute correctly: one incremental response per spread position, each carrying the user-provided label and distinguished by its `path`.
 
+Example query that was rejected but now is correctly processed
+
+```graphql
+{
+    currentUser { ...UserFragment }
+    otherUser { ...UserFragment }
+}
+fragment UserFragment on User {
+    id
+    ... @defer(label: "UserFragmentLabel") {
+        name
+    }
+}
+```
+
 By [@tninesling](https://github.com/tninesling)

--- a/apollo-router/src/spec/query/subselections.rs
+++ b/apollo-router/src/spec/query/subselections.rs
@@ -32,6 +32,10 @@ impl Serialize for SubSelectionKey {
     where
         S: serde::Serializer,
     {
+        debug_assert!(
+            !self.defer_path.iter().any(|segment| segment.contains('|')),
+            "defer_path segments must not contain the `|` separator"
+        );
         let s = format!(
             "{:?}|{}|{}",
             self.defer_conditions.bits,
@@ -57,7 +61,7 @@ impl Visitor<'_> for SubSelectionKeyVisitor {
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         formatter
-            .write_str("a string containing the defer label and defer conditions separated by |")
+            .write_str("a string containing the defer conditions, label and path separated by |")
     }
 
     fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
@@ -65,7 +69,10 @@ impl Visitor<'_> for SubSelectionKeyVisitor {
         E: serde::de::Error,
     {
         if let Some((bits_str, rest)) = s.split_once('|') {
-            let (label, path) = rest.split_once('|').unwrap_or((rest, ""));
+            // Split from the right: `@defer(label:)` is an arbitrary string and may contain `|`,
+            // while path segments are response keys, which cannot. (The fallback parses the
+            // pre-`defer_path` two-field format, where the whole remainder is the label.)
+            let (label, path) = rest.rsplit_once('|').unwrap_or((rest, ""));
             Ok(SubSelectionKey {
                 defer_conditions: BooleanValues {
                     bits: bits_str
@@ -392,4 +399,44 @@ fn collect_from_selection_set<'a>(
         }
     }
     Ok(primary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BooleanValues;
+    use super::SubSelectionKey;
+
+    #[track_caller]
+    fn assert_round_trips(key: SubSelectionKey) {
+        let serialized = serde_json::to_string(&key).unwrap();
+        let deserialized: SubSelectionKey = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, key, "did not round trip through {serialized}");
+    }
+
+    /// `SubSelectionKey` is serialized as a JSON object key when a `Query` goes through the
+    /// distributed query plan cache, so it must round trip: a key that comes back different is a
+    /// lookup miss, and a missed deferred subselection silently yields an empty incremental
+    /// payload. `@defer(label:)` is an arbitrary string and may contain any number of the `|`
+    /// field separator; path segments are response keys, which cannot.
+    #[test]
+    fn sub_selection_key_round_trips() {
+        let cases = [
+            (None, &[][..]),
+            (Some("_UserFrag"), &["currentUser"][..]),
+            (Some("0"), &["currentUser", "activeOrganization"][..]),
+            (Some("_a|b"), &[][..]),
+            (Some("_a|b"), &["a", "b"][..]),
+            (Some("_a|b|c"), &["a", "b"][..]),
+            (Some("_a|"), &["a"][..]),
+        ];
+        for (defer_label, defer_path) in cases {
+            for bits in [0, 5] {
+                assert_round_trips(SubSelectionKey {
+                    defer_label: defer_label.map(str::to_owned),
+                    defer_conditions: BooleanValues { bits },
+                    defer_path: defer_path.iter().map(|s| (*s).to_owned()).collect(),
+                });
+            }
+        }
+    }
 }


### PR DESCRIPTION
`SubSelectionKey` gained a `defer_path` field, serialized as a third `|`-separated component of the JSON object key that a `Query` carries through the distributed query plan cache. `SubSelectionKeyVisitor` parsed that component with a second left-to-right `split_once('|')`, but the label is the unbounded field: `@defer(label:)` is an arbitrary string and may itself contain `|`. A key for label `a|b` with an empty path serialized to `0|a|b|` and came back as label `a`, path `["b|"]`.

A key that does not round trip is a lookup miss on the next cache hit, and a missed deferred subselection is silent: `Query::format_response` sets `data` to an empty object and `Query::contains_error_path` falls back to the whole operation, so the incremental payload is dropped and its errors stop being filtered.

Parse the path with `rsplit_once('|')` instead. `serialize` always emits exactly one separator after the label, and path segments are response keys, which cannot contain `|`, so the last separator is unambiguously the label/path boundary no matter how many appear inside the label. A `debug_assert!` in `serialize` pins the assumption that makes this hold, and the new round-trip test covers labels with one, several, and trailing separators.

Cross-version cache entries are unaffected either way: the plan cache key includes `ROUTER_VERSION`, so the pre-`defer_path` two-field format is never read back. `rsplit_once` still parses it correctly.

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
