### PR TITLE
test(connectors): pin `$batch` representation deduplication and response alignment

### DIFF
--- a/apollo-federation/src/connectors/runtime/responses.rs
+++ b/apollo-federation/src/connectors/runtime/responses.rs
@@ -615,6 +615,11 @@ impl MappedResponse {
                     )
                     .map_err(|e| HandleResponseError::MergeError(e.to_string()))?;
 
+                    // Alignment is by key value, never by position. The API may return
+                    // the batch in any order, include objects that were not requested,
+                    // or omit some that were. Each representation is matched to the
+                    // returned object carrying the same key; unmatched ones become Null.
+                    //
                     // Convert representations into keys for use in the map
                     let key_values = inputs.batch.iter().map(|v| {
                         key_selection

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -820,6 +820,124 @@ mod tests {
         "#);
     }
 
+    /// Batch responses are aligned to representations by key value, never by
+    /// position. One response exercises all three ways the array can differ
+    /// from the request: reordered, an unrequested extra object, and a
+    /// requested object that is missing (which becomes Null).
+    #[tokio::test]
+    async fn test_handle_responses_batch_reordered_extra_and_missing() {
+        let connector = Arc::new(Connector {
+            spec: ConnectSpec::V0_2,
+            id: ConnectId::new_on_object("subgraph_name".into(), None, name!(User), None, 0),
+            schema_subtypes_map: Default::default(),
+            transport: Some(HttpJsonTransport {
+                source_template: "http://localhost/api".parse().ok(),
+                connect_template: "/path".parse().unwrap(),
+                method: HTTPMethod::Post,
+                body: Some(JSONSelection::parse("ids: $batch.id").unwrap()),
+                ..Default::default()
+            }),
+            selection: JSONSelection::parse("$.data { id name }").unwrap(),
+            entity_resolver: Some(EntityResolver::TypeBatch),
+            config: Default::default(),
+            max_requests: None,
+            batch_settings: None,
+            request_headers: Default::default(),
+            response_headers: Default::default(),
+            request_variable_keys: Default::default(),
+            response_variable_keys: Default::default(),
+            error_settings: Default::default(),
+            output_type: None,
+            label: "test label".into(),
+        });
+
+        let keys = connector
+            .resolvable_key(
+                &Schema::parse_and_validate("type Query { _: ID } type User { id: ID! }", "")
+                    .unwrap(),
+            )
+            .unwrap()
+            .unwrap();
+
+        let response1: http::Response<RouterBody> = http::Response::builder()
+            // Requested [1, 2, 3]; returned 2 then 1, plus an unrequested 99,
+            // and no 3 at all.
+            .body(router::body::from_bytes(
+                r#"{"data":[{"id": "2","name":"B"},{"id": "99","name":"unrequested"},{"id": "1","name":"A"}]}"#,
+            ))
+            .unwrap();
+
+        let mut inputs: RequestInputs = RequestInputs::default();
+        let representations = serde_json_bytes::json!([
+            {"__typename": "User", "id": "1"},
+            {"__typename": "User", "id": "2"},
+            {"__typename": "User", "id": "3"},
+        ]);
+        inputs.batch = representations
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_object().unwrap().clone())
+            .collect_vec();
+
+        let response_key1 = ResponseKey::BatchEntity {
+            selection: Arc::new(JSONSelection::parse("$.data { id name }").unwrap()),
+            keys,
+            inputs,
+        };
+
+        let supergraph_request = Arc::new(
+            http::Request::builder()
+                .body(graphql::Request::builder().build())
+                .unwrap(),
+        );
+
+        let res = super::aggregate_responses(
+            vec![
+                process_response(
+                    Ok(response1),
+                    response_key1,
+                    connector.clone(),
+                    &Context::default(),
+                    (None, Default::default()),
+                    None,
+                    supergraph_request,
+                    Default::default(),
+                )
+                .await
+                .mapped_response,
+            ],
+            Context::new(),
+        )
+        .unwrap();
+
+        assert_debug_snapshot!(res.response.body().data, @r#"
+        Some(
+            Object({
+                "_entities": Array([
+                    Object({
+                        "id": String(
+                            "1",
+                        ),
+                        "name": String(
+                            "A",
+                        ),
+                    }),
+                    Object({
+                        "id": String(
+                            "2",
+                        ),
+                        "name": String(
+                            "B",
+                        ),
+                    }),
+                    Null,
+                ]),
+            }),
+        )
+        "#);
+    }
+
     #[tokio::test]
     async fn test_handle_responses_entity_field() {
         let connector = Arc::new(Connector {

--- a/apollo-router/src/plugins/connectors/testdata/batch-compound-key.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/batch-compound-key.graphql
@@ -1,0 +1,71 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.2", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.2", import: ["@source", "@connect"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "http://localhost:4001/api"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "http://none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: CONNECTORS)
+{
+  users: [User!]! @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users"}, selection: "id region"})
+}
+
+type User
+  @join__type(graph: CONNECTORS)
+  @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {POST: "/users-batch", body: "ids: $batch.id regions: $batch.region"}, selection: "id region name"})
+{
+  id: ID!
+  region: String!
+  name: String
+}

--- a/apollo-router/src/plugins/connectors/testdata/batch-compound-key.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/batch-compound-key.yaml
@@ -1,0 +1,25 @@
+subgraphs:
+  connectors:
+    routing_url: http://none
+    schema:
+      sdl: |
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.11")
+          @link(url: "https://specs.apollo.dev/connect/v0.2", import: ["@source", "@connect"])
+          @source(name: "json", http: { baseURL: "http://localhost:4001/api" })
+
+        type Query {
+          users: [User!]!
+            @connect(source: "json", http: { GET: "/users" }, selection: "id region")
+        }
+
+        type User
+          @connect(source: "json"
+            http: { POST: "/users-batch", body: "ids: $$batch.id regions: $$batch.region" }
+            selection: "id region name"
+          )
+        {
+          id: ID!
+          region: String!
+          name: String
+        }

--- a/apollo-router/src/plugins/connectors/tests/connect_on_type.rs
+++ b/apollo-router/src/plugins/connectors/tests/connect_on_type.rs
@@ -1063,3 +1063,82 @@ async fn batch_response_matched_by_key_not_position() {
         ],
     );
 }
+
+/// The canonical statement of the dedup contract, in the shape the question
+/// is usually asked: given input keys `[1, 1, 1, 2]`, the outbound request
+/// asks for only the distinct keys (`?ids=1,2`), and results are fanned back
+/// out to every original position.
+#[tokio::test]
+async fn batch_query_params_request_only_distinct_keys() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "id": 1 },
+            { "id": 1 },
+            { "id": 1 },
+            { "id": 2 },
+        ])))
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/user-details"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "id": 1, "name": "Leanne Graham", "username": "Bret" },
+            { "id": 2, "name": "Ervin Howell", "username": "Antonette" },
+        ])))
+        .mount(&mock_server)
+        .await;
+
+    let response = super::execute(
+        include_str!("../testdata/batch-query.graphql"),
+        &mock_server.uri(),
+        "query { users { id name username } }",
+        Default::default(),
+        None,
+        |_| {},
+        None,
+    )
+    .await;
+
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "users": [
+          {
+            "id": 1,
+            "name": "Leanne Graham",
+            "username": "Bret"
+          },
+          {
+            "id": 1,
+            "name": "Leanne Graham",
+            "username": "Bret"
+          },
+          {
+            "id": 1,
+            "name": "Leanne Graham",
+            "username": "Bret"
+          },
+          {
+            "id": 2,
+            "name": "Ervin Howell",
+            "username": "Antonette"
+          }
+        ]
+      }
+    }
+    "#);
+
+    super::req_asserts::matches(
+        &mock_server.received_requests().await.unwrap(),
+        vec![
+            Matcher::new().method("GET").path("/users"),
+            // `?ids=1,2`, URL-encoded: four references, two distinct keys.
+            Matcher::new()
+                .method("GET")
+                .path("/user-details")
+                .query("ids=1%2C2"),
+        ],
+    );
+}

