### PR TITLE
Parse configuration through the shared crate, without routing anything to it yet

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -60,6 +60,7 @@ mock_subgraphs_testing = []
 addr2line = "0.27.0"
 anyhow = "1.0.86"
 apollo-compiler.workspace = true
+apollo-configuration = "0.6.2"
 apollo-federation = { path = "../apollo-federation", version = "=2.17.0" }
 apollo-redaction = { version = "0.3.1", features = ["schemars"] }
 async-compression = { version = "0.4.6", features = [
@@ -146,6 +147,7 @@ libc = "0.2.155"
 linkme = "0.3.30"
 lru = "0.18.0"
 mediatype = "0.21.0"
+miette = "7"
 mockall = "0.15.0"
 mime = "0.3.17"
 multer = "3.1.0"
@@ -301,7 +303,6 @@ tikv-jemalloc-ctl = { version = "0.7.0", features = ["stats", "profiling"], opti
 tikv-jemalloc-sys = { version = "0.7.0", features = ["profiling"] }
 
 [dev-dependencies]
-apollo-configuration = "0.6.2"
 axum = { version = "0.8.1", features = ["http2", "ws"] }
 ctor = "1.0.0"
 ecdsa = { version = "0.17.0", features = ["algorithm", "pem", "pkcs8"] }
@@ -318,7 +319,6 @@ insta.workspace = true
 maplit = "1.0.2"
 brotli = "8.0.0"
 memchr = { version = "2.7.4", default-features = false }
-miette = "7"
 mockall = "0.15.0"
 num-traits = "0.2.19"
 once_cell.workspace = true

--- a/apollo-router/src/configuration/apollo_configuration_parse.rs
+++ b/apollo-router/src/configuration/apollo_configuration_parse.rs
@@ -1,0 +1,210 @@
+//! Parses router configuration through the shared `apollo-configuration` crate.
+//!
+//! Only tests call this adapter. Cutover blockers include secret redaction through router's
+//! draft 7 `#/definitions/` references and normalization of `plugins: null` to an empty map.
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use apollo_configuration::ParseYamlOptions;
+use serde_json::Value;
+
+use super::Configuration;
+use super::ConfigurationError;
+use super::expansion::Expansion;
+use super::schema::generate_config_schema;
+
+// `Configuration::deserialize` already runs the struct's own cross-field validation, so the
+// shared crate's validation hook has nothing further to check.
+impl apollo_configuration::Validate for Configuration {}
+impl apollo_configuration::Configuration for Configuration {}
+
+/// Uses [`generate_config_schema`] so the shared parser also rejects unknown top-level keys.
+#[allow(dead_code)]
+pub(crate) fn apollo_configuration_options() -> ParseYamlOptions {
+    static SCHEMA: OnceLock<Value> = OnceLock::new();
+    let schema = SCHEMA
+        .get_or_init(|| {
+            serde_json::to_value(generate_config_schema())
+                .expect("router's configuration schema serializes")
+        })
+        .clone();
+    ParseYamlOptions::default().schema(schema)
+}
+
+/// Parses settings, stores the expanded document in `validated_yaml`, and keeps `text` in
+/// `raw_yaml`.
+///
+/// Configure `options` and `expansion` with equivalent external inputs. `options` expands the
+/// settings it deserializes; `expansion` supplies `validated_yaml`.
+///
+/// # Errors
+/// Returns errors from YAML parsing, expansion, or the shared parser.
+#[allow(dead_code)]
+pub(crate) fn parse_via_apollo_configuration(
+    text: &str,
+    options: &ParseYamlOptions,
+    expansion: &Expansion,
+) -> Result<Configuration, ConfigurationError> {
+    // `serde_yaml` rejects blank input; configuration loading accepts it as an empty mapping.
+    let raw: Value = if text.trim().is_empty() {
+        Value::Object(Default::default())
+    } else {
+        serde_yaml::from_str(text).map_err(|error| ConfigurationError::InvalidConfiguration {
+            message: "failed to parse yaml",
+            error: error.to_string(),
+        })?
+    };
+    let expanded = expansion.expand(&raw)?;
+    let mut config: Configuration = options.parse(text)?;
+    config.validated_yaml = Some(expanded);
+    config.raw_yaml = Some(Arc::from(text));
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use apollo_configuration::expansion::MapVariables;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn populates_validated_yaml_and_raw_yaml() {
+        let text = include_str!("testdata/compat/current_minimal.yaml");
+
+        let config = parse_via_apollo_configuration(
+            text,
+            &apollo_configuration_options(),
+            &Expansion::builder().build(),
+        )
+        .expect("the minimal fixture is valid");
+
+        assert_eq!(
+            config.raw_yaml.as_deref(),
+            Some(text),
+            "raw_yaml must hold the exact pre-expansion input"
+        );
+        let validated_yaml = config
+            .validated_yaml
+            .as_ref()
+            .expect("validated_yaml must be populated");
+        assert!(
+            validated_yaml.is_object(),
+            "validated_yaml must hold the expanded document, not be left empty: {validated_yaml:?}"
+        );
+    }
+
+    #[test]
+    fn rejected_input_renders_as_a_miette_diagnostic() {
+        let text = include_str!("testdata/compat/unknown_top_level_key.yaml");
+
+        let error = parse_via_apollo_configuration(
+            text,
+            &apollo_configuration_options(),
+            &Expansion::builder().build(),
+        )
+        .expect_err("the fixture sets a key the schema does not declare");
+
+        let ConfigurationError::ApolloConfiguration(rendered) = &error else {
+            panic!("expected ApolloConfiguration, got: {error:?}");
+        };
+        assert!(
+            rendered.contains("Additional properties are not allowed"),
+            "rendered diagnostic should name the schema violation: {rendered}"
+        );
+        assert!(
+            rendered.contains("this_key_does_not_exist_anywhere"),
+            "rendered diagnostic should quote the offending key: {rendered}"
+        );
+    }
+
+    #[test]
+    fn malformed_yaml_returns_a_parse_error() {
+        let error = parse_via_apollo_configuration(
+            "supergraph: [",
+            &apollo_configuration_options(),
+            &Expansion::builder().build(),
+        )
+        .expect_err("the sequence is unterminated");
+
+        assert!(matches!(
+            error,
+            ConfigurationError::InvalidConfiguration {
+                message: "failed to parse yaml",
+                ..
+            }
+        ));
+        assert!(
+            error
+                .to_string()
+                .contains("expected node content at line 2 column 1"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn unsupported_expansion_returns_the_reference() {
+        let error = parse_via_apollo_configuration(
+            "supergraph:\n  listen: ${unsupported.ADDRESS}\n",
+            &apollo_configuration_options(),
+            &Expansion::builder().supported_mode("env").build(),
+        )
+        .expect_err("the expansion kind is unsupported");
+
+        assert!(matches!(
+            error,
+            ConfigurationError::UnknownExpansionMode { .. }
+        ));
+        assert!(error.to_string().contains("unsupported.ADDRESS"), "{error}");
+    }
+
+    #[test]
+    fn an_empty_document_expands_to_the_same_validated_yaml_as_router() {
+        let config = parse_via_apollo_configuration(
+            "",
+            &apollo_configuration_options(),
+            &Expansion::builder().build(),
+        )
+        .expect("an empty document is valid");
+
+        let router = crate::configuration::schema::validate_yaml_configuration(
+            "",
+            Expansion::builder().build(),
+            crate::configuration::schema::Mode::NoUpgrade,
+        )
+        .expect("router's own pipeline accepts an empty document");
+
+        assert_eq!(config.validated_yaml, router.validated_yaml);
+    }
+
+    #[test]
+    fn validated_yaml_holds_the_expanded_document() {
+        let text = "supergraph:\n  listen: 127.0.0.1:${env.COMPAT_TEST_PORT}\n";
+        let options =
+            apollo_configuration_options().add_variables(MapVariables(HashMap::from([(
+                "COMPAT_TEST_PORT".to_string(),
+                "4001".to_string(),
+            )])));
+        let expansion = Expansion::builder()
+            .supported_mode("env")
+            .mocked_env_var("COMPAT_TEST_PORT", "4001")
+            .build();
+
+        let config = parse_via_apollo_configuration(text, &options, &expansion)
+            .expect("both expanders resolve the reference");
+
+        assert_eq!(
+            config.validated_yaml.as_ref().expect("populated")["supergraph"]["listen"],
+            json!("127.0.0.1:4001"),
+            "validated_yaml must hold the expanded value, not the unexpanded reference"
+        );
+        assert_eq!(
+            config.supergraph.listen.to_string(),
+            "http://127.0.0.1:4001",
+            "the deserialized configuration must agree with validated_yaml"
+        );
+    }
+}

--- a/apollo-router/src/configuration/compatibility.rs
+++ b/apollo-router/src/configuration/compatibility.rs
@@ -4,9 +4,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::sync::OnceLock;
 
-use apollo_configuration::ParseYamlOptions;
 use apollo_configuration::expansion::FileVariables;
 use apollo_configuration::expansion::MapVariables;
 use apollo_configuration::provenance::Injection;
@@ -14,6 +12,8 @@ use serde_json::Value;
 use serde_json::json;
 
 use super::Configuration;
+use super::apollo_configuration_parse::apollo_configuration_options as router_options;
+use super::apollo_configuration_parse::parse_via_apollo_configuration;
 use super::expansion::Expansion;
 use super::expansion::Override;
 use super::expansion::ValueType;
@@ -29,26 +29,10 @@ use crate::spec::Schema;
 use crate::uplink::license_enforcement::LicenseEnforcementReport;
 use crate::uplink::license_enforcement::LicenseState;
 
-// Configuration's Deserialize implementation already runs its cross-field validation.
-impl apollo_configuration::Validate for Configuration {}
-impl apollo_configuration::Configuration for Configuration {}
-
 fn current_major_version() -> i64 {
     env!("CARGO_PKG_VERSION_MAJOR")
         .parse()
         .expect("CARGO_PKG_VERSION_MAJOR should be an integer")
-}
-
-fn router_options() -> ParseYamlOptions {
-    // Cache the patched router schema across parses.
-    static SCHEMA: OnceLock<Value> = OnceLock::new();
-    let schema = SCHEMA
-        .get_or_init(|| {
-            serde_json::to_value(generate_config_schema())
-                .expect("router's configuration schema serializes")
-        })
-        .clone();
-    ParseYamlOptions::default().schema(schema)
 }
 
 /// Which migration, if any, a corpus fixture needs before the shared parser can accept it.
@@ -457,23 +441,6 @@ fn raw_yaml_needs_the_adapter_because_deserialize_always_clears_it() {
         adapted_shared.raw_yaml.as_deref(),
         "the adapter must reproduce the same raw_yaml router itself would have set"
     );
-}
-
-/// Parses settings, stores the expanded document in `validated_yaml` and keeps `text` in
-/// `raw_yaml`. Configure `options` and `expansion` with equivalent external inputs.
-fn parse_via_apollo_configuration(
-    text: &str,
-    options: &ParseYamlOptions,
-    expansion: &Expansion,
-) -> Result<Configuration, String> {
-    let raw: Value = serde_yaml::from_str(text).map_err(|error| error.to_string())?;
-    let expanded = expansion.expand(&raw).map_err(|error| error.to_string())?;
-    let mut config: Configuration = options
-        .parse(text)
-        .map_err(|error| format!("{:?}", miette::Report::new(error)))?;
-    config.validated_yaml = Some(expanded);
-    config.raw_yaml = Some(Arc::from(text));
-    Ok(config)
 }
 
 #[test]

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -62,6 +62,7 @@ use crate::plugins::subscription::SubscriptionConfig;
 use crate::plugins::subscription::notification::Notify;
 use crate::uplink::UplinkConfig;
 
+mod apollo_configuration_parse;
 #[cfg(test)]
 mod compatibility;
 pub(crate) mod connector;
@@ -125,6 +126,16 @@ pub enum ConfigurationError {
 
     /// could not load certificate authorities: {error}
     CertificateAuthorities { error: String },
+
+    /// {0}
+    ApolloConfiguration(String),
+}
+
+impl From<apollo_configuration::ConfigError> for ConfigurationError {
+    fn from(error: apollo_configuration::ConfigError) -> Self {
+        // Render source labels as well as the error summary.
+        Self::ApolloConfiguration(format!("{:?}", miette::Report::new(error)))
+    }
 }
 
 impl From<proteus::Error> for ConfigurationError {


### PR DESCRIPTION
<!-- start metadata -->

<!-- [ROUTER-2104] -->
---

A bare `apollo-configuration` parse builds a typed Router configuration but leaves its original YAML and expanded document unset. Existing consumers need those values for licence checks, feature gates, configuration-usage metrics, hashing, and plugin diagnostics. This PR moves the compatibility suite’s adapter into a normal Router module, preserves those inputs, and renders complete shared-parser diagnostics.

Only tests call the adapter today. `Configuration::from_str`, startup, and reload still use the existing loader. This prepares the production conversion tracked by [ROUTER-2104]; it does not complete that ticket’s cutover.

## How the adapter works

The adapter supplies the Router’s cached, patched schema to `apollo-configuration 0.6.3`, preserving unknown-key rejection and secret annotations. Router cross-field checks continue to run in `Configuration`’s deserializer.

Two parsing paths serve different consumers: Router’s existing `Expansion` computes the expanded document retained in `validated_yaml`, while the shared parser expands and deserializes the typed configuration. Callers must configure equivalent external inputs on both paths. The adapter also stores the exact supplied text in `raw_yaml`; serde skips both fields.

```mermaid
sequenceDiagram
    participant C as Caller (currently tests)
    participant A as Router adapter
    participant E as Router YAML parsing and Expansion
    participant P as Shared parser
    C->>A: Text, parser options, equivalent expansion inputs
    A->>E: Parse YAML and expand retained document
    alt YAML or expansion fails
        E-->>A: Existing Router error
        A-->>C: Error without invoking shared parser
    else Expanded document available
        E-->>A: Expanded value
        A->>P: Parse original text with Router schema and providers
        alt Shared parsing or validation fails
            P-->>A: ConfigError with diagnostic details
            A->>A: Render diagnostic through miette
            A-->>C: ApolloConfiguration error
        else Accepted
            P-->>A: Typed Configuration
            A->>A: Attach expanded value and exact original text
            A-->>C: Configuration with both retained documents
        end
    end
```

No partially populated configuration is returned on failure. Shared-parser errors retain diagnostic details and source labels beyond the error’s summary display; earlier YAML parsing and Router expansion failures keep their existing error variants.

The expansion regression uses:

```yaml
supergraph:
  listen: 127.0.0.1:${env.COMPAT_TEST_PORT}
```

With both providers configured to return `4001`, the retained document contains `127.0.0.1:4001` and the typed listen address agrees. The original expression remains in `raw_yaml`. Blank input becomes an empty mapping for Router’s expansion pass, matching the existing loader.

The compatibility suite imports this adapter and schema builder instead of maintaining private copies, while retaining direct shared-parser tests for specific differences. `apollo-configuration` and `miette` become normal dependencies so the adapter is available outside test builds.

## Secret handling and remaining work

Version 0.6.3 follows the Router’s draft-7 `#/definitions/...` references to secret annotations. A regression places a typed Redis password beside an invalid key: the diagnostic contains `[REDACTED]` and omits the password. This covers that diagnostic path, not every YAML/secret combination. Retained raw and expanded YAML can still contain secrets and must not be treated as redacted logging output.

Production routing, `plugins: null` normalization, and retention/use of validated typed plugin configurations through the production loading path remain cutover work. This PR does not establish production cutover compatibility. The cost of the two parsing paths and the binary-size impact of the dependency promotion have not been measured.

## Dependencies and migration contract

This PR is stacked on [#10215](https://github.com/apollographql/router/pull/10215), which supplies typed secrets and their schema annotations, and must land after that parent. This layer adds the reusable adapter and its regression coverage.

The [merged configuration contract](https://github.com/apollographql/internal-specs/blob/c1d9968614001c180b53e1ba79529243c4b83525/components/router/architecture/configuration.md#where-it-is-going) retains automatic within-major migrations at startup and reload; major migrations require `router config upgrade`. [internal-specs #13](https://github.com/apollographql/internal-specs/pull/13) has merged, so the earlier migration-policy conflict is resolved. This adapter does not itself orchestrate migration.

The migration changes formerly proposed in [#10205](https://github.com/apollographql/router/pull/10205) are excluded from this stack; that PR is closed. The spec’s “How it loads today” section describes migrated-document rejection and diagnostics that this candidate does not implement. The existing loader still falls back to the original document when the migrated form is invalid, and validates that original document before accepting it. This adapter neither changes that fallback nor adds a migrated-document warning. The remaining specification reconciliation belongs to the broader adoption work.

[ROUTER-2104]: https://apollographql.atlassian.net/browse/ROUTER-2104
