### PR TITLE
Type sensitive configuration fields with Redacted

### DIFF
--- a/.changesets/config_redact_sensitive_configuration_fields.md
+++ b/.changesets/config_redact_sensitive_configuration_fields.md
@@ -1,0 +1,5 @@
+### Redact sensitive configuration fields in debug output
+
+Debug output for typed configuration fields now prints `[REDACTED]` for Redis usernames and passwords, AWS SigV4 access keys and secrets, TLS private keys (`tls.supergraph.key`, subgraph and connector `client_authentication.key`, and `telemetry.exporters.*.otlp.grpc.key`), and response-cache invalidation shared keys. The generated configuration schema marks these fields with `x-apollo-secret: true`.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/TBD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "apollo-configuration",
  "apollo-environment-detector",
  "apollo-federation",
+ "apollo-redaction",
  "astral-tokio-tar",
  "async-compression",
  "async-trait",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -61,6 +61,7 @@ addr2line = "0.27.0"
 anyhow = "1.0.86"
 apollo-compiler.workspace = true
 apollo-federation = { path = "../apollo-federation", version = "=2.17.0" }
+apollo-redaction = { version = "0.3.1", features = ["schemars"] }
 async-compression = { version = "0.4.6", features = [
     "tokio",
     "futures-io",

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -298,11 +298,11 @@ impl RedisCacheStorage {
         let is_cluster = client_config.server.is_clustered();
 
         if let Some(username) = config.username {
-            client_config.username = Some(username);
+            client_config.username = Some(username.unredact().clone());
         }
 
         if let Some(password) = config.password {
-            client_config.password = Some(password);
+            client_config.password = Some(password.unredact().clone());
         }
 
         if let Some(tls) = config.tls.as_ref() {

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -13,6 +13,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use apollo_redaction::Redacted;
 use connector::ConnectorConfiguration;
 use derivative::Derivative;
 use displaydoc::Display;
@@ -1002,9 +1003,11 @@ pub(crate) struct QueryPlanRedisCache {
     pub(crate) urls: Vec<url::Url>,
 
     /// Redis username if not provided in the URLs. This field takes precedence over the username in the URL
-    pub(crate) username: Option<String>,
+    #[serde(serialize_with = "crate::plugin::serde::serialize_redacted_option")]
+    pub(crate) username: Option<Redacted<String>>,
     /// Redis password if not provided in the URLs. This field takes precedence over the password in the URL
-    pub(crate) password: Option<String>,
+    #[serde(serialize_with = "crate::plugin::serde::serialize_redacted_option")]
+    pub(crate) password: Option<Redacted<String>>,
 
     #[serde(
         deserialize_with = "humantime_serde::deserialize",
@@ -1094,9 +1097,11 @@ pub(crate) struct RedisCache {
     pub(crate) urls: Vec<url::Url>,
 
     /// Redis username if not provided in the URLs. This field takes precedence over the username in the URL
-    pub(crate) username: Option<String>,
+    #[serde(serialize_with = "crate::plugin::serde::serialize_redacted_option")]
+    pub(crate) username: Option<Redacted<String>>,
     /// Redis password if not provided in the URLs. This field takes precedence over the password in the URL
-    pub(crate) password: Option<String>,
+    #[serde(serialize_with = "crate::plugin::serde::serialize_redacted_option")]
+    pub(crate) password: Option<Redacted<String>>,
 
     #[serde(
         deserialize_with = "humantime_serde::deserialize",
@@ -1200,9 +1205,9 @@ pub(crate) struct TlsSupergraph {
     #[schemars(with = "String")]
     pub(crate) certificate: CertificateDer<'static>,
     /// server key in PEM format
-    #[serde(deserialize_with = "deserialize_key", skip_serializing)]
-    #[schemars(with = "String")]
-    pub(crate) key: PrivateKeyDer<'static>,
+    #[serde(deserialize_with = "deserialize_redacted_key", skip_serializing)]
+    #[schemars(with = "Redacted<String>")]
+    pub(crate) key: Redacted<PrivateKeyDer<'static>>,
     /// list of certificate authorities in PEM format
     #[serde(deserialize_with = "deserialize_certificate_chain", skip_serializing)]
     #[schemars(with = "String")]
@@ -1216,7 +1221,7 @@ impl TlsSupergraph {
 
         let mut config = ServerConfig::builder()
             .with_no_client_auth()
-            .with_single_cert(certificates, self.key.clone_key())
+            .with_single_cert(certificates, self.key.unredact().clone_key())
             .map_err(ApolloRouterError::Rustls)?;
         config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 
@@ -1254,13 +1259,16 @@ where
     load_certs(&data).map_err(serde::de::Error::custom)
 }
 
-fn deserialize_key<'de, D>(deserializer: D) -> Result<PrivateKeyDer<'static>, D::Error>
+fn deserialize_redacted_key<'de, D>(
+    deserializer: D,
+) -> Result<Redacted<PrivateKeyDer<'static>>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let data = String::deserialize(deserializer)?;
-
-    load_key(&data).map_err(serde::de::Error::custom)
+    let data = Redacted::<String>::deserialize(deserializer)?;
+    load_key(data.unredact())
+        .map(Redacted::new)
+        .map_err(|_| serde::de::Error::custom("could not parse TLS private key"))
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -1342,7 +1350,7 @@ impl Default for TlsClient {
 }
 
 /// TLS client authentication
-#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct TlsClientAuth {
     /// list of certificates in PEM format
@@ -1350,9 +1358,17 @@ pub(crate) struct TlsClientAuth {
     #[schemars(with = "String")]
     pub(crate) certificate_chain: Vec<CertificateDer<'static>>,
     /// key in PEM format
-    #[serde(deserialize_with = "deserialize_key", skip_serializing)]
-    #[schemars(with = "String")]
-    pub(crate) key: PrivateKeyDer<'static>,
+    #[serde(deserialize_with = "deserialize_redacted_key", skip_serializing)]
+    #[schemars(with = "Redacted<String>")]
+    pub(crate) key: Redacted<PrivateKeyDer<'static>>,
+}
+
+// Compare key contents because `Redacted` does not implement `PartialEq`.
+impl PartialEq for TlsClientAuth {
+    fn eq(&self, other: &Self) -> bool {
+        self.certificate_chain == other.certificate_chain
+            && self.key.unredact() == other.key.unredact()
+    }
 }
 
 /// Configuration for router reload behavior.

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/tests.rs
-assertion_line: 28
 expression: "&schema"
 ---
 {
@@ -42,7 +41,8 @@ expression: "&schema"
       "properties": {
         "access_key_id": {
           "description": "The ID for this access key.",
-          "type": "string"
+          "type": "string",
+          "x-apollo-secret": true
         },
         "assume_role": {
           "anyOf": [
@@ -61,7 +61,8 @@ expression: "&schema"
         },
         "secret_access_key": {
           "description": "The secret key used to sign requests.",
-          "type": "string"
+          "type": "string",
+          "x-apollo-secret": true
         },
         "service_name": {
           "description": "The service you're trying to access, eg: \"s3\", \"vpc-lattice-svcs\", etc.",
@@ -2145,7 +2146,8 @@ expression: "&schema"
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "x-apollo-secret": true
         },
         "pool_size": {
           "default": 5,
@@ -2184,7 +2186,8 @@ expression: "&schema"
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "x-apollo-secret": true
         }
       },
       "required": [
@@ -5927,7 +5930,8 @@ expression: "&schema"
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "x-apollo-secret": true
         },
         "metadata": {
           "additionalProperties": true,
@@ -8067,7 +8071,8 @@ expression: "&schema"
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "x-apollo-secret": true
         },
         "pool_size": {
           "default": 1,
@@ -8133,7 +8138,8 @@ expression: "&schema"
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "x-apollo-secret": true
         }
       },
       "required": [
@@ -8364,7 +8370,8 @@ expression: "&schema"
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "x-apollo-secret": true
         },
         "pool_size": {
           "default": 1,
@@ -8427,7 +8434,8 @@ expression: "&schema"
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "x-apollo-secret": true
         }
       },
       "required": [
@@ -10341,7 +10349,8 @@ expression: "&schema"
         "shared_key": {
           "default": "",
           "description": "Shared key needed to request the invalidation endpoint",
-          "type": "string"
+          "type": "string",
+          "x-apollo-secret": true
         }
       },
       "type": "object"
@@ -12385,7 +12394,8 @@ expression: "&schema"
         "key": {
           "description": "key in PEM format",
           "type": "string",
-          "writeOnly": true
+          "writeOnly": true,
+          "x-apollo-secret": true
         }
       },
       "required": [
@@ -12411,7 +12421,8 @@ expression: "&schema"
         "key": {
           "description": "server key in PEM format",
           "type": "string",
-          "writeOnly": true
+          "writeOnly": true,
+          "x-apollo-secret": true
         }
       },
       "required": [

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -443,6 +443,64 @@ supergraph:
 }
 
 #[test]
+fn redacted_tls_key_errors_hide_the_input() {
+    for key in [
+        "-----BEGIN secret-key-with-invalid-header",
+        "-----BEGIN secret-key-with-missing-footer-----",
+    ] {
+        let error = serde_json::from_value::<TlsClientAuth>(json!({
+            "certificate_chain": "",
+            "key": key,
+        }))
+        .unwrap_err()
+        .to_string();
+        assert!(!error.contains("secret-key"), "{error}");
+        assert!(error.contains("could not parse TLS private key"), "{error}");
+    }
+}
+
+#[test]
+fn redacted_tls_key_preserves_pem_contents() {
+    let pem = include_str!("../services/http/testdata/client.key");
+    let config: TlsClientAuth = serde_json::from_value(json!({
+        "certificate_chain": "",
+        "key": pem,
+    }))
+    .unwrap();
+    assert_eq!(config.key.unredact(), &load_key(pem).unwrap());
+    assert_eq!(
+        format!("{config:?}"),
+        "TlsClientAuth { certificate_chain: [], key: [REDACTED] }"
+    );
+}
+
+#[test]
+fn redacted_redis_credentials_are_hidden_from_debug_output() {
+    let config: QueryPlanRedisCache = serde_json::from_value(json!({
+        "urls": ["redis://localhost:6379"],
+        "username": "redis-admin",
+        "password": "hunter2-super-secret",
+    }))
+    .expect("valid redis config");
+
+    let debug = format!("{config:?}");
+    assert!(
+        !debug.contains("hunter2-super-secret"),
+        "password must not appear in Debug output: {debug}"
+    );
+    assert!(
+        !debug.contains("redis-admin"),
+        "username must not appear in Debug output: {debug}"
+    );
+
+    // Confirm the credentials survived parsing.
+    let password = config.password.as_ref().expect("password was set");
+    let username = config.username.as_ref().expect("username was set");
+    assert_eq!(password.unredact(), "hunter2-super-secret");
+    assert_eq!(username.unredact(), "redis-admin");
+}
+
+#[test]
 fn line_precise_config_errors_with_inline_sequence_env_expansion() {
     let expansion = Expansion::default_builder()
         .mocked_env_var("TEST_CONFIG_NUMERIC_ENV_UNIQUE", "5")

--- a/apollo-router/src/plugin/serde.rs
+++ b/apollo-router/src/plugin/serde.rs
@@ -3,10 +3,13 @@
 use std::fmt::Formatter;
 use std::str::FromStr;
 
+use apollo_redaction::Redacted;
 use http::HeaderValue;
 use http::header::HeaderName;
 use regex::Regex;
 use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
 use serde::de;
 use serde::de::Error;
 use serde::de::SeqAccess;
@@ -207,4 +210,19 @@ impl serde::de::Visitor<'_> for JSONPathVisitor {
     {
         serde_json_bytes::path::JsonPathInst::from_str(s).map_err(serde::de::Error::custom)
     }
+}
+
+/// Serialize the unredacted value of an `Option<Redacted<T>>` field.
+///
+/// Use with `#[serde(serialize_with)]` when serialization must preserve the original setting.
+/// The output contains plaintext secrets and must stay out of diagnostics.
+pub(crate) fn serialize_redacted_option<T, R, S>(
+    value: &Option<Redacted<T, R>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    T: Serialize,
+    S: Serializer,
+{
+    value.as_ref().map(Redacted::unredact).serialize(serializer)
 }

--- a/apollo-router/src/plugins/authentication/subgraph.rs
+++ b/apollo-router/src/plugins/authentication/subgraph.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
 
+use apollo_redaction::Redacted;
 use aws_config::provider_config::ProviderConfig;
 use aws_credential_types::Credentials;
 use aws_credential_types::provider::ProvideCredentials;
@@ -43,9 +44,11 @@ use crate::services::router::body::RouterBody;
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub(crate) struct AWSSigV4HardcodedConfig {
     /// The ID for this access key.
-    access_key_id: String,
+    #[serde(serialize_with = "apollo_redaction::ser::unredacted")]
+    access_key_id: Redacted<String>,
     /// The secret key used to sign requests.
-    secret_access_key: String,
+    #[serde(serialize_with = "apollo_redaction::ser::unredacted")]
+    secret_access_key: Redacted<String>,
     /// The AWS region this chain applies to.
     region: String,
     /// The service you're trying to access, eg: "s3", "vpc-lattice-svcs", etc.
@@ -62,8 +65,8 @@ impl ProvideCredentials for AWSSigV4HardcodedConfig {
         Self: 'a,
     {
         aws_credential_types::provider::future::ProvideCredentials::ready(Ok(Credentials::new(
-            self.access_key_id.clone(),
-            self.secret_access_key.clone(),
+            self.access_key_id.unredact().clone(),
+            self.secret_access_key.unredact().clone(),
             None,
             None,
             "apollo-router",
@@ -545,8 +548,8 @@ mod test {
     async fn test_signing_settings(service_name: &str) -> SigningSettings {
         let params: SigningParamsConfig = make_signing_params(
             &AuthConfig::AWSSigV4(AWSSigV4Config::Hardcoded(AWSSigV4HardcodedConfig {
-                access_key_id: "id".to_string(),
-                secret_access_key: "secret".to_string(),
+                access_key_id: Redacted::new("id".to_string()),
+                secret_access_key: Redacted::new("secret".to_string()),
                 region: "us-east-1".to_string(),
                 service_name: service_name.to_string(),
                 assume_role: None,
@@ -658,8 +661,8 @@ mod test {
             signing_params: Arc::new(SigningParams {
                 all: make_signing_params(
                     &AuthConfig::AWSSigV4(AWSSigV4Config::Hardcoded(AWSSigV4HardcodedConfig {
-                        access_key_id: "id".to_string(),
-                        secret_access_key: "secret".to_string(),
+                        access_key_id: Redacted::new("id".to_string()),
+                        secret_access_key: Redacted::new("secret".to_string()),
                         region: "us-east-1".to_string(),
                         service_name: "vpc-lattice-svcs".to_string(),
                         assume_role: None,
@@ -726,8 +729,8 @@ mod test {
             signing_params: Arc::new(SigningParams {
                 all: make_signing_params(
                     &AuthConfig::AWSSigV4(AWSSigV4Config::Hardcoded(AWSSigV4HardcodedConfig {
-                        access_key_id: "id".to_string(),
-                        secret_access_key: "secret".to_string(),
+                        access_key_id: Redacted::new("id".to_string()),
+                        secret_access_key: Redacted::new("secret".to_string()),
                         region: "us-east-1".to_string(),
                         service_name: "s3".to_string(),
                         assume_role: None,
@@ -810,8 +813,8 @@ mod test {
             let signing_params = Arc::new(
                 make_signing_params(
                     &AuthConfig::AWSSigV4(AWSSigV4Config::Hardcoded(AWSSigV4HardcodedConfig {
-                        access_key_id: "id".to_string(),
-                        secret_access_key: "secret".to_string(),
+                        access_key_id: Redacted::new("id".to_string()),
+                        secret_access_key: Redacted::new("secret".to_string()),
                         region: "us-east-1".to_string(),
                         service_name: "execute-api".to_string(),
                         assume_role: None,
@@ -870,8 +873,8 @@ mod test {
                         make_signing_params(
                             &AuthConfig::AWSSigV4(AWSSigV4Config::Hardcoded(
                                 AWSSigV4HardcodedConfig {
-                                    access_key_id: "id".to_string(),
-                                    secret_access_key: "secret".to_string(),
+                                    access_key_id: Redacted::new("id".to_string()),
+                                    secret_access_key: Redacted::new("secret".to_string()),
                                     region: "us-east-1".to_string(),
                                     service_name: "execute-api".to_string(),
                                     assume_role: None,
@@ -1066,5 +1069,32 @@ mod test {
         })
         .join()
         .unwrap()
+    }
+
+    #[test]
+    fn redacted_aws_credentials_are_hidden_from_debug_output() {
+        let config = AWSSigV4HardcodedConfig {
+            access_key_id: Redacted::new("AKIASCRATCHACCESSKEY".to_string()),
+            secret_access_key: Redacted::new("wJalrXUtSecretAccessKeyScratch123".to_string()),
+            region: "us-east-1".to_string(),
+            service_name: "s3".to_string(),
+            assume_role: None,
+        };
+
+        let debug = format!("{config:?}");
+        assert!(
+            !debug.contains("AKIASCRATCHACCESSKEY"),
+            "access key ID must not appear in Debug output: {debug}"
+        );
+        assert!(
+            !debug.contains("wJalrXUtSecretAccessKeyScratch123"),
+            "secret access key must not appear in Debug output: {debug}"
+        );
+
+        assert_eq!(config.access_key_id.unredact(), "AKIASCRATCHACCESSKEY");
+        assert_eq!(
+            config.secret_access_key.unredact(),
+            "wJalrXUtSecretAccessKeyScratch123"
+        );
     }
 }

--- a/apollo-router/src/plugins/response_cache/invalidation_endpoint.rs
+++ b/apollo-router/src/plugins/response_cache/invalidation_endpoint.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::task::Poll;
 
+use apollo_redaction::Redacted;
 use bytes::Buf;
 use futures::future::BoxFuture;
 use http::HeaderValue;
@@ -125,13 +126,14 @@ mod invalidation_indexes_tests {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename_all = "snake_case", deny_unknown_fields, default)]
 pub(crate) struct SubgraphInvalidationConfig {
     /// Enable the invalidation
     pub(crate) enabled: bool,
     /// Shared key needed to request the invalidation endpoint
-    pub(crate) shared_key: String,
+    #[serde(serialize_with = "apollo_redaction::ser::unredacted")]
+    pub(crate) shared_key: Redacted<String>,
     /// Which invalidation indexes to maintain for this subgraph's cached entries. Defaults to
     /// all three (`subgraph`, `type`, `cache_tag`) enabled, matching the original
     /// `response_cache` behavior. Operators with workloads that only invalidate by a subset of
@@ -142,6 +144,31 @@ pub(crate) struct SubgraphInvalidationConfig {
     /// useful for pure TTL-based caching without an invalidation API.
     #[serde(default)]
     pub(crate) indexes: InvalidationIndexes,
+}
+
+#[cfg(test)]
+mod subgraph_invalidation_config_tests {
+    use super::*;
+
+    #[test]
+    fn redacted_shared_key_is_hidden_from_debug_output() {
+        let config = SubgraphInvalidationConfig {
+            enabled: true,
+            shared_key: Redacted::new("TopSecretInvalidationKeyScratch1".to_string()),
+            indexes: InvalidationIndexes::default(),
+        };
+
+        let debug = format!("{config:?}");
+        assert!(
+            !debug.contains("TopSecretInvalidationKeyScratch1"),
+            "shared_key must not appear in Debug output: {debug}"
+        );
+
+        assert_eq!(
+            config.shared_key.unredact(),
+            "TopSecretInvalidationKeyScratch1"
+        );
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -381,13 +408,13 @@ fn validate_shared_key(
         .all
         .invalidation
         .as_ref()
-        .map(|i| i.shared_key == shared_key)
+        .map(|i| i.shared_key.unredact() == shared_key)
         .unwrap_or_default()
         || config
             .subgraphs
             .get(subgraph_name)
             .and_then(|s| s.invalidation.as_ref())
-            .map(|i| i.shared_key == shared_key)
+            .map(|i| i.shared_key.unredact() == shared_key)
             .unwrap_or_default()
 }
 
@@ -479,7 +506,7 @@ mod indexes_tests {
             private_id: None,
             invalidation: all_indexes.map(|indexes| SubgraphInvalidationConfig {
                 enabled: true,
-                shared_key: String::from("k"),
+                shared_key: Redacted::new(String::from("k")),
                 indexes,
             }),
         };
@@ -494,7 +521,7 @@ mod indexes_tests {
                     private_id: None,
                     invalidation: Some(SubgraphInvalidationConfig {
                         enabled: true,
-                        shared_key: String::from("k"),
+                        shared_key: Redacted::new(String::from("k")),
                         indexes,
                     }),
                 },
@@ -751,7 +778,7 @@ mod tests {
                 private_id: None,
                 invalidation: Some(SubgraphInvalidationConfig {
                     enabled: true,
-                    shared_key: String::from("test"),
+                    shared_key: Redacted::new(String::from("test")),
                     ..Default::default()
                 }),
             },
@@ -803,7 +830,7 @@ mod tests {
                 private_id: None,
                 invalidation: Some(SubgraphInvalidationConfig {
                     enabled: true,
-                    shared_key: String::from("test"),
+                    shared_key: Redacted::new(String::from("test")),
                     ..Default::default()
                 }),
             },
@@ -816,7 +843,7 @@ mod tests {
                     private_id: None,
                     invalidation: Some(SubgraphInvalidationConfig {
                         enabled: true,
-                        shared_key: String::from("test_test"),
+                        shared_key: Redacted::new(String::from("test_test")),
                         ..Default::default()
                     }),
                 },
@@ -865,7 +892,7 @@ mod tests {
                 private_id: None,
                 invalidation: Some(SubgraphInvalidationConfig {
                     enabled: true,
-                    shared_key: String::from("test"),
+                    shared_key: Redacted::new(String::from("test")),
                     ..Default::default()
                 }),
             },
@@ -879,7 +906,7 @@ mod tests {
                         private_id: None,
                         invalidation: Some(SubgraphInvalidationConfig {
                             enabled: true,
-                            shared_key: String::from("test_test"),
+                            shared_key: Redacted::new(String::from("test_test")),
                             ..Default::default()
                         }),
                     },
@@ -893,7 +920,7 @@ mod tests {
                         private_id: None,
                         invalidation: Some(SubgraphInvalidationConfig {
                             enabled: true,
-                            shared_key: String::from("test_test_bis"),
+                            shared_key: Redacted::new(String::from("test_test_bis")),
                             ..Default::default()
                         }),
                     },
@@ -948,7 +975,7 @@ mod tests {
                 private_id: None,
                 invalidation: Some(SubgraphInvalidationConfig {
                     enabled: true,
-                    shared_key: String::from("test"),
+                    shared_key: Redacted::new(String::from("test")),
                     ..Default::default()
                 }),
             },
@@ -962,7 +989,7 @@ mod tests {
                         private_id: None,
                         invalidation: Some(SubgraphInvalidationConfig {
                             enabled: true,
-                            shared_key: String::from("test_test"),
+                            shared_key: Redacted::new(String::from("test_test")),
                             ..Default::default()
                         }),
                     },
@@ -976,7 +1003,7 @@ mod tests {
                         private_id: None,
                         invalidation: Some(SubgraphInvalidationConfig {
                             enabled: true,
-                            shared_key: String::from("test_test_bis"),
+                            shared_key: Redacted::new(String::from("test_test_bis")),
                             ..Default::default()
                         }),
                     },
@@ -1031,7 +1058,7 @@ mod tests {
                 private_id: None,
                 invalidation: Some(SubgraphInvalidationConfig {
                     enabled: true,
-                    shared_key: String::from("test"),
+                    shared_key: Redacted::new(String::from("test")),
                     ..Default::default()
                 }),
             },

--- a/apollo-router/src/plugins/response_cache/plugin.rs
+++ b/apollo-router/src/plugins/response_cache/plugin.rs
@@ -388,7 +388,7 @@ impl PluginPrivate for ResponseCache {
             .all
             .invalidation
             .as_ref()
-            .map(|i| i.shared_key.is_empty())
+            .map(|i| i.shared_key.unredact().is_empty())
             .unwrap_or_default()
         {
             return Err(
@@ -855,7 +855,9 @@ impl ResponseCache {
                 all: Subgraph {
                     invalidation: Some(SubgraphInvalidationConfig {
                         enabled: true,
-                        shared_key: INVALIDATION_SHARED_KEY.to_string(),
+                        shared_key: apollo_redaction::Redacted::new(
+                            INVALIDATION_SHARED_KEY.to_string(),
+                        ),
                         ..Default::default()
                     }),
                     ..Default::default()

--- a/apollo-router/src/plugins/response_cache/storage/config.rs
+++ b/apollo-router/src/plugins/response_cache/storage/config.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use apollo_redaction::Redacted;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -8,8 +9,9 @@ use crate::configuration::RedisCache;
 use crate::configuration::TlsClient;
 use crate::configuration::default_metrics_interval;
 use crate::configuration::default_required_to_start;
+use crate::plugin::serde::serialize_redacted_option;
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 /// Redis cache configuration
 pub(crate) struct Config {
@@ -17,9 +19,11 @@ pub(crate) struct Config {
     pub(crate) urls: Vec<url::Url>,
 
     /// Redis username if not provided in the URLs. This field takes precedence over the username in the URL
-    pub(crate) username: Option<String>,
+    #[serde(serialize_with = "serialize_redacted_option")]
+    pub(crate) username: Option<Redacted<String>>,
     /// Redis password if not provided in the URLs. This field takes precedence over the password in the URL
-    pub(crate) password: Option<String>,
+    #[serde(serialize_with = "serialize_redacted_option")]
+    pub(crate) password: Option<Redacted<String>>,
 
     #[serde(
         deserialize_with = "humantime_serde::deserialize",
@@ -99,6 +103,25 @@ fn default_maintenance_timeout() -> Duration {
 
 fn default_pool_size() -> u32 {
     5
+}
+
+impl PartialEq for Config {
+    fn eq(&self, other: &Self) -> bool {
+        self.urls == other.urls
+            && self.username.as_ref().map(Redacted::unredact)
+                == other.username.as_ref().map(Redacted::unredact)
+            && self.password.as_ref().map(Redacted::unredact)
+                == other.password.as_ref().map(Redacted::unredact)
+            && self.fetch_timeout == other.fetch_timeout
+            && self.insert_timeout == other.insert_timeout
+            && self.invalidate_timeout == other.invalidate_timeout
+            && self.maintenance_timeout == other.maintenance_timeout
+            && self.namespace == other.namespace
+            && self.tls == other.tls
+            && self.required_to_start == other.required_to_start
+            && self.pool_size == other.pool_size
+            && self.metrics_interval == other.metrics_interval
+    }
 }
 
 impl From<&Config> for RedisCache {

--- a/apollo-router/src/plugins/response_cache/tests.rs
+++ b/apollo-router/src/plugins/response_cache/tests.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use apollo_compiler::Schema;
+use apollo_redaction::Redacted;
 use futures::StreamExt;
 use http::HeaderName;
 use http::HeaderValue;
@@ -79,7 +80,7 @@ pub(super) fn create_subgraph_conf(
         all: Subgraph {
             invalidation: Some(SubgraphInvalidationConfig {
                 enabled: true,
-                shared_key: INVALIDATION_SHARED_KEY.to_string(),
+                shared_key: Redacted::new(INVALIDATION_SHARED_KEY.to_string()),
                 ..Default::default()
             }),
             ..Default::default()

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -1,6 +1,7 @@
 //! Shared configuration for Otlp tracing and metrics.
 use std::collections::HashMap;
 
+use apollo_redaction::Redacted;
 use http::Uri;
 use opentelemetry_sdk::metrics::Temporality as SdkTemporality;
 use schemars::JsonSchema;
@@ -242,7 +243,7 @@ pub(crate) struct HttpExporter {
     pub(crate) headers: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema)]
 #[serde(deny_unknown_fields, default)]
 pub(crate) struct GrpcExporter {
     /// The optional domain name for tls config.
@@ -253,12 +254,24 @@ pub(crate) struct GrpcExporter {
     /// The optional cert for tls config
     pub(crate) cert: Option<String>,
     /// The optional private key file for TLS configuration.
-    pub(crate) key: Option<String>,
+    #[serde(serialize_with = "crate::plugin::serde::serialize_redacted_option")]
+    pub(crate) key: Option<Redacted<String>>,
 
     /// gRPC metadata
     #[serde(with = "http_serde::header_map")]
     #[schemars(schema_with = "header_map", default)]
     pub(crate) metadata: http::HeaderMap,
+}
+
+impl PartialEq for GrpcExporter {
+    fn eq(&self, other: &Self) -> bool {
+        self.domain_name == other.domain_name
+            && self.ca == other.ca
+            && self.cert == other.cert
+            && self.key.as_ref().map(Redacted::unredact)
+                == other.key.as_ref().map(Redacted::unredact)
+            && self.metadata == other.metadata
+    }
 }
 
 fn header_map(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
@@ -280,7 +293,7 @@ impl GrpcExporter {
                 .with_native_roots()
                 .domain_name(domain_name)
                 .ca_certificate(Certificate::from_pem(ca.clone()))
-                .identity(Identity::from_pem(cert.clone(), key.clone())))
+                .identity(Identity::from_pem(cert.clone(), key.unredact().clone())))
         } else {
             // This was a breaking change in tonic where we now have to specify native roots.
             Ok(ClientTlsConfig::new().with_native_roots())
@@ -334,6 +347,25 @@ impl From<Temporality> for SdkTemporality {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn redacted_grpc_key_preserves_serialization_and_change_detection() {
+        let input = serde_json::json!({"key": "synthetic-otlp-private-key"});
+        let config: GrpcExporter = serde_json::from_value(input.clone()).unwrap();
+        let debug = format!("{config:?}");
+        assert!(debug.contains("key: Some([REDACTED])"), "{debug}");
+        assert!(!debug.contains("synthetic-otlp-private-key"), "{debug}");
+        let serialized = serde_json::to_value(&config).unwrap();
+        assert_eq!(serialized["key"], input["key"]);
+        let round_trip: GrpcExporter = serde_json::from_value(serialized).unwrap();
+        assert_eq!(config, round_trip);
+
+        for key in [serde_json::Value::Null, serde_json::json!("rotated-key")] {
+            let changed = serde_json::from_value(serde_json::json!({"key": key})).unwrap();
+            assert_ne!(config, changed);
+        }
+        assert!(serde_json::from_value::<GrpcExporter>(serde_json::json!({"key": 42})).is_err());
+    }
 
     #[test]
     fn endpoint_grpc_defaulting_no_scheme() {

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -568,7 +568,7 @@ pub(crate) fn generate_tls_client_config(
             .with_root_certificates(tls_cert_store)
             .with_client_auth_cert(
                 client_auth_config.certificate_chain.clone(),
-                client_auth_config.key.clone_key(),
+                client_auth_config.key.unredact().clone_key(),
             )?,
         None => tls_builder
             .with_root_certificates(tls_cert_store)

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -6,6 +6,7 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 
+use apollo_redaction::Redacted;
 use async_compression::tokio::write::GzipDecoder;
 use async_compression::tokio::write::GzipEncoder;
 use axum::body::Body;
@@ -600,7 +601,7 @@ mod tls {
                 certificate_authorities: Some(ca_pem.into()),
                 client_authentication: Some(Arc::new(TlsClientAuth {
                     certificate_chain: load_certs(client_certificate_pem).unwrap(),
-                    key: load_key(client_key_pem).unwrap(),
+                    key: Redacted::new(load_key(client_key_pem).unwrap()),
                 })),
             },
         );
@@ -1822,7 +1823,7 @@ mod redis_tls_config {
 
         let client_auth = TlsClientAuth {
             certificate_chain: load_certs(client_cert_pem).unwrap(),
-            key: load_key(client_key_pem).unwrap(),
+            key: Redacted::new(load_key(client_key_pem).unwrap()),
         };
 
         let tls_config = crate::services::subgraph::http::generate_tls_client_config(

--- a/apollo-router/src/services/subgraph/http/mod.rs
+++ b/apollo-router/src/services/subgraph/http/mod.rs
@@ -84,14 +84,14 @@ pub(crate) fn generate_tls_client_config(
         (None, Some(client_auth_config)) => {
             tls_builder.with_native_roots()?.with_client_auth_cert(
                 client_auth_config.certificate_chain.clone(),
-                client_auth_config.key.clone_key(),
+                client_auth_config.key.unredact().clone_key(),
             )?
         }
         (Some(store), Some(client_auth_config)) => tls_builder
             .with_root_certificates(store)
             .with_client_auth_cert(
                 client_auth_config.certificate_chain.clone(),
-                client_auth_config.key.clone_key(),
+                client_auth_config.key.unredact().clone_key(),
             )?,
     })
 }


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-2107] -->
---

Credential-bearing configuration fields can expose their values through derived debug output. This PR wraps twelve fields in `Redacted<T>` so formatting displays `[REDACTED]`, while consumers still receive the original credentials. It also prevents malformed Router TLS private keys from being reproduced in deserialization errors and adds `x-apollo-secret` schema annotations for the shared configuration parser.

This implements the secret-typing layer of [ROUTER-2107](https://apollographql.atlassian.net/browse/ROUTER-2107). Its parent [#10206](https://github.com/apollographql/router/pull/10206) supplies the compatibility corpus and `apollo-configuration 0.6.3`; this layer adds typed credentials and their consumer adaptations.

## How credentials remain usable

The wrapped fields cover Redis usernames and passwords in three configuration types, hardcoded AWS SigV4 access-key IDs and secrets, response-cache invalidation shared keys, Router server/client TLS private keys, and the OTLP gRPC exporter's inline private key. Shared types cover multiple paths, including subgraph and connector client authentication. Public certificates remain unwrapped; the environment-sourced Apollo key is outside these deserialized fields.

`Redacted<T>` preserves the underlying value and requires explicit access through `unredact()`. Consumers unwrap at their existing credential handoff points. Equality implementations compare actual contents so a rotated credential still counts as a configuration change. Configuration names, defaults and accepted value shapes remain unchanged; the schema change adds secret annotations.

The Router TLS key path illustrates where failure handling and formatting differ from runtime access:

```mermaid
sequenceDiagram
    participant L as Configuration loader
    participant D as TLS key deserializer
    participant C as Typed TLS configuration
    participant R as TLS client or server builder
    L->>D: Deserialize private-key PEM
    D->>D: Parse PEM
    alt Invalid PEM
        D-->>L: could not parse TLS private key (no input)
    else Valid PEM
        D-->>L: Redacted private key
        L->>C: Retain wrapped key
        L->>C: Format configuration for Debug
        C-->>L: key shown as [REDACTED]
        R->>C: Explicitly unredact and clone key
        C-->>R: Original private-key contents
    end
```

Wrapping protects formatting without substituting a placeholder into the key used to establish TLS. The deserializer sanitizes a PEM parse failure before returning it to the loader.

The OTLP regression illustrates serialization and change detection with this synthetic `GrpcExporter` fragment:

```json
{"key": "synthetic-otlp-private-key"}
```

Debug output contains `key: Some([REDACTED])` and excludes the value. Serialization returns the original key, a round trip compares equal, and replacing the key with `null` or `"rotated-key"` compares unequal. Unlike the Router TLS deserializer above, the OTLP field retains its inline string representation here.

Previously serialized fields retain explicit plaintext serialization so runtime handoffs and effective-configuration comparisons retain credential values. Optional fields share one serializer; required fields use the crate's explicit unredacted serializer. Router TLS private keys retain their existing `skip_serializing` behavior. Serialized configuration is therefore not safe diagnostic output. An automated audit of the serialization exceptions remains follow-up work.

## Diagnostic protection and limits

For string-valued schema errors, the existing loader substitutes the pre-expansion source value into the message, which can preserve the operator's original expression. This is not blanket protection for every error shape. The shared parser instead relies on schema secret annotations. Version 0.6.3 follows the Router's draft-7 `#/definitions/...` references, so these annotations are available to the subsequent adapter. This PR does not switch production loading to that parser.

Protection is limited to these typed fields and their formatting. It does not guarantee redaction of free-form OTLP headers or gRPC metadata, URL-embedded credentials, raw JSON, or explicitly serialized values. The policy for sensitive entries in free-form maps remains unresolved. External Redis, AWS, OTLP collector and Redis-backed invalidation integrations are outside this validation, so it does not establish end-to-end behavior against those services.

## Remaining adoption work

The dependent [#10218](https://github.com/apollographql/router/pull/10218) adds a shared-parser adapter in normal code and makes the compatibility suite exercise it. It leaves `Configuration::from_str`, startup and reload on the existing loader. These PRs therefore do not complete the production cutover under ROUTER-2104 or acceptance of the overall adoption ticket, ROUTER-2096.

Land the parent #10206, this secret-typing layer, then #10218. The withdrawn #10205 is excluded from this stack.

The [configuration contract](https://github.com/apollographql/internal-specs/blob/c1d9968614001c180b53e1ba79529243c4b83525/components/router/architecture/configuration.md#where-it-is-going) specifies automatic within-major migrations at startup and reload; major upgrades use `router config upgrade`. The contract also describes rejecting invalid migrated documents and warning about migrated-document line numbers. Those additional behaviors are not implemented by this stack: the existing loader still falls back to validating the original document when the migrated value fails schema validation, and reports locations against the original source. The original input is validated before acceptance. This secret-typing change leaves that loader behavior intact.


[ROUTER-2107]: https://apollographql.atlassian.net/browse/ROUTER-2107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROUTER-2107]: https://apollographql.atlassian.net/browse/ROUTER-2107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