--- a/apollo-router/src/plugins/connectors/tests/connect_on_type.rs
+++ b/apollo-router/src/plugins/connectors/tests/connect_on_type.rs
@@ -660,3 +660,318 @@ async fn batch_with_max_size_over_batch_size() {
     ]);
     plan.assert_matches(&mock_server.received_requests().await.unwrap());
 }
+
+// --- $batch DEDUPLICATION ----------------------------------------------------
+//
+// The router dedupes entity representations by value when it builds the
+// `representations` variable for a fetch (see `Variables::new` in
+// `query_planner/fetch.rs`). Connectors receive that already-deduped list as
+// `$batch` and do no further dedup of their own. The tests below pin that
+// contract down from the outside: what reaches the wire, and how the single
+// returned entity is fanned back out to every position that referenced it.
+
+/// The same entity referenced from several positions in the parent data
+/// appears exactly once in `$batch`, and the one returned object is copied
+/// back into every referencing position.
+#[tokio::test]
+async fn batch_dedupes_repeated_representations() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "id": 3 },
+            { "id": 1 },
+            { "id": 3 },
+            { "id": 2 },
+            { "id": 1 },
+        ])))
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/users-batch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "id": 1, "name": "Leanne Graham", "username": "Bret" },
+            { "id": 2, "name": "Ervin Howell", "username": "Antonette" },
+            { "id": 3, "name": "Clementine Bauch", "username": "Samantha" },
+        ])))
+        .mount(&mock_server)
+        .await;
+
+    let response = super::execute(
+        include_str!("../testdata/batch.graphql"),
+        &mock_server.uri(),
+        "query { users { id name username } }",
+        Default::default(),
+        None,
+        |_| {},
+        None,
+    )
+    .await;
+
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "users": [
+          {
+            "id": 3,
+            "name": "Clementine Bauch",
+            "username": "Samantha"
+          },
+          {
+            "id": 1,
+            "name": "Leanne Graham",
+            "username": "Bret"
+          },
+          {
+            "id": 3,
+            "name": "Clementine Bauch",
+            "username": "Samantha"
+          },
+          {
+            "id": 2,
+            "name": "Ervin Howell",
+            "username": "Antonette"
+          },
+          {
+            "id": 1,
+            "name": "Leanne Graham",
+            "username": "Bret"
+          }
+        ]
+      }
+    }
+    "#);
+
+    super::req_asserts::matches(
+        &mock_server.received_requests().await.unwrap(),
+        vec![
+            Matcher::new().method("GET").path("/users"),
+            // Five references, three distinct ids, in order of first appearance.
+            Matcher::new()
+                .method("POST")
+                .path("/users-batch")
+                .body(json!({ "ids": [3, 1, 2] })),
+        ],
+    );
+}
+
+/// Dedup happens before `batch.maxSize` chunking, so chunk boundaries are
+/// computed over distinct keys and a key never appears in two chunks of the
+/// same fetch.
+#[tokio::test]
+async fn batch_dedupes_before_max_size_chunking() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "id": 3 },
+            { "id": 1 },
+            { "id": 3 },
+            { "id": 2 },
+            { "id": 1 },
+            { "id": 4 },
+            { "id": 5 },
+            { "id": 4 },
+            { "id": 6 },
+            { "id": 7 },
+            { "id": 6 },
+            { "id": 3 },
+        ])))
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/users-batch"))
+        .and(body_json(json!({ "ids": [3, 1, 2, 4, 5] })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "id": 1, "name": "Leanne Graham", "username": "Bret" },
+            { "id": 2, "name": "Ervin Howell", "username": "Antonette" },
+            { "id": 3, "name": "Clementine Bauch", "username": "Samantha" },
+            { "id": 4, "name": "John Doe", "username": "jdoe" },
+            { "id": 5, "name": "John Wick", "username": "jwick" },
+        ])))
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/users-batch"))
+        .and(body_json(json!({ "ids": [6, 7] })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "id": 6, "name": "Jack Reacher", "username": "reacher" },
+            { "id": 7, "name": "James Bond", "username": "jbond" },
+        ])))
+        .mount(&mock_server)
+        .await;
+
+    let response = super::execute(
+        include_str!("../testdata/batch-max-size.graphql"),
+        &mock_server.uri(),
+        "query { users { id name username } }",
+        Default::default(),
+        None,
+        |_| {},
+        None,
+    )
+    .await;
+
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "users": [
+          {
+            "id": 3,
+            "name": "Clementine Bauch",
+            "username": "Samantha"
+          },
+          {
+            "id": 1,
+            "name": "Leanne Graham",
+            "username": "Bret"
+          },
+          {
+            "id": 3,
+            "name": "Clementine Bauch",
+            "username": "Samantha"
+          },
+          {
+            "id": 2,
+            "name": "Ervin Howell",
+            "username": "Antonette"
+          },
+          {
+            "id": 1,
+            "name": "Leanne Graham",
+            "username": "Bret"
+          },
+          {
+            "id": 4,
+            "name": "John Doe",
+            "username": "jdoe"
+          },
+          {
+            "id": 5,
+            "name": "John Wick",
+            "username": "jwick"
+          },
+          {
+            "id": 4,
+            "name": "John Doe",
+            "username": "jdoe"
+          },
+          {
+            "id": 6,
+            "name": "Jack Reacher",
+            "username": "reacher"
+          },
+          {
+            "id": 7,
+            "name": "James Bond",
+            "username": "jbond"
+          },
+          {
+            "id": 6,
+            "name": "Jack Reacher",
+            "username": "reacher"
+          },
+          {
+            "id": 3,
+            "name": "Clementine Bauch",
+            "username": "Samantha"
+          }
+        ]
+      }
+    }
+    "#);
+
+    // Twelve references collapse to seven distinct ids, which `maxSize: 5`
+    // splits into a chunk of five and a chunk of two. The two POSTs are
+    // independent, so assert them order-free.
+    let plan = Plan::Sequence(vec![
+        Plan::Fetch(Matcher::new().method("GET").path("/users")),
+        Plan::Parallel(vec![
+            Matcher::new()
+                .method("POST")
+                .path("/users-batch")
+                .body(json!({ "ids": [3, 1, 2, 4, 5] })),
+            Matcher::new()
+                .method("POST")
+                .path("/users-batch")
+                .body(json!({ "ids": [6, 7] })),
+        ]),
+    ]);
+    plan.assert_matches(&mock_server.received_requests().await.unwrap());
+}
+
+/// Dedup is by whole representation, not by any one scalar. With a compound
+/// key, two representations that share an `id` but differ in `region` are
+/// distinct entities, so `$batch.id` legitimately repeats and each entity is
+/// matched back by its full key.
+#[tokio::test]
+async fn batch_compound_key_keeps_representations_that_share_a_scalar() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "id": 1, "region": "A" },
+            { "id": 1, "region": "B" },
+            { "id": 1, "region": "A" },
+        ])))
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/users-batch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            // Returned in the opposite order from the request, to show that
+            // matching is by key value rather than by position.
+            { "id": 1, "region": "B", "name": "Alice from B" },
+            { "id": 1, "region": "A", "name": "Alice from A" },
+        ])))
+        .mount(&mock_server)
+        .await;
+
+    let response = super::execute(
+        include_str!("../testdata/batch-compound-key.graphql"),
+        &mock_server.uri(),
+        "query { users { id region name } }",
+        Default::default(),
+        None,
+        |_| {},
+        None,
+    )
+    .await;
+
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "users": [
+          {
+            "id": 1,
+            "region": "A",
+            "name": "Alice from A"
+          },
+          {
+            "id": 1,
+            "region": "B",
+            "name": "Alice from B"
+          },
+          {
+            "id": 1,
+            "region": "A",
+            "name": "Alice from A"
+          }
+        ]
+      }
+    }
+    "#);
+
+    super::req_asserts::matches(
+        &mock_server.received_requests().await.unwrap(),
+        vec![
+            Matcher::new().method("GET").path("/users"),
+            // Three references, two distinct (id, region) pairs. The `id`
+            // scalar repeats because the representations differ in `region`.
+            Matcher::new()
+                .method("POST")
+                .path("/users-batch")
+                .body(json!({ "ids": [1, 1], "regions": ["A", "B"] })),
+        ],
+    );
+}

