### PR TITLE
fix(authorization): stop warm-up logging filtered operations as auth errors

### DIFF
--- a/.changesets/fix_warmup_authorization_error_log.md
+++ b/.changesets/fix_warmup_authorization_error_log.md
@@ -1,0 +1,7 @@
+### Query plan warm-up no longer logs a false "Authorization error" ([PR #10210](https://github.com/apollographql/router/pull/10210))
+
+When query plan warm-up loads persisted operations, it plans them without auth context. Authorization filtering can remove every field from a `@policy`-protected operation, causing warm-up to log an ERROR-level "Authorization error" during startup or reload.
+
+Warm-up now suppresses this log event. Client requests still log the event when authorization filtering rejects the entire operation on a query plan cache miss and authorization error logging is enabled. Cache hits, including cached rejections populated by warm-up, bypass this log.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/10210

--- a/apollo-router/src/compute_job/mod.rs
+++ b/apollo-router/src/compute_job/mod.rs
@@ -143,6 +143,17 @@ impl From<ComputeJobType> for Priority {
     }
 }
 
+impl ComputeJobType {
+    pub(crate) fn is_warmup(&self) -> bool {
+        match self {
+            ComputeJobType::QueryParsingWarmup | ComputeJobType::QueryPlanningWarmup => true,
+            ComputeJobType::QueryParsing
+            | ComputeJobType::QueryPlanning
+            | ComputeJobType::Introspection => false,
+        }
+    }
+}
+
 impl_otel_value_from_static_str!(ComputeJobType);
 
 pub(crate) struct Job {

--- a/apollo-router/src/query_planner/query_planner_service.rs
+++ b/apollo-router/src/query_planner/query_planner_service.rs
@@ -531,7 +531,9 @@ impl QueryPlannerService {
                             paths,
                             errors: self.authorization_config.error_config(),
                         };
-                        unauthorized.log_unauthorized_paths();
+                        if !compute_job_type.is_warmup() {
+                            unauthorized.log_unauthorized_paths();
+                        }
                         unauthorized.update_response_with_unauthorized_path_errors(&mut response);
                     }
 
@@ -1331,5 +1333,86 @@ mod tests {
         }
         .with_metrics()
         .await;
+    }
+
+    async fn plan_unauthorized_operation(compute_job_type: ComputeJobType) -> QueryPlannerContent {
+        let configuration: Arc<Configuration> = Arc::default();
+        let schema = Schema::parse(
+            include_str!("../../tests/fixtures/directives/policy/policy_basic_schema.graphql"),
+            &configuration,
+        )
+        .unwrap();
+        let planner = QueryPlannerService::new(schema.into(), configuration.clone())
+            .await
+            .unwrap();
+
+        let query = "{ private { id } }";
+        let doc = Query::parse_document(query, None, &planner.schema(), &configuration).unwrap();
+
+        planner
+            .get(
+                QueryKey {
+                    original_query: query.to_string(),
+                    filtered_query: query.to_string(),
+                    operation_name: None,
+                    metadata: CacheKeyMetadata::default(),
+                    plan_options: PlanOptions::default(),
+                },
+                doc,
+                compute_job_type,
+                Default::default(),
+            )
+            .await
+            .expect("filtering an unauthorized operation returns a null response, not an error")
+    }
+
+    /// Events logged while planning, in a buffer owned by a single test.
+    #[derive(Clone, Default)]
+    struct LogBuffer(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl LogBuffer {
+        fn contains(&self, value: &str) -> bool {
+            String::from_utf8(self.0.lock().unwrap().clone())
+                .expect("logs are valid UTF-8")
+                .contains(value)
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogBuffer {
+        type Writer = tracing_subscriber::fmt::writer::MutexGuardWriter<'a, Vec<u8>>;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.0.as_ref().make_writer()
+        }
+    }
+
+    async fn plan_unauthorized_operation_capturing_logs(
+        compute_job_type: ComputeJobType,
+    ) -> (QueryPlannerContent, LogBuffer) {
+        use tracing_futures::WithSubscriber;
+
+        let logs = LogBuffer::default();
+        let content = plan_unauthorized_operation(compute_job_type)
+            .with_subscriber(tracing_subscriber::fmt().with_writer(logs.clone()).finish())
+            .await;
+        (content, logs)
+    }
+
+    #[test(tokio::test)]
+    async fn warm_up_does_not_log_a_filtered_out_operation_as_an_authorization_error() {
+        let (result, logs) =
+            plan_unauthorized_operation_capturing_logs(ComputeJobType::QueryPlanningWarmup).await;
+
+        assert!(matches!(result, QueryPlannerContent::Response { .. }));
+        assert!(!logs.contains("Authorization error"));
+    }
+
+    #[test(tokio::test)]
+    async fn a_real_unauthorized_request_still_logs_an_authorization_error() {
+        let (result, logs) =
+            plan_unauthorized_operation_capturing_logs(ComputeJobType::QueryPlanning).await;
+
+        assert!(matches!(result, QueryPlannerContent::Response { .. }));
+        assert!(logs.contains("Authorization error"));
     }
 }


### PR DESCRIPTION
A schema with `@policy`-protected persisted operations logs one ERROR-level "Authorization error" per operation on every startup and reload — 4,515 of them in the reported case. Warm-up plans each operation with `CacheKeyMetadata::default()`, so no policy is granted, the operation filters to an empty document, and `filter_query` returns `Unauthorized` through the same branch a denied client request takes.

Reported as RH-1378, escalated from a customer who enabled `query_planning.cache.warmed_up_queries`.

### The guard

`ComputeJobType` already distinguished warm-up from a real request and was already a parameter of `get()`, so the fix keys on that rather than on "the document came out empty" — a real request can empty its document too, and that must keep logging. `update_response_with_unauthorized_path_errors` stays outside the guard, so the cached response is byte-identical and only the log is suppressed.

### Evidence

Two tests, as a pair: warm-up stays silent, a real request still logs. They pass together in one process under plain `cargo test`, which matters here — they initially shared `tracing_test`'s process-global buffer, so the warm-up test read its sibling's event and failed. Nextest's process-per-test hid that, so CI would have been green while a contributor running `cargo test` saw a failure. Each test now captures into its own subscriber.

### Known gap, not addressed here

Warm-up caches the null unauthorized response, so a later client request for that same operation hits the cache, never reaches `get`, and logs nothing. `log_unauthorized_paths` has the same two call sites before and after this change, and for a fully-filtered operation execution never runs either — so this predates the change, and the warm-up log it removes was never attributable to a request. Closing it means deciding whether a cached authorization denial should log once or once per request, which is a telemetry-volume call worth its own ticket.

### Gate

Targeted run green: `compute_job::` plus both new tests, 8 passed. The aggregate `cargo xtask all` is not a clean signal in this environment — `cargo xtask lint` is red on `origin/dev` itself with 8 pre-existing `clippy::result_large_err` unfulfilled-expectation errors, and a full-suite run here fails on missing Redis, `protoc` and platform certs. CI is the arbiter for those.