### PR TITLE
Don't require APOLLO_KEY for non-Apollo OCI graph artifact reference

### DIFF
--- a/.changesets/fix_zach_router_1983_oci_apollo_key_optional.md
+++ b/.changesets/fix_zach_router_1983_oci_apollo_key_optional.md
@@ -5,4 +5,4 @@ required `APOLLO_KEY` to be set, even when the graph artifact reference pointed 
 registry that doesn't need Apollo authentication at all. `APOLLO_KEY` is now only required when the
 reference resolves to an Apollo-hosted registry (`*.apollographql.com`).
 
-By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/TODO
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/10204

--- a/.changesets/fix_zach_router_1983_oci_apollo_key_optional.md
+++ b/.changesets/fix_zach_router_1983_oci_apollo_key_optional.md
@@ -1,0 +1,8 @@
+### Don't require `APOLLO_KEY` when `--graph-artifact-reference` points at a non-Apollo OCI registry ([Issue #1983](https://apollographql.atlassian.net/browse/ROUTER-1983))
+
+Starting the router with `--graph-artifact-reference` / `APOLLO_GRAPH_ARTIFACT_REFERENCE` previously
+required `APOLLO_KEY` to be set, even when the graph artifact reference pointed at a non-Apollo OCI
+registry that doesn't need Apollo authentication at all. `APOLLO_KEY` is now only required when the
+reference resolves to an Apollo-hosted registry (`*.apollographql.com`).
+
+By [@BobaFetters](https://github.com/BobaFetters) in https://github.com/apollographql/router/pull/TODO

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -1119,7 +1119,9 @@ mod tests {
             )
             .await;
 
-            let error_msg = result.expect_err("invalid OCI reference should fail").to_string();
+            let error_msg = result
+                .expect_err("invalid OCI reference should fail")
+                .to_string();
             assert!(
                 error_msg.contains("graph artifact reference"),
                 "expected an OCI reference validation error, got: {error_msg}"

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -33,6 +33,7 @@ use crate::plugin::plugins;
 use crate::plugins::telemetry::reload::otel::init_telemetry;
 use crate::plugins::telemetry::reload::otel::shutdown_installed_tracer_provider;
 use crate::registry::OciConfig;
+use crate::registry::is_apollo_graph_artifact_reference;
 use crate::registry::should_use_ssl;
 use crate::registry::validate_oci_reference;
 use crate::router::ConfigurationSource;
@@ -265,11 +266,20 @@ impl Opt {
 
         let use_ssl = should_use_ssl(&validated_reference);
 
+        // `APOLLO_KEY` is only required to authenticate with Apollo's own registry.
+        // A non-Apollo OCI registry should not require a GraphOS account.
+        let apollo_key = if is_apollo_graph_artifact_reference(&validated_reference) {
+            Some(
+                self.apollo_key
+                    .clone()
+                    .ok_or(Self::err_require_opt("APOLLO_KEY"))?,
+            )
+        } else {
+            self.apollo_key.clone()
+        };
+
         Ok(OciConfig {
-            apollo_key: self
-                .apollo_key
-                .clone()
-                .ok_or(Self::err_require_opt("APOLLO_KEY"))?,
+            apollo_key,
             reference: validated_reference,
             hot_reload: self.hot_reload,
             poll_interval,
@@ -528,7 +538,8 @@ impl Executable {
         // 1. CLI --supergraph
         // 2. Env APOLLO_ROUTER_SUPERGRAPH_PATH
         // 3. Env APOLLO_ROUTER_SUPERGRAPH_URLS
-        // 4. Env APOLLO_KEY and APOLLO_GRAPH_ARTIFACT_REFERENCE (CLI/env only)
+        // 4. Env APOLLO_GRAPH_ARTIFACT_REFERENCE (CLI/env only). APOLLO_KEY is only
+        //    required here when the reference points at an Apollo-hosted registry.
         // 5. Env APOLLO_KEY and APOLLO_GRAPH_REF (CLI/env only)
         #[cfg(unix)]
         let akp = &opt.apollo_key_path;
@@ -653,6 +664,15 @@ impl Executable {
                     None => SchemaSource::Registry(opt.uplink_config()?),
                     Some(_) => SchemaSource::OCI(opt.oci_config()?),
                 }
+            }
+            // No APOLLO_KEY anywhere, but a graph artifact reference was given: this
+            // is valid when the reference points at a non-Apollo OCI registry.
+            // `oci_config()` still enforces APOLLO_KEY if the reference turns out to
+            // be Apollo-hosted.
+            (_, None, None, None, None) if opt.graph_artifact_reference.is_some() => {
+                tracing::info!("{apollo_router_msg}");
+                tracing::info!("{apollo_telemetry_msg}");
+                SchemaSource::OCI(opt.oci_config()?)
             }
             _ => {
                 return Err(anyhow!(
@@ -1058,6 +1078,120 @@ mod tests {
                     || error_msg.contains("--graph-artifact-reference"),
                 "Error should mention the conflicting options"
             );
+        }
+
+        #[tokio::test]
+        async fn test_graph_artifact_reference_without_apollo_key_routes_to_oci_config() {
+            // ROUTER-1983: a --graph-artifact-reference with no APOLLO_KEY/APOLLO_KEY_PATH
+            // anywhere must still be routed to `oci_config()` (which itself decides
+            // whether a key is actually required) rather than falling into the
+            // generic "no schema source configured" error. Use a reference that is
+            // guaranteed to fail *offline* validation so this test makes no network
+            // calls, while still proving which code path was reached.
+            let opt = Opt {
+                log_level: "error".to_string(),
+                hot_reload: false,
+                config_path: None,
+                dev: false,
+                supergraph_path: None,
+                supergraph_urls: None,
+                command: None,
+                apollo_key: None,
+                #[cfg(unix)]
+                apollo_key_path: None,
+                apollo_graph_ref: None,
+                apollo_router_license: None,
+                apollo_router_license_path: None,
+                apollo_uplink_endpoints: None,
+                graph_artifact_reference: Some(":bad".to_string()),
+                anonymous_telemetry_disabled: true,
+                apollo_uplink_timeout: Duration::from_secs(30),
+                listen_address: None,
+                version: false,
+            };
+
+            let result = Executable::inner_start(
+                None,
+                None,
+                None,
+                Some(crate::router::LicenseSource::default()),
+                opt,
+            )
+            .await;
+
+            let error_msg = result.expect_err("invalid OCI reference should fail").to_string();
+            assert!(
+                error_msg.contains("graph artifact reference"),
+                "expected an OCI reference validation error, got: {error_msg}"
+            );
+            assert!(
+                !error_msg.contains("requires a composed supergraph schema"),
+                "should not fall back to the generic no-schema-source error, got: {error_msg}"
+            );
+        }
+    }
+
+    mod oci_config_tests {
+        use tokio::time::Duration;
+
+        use super::super::Opt;
+
+        fn base_opt(graph_artifact_reference: String, apollo_key: Option<String>) -> Opt {
+            Opt {
+                log_level: "error".to_string(),
+                hot_reload: false,
+                config_path: None,
+                dev: false,
+                supergraph_path: None,
+                supergraph_urls: None,
+                command: None,
+                apollo_key,
+                #[cfg(unix)]
+                apollo_key_path: None,
+                apollo_graph_ref: None,
+                apollo_router_license: None,
+                apollo_router_license_path: None,
+                apollo_uplink_endpoints: None,
+                graph_artifact_reference: Some(graph_artifact_reference),
+                anonymous_telemetry_disabled: true,
+                apollo_uplink_timeout: Duration::from_secs(30),
+                listen_address: None,
+                version: false,
+            }
+        }
+
+        #[test]
+        fn does_not_require_apollo_key_for_non_apollo_registry() {
+            let opt = base_opt("ghcr.io/my-org/my-graph:latest".to_string(), None);
+
+            let oci_config = opt
+                .oci_config()
+                .expect("non-Apollo registry should not require APOLLO_KEY");
+            assert_eq!(oci_config.apollo_key, None);
+        }
+
+        #[test]
+        fn passes_through_apollo_key_when_present_for_non_apollo_registry() {
+            let opt = base_opt(
+                "ghcr.io/my-org/my-graph:latest".to_string(),
+                Some("test-key".to_string()),
+            );
+
+            let oci_config = opt.oci_config().expect("should succeed");
+            assert_eq!(oci_config.apollo_key, Some("test-key".to_string()));
+        }
+
+        #[test]
+        fn requires_apollo_key_for_apollo_registry() {
+            let opt = base_opt(
+                "registry.apollographql.com/my-graph@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef".to_string(),
+                None,
+            );
+
+            let err = opt
+                .oci_config()
+                .expect_err("Apollo registry should require APOLLO_KEY");
+            assert!(err.to_string().contains("APOLLO_KEY"));
         }
     }
 

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -185,7 +185,9 @@ fn build_auth(reference: &Reference, apollo_key: Option<&str>) -> RegistryAuth {
         .unwrap_or_else(|| reference.resolve_registry());
 
     // Check if the server registry ends with apollographql.com
-    if is_apollo_registry(server) && let Some(apollo_key) = apollo_key {
+    if is_apollo_registry(server)
+        && let Some(apollo_key) = apollo_key
+    {
         tracing::debug!("using registry authentication");
         return RegistryAuth::Basic(APOLLO_REGISTRY_USERNAME.to_string(), apollo_key.to_string());
     }

--- a/apollo-router/src/registry/mod.rs
+++ b/apollo-router/src/registry/mod.rs
@@ -92,8 +92,9 @@ pub(crate) fn validate_oci_reference(
 /// This struct does not change on router reloads - they are all sourced from CLI options.
 #[derive(Debug, Clone)]
 pub struct OciConfig {
-    /// The Apollo key: `<YOUR_GRAPH_API_KEY>`
-    pub apollo_key: String,
+    /// The Apollo key: `<YOUR_GRAPH_API_KEY>`.
+    /// Only required (and present) when `reference` points at an Apollo-hosted registry.
+    pub apollo_key: Option<String>,
 
     /// OCI Compliant URL pointing to the release bundle
     pub reference: String,
@@ -161,14 +162,30 @@ impl From<LicenseError> for OciError {
     }
 }
 
-fn build_auth(reference: &Reference, apollo_key: &str) -> RegistryAuth {
+/// Determine whether a resolved registry hostname belongs to Apollo's own registry.
+fn is_apollo_registry(server: &str) -> bool {
+    server
+        .strip_suffix('/')
+        .unwrap_or(server)
+        .ends_with(APOLLO_REGISTRY_ENDING)
+}
+
+/// Determine whether an (unparsed) OCI graph artifact reference points at an
+/// Apollo-hosted registry. Used to decide whether `APOLLO_KEY` is required.
+pub(crate) fn is_apollo_graph_artifact_reference(reference: &str) -> bool {
+    reference
+        .parse::<Reference>()
+        .is_ok_and(|r| is_apollo_registry(r.resolve_registry()))
+}
+
+fn build_auth(reference: &Reference, apollo_key: Option<&str>) -> RegistryAuth {
     let server = reference
         .resolve_registry()
         .strip_suffix('/')
         .unwrap_or_else(|| reference.resolve_registry());
 
     // Check if the server registry ends with apollographql.com
-    if server.ends_with(APOLLO_REGISTRY_ENDING) {
+    if is_apollo_registry(server) && let Some(apollo_key) = apollo_key {
         tracing::debug!("using registry authentication");
         return RegistryAuth::Basic(APOLLO_REGISTRY_USERNAME.to_string(), apollo_key.to_string());
     }
@@ -385,7 +402,7 @@ impl OciConfig {
 /// Fetch the manifest digest (without fetching the full manifest) to detect changes
 pub(crate) async fn fetch_oci_manifest_digest(oci_config: &OciConfig) -> Result<String, OciError> {
     let reference: Reference = oci_config.reference.as_str().parse()?;
-    let auth = build_auth(&reference, &oci_config.apollo_key);
+    let auth = build_auth(&reference, oci_config.apollo_key.as_deref());
     let protocol = oci_config.client_protocol();
 
     let client = Client::new(ClientConfig {
@@ -430,7 +447,7 @@ pub(crate) async fn fetch_oci_manifest_digest(oci_config: &OciConfig) -> Result<
 /// inferring the correct protocol, and calling the internal fetch function.
 pub(crate) async fn fetch_oci(oci_config: &OciConfig) -> Result<OciContent, OciError> {
     let reference: Reference = oci_config.reference.as_str().parse()?;
-    let auth = build_auth(&reference, &oci_config.apollo_key);
+    let auth = build_auth(&reference, oci_config.apollo_key.as_deref());
     let protocol = oci_config.client_protocol();
 
     tracing::debug!(
@@ -673,7 +690,7 @@ fn stream_license_from_oci(oci_config: OciConfig) -> impl Stream<Item = Result<L
 #[allow(dead_code)]
 async fn fetch_license_oci(oci_config: &OciConfig) -> Result<License, OciError> {
     let reference: Reference = oci_config.reference.as_str().parse()?;
-    let auth = build_auth(&reference, &oci_config.apollo_key);
+    let auth = build_auth(&reference, oci_config.apollo_key.as_deref());
     let protocol = oci_config.client_protocol();
 
     tracing::debug!(
@@ -775,7 +792,7 @@ mod tests {
 
     fn mock_oci_config_with_reference(reference: String) -> OciConfig {
         OciConfig {
-            apollo_key: "test-api-key".to_string(),
+            apollo_key: Some("test-api-key".to_string()),
             reference: reference.clone(),
             hot_reload: false,
             poll_interval: Duration::from_millis(10),
@@ -909,7 +926,7 @@ mod tests {
         let apollo_key = "test-api-key".to_string();
 
         // Call build_auth
-        let auth = build_auth(&reference, &apollo_key);
+        let auth = build_auth(&reference, Some(&apollo_key));
 
         // Check that it returns the correct RegistryAuth
         match auth {
@@ -922,6 +939,21 @@ mod tests {
     }
 
     #[test]
+    fn test_build_auth_apollo_registry_no_key() {
+        // An Apollo registry reference with no key falls through to the
+        // docker-credential/anonymous path rather than panicking.
+        let reference: Reference = "registry.apollographql.com/my-graph:latest"
+            .parse()
+            .unwrap();
+
+        let auth = build_auth(&reference, None);
+
+        if let RegistryAuth::Basic(username, _) = auth {
+            assert_ne!(username, APOLLO_REGISTRY_USERNAME);
+        }
+    }
+
+    #[test]
     fn test_build_auth_non_apollo_registry() {
         // Create a reference for a non-Apollo registry
         let reference: Reference = "docker.io/library/alpine:latest".parse().unwrap();
@@ -930,12 +962,41 @@ mod tests {
         // Mock the docker_credential::get_credential function
         // Since we can't easily mock this in Rust without additional libraries,
         // we'll just verify that it doesn't return the Apollo registry auth
-        let auth = build_auth(&reference, &apollo_key);
+        let auth = build_auth(&reference, Some(&apollo_key));
 
         // Check that it doesn't return the Apollo registry auth
         if let RegistryAuth::Basic(username, _) = auth {
             assert_ne!(username, "apollo_registry");
         }
+    }
+
+    #[test]
+    fn test_build_auth_non_apollo_registry_no_key() {
+        // A non-Apollo registry reference with no APOLLO_KEY set should not
+        // require one; it falls through to docker-credential/anonymous auth.
+        let reference: Reference = "docker.io/library/alpine:latest".parse().unwrap();
+
+        let auth = build_auth(&reference, None);
+
+        if let RegistryAuth::Basic(username, _) = auth {
+            assert_ne!(username, "apollo_registry");
+        }
+    }
+
+    #[test]
+    fn test_is_apollo_graph_artifact_reference() {
+        assert!(is_apollo_graph_artifact_reference(
+            "registry.apollographql.com/my-graph:latest"
+        ));
+        assert!(is_apollo_graph_artifact_reference(
+            "artifact.api.apollographql.com/my-graph:latest"
+        ));
+        assert!(!is_apollo_graph_artifact_reference(
+            "docker.io/library/alpine:latest"
+        ));
+        assert!(!is_apollo_graph_artifact_reference(
+            "ghcr.io/my-org/my-graph:latest"
+        ));
     }
 
     fn generate_manifest_annotations(launch_id: Option<&str>) -> BTreeMap<String, String> {
@@ -1468,7 +1529,7 @@ mod tests {
             .parse::<Reference>()
             .expect("url must be valid");
         let oci_config = OciConfig {
-            apollo_key: "test-api-key".to_string(),
+            apollo_key: Some("test-api-key".to_string()),
             reference: image_reference.to_string(),
             hot_reload: true,
             poll_interval: Duration::from_millis(10),
@@ -2009,7 +2070,7 @@ mod tests {
 
         // Create OciConfig with tag reference and hot-reload enabled
         let oci_config = OciConfig {
-            apollo_key: "test-api-key".to_string(),
+            apollo_key: Some("test-api-key".to_string()),
             reference: image_reference.to_string(),
             hot_reload: true,
             poll_interval: Duration::from_millis(10),
@@ -2045,7 +2106,7 @@ mod tests {
 
         // Create OciConfig with tag reference and hot-reload disabled
         let oci_config = OciConfig {
-            apollo_key: "test-api-key".to_string(),
+            apollo_key: Some("test-api-key".to_string()),
             reference: image_reference.to_string(),
             hot_reload: false,
             poll_interval: Duration::from_millis(10),
@@ -2071,7 +2132,7 @@ mod tests {
 
         // Create OciConfig with digest reference and hot-reload enabled
         let oci_config = OciConfig {
-            apollo_key: "test-api-key".to_string(),
+            apollo_key: Some("test-api-key".to_string()),
             reference: digest_reference.to_string(),
             hot_reload: true,
             poll_interval: Duration::from_millis(10),
@@ -2159,7 +2220,7 @@ mod tests {
 
         // Create OciConfig with digest reference and hot-reload disabled
         let oci_config_digest = OciConfig {
-            apollo_key: "test-api-key".to_string(),
+            apollo_key: Some("test-api-key".to_string()),
             reference: digest_ref,
             hot_reload: false,
             poll_interval: Duration::from_millis(10),
@@ -2390,7 +2451,7 @@ mod tests {
             .parse::<Reference>()
             .expect("url must be valid");
         let oci_config = OciConfig {
-            apollo_key: "test-api-key".to_string(),
+            apollo_key: Some("test-api-key".to_string()),
             reference: image_reference.to_string(),
             hot_reload: true,
             poll_interval: Duration::from_millis(10),


### PR DESCRIPTION
APOLLO_KEY is only needed to authenticate with Apollo's own registry. Starting the router with `--graph-artifact-reference` pointing at a non-Apollo OCI registry no longer requires APOLLO_KEY to be set; it's still required when the reference resolves to an apollographql.com registry.


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