--- a/apollo-router/src/plugins/connectors/tests/connect_on_type.rs
+++ b/apollo-router/src/plugins/connectors/tests/connect_on_type.rs
@@ -975,3 +975,91 @@ async fn batch_compound_key_keeps_representations_that_share_a_scalar() {
         ],
     );
 }
+
+/// Response alignment is by key value, never by position. The API may return
+/// the batch in any order, include objects that were not requested, and omit
+/// some that were. Each requested representation is matched to the returned
+/// object carrying the same key; representations with no match null out.
+#[tokio::test]
+async fn batch_response_matched_by_key_not_position() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "id": 3 },
+            { "id": 1 },
+            { "id": 3 },
+            { "id": 2 },
+            { "id": 4 },
+        ])))
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/users-batch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            // Shuffled relative to the request, with an object nobody asked
+            // for (99) and one that was asked for missing (4).
+            { "id": 2, "name": "Ervin Howell", "username": "Antonette" },
+            { "id": 99, "name": "Not Requested", "username": "extra" },
+            { "id": 3, "name": "Clementine Bauch", "username": "Samantha" },
+            { "id": 1, "name": "Leanne Graham", "username": "Bret" },
+        ])))
+        .mount(&mock_server)
+        .await;
+
+    let response = super::execute(
+        include_str!("../testdata/batch.graphql"),
+        &mock_server.uri(),
+        "query { users { id name username } }",
+        Default::default(),
+        None,
+        |_| {},
+        None,
+    )
+    .await;
+
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "users": [
+          {
+            "id": 3,
+            "name": "Clementine Bauch",
+            "username": "Samantha"
+          },
+          {
+            "id": 1,
+            "name": "Leanne Graham",
+            "username": "Bret"
+          },
+          {
+            "id": 3,
+            "name": "Clementine Bauch",
+            "username": "Samantha"
+          },
+          {
+            "id": 2,
+            "name": "Ervin Howell",
+            "username": "Antonette"
+          },
+          {
+            "id": 4,
+            "name": null,
+            "username": null
+          }
+        ]
+      }
+    }
+    "#);
+
+    super::req_asserts::matches(
+        &mock_server.received_requests().await.unwrap(),
+        vec![
+            Matcher::new().method("GET").path("/users"),
+            Matcher::new()
+                .method("POST")
+                .path("/users-batch")
+                .body(json!({ "ids": [3, 1, 2, 4] })),
+        ],
+    );
+}

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -1361,4 +1361,59 @@ mod tests {
         assert_eq!(errors[1].path.as_ref().unwrap(), &Path(vec![key("users")]));
         assert_eq!(errors[2].path.as_ref().unwrap(), &Path(vec![key("users")]));
     }
