### PR TITLE
JWT auth: make `RedactedError` the default for `on_error` (ROUTER-2053)

### DIFF
--- a/.changesets/breaking_zach_router_2053_jwt_redacted_error_default.md
+++ b/.changesets/breaking_zach_router_2053_jwt_redacted_error_default.md
@@ -13,4 +13,4 @@ authentication:
       on_error: Error
 ```
 
-By [@zachfetters](https://github.com/zachfetters) in https://github.com/apollographql/router/pull/TODO
+By [@zachfetters](https://github.com/zachfetters) in https://github.com/apollographql/router/pull/10191

--- a/.changesets/breaking_zach_router_2053_jwt_redacted_error_default.md
+++ b/.changesets/breaking_zach_router_2053_jwt_redacted_error_default.md
@@ -1,0 +1,16 @@
+### JWT authentication now redacts validation errors by default ([Issue #2053](https://apollographql.atlassian.net/browse/ROUTER-2053))
+
+`authentication.router.jwt.on_error` now defaults to `RedactedError` instead of `Error`. With the previous default, a caller sending a malformed or tampered token received the full validation detail verbatim—for example the byte offset where base64 decoding failed, the complete list of signing algorithms the router accepts, or the issuers and audiences configured on the JWKS. None of that is actionable for a legitimate client, and it gives an attacker a probing oracle for your authentication setup.
+
+With the new default, failed JWT authentication is rejected with the same HTTP status codes as before, but the response body carries a generic `Authentication failed` message instead. The full detail is unaffected: it remains available in the `apollo::authentication::jwt_status` request context value (readable from telemetry selectors, Rhai, and coprocessors) and in the `authentication.jwt.failure_code` attribute on the `apollo.router.operations.authentication.jwt` metric.
+
+To keep the previous behavior, set `on_error` explicitly:
+
+```yaml title="router.yaml"
+authentication:
+  router:
+    jwt:
+      on_error: Error
+```
+
+By [@zachfetters](https://github.com/zachfetters) in https://github.com/apollographql/router/pull/TODO

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/src/configuration/tests.rs
+assertion_line: 28
 expression: "&schema"
 ---
 {
@@ -6899,7 +6900,7 @@ expression: "&schema"
               "$ref": "#/definitions/OnError"
             }
           ],
-          "description": "Control the behavior when an error occurs during the authentication process.\n\nDefaults to `Error`.\n\n* When set to `Continue`, requests that fail JWT authentication will continue to be\n  processed by the router, but without the JWT claims in the context.\n* When set to `Error`, requests that fail JWT authentication will be rejected with a\n  HTTP 403 error.\n* When set to `RedactedError`, requests that fail JWT authentication are rejected in the\n  same way as `Error`, but the response contains a generic error message instead of the\n  details of the validation failure. The details remain available in the\n  `apollo::authentication::jwt_status` context value and in the\n  `apollo.router.operations.authentication.jwt` metric."
+          "description": "Control the behavior when an error occurs during the authentication process.\n\nDefaults to `RedactedError`.\n\n* When set to `RedactedError`, requests that fail JWT authentication are rejected with a\n  generic error message instead of the details of the validation failure. The details\n  remain available in the `apollo::authentication::jwt_status` context value and in the\n  `apollo.router.operations.authentication.jwt` metric.\n* When set to `Error`, requests that fail JWT authentication will be rejected with a\n  HTTP 403 error, and the response contains the details of the validation failure.\n* When set to `Continue`, requests that fail JWT authentication will continue to be\n  processed by the router, but without the JWT claims in the context."
         },
         "sources": {
           "description": "Alternative sources to extract the JWT",

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -85,11 +85,8 @@ struct AuthenticationPlugin {
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Default)]
 enum OnError {
     Continue,
-    // TODO: make `RedactedError` the default in the next major version. Returning the full
-    // validation error to an unauthenticated caller discloses details of the authentication setup
-    // that no client can act on, so the redacting behavior is the safer default.
-    #[default]
     Error,
+    #[default]
     RedactedError,
 }
 
@@ -112,17 +109,16 @@ struct JWTConf {
     sources: Vec<Source>,
     /// Control the behavior when an error occurs during the authentication process.
     ///
-    /// Defaults to `Error`.
+    /// Defaults to `RedactedError`.
     ///
+    /// * When set to `RedactedError`, requests that fail JWT authentication are rejected with a
+    ///   generic error message instead of the details of the validation failure. The details
+    ///   remain available in the `apollo::authentication::jwt_status` context value and in the
+    ///   `apollo.router.operations.authentication.jwt` metric.
+    /// * When set to `Error`, requests that fail JWT authentication will be rejected with a
+    ///   HTTP 403 error, and the response contains the details of the validation failure.
     /// * When set to `Continue`, requests that fail JWT authentication will continue to be
     ///   processed by the router, but without the JWT claims in the context.
-    /// * When set to `Error`, requests that fail JWT authentication will be rejected with a
-    ///   HTTP 403 error.
-    /// * When set to `RedactedError`, requests that fail JWT authentication are rejected in the
-    ///   same way as `Error`, but the response contains a generic error message instead of the
-    ///   details of the validation failure. The details remain available in the
-    ///   `apollo::authentication::jwt_status` context value and in the
-    ///   `apollo.router.operations.authentication.jwt` metric.
     #[serde(default)]
     on_error: OnError,
 }

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -268,7 +268,8 @@ async fn it_rejects_when_there_is_no_auth_header() {
 async fn it_rejects_when_auth_prefix_is_missing() {
     // Explicit `Error`: this test asserts the detailed message, which is only returned in
     // that mode now that `RedactedError` is the default.
-    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
+    let (test_harness, handle) =
+        build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
         .header(http::header::AUTHORIZATION, "invalid")
@@ -299,7 +300,8 @@ async fn it_rejects_when_auth_prefix_is_missing() {
 async fn it_rejects_when_auth_prefix_has_no_jwt_token() {
     // Explicit `Error`: this test asserts the detailed message, which is only returned in
     // that mode now that `RedactedError` is the default.
-    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
+    let (test_harness, handle) =
+        build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
         .header(http::header::AUTHORIZATION, "Bearer")
@@ -330,7 +332,8 @@ async fn it_rejects_when_auth_prefix_has_no_jwt_token() {
 async fn it_rejects_when_auth_prefix_has_invalid_format_jwt() {
     // Explicit `Error`: this test asserts the detailed message, which is only returned in
     // that mode now that `RedactedError` is the default.
-    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
+    let (test_harness, handle) =
+        build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
         .header(http::header::AUTHORIZATION, "Bearer header.payload")
@@ -360,7 +363,8 @@ async fn it_rejects_when_auth_prefix_has_invalid_format_jwt() {
 async fn it_rejects_when_auth_prefix_has_correct_format_but_invalid_jwt() {
     // Explicit `Error`: this test asserts the detailed message, which is only returned in
     // that mode now that `RedactedError` is the default.
-    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
+    let (test_harness, handle) =
+        build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
         .header(
@@ -391,7 +395,8 @@ async fn it_rejects_when_auth_prefix_has_correct_format_but_invalid_jwt() {
 async fn it_rejects_when_auth_prefix_has_correct_format_and_invalid_jwt() {
     // Explicit `Error`: this test asserts the detailed message, which is only returned in
     // that mode now that `RedactedError` is the default.
-    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
+    let (test_harness, handle) =
+        build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
             .header(
@@ -612,7 +617,8 @@ async fn it_inserts_success_jwt_status_into_context() {
 async fn it_inserts_failure_jwt_status_into_context() {
     // Explicit `Error`: this test asserts the detailed message on the response, which is
     // only returned in that mode now that `RedactedError` is the default.
-    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
+    let (test_harness, handle) =
+        build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
         .header(
@@ -1053,10 +1059,12 @@ async fn issuer_check() {
         .build()
         .unwrap();
 
-    let mut config = JWTConf::default();
     // Explicit `Error`: this test asserts the detailed issuer-mismatch message, which is
     // only returned in that mode now that `RedactedError` is the default.
-    config.on_error = OnError::Error;
+    let mut config = JWTConf {
+        on_error: OnError::Error,
+        ..JWTConf::default()
+    };
     config.sources.push(Source::Header {
         name: super::default_header_name(),
         value_prefix: super::default_header_value_prefix(),
@@ -1241,10 +1249,12 @@ async fn audience_check() {
         .build()
         .unwrap();
 
-    let mut config = JWTConf::default();
     // Explicit `Error`: this test asserts the detailed audience-mismatch message, which is
     // only returned in that mode now that `RedactedError` is the default.
-    config.on_error = OnError::Error;
+    let mut config = JWTConf {
+        on_error: OnError::Error,
+        ..JWTConf::default()
+    };
     config.sources.push(Source::Header {
         name: super::default_header_name(),
         value_prefix: super::default_header_value_prefix(),

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -48,6 +48,7 @@ use super::Header;
 use super::JWT_CONTEXT_KEY;
 use super::JWTConf;
 use super::JwtStatus;
+use super::OnError;
 use super::Source;
 use super::authenticate;
 use super::has_authenticated_jwt;
@@ -265,7 +266,9 @@ async fn it_rejects_when_there_is_no_auth_header() {
 
 #[tokio::test]
 async fn it_rejects_when_auth_prefix_is_missing() {
-    let (test_harness, handle) = build_a_default_test_harness().await;
+    // Explicit `Error`: this test asserts the detailed message, which is only returned in
+    // that mode now that `RedactedError` is the default.
+    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
         .header(http::header::AUTHORIZATION, "invalid")
@@ -294,7 +297,9 @@ async fn it_rejects_when_auth_prefix_is_missing() {
 
 #[tokio::test]
 async fn it_rejects_when_auth_prefix_has_no_jwt_token() {
-    let (test_harness, handle) = build_a_default_test_harness().await;
+    // Explicit `Error`: this test asserts the detailed message, which is only returned in
+    // that mode now that `RedactedError` is the default.
+    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
         .header(http::header::AUTHORIZATION, "Bearer")
@@ -323,7 +328,9 @@ async fn it_rejects_when_auth_prefix_has_no_jwt_token() {
 
 #[tokio::test]
 async fn it_rejects_when_auth_prefix_has_invalid_format_jwt() {
-    let (test_harness, handle) = build_a_default_test_harness().await;
+    // Explicit `Error`: this test asserts the detailed message, which is only returned in
+    // that mode now that `RedactedError` is the default.
+    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
         .header(http::header::AUTHORIZATION, "Bearer header.payload")
@@ -351,7 +358,9 @@ async fn it_rejects_when_auth_prefix_has_invalid_format_jwt() {
 
 #[tokio::test]
 async fn it_rejects_when_auth_prefix_has_correct_format_but_invalid_jwt() {
-    let (test_harness, handle) = build_a_default_test_harness().await;
+    // Explicit `Error`: this test asserts the detailed message, which is only returned in
+    // that mode now that `RedactedError` is the default.
+    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
         .header(
@@ -380,7 +389,9 @@ async fn it_rejects_when_auth_prefix_has_correct_format_but_invalid_jwt() {
 
 #[tokio::test]
 async fn it_rejects_when_auth_prefix_has_correct_format_and_invalid_jwt() {
-    let (test_harness, handle) = build_a_default_test_harness().await;
+    // Explicit `Error`: this test asserts the detailed message, which is only returned in
+    // that mode now that `RedactedError` is the default.
+    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
             .header(
@@ -599,7 +610,9 @@ async fn it_inserts_success_jwt_status_into_context() {
 
 #[tokio::test]
 async fn it_inserts_failure_jwt_status_into_context() {
-    let (test_harness, handle) = build_a_test_harness(None, None, false, false, None).await;
+    // Explicit `Error`: this test asserts the detailed message on the response, which is
+    // only returned in that mode now that `RedactedError` is the default.
+    let (test_harness, handle) = build_a_test_harness(None, None, false, false, Some("Error")).await;
 
     let request_with_appropriate_name = supergraph::Request::canned_builder()
         .header(
@@ -1041,6 +1054,9 @@ async fn issuer_check() {
         .unwrap();
 
     let mut config = JWTConf::default();
+    // Explicit `Error`: this test asserts the detailed issuer-mismatch message, which is
+    // only returned in that mode now that `RedactedError` is the default.
+    config.on_error = OnError::Error;
     config.sources.push(Source::Header {
         name: super::default_header_name(),
         value_prefix: super::default_header_value_prefix(),
@@ -1226,6 +1242,9 @@ async fn audience_check() {
         .unwrap();
 
     let mut config = JWTConf::default();
+    // Explicit `Error`: this test asserts the detailed audience-mismatch message, which is
+    // only returned in that mode now that `RedactedError` is the default.
+    config.on_error = OnError::Error;
     config.sources.push(Source::Header {
         name: super::default_header_name(),
         value_prefix: super::default_header_value_prefix(),
@@ -2741,9 +2760,10 @@ mod redacted_errors {
     }
 
     #[tokio::test]
-    async fn it_does_not_redact_by_default() {
-        // Redaction is opt-in: omitting `on_error` must keep today's detailed messages.
-        let (service_response, response) = send_with_authorization(None, UNDECODABLE_JWT).await;
+    async fn it_does_not_redact_when_on_error_is_error() {
+        // Explicitly setting `on_error: Error` must keep the detailed messages.
+        let (service_response, response) =
+            send_with_authorization(Some("Error"), UNDECODABLE_JWT).await;
 
         let expected_error = graphql::Error::builder()
             .message("Cannot decode JWT: Base64 error: Invalid last symbol 66, offset 42.")
@@ -2751,6 +2771,15 @@ mod redacted_errors {
             .build();
 
         crate::assert_errors_eq_ignoring_id!(response.errors, [expected_error]);
+        assert_eq!(StatusCode::UNAUTHORIZED, service_response.response.status());
+    }
+
+    #[tokio::test]
+    async fn it_redacts_by_default() {
+        // Redaction is the default: omitting `on_error` must redact the message.
+        let (service_response, response) = send_with_authorization(None, UNDECODABLE_JWT).await;
+
+        assert_redacted(&response, &["Base64", "offset", "Cannot decode JWT"]);
         assert_eq!(StatusCode::UNAUTHORIZED, service_response.response.status());
     }
 

--- a/docs/source/routing/security/jwt.mdx
+++ b/docs/source/routing/security/jwt.mdx
@@ -64,7 +64,7 @@ Otherwise, if you issue JWTs via a popular third-party IdP (Auth0, Okta, PingOne
          # These keys are optional. Default values are shown.
          header_name: Authorization
          header_value_prefix: Bearer
-         on_error: Error
+         on_error: RedactedError
          # array of alternative token sources
          sources:
            - type: header
@@ -166,10 +166,10 @@ The default value is `Bearer`.
 </td>
 <td>
 
-This setting controls the behavior of the router when an error occurs during JWT validation. Possible values are `Error` (default), `RedactedError`, and `Continue`.
+This setting controls the behavior of the router when an error occurs during JWT validation. Possible values are `RedactedError` (default), `Error`, and `Continue`.
 
+- `RedactedError`: The router rejects the request, and every validation failure returns the same generic `Authentication failed` message with the `AUTH_ERROR` extension code. This is the safer default for routers reachable from the public internet, since the detailed messages returned by `Error` would disclose which signing algorithms the router accepts and which issuers and audiences it's configured with. The details of the failure remain available to you in the request context and in telemetry, as described below.
 - `Error`: The router responds with an error when an error occurs during JWT validation. The error message describes the validation failure—for example, that the token's signature couldn't be decoded, or that its `aud` claim doesn't match the audiences you configured.
-- `RedactedError`: The router rejects the request the same way as `Error`, but every validation failure returns the same generic `Authentication failed` message with the `AUTH_ERROR` extension code. Use this value on routers reachable from the public internet, where the detailed messages would disclose which signing algorithms the router accepts and which issuers and audiences it's configured with. The details of the failure remain available to you in the request context and in telemetry, as described below.
 - `Continue`: The router continues processing the request when an error occurs during JWT validation. Requests with invalid JWTs will be treated as unauthenticated.
 
 Regardless of whether JWT authentication succeeds, the status of JWT processing is inserted into the request context (`apollo::authentication::jwt_status`). This status is informational and may be used for logging or debugging purposes. The context value always carries the full details of the failure, including when `on_error` is `RedactedError`, so you can log the reason a request was rejected without returning it to the client.


### PR DESCRIPTION
The previous default returned full JWT validation detail to unauthenticated callers (base64 error offsets, the list of accepted signing algorithms, configured issuers/audiences), which is not actionable for a client and gives an attacker a probing oracle for the authentication setup. `RedactedError` keeps the same status codes but redacts the message to a generic `Authentication failed`; the full detail remains in the `apollo::authentication::jwt_status` context value and the `apollo.router.operations.authentication.jwt` metric.

Updates the tests that relied on the implicit default to opt into `on_error: Error` explicitly, and regenerates the config schema snapshot.


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
