### PR TITLE
feat(telemetry): record events delivered per subscription

### DIFF
--- a/.changesets/feat_subscription_events_sent_metric.md
+++ b/.changesets/feat_subscription_events_sent_metric.md
@@ -1,0 +1,5 @@
+### Add `apollo.router.operations.subscriptions.events_sent` histogram metric
+
+Apollo Router now records `apollo.router.operations.subscriptions.events_sent` once when each client subscription ends. This histogram counts payloads written to the client's multipart response stream, including error-only termination notices. Its `reason` attribute lets you compare event counts by termination reason.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/10214

--- a/apollo-router/src/protocols/multipart.rs
+++ b/apollo-router/src/protocols/multipart.rs
@@ -72,6 +72,9 @@ pub(crate) struct Multipart {
     /// The telemetry counter stashed from context, used to record termination with
     /// configurable attributes.
     terminated_counter: Option<SubscriptionsTerminatedCounter>,
+    /// Subscription payloads serialized into the response stream, including error-only
+    /// termination notices. Heartbeats and the empty close sentinel are excluded.
+    events_sent: u64,
 }
 
 impl Multipart {
@@ -100,6 +103,7 @@ impl Multipart {
             creation_span: Span::current(),
             end_reason: None,
             terminated_counter: None,
+            events_sent: 0,
         }
     }
 
@@ -242,6 +246,7 @@ impl Drop for Multipart {
                 self.creation_span
                     .set_span_dyn_attribute(SUBSCRIPTION_END_REASON_KEY, reason.as_value());
                 self.emit_subscription_termination_metric(reason);
+                self.emit_events_sent_metric(reason);
             }
             EndReason::Defer(reason) => {
                 self.creation_span
@@ -257,6 +262,16 @@ impl Multipart {
         if let Some(counter) = &self.terminated_counter {
             counter.record(reason.as_str());
         }
+    }
+
+    fn emit_events_sent_metric(&self, reason: SubscriptionEndReason) {
+        u64_histogram_with_unit!(
+            "apollo.router.operations.subscriptions.events_sent",
+            "Number of subscription payloads written to the response stream over the subscription's lifetime",
+            "{event}",
+            self.events_sent,
+            reason = reason.as_str()
+        );
     }
 }
 
@@ -357,6 +372,8 @@ impl Stream for Multipart {
                             };
 
                             serde_json::to_writer(&mut buf, &response)?;
+                            // The empty close sentinel returns before serialization.
+                            self.events_sent += 1;
                         }
                         ProtocolMode::Defer => {
                             has_subgraph_errors =
@@ -570,6 +587,12 @@ mod tests {
                 "subgraph.name" = "test_subgraph",
                 "client.name" = ""
             );
+
+            assert_histogram_sum!(
+                "apollo.router.operations.subscriptions.events_sent",
+                1u64,
+                "reason" = "server_close"
+            );
         }
         .with_metrics()
         .await;
@@ -619,6 +642,12 @@ mod tests {
                 "subgraph.name" = "test_subgraph",
                 "client.name" = ""
             );
+
+            assert_histogram_sum!(
+                "apollo.router.operations.subscriptions.events_sent",
+                2u64,
+                "reason" = "server_close"
+            );
         }
         .with_metrics()
         .await;
@@ -659,6 +688,12 @@ mod tests {
                 "reason" = "server_close",
                 "subgraph.name" = "test_subgraph",
                 "client.name" = ""
+            );
+
+            assert_histogram_sum!(
+                "apollo.router.operations.subscriptions.events_sent",
+                0u64,
+                "reason" = "server_close"
             );
         }
         .with_metrics()
@@ -723,6 +758,12 @@ mod tests {
                 "subgraph.name" = "",
                 "client.name" = "test_client"
             );
+
+            assert_histogram_sum!(
+                "apollo.router.operations.subscriptions.events_sent",
+                0u64,
+                "reason" = "heartbeat_delivery_failed"
+            );
         }
         .with_metrics()
         .await;
@@ -777,6 +818,12 @@ mod tests {
                 "subgraph.name" = "",
                 "client.name" = "test_client"
             );
+
+            assert_histogram_sum!(
+                "apollo.router.operations.subscriptions.events_sent",
+                1u64,
+                "reason" = "client_disconnect"
+            );
         }
         .with_metrics()
         .await;
@@ -800,6 +847,7 @@ mod tests {
                             .extension_code("SUBSCRIPTION_SCHEMA_RELOAD")
                             .build(),
                     )
+                    .extension(SUBSCRIPTION_ERROR_EXTENSION_KEY, true)
                     .subscribed(false)
                     .build(),
             ];
@@ -829,6 +877,12 @@ mod tests {
                 "subgraph.name" = "",
                 "client.name" = ""
             );
+
+            assert_histogram_sum!(
+                "apollo.router.operations.subscriptions.events_sent",
+                2u64,
+                "reason" = "schema_reload"
+            );
         }
         .with_metrics()
         .await;
@@ -853,6 +907,7 @@ mod tests {
                             .extension_code("SUBSCRIPTION_CONFIG_RELOAD")
                             .build(),
                     )