+
+    /// Regression test for the representation dedup that connector `$batch`
+    /// (and plain `_entities` fetches) rely on: identical representations
+    /// collapse to one entry in `representations`, in order of first
+    /// appearance, and `inverted_paths` remembers every path that produced
+    /// each entry so the single returned entity can be fanned back out.
+    #[test]
+    fn variables_dedupe_identical_representations_and_track_all_paths() {
+        let schema = test_schema();
+        let request = Arc::new(
+            http::Request::builder()
+                .body(graphql::Request::builder().build())
+                .unwrap(),
+        );
+        let data = json!({
+            "t": [
+                { "__typename": "T", "id": "1", "extra": "ignored" },
+                { "__typename": "T", "id": "2" },
+                { "__typename": "T", "id": "1", "extra": "also ignored" },
+            ]
+        });
+        let current_dir = Path(vec![key("t"), flatten()]);
+
+        let variables = Variables::new(
+            &make_requires(),
+            &[],
+            &data,
+            &current_dir,
+            &request,
+            &schema,
+            &None,
+            &None,
+        )
+        .expect("at least one representation");
+
+        // Three entities in the parent data, two distinct keys. Fields outside
+        // the `requires` selection (`extra`) play no part in equality.
+        assert_eq!(
+            variables.variables.get("representations"),
+            Some(&json!([{ "id": "1" }, { "id": "2" }])),
+        );
+
+        // Representation 0 (`id: 1`) came from t/0 and t/2; representation 1
+        // (`id: 2`) came from t/1 alone.
+        assert_eq!(
+            variables.inverted_paths,
+            vec![
+                vec![
+                    Path(vec![key("t"), index(0)]),
+                    Path(vec![key("t"), index(2)]),
+                ],
+                vec![Path(vec![key("t"), index(1)])],
+            ],
+        );
+    }
 }


