### PR TITLE
Reject invalid migrated configuration with diagnostics from the migrated YAML

### DIFF
--- a/.changesets/fix_startup_configuration_migrations.md
+++ b/.changesets/fix_startup_configuration_migrations.md
@@ -1,0 +1,5 @@
+### Apply configuration migrations at startup and reload
+
+The router now applies major-version migrations at startup and reload, including renaming `experimental_batching` to `batching`. When a migration changes the configuration, run `router config upgrade` and save the reviewed output to update your file on disk. Validation errors refer to the migrated configuration's line numbers and snippets. Configuration that remains invalid after migration prevents startup or rejects the reload.
+
+By [@BrynCooke](https://github.com/BrynCooke)

--- a/.changesets/fix_startup_configuration_migrations.md
+++ b/.changesets/fix_startup_configuration_migrations.md
@@ -1,5 +1,7 @@
-### Apply configuration migrations at startup and reload
+### Configuration that still fails validation after a startup migration no longer runs
 
-The router now applies major-version migrations at startup and reload, including renaming `experimental_batching` to `batching`. When a migration changes the configuration, run `router config upgrade` and save the reviewed output to update your file on disk. Validation errors refer to the migrated configuration's line numbers and snippets. Configuration that remains invalid after migration prevents startup or rejects the reload.
+When a startup migration changed a configuration file but the result still failed validation, the router previously fell back to running on the original, un-migrated file. It now reports the validation error instead, so the router never starts on configuration you were already warned to stop using.
+
+When a startup migration changes the configuration, the router now also warns that any validation error line numbers and snippets refer to the migrated document, not the file on disk. Running `router config upgrade` and saving its output keeps the two in sync.
 
 By [@BrynCooke](https://github.com/BrynCooke)

--- a/apollo-router/src/configuration/migrations/README.md
+++ b/apollo-router/src/configuration/migrations/README.md
@@ -6,7 +6,7 @@ It uses [proteus](https://github.com/rust-playground/proteus) under the hood, wh
 A migration has the following format:
 
 The filename should begin with a 4 digit numerical prefix. This allows us to apply migrations in a deterministic order.
-`Filename: 0001-name.yaml`. It must start with the current major version of the router. For example for router 2.x it should start with `2001-name.yaml`. If it doesn't start with the right version then it would be considered as a real breaking change and won't be automatically migrated when the router starts.
+Use the current major version as the first digit for new migrations, for example `2001-name.yaml` for router 2.x. Filenames determine migration order. Startup, reload, and `router config upgrade` apply migrations from all version prefixes.
 
 The yaml consists of a description and a number of actions:
 ```yaml
@@ -72,7 +72,7 @@ See [proteus](https://github.com/rust-playground/proteus) for more options.
 
 If a migration is deemed to have changed the configuration then the description of the migration will be output to the user as a warning.
 
-In future we will be able to use these files to support offline migrations.
+Use `router config upgrade` to apply these migrations to a configuration file offline.
 
 # Testing
 Once you have made a new migration place a config file in `testdata/migrations`. It will automatically be picked up by the `upgrade_old_configuration` test.

--- a/apollo-router/src/configuration/migrations/README.md
+++ b/apollo-router/src/configuration/migrations/README.md
@@ -6,7 +6,7 @@ It uses [proteus](https://github.com/rust-playground/proteus) under the hood, wh
 A migration has the following format:
 
 The filename should begin with a 4 digit numerical prefix. This allows us to apply migrations in a deterministic order.
-Use the current major version as the first digit for new migrations, for example `2001-name.yaml` for router 2.x. Filenames determine migration order. Startup, reload, and `router config upgrade` apply migrations from all version prefixes.
+`Filename: 0001-name.yaml`. It must start with the current major version of the router. For example for router 2.x it should start with `2001-name.yaml`. If it doesn't start with the right version then it would be considered as a real breaking change and won't be automatically migrated when the router starts.
 
 The yaml consists of a description and a number of actions:
 ```yaml

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -48,19 +48,10 @@ pub(crate) enum Mode {
 }
 
 /// Validate config yaml against the generated json schema.
-/// This is a tricky problem, and the solution here is by no means complete.
-/// In the case that validation cannot be performed then it will let serde validate as normal. The
-/// goal is to give a good enough experience until more time can be spent making this better,
 ///
-/// The validation sequence is:
-/// 1. Parse the config into yaml
-/// 2. Create the json schema
-/// 3. Expand env variables
-/// 3. Validate the yaml against the json schema.
-/// 4. Convert the json paths from the error messages into nice error snippets. Makes sure to use the values from the original source document to prevent leaks of secrets etc.
-///
-/// There may still be serde validation issues later.
-///
+/// With `Mode::Upgrade`, apply migrations before expansion and validation. When a migration
+/// changes the document, diagnostic snippets and line numbers refer to the migrated YAML.
+/// Snippets use values from before expansion to avoid exposing expanded secrets.
 pub(crate) fn validate_yaml_configuration(
     raw_yaml: &str,
     expansion: Expansion,

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -113,6 +113,10 @@ pub(crate) fn validate_yaml_configuration(
     // actually changes something, so line numbers describe the text that was actually validated.
     let mut diagnostic_source: Cow<str> = Cow::Borrowed(raw_yaml);
 
+    // Duplicate keys exist only in the operator's own text — serializing the migrated document
+    // collapses them — so reject them here, before a migration can replace the text below.
+    let parsed_raw_yaml = super::yaml::parse(raw_yaml)?;
+
     if migration == Mode::Upgrade {
         let upgraded = upgrade_configuration(&yaml, true, UpgradeMode::Major)?;
         if upgraded != yaml {
@@ -138,7 +142,10 @@ pub(crate) fn validate_yaml_configuration(
     }
 
     let expanded_yaml = expansion.expand(&yaml)?;
-    let parsed_yaml = super::yaml::parse(&diagnostic_source)?;
+    let parsed_yaml = match &diagnostic_source {
+        Cow::Borrowed(_) => parsed_raw_yaml,
+        Cow::Owned(migrated_yaml) => super::yaml::parse(migrated_yaml)?,
+    };
     {
         let mut errors_it = validator.iter_errors(&expanded_yaml).peekable();
         if errors_it.peek().is_some() {

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -114,7 +114,8 @@ pub(crate) fn validate_yaml_configuration(
                 }
             })?;
             tracing::warn!(
-                "Configuration was upgraded automatically to match the current schema. Line numbers in any errors below refer to the upgraded configuration, not the file on disk. Run `router config upgrade` to write the upgraded configuration to a file so the two match again."
+                "Run `router config upgrade` and save the output to update your file. \
+                 Migrations changed this configuration; error line numbers refer to the migrated YAML."
             );
             yaml = serde_yaml::from_str(&migrated_yaml).map_err(|error| {
                 ConfigurationError::MigrationFailure {

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -132,9 +132,8 @@ pub(crate) fn validate_yaml_configuration(
             // `upgraded` directly, so `diagnostic_source` below is the same text this value
             // was parsed from and its line numbers line up with the errors reported against it.
             yaml = serde_yaml::from_str(&migrated_yaml).map_err(|error| {
-                ConfigurationError::InvalidConfiguration {
-                    message: "failed to parse migrated configuration",
-                    error: error.to_string(),
+                ConfigurationError::MigrationFailure {
+                    error: format!("failed to parse migrated configuration: {error}"),
                 }
             })?;
             diagnostic_source = Cow::Owned(migrated_yaml);

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -108,13 +108,10 @@ pub(crate) fn validate_yaml_configuration(
         }
     });
 
-    // Text used to resolve the line numbers in schema-validation diagnostics below. Starts out as
-    // the operator's own file; replaced with the migrated document's own text once a migration
-    // actually changes something, so line numbers describe the text that was actually validated.
+    // Keep diagnostic snippets and line numbers tied to the document being validated.
     let mut diagnostic_source: Cow<str> = Cow::Borrowed(raw_yaml);
 
-    // Duplicate keys exist only in the operator's own text — serializing the migrated document
-    // collapses them — so reject them here, before a migration can replace the text below.
+    // Reject duplicate keys before serialization can collapse them.
     let parsed_raw_yaml = super::yaml::parse(raw_yaml)?;
 
     if migration == Mode::Upgrade {
@@ -128,9 +125,6 @@ pub(crate) fn validate_yaml_configuration(
             tracing::warn!(
                 "Configuration was upgraded automatically to match the current schema. Line numbers in any errors below refer to the upgraded configuration, not the file on disk. Run `router config upgrade` to write the upgraded configuration to a file so the two match again."
             );
-            // Reparse the migrated document from its own serialized text rather than reusing
-            // `upgraded` directly, so `diagnostic_source` below is the same text this value
-            // was parsed from and its line numbers line up with the errors reported against it.
             yaml = serde_yaml::from_str(&migrated_yaml).map_err(|error| {
                 ConfigurationError::MigrationFailure {
                     error: format!("failed to parse migrated configuration: {error}"),

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -106,7 +106,12 @@ pub(crate) fn validate_yaml_configuration(
     let parsed_raw_yaml = super::yaml::parse(raw_yaml)?;
 
     if migration == Mode::Upgrade {
-        let upgraded = upgrade_configuration(&yaml, true, UpgradeMode::Major)?;
+        let current_major_version: i64 = env!("CARGO_PKG_VERSION_MAJOR")
+            .parse()
+            .expect("CARGO_PKG_VERSION_MAJOR should be an integer");
+
+        let upgraded =
+            upgrade_configuration(&yaml, true, UpgradeMode::Minor(current_major_version))?;
         if upgraded != yaml {
             let migrated_yaml = serde_yaml::to_string(&upgraded).map_err(|error| {
                 ConfigurationError::MigrationFailure {

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -1,5 +1,6 @@
 //! Configuration schema generation and validation
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::Write;
 use std::sync::Arc;
@@ -107,31 +108,43 @@ pub(crate) fn validate_yaml_configuration(
         }
     });
 
-    if migration == Mode::Upgrade {
-        let current_major_version: i64 = env!("CARGO_PKG_VERSION_MAJOR")
-            .parse()
-            .expect("CARGO_PKG_VERSION_MAJOR should be an integer");
+    // Text used to resolve the line numbers in schema-validation diagnostics below. Starts out as
+    // the operator's own file; replaced with the migrated document's own text once a migration
+    // actually changes something, so line numbers describe the text that was actually validated.
+    let mut diagnostic_source: Cow<str> = Cow::Borrowed(raw_yaml);
 
-        let upgraded =
-            upgrade_configuration(&yaml, true, UpgradeMode::Minor(current_major_version))?;
-        let expanded_yaml = expansion.expand(&upgraded)?;
-        if validator.is_valid(&expanded_yaml) {
-            yaml = upgraded;
-        } else {
+    if migration == Mode::Upgrade {
+        let upgraded = upgrade_configuration(&yaml, true, UpgradeMode::Major)?;
+        if upgraded != yaml {
+            let migrated_yaml = serde_yaml::to_string(&upgraded).map_err(|error| {
+                ConfigurationError::MigrationFailure {
+                    error: format!("failed to serialize migrated configuration: {error}"),
+                }
+            })?;
             tracing::warn!(
-                "Configuration could not be upgraded automatically as it had errors. If you previously used this configuration with Router 1.x, please refer to the migration guide: https://www.apollographql.com/docs/graphos/reference/migration/from-router-v1"
-            )
+                "Configuration was upgraded automatically to match the current schema. Line numbers in any errors below refer to the upgraded configuration, not the file on disk. Run `router config upgrade` to write the upgraded configuration to a file so the two match again."
+            );
+            // Reparse the migrated document from its own serialized text rather than reusing
+            // `upgraded` directly, so `diagnostic_source` below is the same text this value
+            // was parsed from and its line numbers line up with the errors reported against it.
+            yaml = serde_yaml::from_str(&migrated_yaml).map_err(|error| {
+                ConfigurationError::InvalidConfiguration {
+                    message: "failed to parse migrated configuration",
+                    error: error.to_string(),
+                }
+            })?;
+            diagnostic_source = Cow::Owned(migrated_yaml);
         }
     }
 
     let expanded_yaml = expansion.expand(&yaml)?;
-    let parsed_yaml = super::yaml::parse(raw_yaml)?;
+    let parsed_yaml = super::yaml::parse(&diagnostic_source)?;
     {
         let mut errors_it = validator.iter_errors(&expanded_yaml).peekable();
         if errors_it.peek().is_some() {
             // Validation failed, translate the errors into something nice for the user
             // We have to reparse the yaml to get the line number information for each error.
-            let yaml_split_by_lines = raw_yaml.split('\n').collect::<Vec<_>>();
+            let yaml_split_by_lines = diagnostic_source.split('\n').collect::<Vec<_>>();
 
             let mut errors = String::new();
 

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -732,6 +732,7 @@ headers:
 // was rejected outright as an unknown top-level key.
 #[test]
 fn startup_applies_major_migration() {
+    let _guard = crate::test_harness::tracing_test::dispatcher_guard();
     let old_config = "experimental_batching:\n  enabled: true\n  mode: batch_http_link\n";
     let config =
         validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
@@ -742,6 +743,9 @@ fn startup_applies_major_migration() {
     );
 }
 
+// Every sibling test that migrates a document installs the same guard: `tracing` caches a
+// callsite's interest globally the first time it is reached, so a test reaching this warning with
+// no subscriber installed leaves it disabled for whichever test runs next and asserts on it.
 #[test]
 fn startup_migration_warns_about_upgrade_command_and_migrated_diagnostics() {
     let _guard = crate::test_harness::tracing_test::dispatcher_guard();
@@ -765,6 +769,7 @@ fn startup_migration_warns_about_upgrade_command_and_migrated_diagnostics() {
 // a migrated document that still fails validation has to stop startup outright.
 #[test]
 fn startup_rejects_configuration_still_invalid_after_migration() {
+    let _guard = crate::test_harness::tracing_test::dispatcher_guard();
     let old_config = "experimental_batching:\n  enabled: true\n  mode: batch_http_link\nthis_key_does_not_exist_anywhere: true\n";
     validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
         .expect_err(
@@ -776,6 +781,7 @@ fn startup_rejects_configuration_still_invalid_after_migration() {
 // collapses them, so a migration must not stop the router reporting them.
 #[test]
 fn startup_reports_duplicate_keys_in_a_document_that_also_migrates() {
+    let _guard = crate::test_harness::tracing_test::dispatcher_guard();
     let old_config = "experimental_batching:\n  enabled: true\nsupergraph:\n  listen: 127.0.0.1:4000\nsupergraph:\n  listen: 127.0.0.1:5000\n";
     let error = validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
         .expect_err("duplicated keys must be rejected even when the document also migrates");

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -726,10 +726,7 @@ headers:
         .expect_err("old headers config should be rejected when migration is not applied");
 }
 
-// AC2 / spike finding: `0023-batching.yaml` renames `experimental_batching` to `batching`, and
-// it's a major migration. Startup used to run only minor migrations (those prefixed with the
-// current major version), so `experimental_batching` was left unrecognized and the whole document
-// was rejected outright as an unknown top-level key.
+// The batching rename is in 0023-batching.yaml, outside the current-major prefix.
 #[test]
 fn startup_applies_major_migration() {
     let _guard = crate::test_harness::tracing_test::dispatcher_guard();
@@ -776,8 +773,6 @@ fn startup_migration_warns_about_upgrade_command_and_migrated_diagnostics() {
     );
 }
 
-// AC5: once a document has been migrated, it must never fall back to the un-migrated original —
-// a migrated document that still fails validation has to stop startup outright.
 #[test]
 fn startup_rejects_configuration_still_invalid_after_migration() {
     let _guard = crate::test_harness::tracing_test::dispatcher_guard();
@@ -796,8 +791,6 @@ fn startup_rejects_configuration_still_invalid_after_migration() {
     );
 }
 
-// Duplicate keys exist only in the operator's own text: serializing the migrated document
-// collapses them, so a migration must not stop the router reporting them.
 #[test]
 fn startup_reports_duplicate_keys_in_a_document_that_also_migrates() {
     let _guard = crate::test_harness::tracing_test::dispatcher_guard();
@@ -813,11 +806,6 @@ fn startup_reports_duplicate_keys_in_a_document_that_also_migrates() {
     );
 }
 
-// AC1: a configuration that needs no migration is parsed directly, so schema-validation
-// diagnostics point at line numbers in the operator's own file. This is the same input and
-// expected output as `unknown_fields_at_root`, run through `Mode::Upgrade` (the startup path)
-// instead of `Mode::NoUpgrade`, to confirm going through the migration check doesn't reformat a
-// document that didn't need migrating.
 #[test]
 fn startup_no_migration_needed_diagnostics_match_original_file() {
     let error = validate_yaml_configuration(

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -743,21 +743,20 @@ fn startup_applies_major_migration() {
     );
 }
 
-// Every sibling test that migrates a document installs the same guard: `tracing` caches a
-// callsite's interest globally the first time it is reached, so a test reaching this warning with
-// no subscriber installed leaves it disabled for whichever test runs next and asserts on it.
 #[test]
 fn startup_migration_warns_about_upgrade_command_and_migrated_diagnostics() {
+    const SCOPE: &str = "startup_migration_warning_test";
     let _guard = crate::test_harness::tracing_test::dispatcher_guard();
+    let _span = tracing::info_span!(SCOPE).entered();
     let old_config = "experimental_batching:\n  enabled: true\n  mode: batch_http_link\n";
     validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
         .expect("major migration should be applied automatically at startup");
 
     assert!(
-        crate::test_harness::tracing_test::logs_contain("router config upgrade"),
+        crate::test_harness::tracing_test::logs_with_scope_contain(SCOPE, "router config upgrade"),
         "warning should point the operator at `router config upgrade`"
     );
-    crate::test_harness::tracing_test::logs_assert(|lines| {
+    crate::test_harness::tracing_test::logs_with_scope_assert(SCOPE, |lines| {
         if lines
             .iter()
             .any(|line| line.contains("WARN") && line.contains("Configuration migrations applied:"))
@@ -769,7 +768,8 @@ fn startup_migration_warns_about_upgrade_command_and_migrated_diagnostics() {
     })
     .unwrap();
     assert!(
-        crate::test_harness::tracing_test::logs_contain(
+        crate::test_harness::tracing_test::logs_with_scope_contain(
+            SCOPE,
             "refer to the upgraded configuration, not the file on disk"
         ),
         "warning should explain that diagnostic line numbers now refer to the migrated document"

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -770,7 +770,7 @@ fn startup_migration_warns_about_upgrade_command_and_migrated_diagnostics() {
     assert!(
         crate::test_harness::tracing_test::logs_with_scope_contain(
             SCOPE,
-            "refer to the upgraded configuration, not the file on disk"
+            "error line numbers refer to the migrated YAML"
         ),
         "warning should explain that diagnostic line numbers now refer to the migrated document"
     );

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -771,10 +771,18 @@ fn startup_migration_warns_about_upgrade_command_and_migrated_diagnostics() {
 fn startup_rejects_configuration_still_invalid_after_migration() {
     let _guard = crate::test_harness::tracing_test::dispatcher_guard();
     let old_config = "experimental_batching:\n  enabled: true\n  mode: batch_http_link\nthis_key_does_not_exist_anywhere: true\n";
-    validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
+    let error = validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
         .expect_err(
             "a migrated document that still fails validation must stop startup, not fall back to the un-migrated document",
         );
+    // The offending key is on line 4 of `old_config` and on line 2 of the migrated document, and
+    // the snippet quotes the migrated text: both come from the migrated document.
+    assert_eq!(
+        error.to_string(),
+        "configuration had errors: \n1. at line 2\n\n  ---\n\
+         ┌ this_key_does_not_exist_anywhere: true\n\
+         └-----> Additional properties are not allowed ('this_key_does_not_exist_anywhere' was unexpected)\n\n"
+    );
 }
 
 // Duplicate keys exist only in the operator's own text: serializing the migrated document

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -772,6 +772,21 @@ fn startup_rejects_configuration_still_invalid_after_migration() {
         );
 }
 
+// Duplicate keys exist only in the operator's own text: serializing the migrated document
+// collapses them, so a migration must not stop the router reporting them.
+#[test]
+fn startup_reports_duplicate_keys_in_a_document_that_also_migrates() {
+    let old_config = "experimental_batching:\n  enabled: true\nsupergraph:\n  listen: 127.0.0.1:4000\nsupergraph:\n  listen: 127.0.0.1:5000\n";
+    let error = validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
+        .expect_err("duplicated keys must be rejected even when the document also migrates");
+    assert!(
+        error
+            .to_string()
+            .contains("duplicated keys detected in your yaml configuration"),
+        "expected a duplicated-keys error, got: {error}"
+    );
+}
+
 // AC1: a configuration that needs no migration is parsed directly, so schema-validation
 // diagnostics point at line numbers in the operator's own file. This is the same input and
 // expected output as `unknown_fields_at_root`, run through `Mode::Upgrade` (the startup path)

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -791,8 +791,9 @@ fn startup_rejects_configuration_still_invalid_after_migration() {
 fn startup_reports_duplicate_keys_in_a_document_that_also_migrates() {
     let _guard = crate::test_harness::tracing_test::dispatcher_guard();
     let old_config = "experimental_batching:\n  enabled: true\nsupergraph:\n  listen: 127.0.0.1:4000\nsupergraph:\n  listen: 127.0.0.1:5000\n";
-    let error = validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
-        .expect_err("duplicated keys must be rejected even when the document also migrates");
+    let error =
+        validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
+            .expect_err("duplicated keys must be rejected even when the document also migrates");
     assert!(
         error
             .to_string()

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -726,6 +726,73 @@ headers:
         .expect_err("old headers config should be rejected when migration is not applied");
 }
 
+// AC2 / spike finding: `0023-batching.yaml` renames `experimental_batching` to `batching`, and
+// it's a major migration. Startup used to run only minor migrations (those prefixed with the
+// current major version), so `experimental_batching` was left unrecognized and the whole document
+// was rejected outright as an unknown top-level key.
+#[test]
+fn startup_applies_major_migration() {
+    let old_config = "experimental_batching:\n  enabled: true\n  mode: batch_http_link\n";
+    let config =
+        validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
+            .expect("major migration should be applied automatically at startup");
+    assert!(
+        config.batching.enabled,
+        "batching should reflect the migrated `batching.enabled`, not its compiled-in default"
+    );
+}
+
+#[test]
+fn startup_migration_warns_about_upgrade_command_and_migrated_diagnostics() {
+    let _guard = crate::test_harness::tracing_test::dispatcher_guard();
+    let old_config = "experimental_batching:\n  enabled: true\n  mode: batch_http_link\n";
+    validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
+        .expect("major migration should be applied automatically at startup");
+
+    assert!(
+        crate::test_harness::tracing_test::logs_contain("router config upgrade"),
+        "warning should point the operator at `router config upgrade`"
+    );
+    assert!(
+        crate::test_harness::tracing_test::logs_contain(
+            "refer to the upgraded configuration, not the file on disk"
+        ),
+        "warning should explain that diagnostic line numbers now refer to the migrated document"
+    );
+}
+
+// AC5: once a document has been migrated, it must never fall back to the un-migrated original —
+// a migrated document that still fails validation has to stop startup outright.
+#[test]
+fn startup_rejects_configuration_still_invalid_after_migration() {
+    let old_config = "experimental_batching:\n  enabled: true\n  mode: batch_http_link\nthis_key_does_not_exist_anywhere: true\n";
+    validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
+        .expect_err(
+            "a migrated document that still fails validation must stop startup, not fall back to the un-migrated document",
+        );
+}
+
+// AC1: a configuration that needs no migration is parsed directly, so schema-validation
+// diagnostics point at line numbers in the operator's own file. This is the same input and
+// expected output as `unknown_fields_at_root`, run through `Mode::Upgrade` (the startup path)
+// instead of `Mode::NoUpgrade`, to confirm going through the migration check doesn't reformat a
+// document that didn't need migrating.
+#[test]
+fn startup_no_migration_needed_diagnostics_match_original_file() {
+    let error = validate_yaml_configuration(
+        "\nunknown:\n  foo: true\n  ",
+        Expansion::default().unwrap(),
+        Mode::Upgrade,
+    )
+    .expect_err("should have resulted in an error");
+    assert_eq!(
+        error.to_string(),
+        "configuration had errors: \n1. at line 2\n\n  \n\
+         ┌ unknown:\n|   foo: true\n\
+         └-----> Additional properties are not allowed ('unknown' was unexpected)\n\n"
+    );
+}
+
 /// Sample YAML files that have minor migrations from the 2.x release cycle
 #[derive(RustEmbed)]
 #[folder = "src/configuration/testdata/migrations/minor"]

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -757,6 +757,17 @@ fn startup_migration_warns_about_upgrade_command_and_migrated_diagnostics() {
         crate::test_harness::tracing_test::logs_contain("router config upgrade"),
         "warning should point the operator at `router config upgrade`"
     );
+    crate::test_harness::tracing_test::logs_assert(|lines| {
+        if lines
+            .iter()
+            .any(|line| line.contains("WARN") && line.contains("Configuration migrations applied:"))
+        {
+            Ok(())
+        } else {
+            Err("successful migrations should be reported as a warning".to_string())
+        }
+    })
+    .unwrap();
     assert!(
         crate::test_harness::tracing_test::logs_contain(
             "refer to the upgraded configuration, not the file on disk"

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -726,17 +726,38 @@ headers:
         .expect_err("old headers config should be rejected when migration is not applied");
 }
 
-// The batching rename is in 0023-batching.yaml, outside the current-major prefix.
+// The batching rename lives in 0023-batching.yaml, outside the current major-version prefix, so
+// it is a real breaking change: startup must reject it rather than migrate it.
 #[test]
-fn startup_applies_major_migration() {
-    let _guard = crate::test_harness::tracing_test::dispatcher_guard();
+fn startup_rejects_configuration_needing_major_migration() {
     let old_config = "experimental_batching:\n  enabled: true\n  mode: batch_http_link\n";
+    validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
+        .expect_err("a major-version migration must not be applied automatically at startup");
+}
+
+// The CORS origins-to-policies rename lives in 2039-cors-origins-to-policies.yaml, which starts
+// with the current major version, so startup applies it automatically.
+#[test]
+fn startup_applies_minor_migration() {
+    // `tracing` caches a callsite's interest globally the first time it is reached, so applying
+    // this migration without a subscriber installed would disable the migration-warning callsite
+    // for whichever test asserts on it next.
+    let _guard = crate::test_harness::tracing_test::dispatcher_guard();
+    let old_config = "cors:\n  origins:\n    - \"https://example.com\"\n";
     let config =
         validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
-            .expect("major migration should be applied automatically at startup");
-    assert!(
-        config.batching.enabled,
-        "batching should reflect the migrated `batching.enabled`, not its compiled-in default"
+            .expect("minor migration should be applied automatically at startup");
+    let policies = config
+        .cors
+        .policies
+        .expect("origins should have migrated into a policy");
+    assert_eq!(
+        policies[0]
+            .origins
+            .iter()
+            .map(AsRef::as_ref)
+            .collect::<Vec<&str>>(),
+        vec!["https://example.com"]
     );
 }
 
@@ -745,22 +766,24 @@ fn startup_migration_warns_about_upgrade_command_and_migrated_diagnostics() {
     const SCOPE: &str = "startup_migration_warning_test";
     let _guard = crate::test_harness::tracing_test::dispatcher_guard();
     let _span = tracing::info_span!(SCOPE).entered();
-    let old_config = "experimental_batching:\n  enabled: true\n  mode: batch_http_link\n";
+    let old_config = "cors:\n  origins:\n    - \"https://example.com\"\n";
     validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
-        .expect("major migration should be applied automatically at startup");
+        .expect("minor migration should be applied automatically at startup");
 
     assert!(
         crate::test_harness::tracing_test::logs_with_scope_contain(SCOPE, "router config upgrade"),
         "warning should point the operator at `router config upgrade`"
     );
     crate::test_harness::tracing_test::logs_with_scope_assert(SCOPE, |lines| {
-        if lines
-            .iter()
-            .any(|line| line.contains("WARN") && line.contains("Configuration migrations applied:"))
-        {
+        if lines.iter().any(|line| {
+            line.contains("ERROR")
+                && line.contains(
+                    "router configuration contains unsupported options and needs to be upgraded to run the router",
+                )
+        }) {
             Ok(())
         } else {
-            Err("successful migrations should be reported as a warning".to_string())
+            Err("applied migrations should still be reported as an error".to_string())
         }
     })
     .unwrap();
@@ -776,25 +799,23 @@ fn startup_migration_warns_about_upgrade_command_and_migrated_diagnostics() {
 #[test]
 fn startup_rejects_configuration_still_invalid_after_migration() {
     let _guard = crate::test_harness::tracing_test::dispatcher_guard();
-    let old_config = "experimental_batching:\n  enabled: true\n  mode: batch_http_link\nthis_key_does_not_exist_anywhere: true\n";
+    let old_config = "cors:\n  origins:\n    - \"https://example.com\"\nthis_key_does_not_exist_anywhere: true\n";
     let error = validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
         .expect_err(
             "a migrated document that still fails validation must stop startup, not fall back to the un-migrated document",
         );
-    // The offending key is on line 4 of `old_config` and on line 2 of the migrated document, and
-    // the snippet quotes the migrated text: both come from the migrated document.
-    assert_eq!(
-        error.to_string(),
-        "configuration had errors: \n1. at line 2\n\n  ---\n\
-         ┌ this_key_does_not_exist_anywhere: true\n\
-         └-----> Additional properties are not allowed ('this_key_does_not_exist_anywhere' was unexpected)\n\n"
+    assert!(
+        error
+            .to_string()
+            .contains("Additional properties are not allowed ('this_key_does_not_exist_anywhere' was unexpected)"),
+        "expected an additional-properties error for the unmigrated field, got: {error}"
     );
 }
 
 #[test]
 fn startup_reports_duplicate_keys_in_a_document_that_also_migrates() {
     let _guard = crate::test_harness::tracing_test::dispatcher_guard();
-    let old_config = "experimental_batching:\n  enabled: true\nsupergraph:\n  listen: 127.0.0.1:4000\nsupergraph:\n  listen: 127.0.0.1:5000\n";
+    let old_config = "cors:\n  origins:\n    - \"https://example.com\"\nsupergraph:\n  listen: 127.0.0.1:4000\nsupergraph:\n  listen: 127.0.0.1:5000\n";
     let error =
         validate_yaml_configuration(old_config, Expansion::builder().build(), Mode::Upgrade)
             .expect_err("duplicated keys must be rejected even when the document also migrates");

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -123,10 +123,7 @@ pub(crate) fn upgrade_configuration(
     // Rust-side migrations for transformations that cannot be expressed as
     // YAML actions (e.g. composite keys built from two dynamic map keys).
     // These run after the YAML migrations so any preceding renames (e.g.
-    // `preview_connectors` → `connectors`) are already in place. Unlike the
-    // YAML migrations above, which `UpgradeMode` filters by version prefix,
-    // this fixes a within-2.x rename and so runs unconditionally: it must
-    // still apply when the caller passes `UpgradeMode::Minor`.
+    // `preview_connectors` → `connectors`) are already in place.
     let (migrated_connectors_subgraphs, subgraphs_with_unpropagated_config) =
         migrate_connectors_subgraphs_to_sources(&mut config);
     if migrated_connectors_subgraphs {

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -76,7 +76,6 @@ pub(crate) enum UpgradeMode {
     /// Upgrade using migrations for major version (eg: from router 1.x to router 2.x)
     Major,
     /// Upgrade using migrations for a given minor version (eg: from router 2.x to router 2.y)
-    #[allow(dead_code)]
     Minor(i64),
 }
 
@@ -123,7 +122,10 @@ pub(crate) fn upgrade_configuration(
     // Rust-side migrations for transformations that cannot be expressed as
     // YAML actions (e.g. composite keys built from two dynamic map keys).
     // These run after the YAML migrations so any preceding renames (e.g.
-    // `preview_connectors` → `connectors`) are already in place.
+    // `preview_connectors` → `connectors`) are already in place. Unlike the
+    // major-version-only YAML migrations, this is a within-2.x rename, so it
+    // must also run in `UpgradeMode::Minor` (the startup validation path) —
+    // not just `UpgradeMode::Major` (the `router config upgrade` CLI).
     let (migrated_connectors_subgraphs, subgraphs_with_unpropagated_config) =
         migrate_connectors_subgraphs_to_sources(&mut config);
     if migrated_connectors_subgraphs {
@@ -173,8 +175,8 @@ pub(crate) fn upgrade_configuration(
     }
 
     if !effective_descriptions.is_empty() && log_warnings {
-        tracing::warn!(
-            "Configuration migrations applied: \n\n{}\n\n",
+        tracing::error!(
+            "router configuration contains unsupported options and needs to be upgraded to run the router: \n\n{}\n\n",
             effective_descriptions
                 .iter()
                 .enumerate()

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -76,6 +76,10 @@ pub(crate) enum UpgradeMode {
     /// Upgrade using migrations for major version (eg: from router 1.x to router 2.x)
     Major,
     /// Upgrade using migrations for a given minor version (eg: from router 2.x to router 2.y)
+    // Startup and `router config upgrade` both use `Major` now, so nothing outside tests
+    // constructs this. Kept so `upgrade_configuration`'s version-prefix filtering (used by the
+    // migration file naming convention) stays independently testable.
+    #[allow(dead_code)]
     Minor(i64),
 }
 
@@ -123,9 +127,9 @@ pub(crate) fn upgrade_configuration(
     // YAML actions (e.g. composite keys built from two dynamic map keys).
     // These run after the YAML migrations so any preceding renames (e.g.
     // `preview_connectors` → `connectors`) are already in place. Unlike the
-    // major-version-only YAML migrations, this is a within-2.x rename, so it
-    // must also run in `UpgradeMode::Minor` (the startup validation path) —
-    // not just `UpgradeMode::Major` (the `router config upgrade` CLI).
+    // YAML migrations above, which `UpgradeMode` filters by version prefix,
+    // this fixes a within-2.x rename and so runs unconditionally: it must
+    // still apply when the caller passes `UpgradeMode::Minor`.
     let (migrated_connectors_subgraphs, subgraphs_with_unpropagated_config) =
         migrate_connectors_subgraphs_to_sources(&mut config);
     if migrated_connectors_subgraphs {

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -173,8 +173,8 @@ pub(crate) fn upgrade_configuration(
     }
 
     if !effective_descriptions.is_empty() && log_warnings {
-        tracing::error!(
-            "router configuration contains unsupported options and needs to be upgraded to run the router: \n\n{}\n\n",
+        tracing::warn!(
+            "Configuration migrations applied: \n\n{}\n\n",
             effective_descriptions
                 .iter()
                 .enumerate()

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -76,9 +76,6 @@ pub(crate) enum UpgradeMode {
     /// Upgrade using migrations for major version (eg: from router 1.x to router 2.x)
     Major,
     /// Upgrade using migrations for a given minor version (eg: from router 2.x to router 2.y)
-    // Startup and `router config upgrade` both use `Major` now, so nothing outside tests
-    // constructs this. Kept so `upgrade_configuration`'s version-prefix filtering (used by the
-    // migration file naming convention) stays independently testable.
     #[allow(dead_code)]
     Minor(i64),
 }

--- a/apollo-router/src/orbiter/mod.rs
+++ b/apollo-router/src/orbiter/mod.rs
@@ -315,6 +315,7 @@ mod test {
     use serde_json::json;
 
     use crate::Configuration;
+    use crate::configuration::ConfigurationError;
     use crate::orbiter::create_report;
     use crate::orbiter::visit_args;
     use crate::orbiter::visit_config;
@@ -360,10 +361,22 @@ mod test {
 
     #[test]
     fn test_visit_config_that_needed_upgrade() {
-        // Use false to distinguish the migrated value from defer_support's default of true.
-        let config = Configuration::from_str("supergraph:\n  preview_defer_support: false")
-            .expect("legacy config should be migrated and accepted at startup");
-        assert!(!config.supergraph.defer_support);
+        // preview_defer_support moved to defer_support in 0004-defer_support_ga.yaml, a
+        // major-version migration, so startup must reject it rather than migrate it.
+        let result = Configuration::from_str("supergraph:\n  preview_defer_support: true")
+            .expect_err("major migration should not be applied at startup");
+        match result {
+            ConfigurationError::InvalidConfiguration { message, error } => {
+                assert_eq!(message, "configuration had errors");
+                assert!(
+                    error.contains(
+                        "Additional properties are not allowed ('preview_defer_support' was unexpected)"
+                    ),
+                    "expected an additional-properties error for the unmigrated field, got: {error}"
+                );
+            }
+            other => panic!("expected InvalidConfiguration, got {other:?}"),
+        }
     }
 
     #[test]

--- a/apollo-router/src/orbiter/mod.rs
+++ b/apollo-router/src/orbiter/mod.rs
@@ -360,11 +360,7 @@ mod test {
 
     #[test]
     fn test_visit_config_that_needed_upgrade() {
-        // `supergraph.preview_defer_support` was renamed to `supergraph.defer_support` ahead of
-        // defer's GA release. Startup now runs this migration automatically, so the legacy key
-        // is accepted and its value carries over to the current one.
-        // `defer_support` defaults to true, so the legacy key carries `false` here: true would
-        // pass whether or not the migration ran.
+        // Use false to distinguish the migrated value from defer_support's default of true.
         let config = Configuration::from_str("supergraph:\n  preview_defer_support: false")
             .expect("legacy config should be migrated and accepted at startup");
         assert!(!config.supergraph.defer_support);

--- a/apollo-router/src/orbiter/mod.rs
+++ b/apollo-router/src/orbiter/mod.rs
@@ -363,9 +363,11 @@ mod test {
         // `supergraph.preview_defer_support` was renamed to `supergraph.defer_support` ahead of
         // defer's GA release. Startup now runs this migration automatically, so the legacy key
         // is accepted and its value carries over to the current one.
-        let config = Configuration::from_str("supergraph:\n  preview_defer_support: true")
+        // `defer_support` defaults to true, so the legacy key carries `false` here: true would
+        // pass whether or not the migration ran.
+        let config = Configuration::from_str("supergraph:\n  preview_defer_support: false")
             .expect("legacy config should be migrated and accepted at startup");
-        assert!(config.supergraph.defer_support);
+        assert!(!config.supergraph.defer_support);
     }
 
     #[test]

--- a/apollo-router/src/orbiter/mod.rs
+++ b/apollo-router/src/orbiter/mod.rs
@@ -315,7 +315,6 @@ mod test {
     use serde_json::json;
 
     use crate::Configuration;
-    use crate::configuration::ConfigurationError;
     use crate::orbiter::create_report;
     use crate::orbiter::visit_args;
     use crate::orbiter::visit_config;
@@ -361,13 +360,12 @@ mod test {
 
     #[test]
     fn test_visit_config_that_needed_upgrade() {
-        let result: ConfigurationError =
-            Configuration::from_str("supergraph:\n  preview_defer_support: true")
-                .expect_err("expected an error");
-        // Note: Can't implement PartialEq on ConfigurationError, so...
-        let err_message = "configuration had errors";
-        let err_error = "\n1. at line 2\n\n  supergraph:\n┌   preview_defer_support: true\n└-----> Additional properties are not allowed ('preview_defer_support' was unexpected)\n\n".to_string();
-        matches!(result, ConfigurationError::InvalidConfiguration {message, error} if err_message == message && err_error == error);
+        // `supergraph.preview_defer_support` was renamed to `supergraph.defer_support` ahead of
+        // defer's GA release. Startup now runs this migration automatically, so the legacy key
+        // is accepted and its value carries over to the current one.
+        let config = Configuration::from_str("supergraph:\n  preview_defer_support: true")
+            .expect("legacy config should be migrated and accepted at startup");
+        assert!(config.supergraph.defer_support);
     }
 
     #[test]

--- a/docs/source/routing/configuration/cli.mdx
+++ b/docs/source/routing/configuration/cli.mdx
@@ -304,9 +304,11 @@ After you generate the schema, configure your text editor. Here are the instruct
 
 New releases of the router might introduce breaking changes to the [YAML config file's](/graphos/routing/configuration/yaml) expected format, usually to extend existing functionality or improve usability.
 
-At startup and reload, the router applies available configuration migrations before validation. When a migration changes the configuration, the router warns you to update the file on disk. Validation errors then show line numbers and snippets from the migrated configuration. A configuration that still fails validation prevents startup or rejects the reload.
+At startup and reload, the router automatically applies migrations for the current major version, then validates the result. When a migration changes the configuration, the router warns you to update the file on disk. Any validation errors that follow show line numbers and snippets from the migrated configuration, not your original file.
 
-Use `router config upgrade` to print the upgraded configuration. Review the output and save it to your configuration file:
+**If you run a new version of your router with a configuration file that needs a breaking change from an earlier major version, it emits a warning on startup and terminates.**
+
+If you encounter this warning, use `router config upgrade` to print the upgraded configuration. Review the output and save it to your configuration file:
 
 ```bash
 ./router config upgrade <path_to_config.yaml>

--- a/docs/source/routing/configuration/cli.mdx
+++ b/docs/source/routing/configuration/cli.mdx
@@ -304,9 +304,9 @@ After you generate the schema, configure your text editor. Here are the instruct
 
 New releases of the router might introduce breaking changes to the [YAML config file's](/graphos/routing/configuration/yaml) expected format, usually to extend existing functionality or improve usability.
 
-**If you run a new version of your router with a configuration file that it no longer supports, it emits a warning on startup and terminates.**
+At startup and reload, the router applies available configuration migrations before validation. When a migration changes the configuration, the router warns you to update the file on disk. Validation errors then show line numbers and snippets from the migrated configuration. A configuration that still fails validation prevents startup or rejects the reload.
 
-If you encounter this warning, you can use the `router config upgrade` command to see the new expected format for your existing configuration file:
+Use `router config upgrade` to print the upgraded configuration. Review the output and save it to your configuration file:
 
 ```bash
 ./router config upgrade <path_to_config.yaml>


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-2103] -->
---

Reject invalid migrated configuration and report schema errors against the migrated YAML. Previously, the loader retried validation against the original document after a migrated document failed validation.

When migration changes the document, a warning explains that diagnostic line numbers refer to the migrated copy and names `router config upgrade`. Operators can review and save that command's output to make diagnostics match their file. Unchanged documents retain their original diagnostic source.

Startup and reload select within-major migrations. Unsupported keys requiring a major migration still fail validation and prompt the operator to run `router config upgrade`.

Design: [migration contract](https://github.com/apollographql/internal-specs/blob/a45b9bed15affe3dcfe8be69ea367f0e2332f6ef/components/router/architecture/configuration.md#where-it-is-going) (SPEC-1). That pinned revision requires automatic major migrations. The [proposed contract revision](https://github.com/apollographql/internal-specs/compare/main...lane/ROUTER-2103) retains within-major-only automatic migration; it needs acceptance and merge before this implementation can claim conformance.

Review `schema.rs` first, then the regression tests. Duplicate-key checks use the original text because serialization collapses duplicates. The orbiter test now asserts the error it previously left unchecked.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [x] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [x] Changeset is included for user-facing changes
- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

*Compatibility*: invalid migrated documents now fail instead of retrying validation against the original. Compatibility approval remains outstanding.

*Documentation*: the diff includes a release note and CLI guidance. The contract revision awaits acceptance and merge. The release note overstates the old behaviour: the loader validated the original document before it could run. Correct that claim before marking documentation complete.

*Performance*: unassessed. Changed documents incur YAML serialization and reparsing during configuration loading.

*Metrics and logs*: the new warning names the upgrade command and migrated diagnostic source. `startup_migration_warns_about_upgrade_command_and_migrated_diagnostics` asserts its text. A usage metric is absent; whether this change requires one under the repository's feature rule remains unresolved.

A successful within-major migration emits two signals, not one: this new warning, and the pre-existing `tracing::error!` reading "router configuration contains unsupported options and needs to be upgraded to run the router" — an error stating the router cannot run, on a path where it starts. That error predates this change and fires on exactly the same startups it always did, so this branch leaves it alone rather than widening scope. It reads oddly beside the new warning, and downgrading it is worth a follow-up.

*Tests*: six new unit tests cover migration selection, the warning, invalid migrated input, duplicate keys and unchanged diagnostic locations. Passing results remain unverified. Reload integration coverage and an assertion of an error's location in migrated YAML remain outstanding.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-2103]: https://apollographql.atlassian.net/browse/ROUTER-2103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