+                    .extension(SUBSCRIPTION_ERROR_EXTENSION_KEY, true)
                     .subscribed(false)
                     .build(),
             ];
@@ -882,6 +937,12 @@ mod tests {
                 "subgraph.name" = "",
                 "client.name" = ""
             );
+
+            assert_histogram_sum!(
+                "apollo.router.operations.subscriptions.events_sent",
+                2u64,
+                "reason" = "config_reload"
+            );
         }
         .with_metrics()
         .await;
@@ -907,6 +968,7 @@ mod tests {
                             .extension_code("SUBSCRIPTION_MAX_LIFETIME_EXCEEDED")
                             .build(),
                     )
+                    .extension(SUBSCRIPTION_ERROR_EXTENSION_KEY, true)
                     .subscribed(false)
                     .build(),
             ];
@@ -935,6 +997,12 @@ mod tests {
                 "reason" = "max_lifetime",
                 "subgraph.name" = "",
                 "client.name" = ""
+            );
+
+            assert_histogram_sum!(
+                "apollo.router.operations.subscriptions.events_sent",
+                2u64,
+                "reason" = "max_lifetime"
             );
         }
         .with_metrics()
@@ -1496,6 +1564,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_events_sent_records_one_sample_per_lifetime() {
+        for event_count in [0u64, 2] {
+            async move {
+                let responses = (0..event_count).map(|_| {
+                    graphql::Response::builder()
+                        .data(serde_json_bytes::Value::String(ByteString::from("data")))
+                        .subscribed(true)
+                        .build()
+                });
+                let mut protocol =
+                    Multipart::new(stream::iter(responses), ProtocolMode::Subscription);
+
+                while let Some(chunk) = protocol.next().await {
+                    chunk.unwrap();
+                    assert_histogram_not_exists!(
+                        "apollo.router.operations.subscriptions.events_sent",
+                        u64
+                    );
+                }
+                assert_histogram_not_exists!(
+                    "apollo.router.operations.subscriptions.events_sent",
+                    u64
+                );
+
+                drop(protocol);
+
+                assert_histogram_count!(
+                    "apollo.router.operations.subscriptions.events_sent",
+                    1u64,
+                    "reason" = "server_close"
+                );
+                assert_histogram_sum!(
+                    "apollo.router.operations.subscriptions.events_sent",
+                    event_count,
+                    "reason" = "server_close"
+                );
+            }
+            .with_metrics()
+            .await;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_defer_mode_records_no_events_sent() {
+        async {
+            let (_guard, _layer) = setup_tracing();
+            let span = tracing::info_span!("test_span");
+            let _span_guard = span.enter();
+            let responses = vec![
+                graphql::Response::builder()
+                    .data(serde_json_bytes::Value::String(ByteString::from("initial")))
+                    .has_next(true)
+                    .build(),
+                graphql::Response::builder()
+                    .data(serde_json_bytes::Value::String(ByteString::from(
+                        "deferred",
+                    )))
+                    .has_next(false)
+                    .build(),
+            ];
+            let gql_responses = stream::iter(responses);
+            let mut protocol = Multipart::new(gql_responses, ProtocolMode::Defer);
+
+            while protocol.next().await.is_some() {}
+
+            drop(protocol);
+            drop(_span_guard);
+            drop(span);
+
+            assert_histogram_not_exists!("apollo.router.operations.subscriptions.events_sent", u64);
+        }
+        .with_metrics()
+        .await;
+    }
+
+    #[tokio::test]
     async fn test_end_reason_subgraph_error() {
         async {
             // Test: Subscription terminated because the subgraph WebSocket connection
@@ -1544,6 +1688,12 @@ mod tests {
                 "reason" = "subgraph_error",
                 "subgraph.name" = "flaky_subgraph",
                 "client.name" = ""
+            );
+
+            assert_histogram_sum!(
+                "apollo.router.operations.subscriptions.events_sent",
+                1u64,
+                "reason" = "subgraph_error"
             );
         }
         .with_metrics()
@@ -1598,6 +1748,12 @@ mod tests {
                 "reason" = "subgraph_error",
                 "subgraph.name" = "error_subgraph",
                 "client.name" = ""
+            );
+
+            assert_histogram_sum!(
+                "apollo.router.operations.subscriptions.events_sent",
+                1u64,
+                "reason" = "subgraph_error"
             );
         }
         .with_metrics()

--- a/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
+++ b/docs/source/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments.mdx
@@ -307,6 +307,8 @@ telemetry:
   - `subgraph.name`: The name of the subgraph that closed the connection.
 - `apollo.router.operations.subscriptions.reconnect` - Number of subgraph WebSocket reconnect attempts. Incremented once per attempt when `max_reconnect_attempts > 0` is configured and the connection drops unexpectedly. Counts only attempts that actually issue a handshake — a closing signal received during the reconnect delay or during the handshake itself short-circuits without incrementing. Attributes:
   - `subgraph.name`: The name of the subgraph being reconnected to.
+- `apollo.router.operations.subscriptions.events_sent` - A histogram of payloads written to each client's multipart subscription response stream. It records one value when the stream ends, including zero for streams that sent no payloads. Error-only termination notices count; heartbeats and empty close signals are excluded. Writing a payload to the stream does not confirm that the client received it. Attributes:
+  - `reason`: The termination reason: `server_close`, `subgraph_error`, `client_disconnect`, `heartbeat_delivery_failed`, `schema_reload`, `config_reload`, or `max_lifetime`. This instrument emits `reason` independently of the attribute configuration for `apollo.router.operations.subscriptions.terminated.client`.
 
 ## Batching
 

--- a/docs/source/routing/operations/subscriptions/configuration.mdx
+++ b/docs/source/routing/operations/subscriptions/configuration.mdx
@@ -648,7 +648,25 @@ The `apollo.router.operations.subscriptions.terminated.client` metric includes `
 
 The `apollo.router.operations.subscriptions.terminated.subgraph` and `apollo.router.operations.subscriptions.terminated.client` metrics operate at different granularities. `terminated.subgraph` increments once per subgraph WebSocket closure, while `terminated.client` increments once per client that was listening on that connection. For example, if 5 clients are deduplicated onto a single subgraph WebSocket and the subgraph closes the connection, you'll see 1 `terminated.subgraph` event and 5 `terminated` events with `reason=server_close`. This means the `terminated` count can be significantly higher than `terminated.subgraph` — the ratio reflects your deduplication factor.
 
-#### Example: Monitor subscription health
+### Tracking events per subscription
+
+Use the `apollo.router.operations.subscriptions.events_sent` histogram to compare payload counts per client subscription by termination reason. See [subscription instruments](/graphos/routing/observability/router-telemetry-otel/enabling-telemetry/standard-instruments#subscriptions) for counting rules and attributes.
+
+The default histogram buckets end at 10. To distinguish subscriptions with larger event counts, configure a view with boundaries suited to your traffic. For example:
+
+```yaml title="router.yaml"
+telemetry:
+  exporters:
+    metrics:
+      common:
+        views:
+          - name: apollo.router.operations.subscriptions.events_sent
+            aggregation:
+              histogram:
+                buckets: [0, 1, 10, 100, 1000, 10000]
+```
+
+### Example: Monitor subscription health
 
 Use the `apollo.subscription.end_reason` attribute and subgraph counter metrics to monitor the health of your subscriptions:
 


### PR DESCRIPTION
**Already shipped, nothing added:** `apollo.router.operations.subscriptions.terminated.client` counts completed subscriptions, with a `reason` attribute covering all seven termination causes, recorded from `Drop` so every route reaches it.

**The real gap:** `...subscriptions.events` counts events router-wide, so it cannot say how many events one subscription served before ending. `...subscriptions.events_sent` is a histogram recorded once per subscription, same `reason` attribute, so the distribution is queryable rather than only a mean.

A histogram at end of life rather than a counter per event: a counter gives a router-wide rate that has to be divided by the termination count to get an average, which loses the distribution the ask is about.

### Evidence

27 multipart tests pass. The count is pinned for every `SubscriptionEndReason` including the zero cases, and the increment sits after the magic-empty-response early return so the graceful-close signal is not counted as an event.

The reload and max-lifetime fixtures now carry the fatal-error extension that `subscription_fatal_error` always sets in production. Without it the new assertions exercised the non-transport-error branch of `poll_next` rather than the branch production takes — the asserted values were unchanged once fixed, so the branch was the only thing wrong.

### Three decisions I would rather you made than I did

**The counting rule is not uniform across `reason`.** The router's own termination notice is a payload, so it counts for `schema_reload`, `config_reload`, `max_lifetime` and `subgraph_error`; there is no notice for `server_close` via the magic empty response, nor for `heartbeat_delivery_failed`. Four reasons carry a constant +1 that three do not. The docs state the rule. Making it uniform means skipping the increment for transport errors, which still leaves `subgraph_error` asymmetric, since a subgraph's own error response is a genuine payload.

**Histograms inherit the global default buckets, which are latency-shaped and end at 10.0.** Every subscription past ten events lands in `+Inf`, leaving only sum and count. The docs say this and show the view YAML to widen it. Shipping a default view instead means choosing boundaries, and the sibling count histograms `apollo.router.operations.recursion` and `lexical_tokens` shipped without one — so this is a call about whether to fix a codebase-wide gap here or match the neighbours.

**It is not a configurable standard instrument, unlike the metric it sits beside in the docs.** `reason` is hard-coded, it cannot be disabled, and it cannot be correlated with `subgraph.name` or `client.name`. Giving it that surface needs a `DefaultedStandardInstrument` field, an attributes struct, static registration, a config-schema change and a refreshed snapshot. The docs state the difference so the two cannot silently disagree.

### Review coverage

This lane got one review pass, not the usual two — the delegated reviewer returned unavailable with a malformed reason, so a second independent pass has not read this. Worth weighing when deciding how hard to look.

Also found, unrelated and not addressed: the documented `reason` values for `terminated.client` omit `max_lifetime`, which the code emits and an existing test covers.