### PR DESCRIPTION
### Motivation

Connectors `$batch` keeps raising the same question: when the parent data references the same entity several times, does the outbound batch request ask for that key more than once? The answer is no, and has been for a while, but nothing in the test suite said so. These tests state the contract so it can be pointed at rather than re-derived each time.

No behavior changes. This is tests plus two clarifying comments at the sites that implement the contract.

### What this pins

**Dedup, at the source** (`apollo-router/src/query_planner/fetch.rs`)

`Variables::new` collapses identical entity representations to a single entry in `representations`, in order of first appearance, and `inverted_paths` remembers every path that produced each entry so the one returned entity is fanned back out. Fields outside the `requires` selection play no part in equality.

**Dedup, end to end** (`plugins/connectors/tests/connect_on_type.rs`)

Four tests that assert on what actually reaches the wire:

- repeated references collapse to one key each in the POST body
- dedup happens before `batch.maxSize` chunking, so a key never appears in two chunks of the same fetch
- with a compound key, representations sharing one scalar but differing in another stay distinct, so `$batch.id` can legitimately repeat
- the query-parameter form: input keys `[1, 1, 1, 2]` produce `?ids=1,2`, and results fan back out to all four positions

**Response alignment** (`plugins/connectors/handle_responses.rs`, `apollo-federation/src/connectors/runtime/responses.rs`)

Batch responses are matched to representations by key value, never by position. One test covers all three ways the returned array can diverge from the request: reordered, carrying an object nobody asked for, and omitting one that was requested (which nulls out). Verified at the connector layer and end to end.

New fixtures: `testdata/batch-compound-key.graphql` and `.yaml`.

<!-- start metadata -->

---

**Checklist**

- [x] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [x] Changes are compatible
- [ ] Documentation completed
- [x] Performance impact assessed and acceptable
- [ ] Metrics and logs are added and documented
- Tests added and passing
    - [x] Unit tests
    - [x] Integration tests
    - [ ] Manual tests, as necessary

**Exceptions**

- No changeset: nothing here is user-facing. The PR adds tests and two comments and changes no production logic.
- No new metrics or configuration, so nothing to document or instrument.
- No ticket linked. Happy to attach one if this should be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
