### PR TITLE
fix(axum): report 499 for client-disconnected requests instead of 500

### DIFF
--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -527,7 +527,18 @@ async fn handle_graphql<RF: RouterFactory>(
     };
 
     match res {
-        Err(err) => internal_server_error(err),
+        Err(err) => {
+            // If the client went away while the router was still reading the
+            // request body or producing the response, the pipeline surfaces a
+            // connection-closed error here. That is a client cancellation, not a
+            // server fault, so report 499 (matching the CanceledRequest handling
+            // on the Ok path in RouterService) instead of an unconditional 500
+            // that inflates error-rate / SLO metrics.
+            if is_client_disconnected(err.as_ref()) {
+                return client_closed_request();
+            }
+            internal_server_error(err)
+        }
         Ok(response) => {
             let (mut parts, body) = response.response.into_parts();
 
@@ -570,6 +581,54 @@ where
     let response = graphql::Response::builder().error(error).build();
 
     (StatusCode::INTERNAL_SERVER_ERROR, Json(json!(response))).into_response()
+}
+
+/// Best-effort detection of a pipeline error caused by the client closing the
+/// connection (most commonly a request-body read that failed mid-stream). Walks
+/// the error source chain looking for a hyper incomplete-message/canceled error
+/// or an IO error indicating the peer went away.
+///
+/// NOTE (draft): the exact error taxonomy here needs maintainer input — the
+/// connection-closed error may be wrapped by tower/axum layers before it reaches
+/// this point, in which case a marker set at the failing `into_bytes` site would
+/// be more robust than downcasting.
+fn is_client_disconnected(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut source = Some(err);
+    while let Some(e) = source {
+        if let Some(hyper_err) = e.downcast_ref::<hyper::Error>() {
+            if hyper_err.is_incomplete_message() || hyper_err.is_canceled() {
+                return true;
+            }
+        }
+        if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+            use std::io::ErrorKind::{BrokenPipe, ConnectionAborted, ConnectionReset, UnexpectedEof};
+            if matches!(
+                io_err.kind(),
+                BrokenPipe | ConnectionReset | ConnectionAborted | UnexpectedEof
+            ) {
+                return true;
+            }
+        }
+        source = e.source();
+    }
+    false
+}
+
+/// 499 Client Closed Request: the client disconnected before the router could
+/// finish handling the request. Mirrors the 499 the Ok path already returns for
+/// a CanceledRequest.
+fn client_closed_request() -> Response {
+    let error = graphql::Error::builder()
+        .message("client closed request")
+        .extension_code("CLIENT_CLOSED_REQUEST")
+        .build();
+    let response = graphql::Response::builder().error(error).build();
+
+    (
+        StatusCode::from_u16(499).expect("499 is not a standard status code but common enough"),
+        Json(json!(response)),
+    )
+        .into_response()
 }
 
 struct CancelHandler<'a> {


### PR DESCRIPTION
> **Draft — untested, seeking maintainer direction.** I have not compiled this against the full build; the error-detection approach in particular needs your input (see caveat at the bottom). Opening as a draft PR because direct issue creation is restricted on this repo — the bug report is inline below.

## The bug

When a client closes the connection while the router is still reading the request body, the resulting connection error is reported as an unconditional **HTTP 500**. These are client cancellations, not server faults, so they inflate `apollo.router.operations{http.response.status_code:500}` and any error-rate / SLO monitors built on it. The router already has a 499 ("client closed the connection") classification on the success path, but the error path never uses it.

Observed on **v2.12.0** (relevant paths appear unchanged on `dev`).

## Mechanism / evidence

With `supergraph.early_cancel: false` (the default), the pipeline runs in a detached task and continues after the client disconnects. In the coprocessor router-request stage the client body is read at [`plugins/coprocessor/mod.rs#L902`](https://github.com/apollographql/router/blob/v2.12.0/apollo-router/src/plugins/coprocessor/mod.rs#L902):

```rust
let bytes = router::body::into_bytes(body).await?;   // fails: "error reading a body from connection"
...
*executed = true;                                    // never reached on failure
```

This is the **only** awaited fallible op before `*executed = true`, so the failure logs `coprocessor: router request stage error: error reading a body from connection` but does **not** increment `apollo.router.operations.coprocessor{succeeded:false}` (recorded only `if executed`). In production the log line occurs orders of magnitude more often than that coprocessor-failure metric — confirming the failing operation is the **client** body read, not the coprocessor call.

The error propagates to [`axum_factory/axum_http_server_factory.rs#L529`](https://github.com/apollographql/router/blob/v2.12.0/apollo-router/src/axum_factory/axum_http_server_factory.rs#L529) → `internal_server_error()` → 500. That `Err` arm never checks `CanceledRequest`, unlike the `Ok` arm ([`services/router/service.rs#L301`](https://github.com/apollographql/router/blob/v2.12.0/apollo-router/src/services/router/service.rs#L301)) which already downgrades to 499.

The coprocessor is just where it is most visible (enabling it buffers the body early); the underlying issue is general to the request-body read.

## Expected

A request that fails solely because the client closed the connection should be **499**, consistent with the existing `CanceledRequest` handling — not 500.

## This change

In the `Err` arm of `handle_graphql`, detect a connection-closed error and return `499 Client Closed Request` instead of an unconditional 500, mirroring the Ok-path behavior. Adds `is_client_disconnected()` (walks the error source chain for a hyper incomplete-message/canceled error or an IO `BrokenPipe`/`ConnectionReset`/`ConnectionAborted`/`UnexpectedEof`) and `client_closed_request()`.

## Caveat for reviewers

The connection-closed error may be wrapped by tower/axum layers before it reaches this arm, so the downcast heuristic may not fire reliably. An alternative that may be more robust: set a marker (like `CanceledRequest`) at the failing `into_bytes` site so the existing 499 machinery picks it up. Happy to rework in whichever direction you prefer. `early_cancel: true` avoids the symptom but drops telemetry for canceled requests, so it isn't a general fix.
