### PR TITLE
Update to `shape` 0.9.0 by way of the new `apollo-shape` 0.2.0 wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "apollo-compiler",
  "apollo-federation",
  "apollo-parser",
+ "apollo-shape",
  "clap",
  "derive_more",
  "dhat",
@@ -247,7 +248,6 @@ dependencies = [
  "serde_json",
  "serde_json_bytes",
  "sha1 0.10.6",
- "shape",
  "similar 3.2.0",
  "strum 0.28.0",
  "strum_macros 0.28.0",
@@ -478,6 +478,17 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
+]
+
+[[package]]
+name = "apollo-shape"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26e74e0ee7687c709e6e7735366fd443340d84b3622331facd165bfb001fc8b2"
+dependencies = [
+ "apollo-compiler",
+ "indexmap 2.14.2",
+ "shape",
 ]
 
 [[package]]
@@ -2308,7 +2319,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2552,7 +2563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3616,7 +3627,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -4624,7 +4635,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6398,7 +6409,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6791,11 +6802,10 @@ dependencies = [
 
 [[package]]
 name = "shape"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f760e846df748dda86464a7b53022f7d91c27a04fa97913e9fd731bada8d3c3"
+checksum = "53ef86b89d8115c8155fd1072471ed345dfc68ad18fa6d905c21c0292efd9bf1"
 dependencies = [
- "apollo-compiler",
  "indexmap 2.14.2",
  "serde_json",
  "serde_json_bytes",
@@ -7210,10 +7220,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -8406,7 +8416,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/apollo-federation/CHANGELOG.md
+++ b/apollo-federation/CHANGELOG.md
@@ -120,6 +120,29 @@ a test snapshot or a log query, needs updating.
 
 By [@benjamn](https://github.com/benjamn) and [@tninesling](https://github.com/tninesling) in <https://github.com/apollographql/router/pull/9947>
 
+### Connectors validation depends on `apollo-shape` rather than `shape` ([PR #10208](https://github.com/apollographql/router/pull/10208))
+
+`shape` 0.9.0 moved its GraphQL front end into a new `apollo-shape` crate, so
+that `shape` itself no longer depends on `apollo-compiler` and an
+`apollo-compiler` upgrade is no longer a `shape` release. Connectors validation
+now depends on `apollo-shape` 0.2.0, which re-exports all of `shape`.
+
+One change reaches composition diagnostics. An input object field whose type is
+a built-in scalar now carries that scalar's shape rather than `Unknown`, so a
+composition error quoting such a shape names the real field type:
+
+```
+does not accept `One<{ val: One<String, null> }, null>`
+```
+
+where it previously said `{ val: Unknown }`. Object *output* fields were
+already correct, since connectors converts those types itself.
+
+No validation outcome changes. Anything matching on the previous strings, such
+as a test snapshot or a log query, needs updating.
+
+By [@benjamn](https://github.com/benjamn) in <https://github.com/apollographql/router/pull/10208>
+
 # [2.16.2](https://crates.io/crates/apollo-federation/2.16.2) - 2026-08-13
 
 ### Propagate directives from `@interfaceObject` fields to `@external` implementations ([PR #9831](https://github.com/apollographql/router/pull/9831))

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -59,7 +59,7 @@ url = "2"
 either = "1.13.0"
 tracing = "0.1.40"
 ron = { version = "0.12.0", optional = true }
-shape = "=0.8.3"
+apollo-shape = "=0.2.0"
 form_urlencoded = "1.2.1"
 parking_lot = "0.12.4"
 mime = "0.3.17"

--- a/apollo-federation/src/connectors/expand/visitors/selection.rs
+++ b/apollo-federation/src/connectors/expand/visitors/selection.rs
@@ -10,11 +10,11 @@ use apollo_compiler::schema::InterfaceType;
 use apollo_compiler::schema::ObjectType;
 use apollo_compiler::schema::ScalarType;
 use apollo_compiler::schema::UnionType;
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use itertools::Itertools;
-use shape::Shape;
-use shape::ShapeCase;
 
 use super::FieldVisitor;
 use super::GroupVisitor;
@@ -848,10 +848,10 @@ fn is_satisfiable_typename_shape(shape: &Shape) -> bool {
 mod tests {
     use apollo_compiler::Schema;
     use apollo_compiler::name;
+    use apollo_shape::Shape;
     use indexmap::IndexMap;
     use indexmap::IndexSet;
     use insta::assert_snapshot;
-    use shape::Shape;
 
     use super::walk_type_with_shape;
     use crate::connectors::ConnectSpec;

--- a/apollo-federation/src/connectors/json_selection/analysis.rs
+++ b/apollo-federation/src/connectors/json_selection/analysis.rs
@@ -31,8 +31,8 @@
 
 use std::sync::Arc;
 
-use shape::Shape;
-use shape::location::SourceId;
+use apollo_shape::Shape;
+use apollo_shape::location::SourceId;
 
 use super::JSONSelection;
 use super::SelectionTrie;

--- a/apollo-federation/src/connectors/json_selection/apply_to.rs
+++ b/apollo-federation/src/connectors/json_selection/apply_to.rs
@@ -5,13 +5,13 @@ use std::hash::Hash;
 
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
+use apollo_shape::location::Location;
+use apollo_shape::location::SourceId;
 use serde_json_bytes::Map as JSONMap;
 use serde_json_bytes::Value as JSON;
 use serde_json_bytes::json;
-use shape::Shape;
-use shape::ShapeCase;
-use shape::location::Location;
-use shape::location::SourceId;
 
 use super::Ref;
 use super::helpers::json_merge;
@@ -1102,7 +1102,7 @@ impl ApplyToInternal for WithRange<PathList> {
                         let mut iter = pending_messages.into_iter();
                         let first = iter.next().unwrap_or_default();
                         return iter.fold(Shape::error(first, tail_location), |acc, msg| {
-                            acc.with_error(shape::Error { message: msg })
+                            acc.with_error(apollo_shape::Error { message: msg })
                         });
                     }
 
@@ -4650,8 +4650,8 @@ mod tests {
     mod spread {
         use serde_json_bytes::Value as JSON;
         use serde_json_bytes::json;
-        use shape::Shape;
-        use shape::location::SourceId;
+        use apollo_shape::Shape;
+        use apollo_shape::location::SourceId;
 
         use crate::connectors::ConnectSpec;
         use crate::connectors::json_selection::ShapeContext;

--- a/apollo-federation/src/connectors/json_selection/location.rs
+++ b/apollo-federation/src/connectors/json_selection/location.rs
@@ -1,9 +1,9 @@
+use apollo_shape::location::Location;
+use apollo_shape::location::SourceId;
 use nom::Parser;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
 use nom_locate::LocatedSpan;
-use shape::location::Location;
-use shape::location::SourceId;
 
 use crate::connectors::ConnectSpec;
 

--- a/apollo-federation/src/connectors/json_selection/methods.rs
+++ b/apollo-federation/src/connectors/json_selection/methods.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use super::ApplyToError;
 use super::MethodArgs;

--- a/apollo-federation/src/connectors/json_selection/methods/common.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/common.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
 use serde_json::Number;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::ApplyToError;
 use crate::connectors::json_selection::immutable::InputPath;

--- a/apollo-federation/src/connectors/json_selection/methods/future/has.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/future/has.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;

--- a/apollo-federation/src/connectors/json_selection/methods/future/keys.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/future/keys.rs
@@ -1,8 +1,8 @@
 use std::iter::empty;
 
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::MethodArgs;

--- a/apollo-federation/src/connectors/json_selection/methods/future/match_if.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/future/match_if.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;

--- a/apollo-federation/src/connectors/json_selection/methods/future/typeof.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/future/typeof.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::MethodArgs;

--- a/apollo-federation/src/connectors/json_selection/methods/future/values.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/future/values.rs
@@ -1,8 +1,8 @@
 use std::iter::empty;
 
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::MethodArgs;

--- a/apollo-federation/src/connectors/json_selection/methods/public/and.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/and.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -262,8 +262,8 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
-    use shape::location::Location;
-    use shape::location::SourceId;
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
 
     use super::*;
     use crate::connectors::Key;

--- a/apollo-federation/src/connectors/json_selection/methods/public/arithmetic.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/arithmetic.rs
@@ -1,7 +1,7 @@
 use apollo_compiler::collections::IndexSet;
+use apollo_shape::Shape;
 use serde_json::Number;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -842,10 +842,10 @@ mod tests {
 
 #[cfg(test)]
 mod shape_tests {
+    use apollo_shape::Shape;
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
     use serde_json::Number;
-    use shape::Shape;
-    use shape::location::Location;
-    use shape::location::SourceId;
 
     use crate::connectors::json_selection::MethodArgs;
     use crate::connectors::json_selection::ShapeContext;

--- a/apollo-federation/src/connectors/json_selection/methods/public/as.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/as.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -275,9 +275,9 @@ fn as_shape(
 #[cfg(test)]
 mod tests {
     use apollo_compiler::collections::IndexMap;
+    use apollo_shape::Shape;
+    use apollo_shape::location::SourceId;
     use serde_json_bytes::json;
-    use shape::Shape;
-    use shape::location::SourceId;
 
     use crate::connectors::ApplyToError;
     use crate::connectors::ConnectSpec;

--- a/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/contains.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::ConnectSpec;
 use crate::connectors::json_selection::ApplyToError;
@@ -457,9 +457,9 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
     use serde_json::Number;
-    use shape::location::Location;
-    use shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/echo.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/echo.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;

--- a/apollo-federation/src/connectors/json_selection/methods/public/entries.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/entries.rs
@@ -1,8 +1,8 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::ByteString;
 use serde_json_bytes::Map as JSONMap;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::ConnectSpec;
 use crate::connectors::json_selection::ApplyToError;

--- a/apollo-federation/src/connectors/json_selection/methods/public/eq.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/eq.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -380,9 +380,9 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
     use serde_json::Number;
-    use shape::location::Location;
-    use shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/filter.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/filter.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -353,8 +353,8 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
-    use shape::location::Location;
-    use shape::location::SourceId;
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
 
     use super::*;
     use crate::connectors::ConnectSpec;

--- a/apollo-federation/src/connectors/json_selection/methods/public/find.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/find.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::ConnectSpec;
 use crate::connectors::json_selection::ApplyToError;
@@ -415,8 +415,8 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
-    use shape::location::Location;
-    use shape::location::SourceId;
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
 
     use super::*;
     use crate::connectors::ConnectSpec;

--- a/apollo-federation/src/connectors/json_selection/methods/public/first.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/first.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::MethodArgs;

--- a/apollo-federation/src/connectors/json_selection/methods/public/get.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/get.rs
@@ -1,8 +1,8 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
+use apollo_shape::location::SourceId;
 use serde_json_bytes::ByteString;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
-use shape::location::SourceId;
 
 use crate::connectors::ConnectSpec;
 use crate::connectors::json_selection::ApplyToError;
@@ -792,9 +792,9 @@ mod tests {
 
 #[cfg(test)]
 mod shape_tests {
+    use apollo_shape::location::Location;
     use indexmap::IndexMap;
     use serde_json::Number;
-    use shape::location::Location;
 
     use super::*;
     use crate::connectors::Key;

--- a/apollo-federation/src/connectors/json_selection/methods/public/gt.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/gt.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -381,9 +381,9 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
     use serde_json::Number;
-    use shape::location::Location;
-    use shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/gte.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/gte.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -377,9 +377,9 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
     use serde_json::Number;
-    use shape::location::Location;
-    use shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/in.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/in.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::ConnectSpec;
 use crate::connectors::json_selection::ApplyToError;
@@ -454,9 +454,9 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
     use serde_json::Number;
-    use shape::location::Location;
-    use shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/join_not_null.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/join_not_null.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -205,8 +205,8 @@ fn join_not_null_method_shape(
 
 #[cfg(test)]
 mod tests {
+    use apollo_shape::location::SourceId;
     use serde_json_bytes::json;
-    use shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::ApplyToError;

--- a/apollo-federation/src/connectors/json_selection/methods/public/json_parse.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/json_parse.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::MethodArgs;

--- a/apollo-federation/src/connectors/json_selection/methods/public/json_stringify.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/json_stringify.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::MethodArgs;

--- a/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use heck::ToLowerCamelCase;
 use serde_json_bytes::ByteString;
 use serde_json_bytes::Map as JSONMap;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::ConnectSpec;
 use crate::connectors::json_selection::ApplyToError;
@@ -134,7 +134,7 @@ pub(super) fn transform_keys(
 pub(super) fn transform_shape(
     input_shape: Shape,
     recursive: bool,
-    locations: impl IntoIterator<Item = shape::location::Location> + Clone,
+    locations: impl IntoIterator<Item = apollo_shape::location::Location> + Clone,
 ) -> Shape {
     match input_shape.case() {
         ShapeCase::Object { fields, rest, .. } => {
@@ -403,8 +403,8 @@ mod tests {
 
 #[cfg(test)]
 mod shape_tests {
-    use shape::location::Location;
-    use shape::location::SourceId;
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case_deep.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/keys_to_camel_case_deep.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use super::keys_to_camel_case::transform_keys;
 use super::keys_to_camel_case::transform_shape;
@@ -214,8 +214,8 @@ mod tests {
 
 #[cfg(test)]
 mod shape_tests {
-    use shape::location::Location;
-    use shape::location::SourceId;
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/last.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/last.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::MethodArgs;

--- a/apollo-federation/src/connectors/json_selection/methods/public/lt.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/lt.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::ConnectSpec;
 use crate::connectors::json_selection::ApplyToError;
@@ -381,9 +381,9 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
     use serde_json::Number;
-    use shape::location::Location;
-    use shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/lte.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/lte.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -377,9 +377,9 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
     use serde_json::Number;
-    use shape::location::Location;
-    use shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/map.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/map.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;

--- a/apollo-federation/src/connectors/json_selection/methods/public/match.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/match.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;

--- a/apollo-federation/src/connectors/json_selection/methods/public/ne.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/ne.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -379,9 +379,9 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
     use serde_json::Number;
-    use shape::location::Location;
-    use shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/not.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/not.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::ConnectSpec;
 use crate::connectors::json_selection::ApplyToError;
@@ -159,8 +159,8 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
-    use shape::location::Location;
-    use shape::location::SourceId;
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/or.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/or.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;
@@ -242,8 +242,8 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
-    use shape::location::Location;
-    use shape::location::SourceId;
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
 
     use super::*;
     use crate::connectors::Key;

--- a/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/parse_int.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::ConnectSpec;
 use crate::connectors::json_selection::ApplyToError;
@@ -767,8 +767,8 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
-    use shape::location::Location;
-    use shape::location::SourceId;
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
 
     use super::*;
     use crate::connectors::Key;

--- a/apollo-federation/src/connectors/json_selection/methods/public/size.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/size.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::MethodArgs;

--- a/apollo-federation/src/connectors/json_selection/methods/public/slice.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/slice.rs
@@ -1,8 +1,8 @@
 use std::iter::empty;
 
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;

--- a/apollo-federation/src/connectors/json_selection/methods/public/split.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/split.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;

--- a/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/to_string.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::ConnectSpec;
 use crate::connectors::json_selection::ApplyToError;
@@ -274,8 +274,8 @@ mod method_tests {
 
 #[cfg(test)]
 mod shape_tests {
-    use shape::location::Location;
-    use shape::location::SourceId;
+    use apollo_shape::location::Location;
+    use apollo_shape::location::SourceId;
 
     use super::*;
     use crate::connectors::json_selection::lit_expr::LitExpr;

--- a/apollo-federation/src/connectors/json_selection/methods/public/trim.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/trim.rs
@@ -1,6 +1,6 @@
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::MethodArgs;

--- a/apollo-federation/src/connectors/json_selection/methods/public/with_error.rs
+++ b/apollo-federation/src/connectors/json_selection/methods/public/with_error.rs
@@ -1,5 +1,5 @@
+use apollo_shape::Shape;
 use serde_json_bytes::Value as JSON;
-use shape::Shape;
 
 use crate::connectors::json_selection::ApplyToError;
 use crate::connectors::json_selection::ApplyToInternal;

--- a/apollo-federation/src/connectors/json_selection/selection_trie.rs
+++ b/apollo-federation/src/connectors/json_selection/selection_trie.rs
@@ -6,8 +6,8 @@ use std::ops::Range;
 
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
-use shape::name::Name;
-use shape::name::NameCase;
+use apollo_shape::name::Name;
+use apollo_shape::name::NameCase;
 
 use super::Ref;
 use super::helpers::quote_if_necessary;
@@ -130,11 +130,11 @@ impl SelectionTrie {
             .set_leaf()
     }
 
-    /// Walk a [`shape::name::Name`] chain into this trie, creating subtrie
+    /// Walk a [`apollo_shape::name::Name`] chain into this trie, creating subtrie
     /// entries for each path-component segment of the name. Used by
     /// `compute_output_shape` to record consumption byproducts: every shape
     /// produced during the recursion exposes the input paths it came from
-    /// via its [`shape::Name`] metadata, and feeding those names through this
+    /// via its [`apollo_shape::Name`] metadata, and feeding those names through this
     /// method accumulates them into a single per-namespace consumption trie.
     ///
     /// Mapping from [`NameCase`] segments to trie keys:

--- a/apollo-federation/src/connectors/models.rs
+++ b/apollo-federation/src/connectors/models.rs
@@ -16,9 +16,9 @@ use apollo_compiler::executable::FieldSet;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::schema::Type;
 use apollo_compiler::validation::Valid;
+use apollo_shape::Shape;
 use keys::make_key_field_set_from_variables;
 use serde_json::Value;
-use shape::Shape;
 
 pub use self::headers::Header;
 pub(crate) use self::headers::HeaderParseError;
@@ -1010,7 +1010,7 @@ mod tests {
     // `Shape::one([normal_shape, error_shape], [])` pattern is the foundation
     // downstream consumers (entity-key checker, type walker) can build on.
     mod output_shape {
-        use shape::ShapeCase;
+        use apollo_shape::ShapeCase;
 
         use super::*;
         use crate::connectors::JSONSelection;

--- a/apollo-federation/src/connectors/schema_type_ref.rs
+++ b/apollo-federation/src/connectors/schema_type_ref.rs
@@ -10,7 +10,7 @@ use apollo_compiler::schema::Component;
 use apollo_compiler::schema::ExtendedType;
 #[cfg(test)]
 use apollo_compiler::schema::ObjectType;
-use shape::Shape;
+use apollo_shape::Shape;
 
 /// A [`SchemaTypeRef`] is a `Copy`able reference to a named type within a
 /// [`Schema`]. Because [`SchemaTypeRef`] holds a `&'schema Schema` reference to

--- a/apollo-federation/src/connectors/validation/connect/http.rs
+++ b/apollo-federation/src/connectors/validation/connect/http.rs
@@ -6,8 +6,8 @@ use std::str::FromStr;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::ast::Value;
+use apollo_shape::Shape;
 use multi_try::MultiTry;
-use shape::Shape;
 
 use crate::connectors::HTTPMethod;
 use crate::connectors::Namespace;

--- a/apollo-federation/src/connectors/validation/connect/selection.rs
+++ b/apollo-federation/src/connectors/validation/connect/selection.rs
@@ -10,11 +10,11 @@ use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::parser::LineColumn;
 use apollo_compiler::schema::ExtendedType;
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
+use apollo_shape::graphql::source_file;
+use apollo_shape::location::Location;
 use itertools::Itertools;
-use shape::Shape;
-use shape::ShapeCase;
-use shape::location::Location;
-use shape::location::SourceId;
 
 use self::variables::VariableResolver;
 use super::Code;
@@ -559,13 +559,13 @@ impl<'schema> SelectionValidator<'schema> {
     ) -> Vec<Range<LineColumn>> {
         shape_locations
             .into_iter()
-            .filter_map(|location| match &location.source_id {
-                SourceId::GraphQL(file_id) => self
-                    .schema
-                    .sources
-                    .get(file_id)
-                    .and_then(|source| source.get_line_column_range(location.span.clone())),
-                SourceId::Other(_) => {
+            .filter_map(|location| {
+                // GraphQL locations are `graphql:<path>` `SourceId::Other` values
+                // since apollo-shape 0.1.0; `source_file` returns `None` for the
+                // JSONSelection ids, which is how the two are told apart here.
+                if let Some(source) = source_file(self.schema, &location.source_id) {
+                    source.get_line_column_range(location.span.clone())
+                } else {
                     // JSONSelection location - convert to range in the selection string
                     subslice_location(self.node, location.span.clone(), self.schema)
                 }

--- a/apollo-federation/src/connectors/validation/errors.rs
+++ b/apollo-federation/src/connectors/validation/errors.rs
@@ -7,8 +7,8 @@ use std::fmt::Formatter;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::ast::Value;
+use apollo_shape::Shape;
 use multi_try::MultiTry;
-use shape::Shape;
 
 use super::coordinates::ConnectDirectiveCoordinate;
 use super::coordinates::IsSuccessCoordinate;

--- a/apollo-federation/src/connectors/validation/expression.rs
+++ b/apollo-federation/src/connectors/validation/expression.rs
@@ -11,13 +11,13 @@ use apollo_compiler::ast::Value;
 use apollo_compiler::collections::HashSet;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::parser::LineColumn;
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
+use apollo_shape::graphql::shape_for_arguments;
+use apollo_shape::graphql::source_file;
+use apollo_shape::location::Location;
+use apollo_shape::name::NameCase;
 use itertools::Itertools;
-use shape::Shape;
-use shape::ShapeCase;
-use shape::graphql::shape_for_arguments;
-use shape::location::Location;
-use shape::location::SourceId;
-use shape::name::NameCase;
 
 use crate::connectors::JSONSelection;
 use crate::connectors::Namespace;
@@ -86,7 +86,7 @@ impl<'schema> Context<'schema> {
                 parent_category,
             } => {
                 let mut var_lookup: IndexMap<Namespace, Shape> = [
-                    (Namespace::Args, shape_for_arguments(field_def)),
+                    (Namespace::Args, shape_for_arguments(schema, field_def)),
                     (Namespace::Config, Shape::unknown([])),
                     (Namespace::Context, Shape::unknown([])),
                     (Namespace::Request, REQUEST_SHAPE.clone()),
@@ -145,7 +145,7 @@ impl<'schema> Context<'schema> {
                 parent_category,
             } => {
                 let mut var_lookup: IndexMap<Namespace, Shape> = [
-                    (Namespace::Args, shape_for_arguments(field_def)),
+                    (Namespace::Args, shape_for_arguments(schema, field_def)),
                     (Namespace::Config, Shape::unknown([])),
                     (Namespace::Context, Shape::unknown([])),
                     (Namespace::Status, Shape::int([])),
@@ -597,14 +597,14 @@ fn transform_locations<'a>(
 ) -> Vec<Range<LineColumn>> {
     let mut locations: Vec<_> = locations
         .into_iter()
-        .filter_map(|location| match &location.source_id {
-            SourceId::GraphQL(file_id) => context
-                .schema
-                .sources
-                .get(file_id)
-                .and_then(|source| source.get_line_column_range(location.span.clone())),
-            SourceId::Other(_) => {
-                // Right now, this always refers to the JSONSelection location
+        .filter_map(|location| {
+            // Since apollo-shape 0.1.0, a GraphQL location is a `SourceId::Other`
+            // of the form `graphql:<path>` rather than its own variant, so it is
+            // `source_file` that tells one apart from the `JSONSelection` ids we
+            // mint ourselves: it returns `None` for anything it did not produce.
+            if let Some(source) = source_file(context.schema, &location.source_id) {
+                source.get_line_column_range(location.span.clone())
+            } else {
                 subslice_location(
                     context.node,
                     location.span.start + expression.location.start

--- a/apollo-federation/src/connectors/validation/graphql.rs
+++ b/apollo-federation/src/connectors/validation/graphql.rs
@@ -4,8 +4,8 @@ use std::ops::Deref;
 use apollo_compiler::Name;
 use apollo_compiler::Schema;
 use apollo_compiler::collections::IndexMap;
+use apollo_shape::Shape;
 use line_col::LineColLookup;
-use shape::Shape;
 
 mod strings;
 
@@ -33,7 +33,7 @@ impl<'schema> SchemaInfo<'schema> {
             len: src.len(),
             lookup: LineColLookup::new(src),
             connect_link,
-            shape_lookup: shape::graphql::shapes_for_schema(schema),
+            shape_lookup: apollo_shape::graphql::shapes_for_schema(schema),
         }
     }
 

--- a/apollo-federation/src/connectors/validation/http/url_properties.rs
+++ b/apollo-federation/src/connectors/validation/http/url_properties.rs
@@ -4,8 +4,8 @@ use std::sync::LazyLock;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::ast::Value;
+use apollo_shape::Shape;
 use itertools::Itertools;
-use shape::Shape;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 

--- a/apollo-federation/src/connectors/validation/schema.rs
+++ b/apollo-federation/src/connectors/validation/schema.rs
@@ -15,12 +15,12 @@ use apollo_compiler::schema::Component;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::schema::ObjectType;
 use apollo_compiler::validation::Valid;
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
+use apollo_shape::ShapeVisitor;
 use hashbrown::HashSet;
 use indexmap::IndexMap;
 use itertools::Itertools;
-use shape::Shape;
-use shape::ShapeCase;
-use shape::ShapeVisitor;
 
 use self::keys::EntityKeyChecker;
 use self::keys::field_set_error;

--- a/apollo-federation/src/connectors/validation/schema/keys.rs
+++ b/apollo-federation/src/connectors/validation/schema/keys.rs
@@ -13,9 +13,9 @@ use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable::FieldSet;
 use apollo_compiler::executable::Selection;
 use apollo_compiler::validation::Valid;
+use apollo_shape::Shape;
+use apollo_shape::ShapeCase;
 use itertools::Itertools;
-use shape::Shape;
-use shape::ShapeCase;
 
 use crate::connectors::Connector;
 use crate::connectors::Namespace;
@@ -402,7 +402,7 @@ mod tests {
     /// Test case: __typename field is itself a union of string literals
     #[test]
     fn test_extract_typename_union_of_strings() {
-        use shape::Shape;
+        use apollo_shape::Shape;
 
         // Build shape: { __typename: One(["TypeA", "TypeB"]), id: String }
         let typename_union = Shape::one(
@@ -434,7 +434,7 @@ mod tests {
     /// Test case: Nested __typename values should NOT be extracted
     #[test]
     fn test_does_not_extract_nested_typename() {
-        use shape::Shape;
+        use apollo_shape::Shape;
 
         // Build shape: { id: String, author: { __typename: "User", id: String } }
         let nested_object = Shape::closed_record(
@@ -470,7 +470,7 @@ mod tests {
     /// have two different concrete types at once.
     #[test]
     fn test_does_not_extract_conflicting_typename_intersection() {
-        use shape::Shape;
+        use apollo_shape::Shape;
 
         // Build shape: { __typename: All<"Cat", "Dog">, id: String }
         // This represents an impossible object with conflicting typenames
@@ -508,7 +508,7 @@ mod tests {
     /// conflicting intersections - only the valid ones should be extracted.
     #[test]
     fn test_extracts_only_valid_typename_from_mixed_union() {
-        use shape::Shape;
+        use apollo_shape::Shape;
 
         // Valid object: { __typename: "Cat", id: String }
         let valid_cat = Shape::closed_record(

--- a/apollo-federation/src/connectors/validation/snapshots/validation_tests@uri_templates__invalid_types.graphql.snap
+++ b/apollo-federation/src/connectors/validation/snapshots/validation_tests@uri_templates__invalid_types.graphql.snap
@@ -14,7 +14,7 @@ input_file: apollo-federation/src/connectors/validation/test_data/uri_templates/
     },
     Message {
         code: InvalidUrl,
-        message: "In `GET` in `@connect(http:)` on `Query.argIsObject`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<{ val: Unknown }, null>`",
+        message: "In `GET` in `@connect(http:)` on `Query.argIsObject`: expected union but received incompatible union\nDetails: `One<Float, Bool, String, null, None>` does not accept `One<{ val: One<String, null> }, null>`",
         locations: [
             36:1..38:2,
             14:22..14:27,

--- a/apollo-federation/tests/dhat_profiling/connectors_validation.rs
+++ b/apollo-federation/tests/dhat_profiling/connectors_validation.rs
@@ -9,7 +9,15 @@ pub(crate) static ALLOC: dhat::Alloc = dhat::Alloc;
 fn valid_large_body() {
     const SCHEMA: &str = "src/connectors/validation/test_data/valid_large_body.graphql";
 
-    const MAX_BYTES: usize = 275_000;
+    // Bumped from 275_000 with apollo-shape 0.2.0, which gives GraphQL types the
+    // shapes their schemas describe: a built-in scalar field is now a concrete
+    // shape rather than a shared `Unknown`, a nullable one is a two-member `One`,
+    // and nested lists keep every level. Peak live bytes grew 15.7% (269,550 ->
+    // 311,925) while total allocation churn moved 1.1% (3,923,053 -> 3,966,885),
+    // so this is more shape held live at once rather than more allocation
+    // traffic. Note also that 275_000 sat only 2% above the measured peak,
+    // tighter than the ~10% this file asks for; 345_000 restores that margin.
+    const MAX_BYTES: usize = 345_000;
     // Bumped from 27_000 once the fused-trie consumption infrastructure
     // landed: `compute_output_shape` now records into a `SelectionTrie`
     // baton on every recursive step, which roughly doubles allocation


### PR DESCRIPTION
Stacked on #9947, which this PR targets as its base. Review that one first; the diff here is only the move to `shape` 0.9.0.

`shape` 0.9.0 moves its GraphQL front end out into a separate [`apollo-shape`](https://crates.io/crates/apollo-shape) crate, so that `shape` itself no longer depends on `apollo-compiler` and an `apollo-compiler` upgrade is no longer a `shape` release. `apollo-shape` re-exports all of `shape`, so `apollo-federation` depends on the wrapper alone, at `=0.2.0`, and reaches `Shape` and everything around it through that.

## What changed

Most of the diff is mechanical: `shape::` becomes `apollo_shape::` at 147 occurrences across 54 files under `apollo-federation/src/connectors`, plus the import reordering rustfmt asks for afterwards, since `apollo_shape` sorts where `shape` did not. The substantive changes are four.

**The dependency.** `apollo-federation/Cargo.toml` swaps `shape = "=0.8.3"` for `apollo-shape = "=0.2.0"`. Cargo re-resolved only those two packages, and the lockfile records `shape` dropping `apollo-compiler` from its dependency list, which is the point of the split.

**The module path.** `shape::graphql` becomes `apollo_shape::graphql`, in `validation/graphql.rs` and `validation/expression.rs`.

**`shape_for_arguments` takes the `&Schema` first**, because attributing argument spans to their source files needs the schema's source map. Both call sites in `expression.rs` already hold the `SchemaInfo`, which derefs to `Schema`.

**`SourceId::GraphQL(FileId)` is gone**, its payload having been an `apollo-compiler` type. GraphQL locations now arrive as `SourceId::Other("graphql:<path>")`, the same variant the JSONSelection ids use, so the variant no longer tells the two apart. The two `match`es on it become `if let Some(source) = source_file(..)`, which returns `None` for any id `apollo-shape` did not produce. That also disposes of `SourceId`'s new `#[non_exhaustive]`: those were the only matches that would have needed a wildcard arm.

Two other breaking changes in 0.9.0 cost nothing here. `Shape::never` now requires a reason for the shape being unsatisfiable, and there is no `Shape::never` call site in this repository. The `ToShape` trait replaces the `From<&ExtendedType> for Shape` impls, which connectors never used, since `schema_type_ref.rs` does that conversion itself.

## What taking the wrapper at 0.2.0 rather than 0.1.0 adds

0.2.0 gives GraphQL types the shapes their schemas actually describe: a built-in scalar field is no longer `Unknown` (`String` is `String`, `ID` is `One<String, Int>`), `shape_for_arguments` and the `ToShape` impls stop carrying a second and disagreeing scalar mapping of their own, a list's elements keep their own nullability, and a list of lists stays a list of lists. None of that changes the API, so it needs no source change beyond the version.

Only one of those four is visible from here, and the reason is worth recording: `connectors/schema_type_ref.rs` carries the router's own `ExtendedType` -> `Shape` conversion, and its scalar arm already agrees with 0.2.0 exactly, down to `ID` being `One<String, Int>`. So the output-type path was already right and does not move. The list fixes do not show either, since the fixtures use `[String]`, the one combination whose shape is unchanged.

What moves is the input-object path, which goes through `apollo-shape` rather than through our own converter. One snapshot line, for `input Input { val: String }`:

```diff
-  does not accept `One<{ val: Unknown }, null>`
+  does not accept `One<{ val: One<String, null> }, null>`
```

Same code, same locations, and the `Details:` now names the real field type instead of admitting nothing. The field is nullable, so `One<String, null>` is correct.

That is what the CHANGELOG entry reports, and the only thing it reports. 0.9.0 also makes an unsatisfiable shape carry the reason it cannot be satisfied, which is a real improvement in the crate, but it is not reachable from connectors validation today: a two-type conflict such as `All<String, Int>` is retained rather than collapsed to a `Never`, so it still carries no reason.

## The `valid_large_body` heap budget

`MAX_BYTES` goes from 275,000 to 345,000. Measured either side of the bump:

| | peak bytes | peak blocks | total bytes | total blocks |
|---|---|---|---|---|
| 0.1.0 | 269,550 | 2,886 | 3,923,053 | 57,642 |
| 0.2.0 | 311,925 | 3,256 | 3,966,885 | 58,042 |

Peak live bytes grew 15.7% while total allocation churn moved 1.1%, which is the signature of more shape held live at once rather than more allocation traffic: a concrete scalar, and especially a two-member nullable union, costs more than the shared `Unknown` that used to sit there. Expected, and proportionate to what 0.2.0 buys.

Worth noting for whoever tunes this next: 275,000 was only 2% above the old peak, where the comment at the top of that file asks for ~10%, so the guard was nearly exhausted before this change. 345,000 restores the stated margin. `MAX_ALLOCATIONS` still has 10% of headroom and is left alone.

## Testing

`cargo test -p apollo-federation`: 1949 lib, 840 integration, 3 dhat profiling and 8 doctests pass. `cargo clippy -p apollo-federation --all-targets --all-features -- -D warnings` clean, `cargo fmt --check` clean, and `cargo check -p apollo-router` builds against it.

The three `with_error.rs` doctests fail, as they already do on `dev`: their JSONSelection examples are 4-space-indented blocks that rustdoc compiles as Rust. That arrived with #10050 and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
